### PR TITLE
impl(generator/rust): custom encoding for `[iu]64`

### DIFF
--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -492,7 +492,7 @@ func TestOneOfAnnotations(t *testing.T) {
 		BranchName:         "OneofFieldInteger",
 		FQMessageName:      "crate::model::Message",
 		DocLines:           nil,
-		Attributes:         []string{`#[serde_as(as = "serde_with::DisplayFromStr")]`},
+		Attributes:         []string{`#[serde_as(as = "wkt::internal::I64")]`},
 		FieldType:          "i64",
 		PrimitiveFieldType: "i64",
 		AddQueryParameter:  `let builder = req.oneof_field_integer().iter().fold(builder, |builder, p| builder.query(&[("oneofFieldInteger", p)]));`,
@@ -1049,7 +1049,7 @@ func TestFieldAnnotations(t *testing.T) {
 		FQMessageName: "crate::model::TestMessage",
 		Attributes: []string{
 			`#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]`,
-			`#[serde_as(as = "std::collections::HashMap<wkt::internal::I32, serde_with::DisplayFromStr>")]`,
+			`#[serde_as(as = "std::collections::HashMap<wkt::internal::I32, wkt::internal::I64>")]`,
 		},
 		FieldType:          "std::collections::HashMap<i32,i64>",
 		PrimitiveFieldType: "std::collections::HashMap<i32,i64>",

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -409,12 +409,10 @@ func scalarFieldType(f *api.Field) string {
 
 func fieldFormatter(typez api.Typez) string {
 	switch typez {
-	case api.INT64_TYPE,
-		api.UINT64_TYPE,
-		api.FIXED64_TYPE,
-		api.SFIXED64_TYPE,
-		api.SINT64_TYPE:
-		return "serde_with::DisplayFromStr"
+	case api.INT64_TYPE, api.SINT64_TYPE, api.SFIXED64_TYPE:
+		return "wkt::internal::I64"
+	case api.UINT64_TYPE, api.FIXED64_TYPE:
+		return "wkt::internal::U64"
 	case api.INT32_TYPE, api.SINT32_TYPE, api.SFIXED32_TYPE:
 		return "wkt::internal::I32"
 	case api.UINT32_TYPE, api.FIXED32_TYPE:

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -496,9 +496,9 @@ func TestFieldAttributes(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{enum}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
-		"f_int64":          `#[serde(skip_serializing_if = "wkt::internal::is_default")]` + "\n" + `#[serde_as(as = "serde_with::DisplayFromStr")]`,
-		"f_int64_optional": `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]`,
-		"f_int64_repeated": `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]`,
+		"f_int64":          `#[serde(skip_serializing_if = "wkt::internal::is_default")]` + "\n" + `#[serde_as(as = "wkt::internal::I64")]`,
+		"f_int64_optional": `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<wkt::internal::I64>")]`,
+		"f_int64_repeated": `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]`,
 
 		"f_bytes":          `#[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]` + "\n" + `#[serde_as(as = "serde_with::base64::Base64")]`,
 		"f_bytes_optional": `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<serde_with::base64::Base64>")]`,
@@ -656,8 +656,8 @@ func TestMapFieldAttributes(t *testing.T) {
 	expectedAttributes := map[string]string{
 		"target":      `#[serde(skip_serializing_if = "std::option::Option::is_none")]`,
 		"map":         `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]`,
-		"map_i64":     `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]`,
-		"map_i64_key": `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]`,
+		"map_i64":     `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]`,
+		"map_i64_key": `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<wkt::internal::I64, _>")]`,
 		"map_bytes":   `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<_, serde_with::base64::Base64>")]`,
 		"map_bool":    `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]`,
 	}
@@ -754,10 +754,10 @@ func TestWktFieldAttributes(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
-		"f_int64":           `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]`,
-		"f_int64_repeated":  `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]`,
-		"f_uint64":          `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]`,
-		"f_uint64_repeated": `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]`,
+		"f_int64":           `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<wkt::internal::I64>")]`,
+		"f_int64_repeated":  `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]`,
+		"f_uint64":          `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<wkt::internal::U64>")]`,
+		"f_uint64_repeated": `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]`,
 		"f_bytes":           `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<serde_with::base64::Base64>")]`,
 		"f_bytes_repeated":  `#[serde(skip_serializing_if = "std::vec::Vec::is_empty")]` + "\n" + `#[serde_as(as = "std::vec::Vec<serde_with::base64::Base64>")]`,
 		"f_string":          `#[serde(skip_serializing_if = "std::option::Option::is_none")]`,
@@ -808,7 +808,7 @@ func TestFieldLossyName(t *testing.T) {
 			`#[serde_as(as = "serde_with::base64::Base64")]`,
 		"dataCrc32c": `#[serde(rename = "dataCrc32c")]` + "\n" +
 			`#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" +
-			`#[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]`,
+			`#[serde_as(as = "std::option::Option<wkt::internal::I64>")]`,
 	}
 	loadWellKnownTypes(model.State)
 	for _, field := range message.Fields {

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -1082,7 +1082,7 @@ pub mod value {
         /// A boolean value.
         BooleanValue(bool),
         /// An integer value.
-        IntegerValue(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        IntegerValue(#[serde_as(as = "wkt::internal::I64")] i64),
         /// A double value.
         DoubleValue(#[serde_as(as = "wkt::internal::F64")] f64),
         /// A timestamp value.
@@ -3628,7 +3628,7 @@ pub struct PartitionQueryRequest {
     /// queries to be run, or in running a data pipeline job, one fewer than the
     /// number of workers or compute instances available.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub partition_count: i64,
 
     /// The `next_page_token` value returned from a previous call to
@@ -7853,7 +7853,7 @@ pub mod structured_aggregation_query {
             ///
             /// * Must be greater than zero when present.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub up_to: std::option::Option<wkt::Int64Value>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8281,7 +8281,7 @@ pub struct ExecutionStats {
     /// Total number of results returned, including documents, projections,
     /// aggregation results, keys.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub results_returned: i64,
 
     /// Total time to execute the query in the backend.
@@ -8290,7 +8290,7 @@ pub struct ExecutionStats {
 
     /// Total billable read operations.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub read_operations: i64,
 
     /// Debugging statistics from the execution of the query. Note that the

--- a/src/generated/api/cloudquotas/v1/src/model.rs
+++ b/src/generated/api/cloudquotas/v1/src/model.rs
@@ -1388,7 +1388,7 @@ pub struct QuotaConfig {
     /// Required. The preferred value. Must be greater than or equal to -1. If set
     /// to -1, it means the value is "unlimited".
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub preferred_value: i64,
 
     /// Output only. Optional details about the state of this quota preference.
@@ -1397,7 +1397,7 @@ pub struct QuotaConfig {
 
     /// Output only. Granted quota value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub granted_value: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The trace id that the Google Cloud uses to provision the
@@ -1723,7 +1723,7 @@ impl wkt::message::Message for DimensionsInfo {
 pub struct QuotaDetails {
     /// The value currently in effect and being enforced.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub value: i64,
 
     /// Rollout information of this quota.

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -416,7 +416,7 @@ pub mod check_error {
 pub struct Distribution {
     /// The total number of samples in the distribution. Must be >= 0.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub count: i64,
 
     /// The arithmetic mean of the samples in the distribution. If `count` is
@@ -455,7 +455,7 @@ pub struct Distribution {
     ///
     /// Any suffix of trailing zeros may be omitted.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub bucket_counts: std::vec::Vec<i64>,
 
     /// Example points. Must be in increasing order of `value` field.
@@ -906,7 +906,7 @@ pub struct HttpRequest {
     /// The size of the HTTP request message in bytes, including the request
     /// headers and the request body.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub request_size: i64,
 
     /// The response code indicating the status of the response.
@@ -918,7 +918,7 @@ pub struct HttpRequest {
     /// The size of the HTTP response message sent back to the client, in bytes,
     /// including the response headers and the response body.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub response_size: i64,
 
     /// The user agent sent by the client. Example:
@@ -966,7 +966,7 @@ pub struct HttpRequest {
     /// The number of HTTP response bytes inserted into cache. Set only when a
     /// cache fill was attempted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub cache_fill_bytes: i64,
 
     /// Protocol used for the request. Examples: "HTTP/1.1", "HTTP/2", "websocket"
@@ -1468,7 +1468,7 @@ pub struct LogEntrySourceLocation {
     /// Optional. Line within the source file. 1-based; 0 indicates no line number
     /// available.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub line: i64,
 
     /// Optional. Human-readable name of the function or method being invoked, with
@@ -1765,7 +1765,7 @@ pub mod metric_value {
         /// A boolean value.
         BoolValue(bool),
         /// A signed 64-bit integer value.
-        Int64Value(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        Int64Value(#[serde_as(as = "wkt::internal::I64")] i64),
         /// A double precision floating point value.
         DoubleValue(#[serde_as(as = "wkt::internal::F64")] f64),
         /// A text string value.
@@ -3162,7 +3162,7 @@ pub mod check_response {
         /// NOTE: This field is deprecated after we support flexible consumer
         /// id. New code should not depend on this field anymore.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub project_number: i64,
 
         /// The type of the consumer which should have been defined in
@@ -3175,7 +3175,7 @@ pub mod check_response {
         /// number or organization number e.g. 1234567890. A value of 0 indicates no
         /// consumer number is found.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub consumer_number: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -3280,7 +3280,7 @@ pub struct Distribution {
     /// must equal the sum of the values in `bucket_counts` if a histogram is
     /// provided.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub count: i64,
 
     /// The arithmetic mean of the values in the population. If `count` is zero
@@ -3330,7 +3330,7 @@ pub struct Distribution {
     /// counts for the finite buckets (number 1 through N-2). The N'th value in
     /// `bucket_counts` is the count for the overflow bucket (number N-1).
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub bucket_counts: std::vec::Vec<i64>,
 
     /// Must be in increasing order of `value` field.
@@ -7401,7 +7401,7 @@ pub struct MetricRule {
     /// increased for the metric against which the quota limits are defined.
     /// The value must not be negative.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub metric_costs: std::collections::HashMap<std::string::String, i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7472,7 +7472,7 @@ pub struct QuotaLimit {
     ///
     /// Used by group-based quotas only.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub default_limit: i64,
 
     /// Maximum number of tokens that can be consumed during the specified
@@ -7485,7 +7485,7 @@ pub struct QuotaLimit {
     ///
     /// Used by group-based quotas only.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_limit: i64,
 
     /// Free tier value displayed in the Developers Console for this limit.
@@ -7497,7 +7497,7 @@ pub struct QuotaLimit {
     ///
     /// Used by group-based quotas only.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub free_tier: i64,
 
     /// Duration of this limit in textual notation. Must be "100s" or "1d".
@@ -7531,7 +7531,7 @@ pub struct QuotaLimit {
     /// integer value that is the maximum number of requests allowed for the
     /// specified unit. Currently only STANDARD is supported.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub values: std::collections::HashMap<std::string::String, i64>,
 
     /// User-visible display name for this limit.

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -5958,7 +5958,7 @@ pub struct Instance {
 
     /// Output only. Total memory in use (bytes).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub memory_usage: i64,
 
     /// Output only. Status of the virtual machine where this instance lives. Only applicable
@@ -7379,7 +7379,7 @@ pub struct Version {
     ///
     /// @OutputOnly
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_usage_bytes: i64,
 
     /// The version of the API in the given runtime environment. Please see the

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -913,14 +913,14 @@ pub mod create_cluster_metadata {
     pub struct TableProgress {
         /// Estimate of the size of the table to be copied.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub estimated_size_bytes: i64,
 
         /// Estimate of the number of bytes copied so far for this table.
         /// This will eventually reach 'estimated_size_bytes' unless the table copy
         /// is CANCELLED.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub estimated_copied_bytes: i64,
 
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -10880,7 +10880,7 @@ pub struct Snapshot {
     /// asynchronously via a background process and a placeholder of 0 will be used
     /// in the meantime.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub data_size_bytes: i64,
 
     /// Output only. The time when the snapshot is created.
@@ -11195,7 +11195,7 @@ pub struct Backup {
 
     /// Output only. Size of the backup in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. The current state of the backup.

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -52,7 +52,7 @@ pub struct CloudSQLBackupRunSource {
 
     /// Required. The CloudSQL backup run ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub backup_run_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3013,7 +3013,7 @@ pub mod cluster {
         /// Output only. The project number that needs to be allowlisted on the
         /// network attachment to enable outbound connectivity.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub service_owned_project_number: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5506,7 +5506,7 @@ pub struct Backup {
 
     /// Output only. The size of the backup in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. The time at which after the backup is eligible to be garbage
@@ -6496,12 +6496,12 @@ pub mod supported_database_flag {
     pub struct IntegerRestrictions {
         /// The minimum value that can be specified, if applicable.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub min_value: std::option::Option<wkt::Int64Value>,
 
         /// The maximum value that can be specified, if applicable.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub max_value: std::option::Option<wkt::Int64Value>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6862,7 +6862,7 @@ pub mod supported_database_flag {
         RecommendedStringValue(std::string::String),
         /// The recommended value for an INTEGER flag.
         RecommendedIntegerValue(
-            #[serde_as(as = "std::boxed::Box<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::boxed::Box<wkt::internal::I64>")]
             std::boxed::Box<wkt::Int64Value>,
         ),
     }
@@ -8472,7 +8472,7 @@ pub mod import_cluster_request {
 pub struct ImportClusterResponse {
     /// Required. Size of the object downloaded from Google Cloud Storage in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_downloaded: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -877,7 +877,7 @@ pub struct HttpResponse {
     /// is "HEAD", values >= 0 indicate that the given number of bytes may
     /// be read from Body.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub content_length: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -5736,7 +5736,7 @@ pub struct QueryResult {
 
     /// Total rows of the whole query results.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_rows: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -688,7 +688,7 @@ pub mod workload {
         /// Resource identifier.
         /// For a project this represents project_number.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub resource_id: i64,
 
         /// Indicates the type of resource.

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -4032,7 +4032,7 @@ pub struct BackupVault {
 
     /// Output only. The number of backups in this backup vault.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub backup_count: i64,
 
     /// Output only. Service account used by the BackupVault Service for this
@@ -4043,7 +4043,7 @@ pub struct BackupVault {
 
     /// Output only. Total size of the storage used by all backup resources.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_stored_bytes: i64,
 
     /// Output only. Immutable after resource creation until resource deletion.
@@ -4620,7 +4620,7 @@ pub struct DataSource {
 
     /// Number of backups in the data source.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub backup_count: std::option::Option<i64>,
 
     /// Server specified ETag for the ManagementServer resource to prevent
@@ -4630,7 +4630,7 @@ pub struct DataSource {
 
     /// The number of bytes (metadata and data) stored in this datasource.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub total_stored_bytes: std::option::Option<i64>,
 
     /// Output only. The backup configuration state.
@@ -5479,12 +5479,12 @@ pub struct BackupApplianceBackupConfig {
 
     /// The ID of the backup appliance.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub backup_appliance_id: i64,
 
     /// The ID of the SLA of this application.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub sla_id: i64,
 
     /// The name of the application.
@@ -5717,7 +5717,7 @@ pub struct DataSourceBackupApplianceApplication {
 
     /// Appliance Id of the Backup Appliance.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub appliance_id: i64,
 
     /// The type of the application. e.g. VMBackup
@@ -5727,7 +5727,7 @@ pub struct DataSourceBackupApplianceApplication {
 
     /// The appid field of the application within the Backup Appliance.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub application_id: i64,
 
     /// Hostname of the host where the application is running.
@@ -5736,7 +5736,7 @@ pub struct DataSourceBackupApplianceApplication {
 
     /// Hostid of the application host.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub host_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5846,7 +5846,7 @@ impl wkt::message::Message for ServiceLockInfo {
 pub struct BackupApplianceLockInfo {
     /// Required. The ID of the backup/recovery appliance that created this lock.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub backup_appliance_id: i64,
 
     /// Required. The name of the backup/recovery appliance that created this lock.
@@ -6007,7 +6007,7 @@ pub mod backup_appliance_lock_info {
         /// The image name that depends on this Backup.
         BackupImage(std::string::String),
         /// The SLA on the backup/recovery appliance that owns the lock.
-        SlaId(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        SlaId(#[serde_as(as = "wkt::internal::I64")] i64),
     }
 }
 
@@ -6227,7 +6227,7 @@ pub struct Backup {
 
     /// Output only. source resource size in bytes at the time of the backup.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub resource_size_bytes: i64,
 
     /// Workload specific backup properties.
@@ -9879,12 +9879,12 @@ pub struct ComputeInstanceDataSourceProperties {
 
     /// The total number of disks attached to the Instance.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_disk_count: i64,
 
     /// The sum of all the disk sizes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_disk_size_gb: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13055,7 +13055,7 @@ pub mod scheduling {
 pub struct SchedulingDuration {
     /// Optional. Span of time at a resolution of a second.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub seconds: std::option::Option<i64>,
 
     /// Optional. Span of time that's a fraction of a second at nanosecond
@@ -13250,7 +13250,7 @@ pub struct AttachedDisk {
     /// Optional. A zero-based index to this disk, where 0 is reserved for the
     /// boot disk.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub index: std::option::Option<i64>,
 
     /// Optional. Indicates that this is a boot disk. The virtual machine will use
@@ -13283,7 +13283,7 @@ pub struct AttachedDisk {
 
     /// Optional. The size of the disk in GB.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub disk_size_gb: std::option::Option<i64>,
 
     /// Optional. Output only. The state of the disk.

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -1528,7 +1528,7 @@ pub struct Lun {
 
     /// The size of this LUN, in gigabytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_gb: i64,
 
     /// The LUN multiprotocol type ensures the characteristics of the LUN are
@@ -2976,7 +2976,7 @@ pub mod vrf {
     pub struct VlanAttachment {
         /// The peer vlan ID of the attachment.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub peer_vlan_id: i64,
 
         /// The peer IP of the attachment.
@@ -3877,7 +3877,7 @@ pub struct NfsShare {
 
     /// The requested size, in GiB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub requested_size_gib: i64,
 
     /// Immutable. The storage type of the underlying volume.
@@ -5947,11 +5947,11 @@ pub mod provisioning_quota {
     #[non_exhaustive]
     pub enum Availability {
         /// Server count.
-        ServerCount(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        ServerCount(#[serde_as(as = "wkt::internal::I64")] i64),
         /// Network bandwidth, Gbps
-        NetworkBandwidth(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        NetworkBandwidth(#[serde_as(as = "wkt::internal::I64")] i64),
         /// Storage size (GB).
-        StorageGib(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        StorageGib(#[serde_as(as = "wkt::internal::I64")] i64),
     }
 }
 
@@ -8432,42 +8432,42 @@ pub struct Volume {
 
     /// The requested size of this storage volume, in GiB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub requested_size_gib: i64,
 
     /// Originally requested size, in GiB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub originally_requested_size_gib: i64,
 
     /// The current size of this storage volume, in GiB, including space reserved
     /// for snapshots. This size might be different than the requested size if the
     /// storage volume has been configured with auto grow or auto shrink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub current_size_gib: i64,
 
     /// Additional emergency size that was requested for this Volume, in GiB.
     /// current_size_gib includes this value.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub emergency_size_gib: i64,
 
     /// Maximum size volume can be expanded to in case of evergency, in GiB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_size_gib: i64,
 
     /// The size, in GiB, that this storage volume has expanded as a result of an
     /// auto grow policy. In the absence of auto-grow, the value is 0.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub auto_grown_size_gib: i64,
 
     /// The space remaining in the storage volume for new LUNs, in GiB, excluding
     /// space reserved for snapshots.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub remaining_space_gib: i64,
 
     /// Details about snapshot space reservation and usage on the storage volume.
@@ -8755,7 +8755,7 @@ pub mod volume {
     pub struct SnapshotReservationDetail {
         /// The space on this storage volume reserved for snapshots, shown in GiB.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub reserved_space_gib: i64,
 
         /// The percent of snapshot space on this storage volume actually being used
@@ -8769,7 +8769,7 @@ pub mod volume {
         /// The amount, in GiB, of available space in this storage volume's reserved
         /// snapshot space.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub reserved_space_remaining_gib: i64,
 
         /// Percent of the total Volume size reserved for snapshot copies.
@@ -9851,7 +9851,7 @@ pub struct ResizeVolumeRequest {
 
     /// New Volume size, in GiB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_gib: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -44,7 +44,7 @@ pub struct AppConnectorInstanceConfig {
     /// by the API provider. Every time a config changes in the backend, the
     /// sequenceNumber should be bumped up to reflect the change.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub sequence_number: i64,
 
     /// The SLM instance agent configuration.

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -5622,13 +5622,13 @@ pub struct CloudStorageConfig {
     /// before a new file is created. Min 1 KB, max 10 GiB. The max_bytes limit may
     /// be exceeded in cases where messages are larger than the limit.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_bytes: i64,
 
     /// Optional. The maximum number of messages that can be written to a Cloud
     /// Storage file before a new file is created. Min 1000 messages.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_messages: i64,
 
     /// Optional. The service account to use to write to Cloud Storage. The

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -391,12 +391,12 @@ pub struct Connection {
 
     /// Output only. The creation timestamp of the connection.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub creation_time: i64,
 
     /// Output only. The last update timestamp of the connection.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_modified_time: i64,
 
     /// Output only. True, if credential is configured for this connection.

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -3248,7 +3248,7 @@ pub struct TransferConfig {
 
     /// Deprecated. Unique ID of the user on whose behalf transfer is done.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub user_id: i64,
 
     /// Output only. Region in which BigQuery dataset is located.
@@ -3692,7 +3692,7 @@ pub struct TransferRun {
 
     /// Deprecated. Unique ID of the user on whose behalf transfer is done.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub user_id: i64,
 
     /// Output only. Describes the schedule of this transfer run if it was

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -1875,7 +1875,7 @@ pub mod typed_value {
         /// A Boolean value: `true` or `false`.
         BoolValue(bool),
         /// A 64-bit integer. Its range is approximately `+/-9.2x10^18`.
-        Int64Value(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        Int64Value(#[serde_as(as = "wkt::internal::I64")] i64),
         /// A 64-bit double-precision floating-point number. Its magnitude
         /// is approximately `+/-10^(+/-300)` and it has 16 significant digits of
         /// precision.

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -60,7 +60,7 @@ pub struct Reservation {
     /// slots exceed your committed slots. Otherwise, you can decrease your
     /// baseline slots every few minutes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub slot_capacity: i64,
 
     /// If false, any query or pipeline job using this reservation will use idle
@@ -83,7 +83,7 @@ pub struct Reservation {
     /// NOTE: this field is exposed as target job concurrency in the Information
     /// Schema, DDL and BigQuery CLI.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub concurrency: i64,
 
     /// Output only. Creation time of the reservation.
@@ -309,12 +309,12 @@ pub mod reservation {
         /// current_slots may stay in the original value and could be larger than
         /// max_slots for that brief period (less than one minute)
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub current_slots: i64,
 
         /// Number of slots to be scaled when needed.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_slots: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -464,7 +464,7 @@ pub struct CapacityCommitment {
 
     /// Number of slots in this commitment.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub slot_count: i64,
 
     /// Capacity commitment commitment plan.
@@ -1750,7 +1750,7 @@ pub struct SplitCapacityCommitmentRequest {
 
     /// Number of slots in the capacity commitment after the split.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub slot_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3021,7 +3021,7 @@ pub struct BiReservation {
 
     /// Size of a reservation, in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size: i64,
 
     /// Preferred tables to use BI capacity for.

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -873,7 +873,7 @@ pub struct Dataset {
     /// table, that value takes precedence over the default expiration time
     /// indicated by this property.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub default_table_expiration_ms: std::option::Option<wkt::Int64Value>,
 
     /// This default partition expiration, expressed in milliseconds.
@@ -888,7 +888,7 @@ pub struct Dataset {
     /// is set, the `defaultTableExpirationMs` value is ignored and the table
     /// will not be inherit a table expiration deadline.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub default_partition_expiration_ms: std::option::Option<wkt::Int64Value>,
 
     /// The labels associated with this dataset. You can use these
@@ -917,13 +917,13 @@ pub struct Dataset {
     /// Output only. The time when this dataset was created, in milliseconds since
     /// the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub creation_time: i64,
 
     /// Output only. The date when this dataset was last modified, in milliseconds
     /// since the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_modified_time: i64,
 
     /// The geographic location where the dataset should reside. See
@@ -1018,7 +1018,7 @@ pub struct Dataset {
     /// to 168 hours (2 to 7 days). The default value is 168 hours if this is not
     /// set.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub max_time_travel_hours: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Tags for the dataset. To provide tags as inputs, use the
@@ -3512,7 +3512,7 @@ pub struct CsvOptions {
     ///   headers in row N. If headers are not detected, row N is just skipped.
     ///   Otherwise row N is used to extract column names for the detected schema.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub skip_leading_rows: std::option::Option<wkt::Int64Value>,
 
     /// Optional. The value that is used to quote data sections in a CSV file.
@@ -4204,7 +4204,7 @@ pub struct GoogleSheetsOptions {
     ///   headers in row N. If headers are not detected, row N is just skipped.
     ///   Otherwise row N is used to extract column names for the detected schema.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub skip_leading_rows: std::option::Option<wkt::Int64Value>,
 
     /// Optional. Range of a sheet to query from. Only used when non-empty.
@@ -5372,7 +5372,7 @@ pub struct RemoteModelInfo {
     /// Output only. Max number of rows in each batch sent to the remote service.
     /// If unset, the number of rows in each batch is set dynamically.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_batching_rows: i64,
 
     /// Output only. The model version for LLM.
@@ -5767,13 +5767,13 @@ pub struct Model {
     /// Output only. The time when this model was created, in millisecs since the
     /// epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub creation_time: i64,
 
     /// Output only. The time when this model was last modified, in millisecs since
     /// the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_modified_time: i64,
 
     /// Optional. A user-friendly description of this model.
@@ -5799,7 +5799,7 @@ pub struct Model {
     /// property of the encapsulating dataset can be used to set a default
     /// expirationTime on newly created models.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub expiration_time: i64,
 
     /// Output only. The geographic location where the model resides. This value
@@ -5850,7 +5850,7 @@ pub struct Model {
     /// tuning](https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-hp-tuning-overview)
     /// models, this is the smallest trial ID among all Pareto optimal trials.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub default_trial_id: i64,
 
     /// Output only. Trials of a [hyperparameter
@@ -5866,7 +5866,7 @@ pub struct Model {
     /// tuning](https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-hp-tuning-overview)
     /// models, it contains all Pareto optimal trials sorted by trial_id.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub optimal_trial_ids: std::vec::Vec<i64>,
 
     /// Output only. Remote model info
@@ -7653,22 +7653,22 @@ pub mod model {
 
             /// Number of true samples predicted as true.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub true_positives: std::option::Option<wkt::Int64Value>,
 
             /// Number of false samples predicted as true.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub false_positives: std::option::Option<wkt::Int64Value>,
 
             /// Number of true samples predicted as false.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub true_negatives: std::option::Option<wkt::Int64Value>,
 
             /// Number of false samples predicted as false.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub false_negatives: std::option::Option<wkt::Int64Value>,
 
             /// The fraction of actual positive predictions that had positive actual
@@ -8028,7 +8028,7 @@ pub mod model {
 
                 /// Number of items being predicted as this label.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
-                #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+                #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
                 pub item_count: std::option::Option<wkt::Int64Value>,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8223,7 +8223,7 @@ pub mod model {
         pub struct Cluster {
             /// Centroid id.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub centroid_id: i64,
 
             /// Values of highly variant features for this cluster.
@@ -8233,7 +8233,7 @@ pub mod model {
 
             /// Count of training data rows that were assigned to this cluster.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub count: std::option::Option<wkt::Int64Value>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8470,7 +8470,7 @@ pub mod model {
                         /// The count of training samples matching the category within the
                         /// cluster.
                         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-                        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+                        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
                         pub count: std::option::Option<wkt::Int64Value>,
 
                         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9378,17 +9378,17 @@ pub mod model {
     pub struct ArimaOrder {
         /// Order of the autoregressive part.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub p: std::option::Option<wkt::Int64Value>,
 
         /// Order of the differencing part.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub d: std::option::Option<wkt::Int64Value>,
 
         /// Order of the moving-average part.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub q: std::option::Option<wkt::Int64Value>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -10382,7 +10382,7 @@ pub mod model {
             /// The maximum number of iterations in training. Used only for iterative
             /// training algorithms.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub max_iterations: i64,
 
             /// Type of loss function used during training run.
@@ -10481,7 +10481,7 @@ pub mod model {
 
             /// Number of clusters for clustering models.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub num_clusters: i64,
 
             /// Google Cloud Storage URI from which the model was imported. Only
@@ -10495,12 +10495,12 @@ pub mod model {
 
             /// Hidden units for dnn models.
             #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-            #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
             pub hidden_units: std::vec::Vec<i64>,
 
             /// Batch size for dnn models.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub batch_size: i64,
 
             /// Dropout probability for dnn models.
@@ -10510,7 +10510,7 @@ pub mod model {
 
             /// Maximum depth of a tree for boosted tree models.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub max_tree_depth: i64,
 
             /// Subsample fraction of the training data to grow tree to prevent
@@ -10531,7 +10531,7 @@ pub mod model {
             /// Number of parallel trees constructed during each iteration for boosted
             /// tree models.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub num_parallel_tree: std::option::Option<wkt::Int64Value>,
 
             /// Type of normalization algorithm for boosted tree models using
@@ -10547,7 +10547,7 @@ pub mod model {
             /// Minimum sum of instance weight needed in a child for boosted tree
             /// models.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub min_tree_child_weight: std::option::Option<wkt::Int64Value>,
 
             /// Subsample ratio of columns when constructing each tree for boosted tree
@@ -10569,7 +10569,7 @@ pub mod model {
 
             /// Num factors specified for matrix factorization models.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub num_factors: i64,
 
             /// Feedback type that specifies which algorithm to run for matrix
@@ -10657,27 +10657,27 @@ pub mod model {
 
             /// The number of periods ahead that need to be forecasted.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub horizon: i64,
 
             /// The max value of the sum of non-seasonal p and q.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub auto_arima_max_order: i64,
 
             /// The min value of the sum of non-seasonal p and q.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub auto_arima_min_order: i64,
 
             /// Number of trials to run this hyperparameter tuning job.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub num_trials: i64,
 
             /// Maximum number of trials to run in parallel.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub max_parallel_trials: i64,
 
             /// The target evaluation metrics to optimize the hyperparameters for.
@@ -10704,12 +10704,12 @@ pub mod model {
 
             /// Number of paths for the sampled Shapley explain method.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub sampled_shapley_num_paths: i64,
 
             /// Number of integral steps for the integrated gradients explain method.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub integrated_gradients_num_steps: i64,
 
             /// Categorical feature encoding method.
@@ -10740,7 +10740,7 @@ pub mod model {
             /// element is padded to fill the smoothing window before the average is
             /// applied.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub trend_smoothing_window_size: i64,
 
             /// The fraction of the interpolated length of the time series that's used
@@ -10763,14 +10763,14 @@ pub mod model {
             /// the `minTimeSeriesLength` value, then the query uses all available time
             /// points.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub min_time_series_length: i64,
 
             /// The maximum number of time points in a time series that can be used in
             /// modeling the trend component of the time series. Don't use this option
             /// with the `timeSeriesLengthFraction` or `minTimeSeriesLength` options.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub max_time_series_length: i64,
 
             /// User-selected XGBoost versions for training of XGBoost models.
@@ -10789,7 +10789,7 @@ pub mod model {
             /// Number of principal components to keep in the PCA model. Must be <= the
             /// number of features.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub num_principal_components: i64,
 
             /// The minimum ratio of cumulative explained variance that needs to be
@@ -11992,7 +11992,7 @@ pub mod model {
 
             /// Time taken to run the iteration in milliseconds.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub duration_ms: std::option::Option<wkt::Int64Value>,
 
             /// Loss computed on the training data at the end of iteration.
@@ -12182,7 +12182,7 @@ pub mod model {
             pub struct ClusterInfo {
                 /// Centroid id.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                #[serde_as(as = "serde_with::DisplayFromStr")]
+                #[serde_as(as = "wkt::internal::I64")]
                 pub centroid_id: i64,
 
                 /// Cluster radius, the average distance from centroid
@@ -12193,7 +12193,7 @@ pub mod model {
 
                 /// Cluster size, the total number of points assigned to the cluster.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
-                #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+                #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
                 pub cluster_size: std::option::Option<wkt::Int64Value>,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -12660,7 +12660,7 @@ pub mod model {
             pub struct PrincipalComponentInfo {
                 /// Id of the principal component.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
-                #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+                #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
                 pub principal_component_id: std::option::Option<wkt::Int64Value>,
 
                 /// Explained variance by this principal component, which is simply the
@@ -13155,12 +13155,12 @@ pub mod model {
         pub struct IntRange {
             /// Min value of the int parameter.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub min: std::option::Option<wkt::Int64Value>,
 
             /// Max value of the int parameter.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub max: std::option::Option<wkt::Int64Value>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13223,7 +13223,7 @@ pub mod model {
         pub struct IntCandidates {
             /// Candidates for the int parameter in increasing order.
             #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-            #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
             pub candidates: std::vec::Vec<wkt::Int64Value>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13355,7 +13355,7 @@ pub mod model {
         pub struct IntArray {
             /// Elements in the int array.
             #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-            #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
             pub elements: std::vec::Vec<i64>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13907,17 +13907,17 @@ pub mod model {
     pub struct HparamTuningTrial {
         /// 1-based index of the trial.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub trial_id: i64,
 
         /// Starting time of the trial.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub start_time_ms: i64,
 
         /// Ending time of the trial.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub end_time_ms: i64,
 
         /// The hyperprameters selected for this trial.
@@ -16769,7 +16769,7 @@ impl wkt::message::Message for PartitionedColumn {
 pub struct AggregationThresholdPolicy {
     /// Optional. The threshold for the "aggregation threshold" policy.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub threshold: std::option::Option<i64>,
 
     /// Optional. The privacy unit column(s) associated with this policy.
@@ -16854,7 +16854,7 @@ pub struct DifferentialPrivacyPolicy {
     /// contribute. Changing this value does not improve or worsen privacy. The
     /// best value for accuracy and utility depends on the query and data.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub max_groups_contributed: std::option::Option<i64>,
 
     /// Optional. The privacy unit column associated with this policy. Differential
@@ -18233,13 +18233,13 @@ pub struct Routine {
     /// Output only. The time when this routine was created, in milliseconds since
     /// the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub creation_time: i64,
 
     /// Output only. The time when this routine was last modified, in milliseconds
     /// since the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_modified_time: i64,
 
     /// Optional. Defaults to "SQL" if remote_function_options field is absent, not
@@ -19014,7 +19014,7 @@ pub mod routine {
         /// If absent or if 0, BigQuery dynamically decides the number of rows in a
         /// batch.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_batching_rows: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21886,13 +21886,13 @@ pub struct TableReplicationInfo {
     /// It's Optional. If not specified, default replication interval would be
     /// applied.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub replication_interval_ms: i64,
 
     /// Optional. Output only. If source is a materialized view, this field
     /// signifies the last refresh time of the source.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub replicated_source_last_refresh_time: i64,
 
     /// Optional. Output only. Replication status of configured replication.
@@ -22317,7 +22317,7 @@ pub struct MaterializedViewDefinition {
     /// Output only. The time when this materialized view was last refreshed, in
     /// milliseconds since the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_refresh_time: i64,
 
     /// Optional. Enable automatic refresh of the materialized view when the base
@@ -22328,7 +22328,7 @@ pub struct MaterializedViewDefinition {
     /// Optional. The maximum frequency at which this materialized view will be
     /// refreshed. The default value is "1800000" (30 minutes).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::U64>")]
     pub refresh_interval_ms: std::option::Option<wkt::UInt64Value>,
 
     /// Optional. This option declares the intention to construct a materialized
@@ -22636,20 +22636,20 @@ pub struct Streamingbuffer {
     /// Output only. A lower-bound estimate of the number of bytes currently in
     /// the streaming buffer.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub estimated_bytes: u64,
 
     /// Output only. A lower-bound estimate of the number of rows currently in the
     /// streaming buffer.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub estimated_rows: u64,
 
     /// Output only. Contains the timestamp of the oldest entry in the streaming
     /// buffer, in milliseconds since the epoch, if the streaming buffer is
     /// available.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub oldest_entry_time: u64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22763,31 +22763,31 @@ pub struct Table {
     /// Output only. The size of this table in logical bytes, excluding any data in
     /// the streaming buffer.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The physical size of this table in bytes. This includes
     /// storage used for time travel.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_physical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The number of logical bytes in the table that are considered
     /// "long-term storage".
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_long_term_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The number of rows of data in this table, excluding any data
     /// in the streaming buffer.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::U64>")]
     pub num_rows: std::option::Option<wkt::UInt64Value>,
 
     /// Output only. The time when this table was created, in milliseconds since
     /// the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub creation_time: i64,
 
     /// Optional. The time when this table expires, in milliseconds since the
@@ -22796,13 +22796,13 @@ pub struct Table {
     /// property of the encapsulating dataset can be used to set a default
     /// expirationTime on newly created tables.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub expiration_time: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The time when this table was last modified, in milliseconds
     /// since the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub last_modified_time: u64,
 
     /// Output only. Describes the table type. The following values are supported:
@@ -22899,58 +22899,58 @@ pub struct Table {
     /// or changed data). This data is not kept in real time, and might be delayed
     /// by a few seconds to a few minutes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_time_travel_physical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Total number of logical bytes in the table or materialized
     /// view.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_total_logical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Number of logical bytes that are less than 90 days old.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_active_logical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Number of logical bytes that are more than 90 days old.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_long_term_logical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Number of physical bytes used by current live data storage.
     /// This data is not kept in real time, and might be delayed by a few seconds
     /// to a few minutes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_current_physical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The physical size of this table in bytes. This also includes
     /// storage used for time travel. This data is not kept in real time, and might
     /// be delayed by a few seconds to a few minutes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_total_physical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Number of physical bytes less than 90 days old. This data is
     /// not kept in real time, and might be delayed by a few seconds to a few
     /// minutes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_active_physical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. Number of physical bytes more than 90 days old.
     /// This data is not kept in real time, and might be delayed by a few seconds
     /// to a few minutes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_long_term_physical_bytes: std::option::Option<wkt::Int64Value>,
 
     /// Output only. The number of partitions present in the table or materialized
     /// view. This data is not kept in real time, and might be delayed by a few
     /// seconds to a few minutes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub num_partitions: std::option::Option<wkt::Int64Value>,
 
     /// Optional. The maximum staleness of data that could be returned when the
@@ -24420,14 +24420,14 @@ pub struct ListFormatTable {
     /// Output only. The time when this table was created, in milliseconds since
     /// the epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub creation_time: i64,
 
     /// The time when this table expires, in milliseconds since the
     /// epoch. If not present, the table will persist indefinitely. Expired tables
     /// will be deleted and their storage reclaimed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub expiration_time: i64,
 
     /// Optional. If set to true, queries including this table must specify a
@@ -25332,7 +25332,7 @@ pub struct TableFieldSchema {
     ///
     /// It is invalid to set this field if type &ne; "STRING" and &ne; "BYTES".
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_length: i64,
 
     /// Optional. Precision (maximum number of total digits in base 10) and scale
@@ -25369,12 +25369,12 @@ pub struct TableFieldSchema {
     ///
     /// If scale is specified but not precision, then it is invalid.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub precision: i64,
 
     /// Optional. See documentation for precision.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub scale: i64,
 
     /// Optional. Specifies the rounding mode to be used when storing values of
@@ -25837,7 +25837,7 @@ pub struct TimePartitioning {
     /// partition.
     /// A wrapper is used here because 0 is an invalid value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub expiration_ms: std::option::Option<wkt::Int64Value>,
 
     /// Optional. If not set, the table is partitioned by pseudo

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -660,7 +660,7 @@ pub struct Workload {
 
     /// Output only. Folder id this workload is associated with
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub folder_id: i64,
 
     /// Output only. Time the resource was created.
@@ -3213,7 +3213,7 @@ pub struct Violation {
 
     /// The folder_id of the violation
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub folder_id: i64,
 
     /// Output only. Compliance violation remediation

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -5164,7 +5164,7 @@ pub struct CloudSqlSettings {
     /// The maximum size to which storage capacity can be automatically increased.
     /// The default value is 0, which specifies that there is no limit.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub storage_auto_resize_limit: std::option::Option<wkt::Int64Value>,
 
     /// The activation policy specifies when the instance is activated; it is
@@ -5205,7 +5205,7 @@ pub struct CloudSqlSettings {
     /// The storage capacity available to the database, in GB.
     /// The minimum (and default) size is 10GB.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_disk_size_gb: std::option::Option<wkt::Int64Value>,
 
     /// The Google Cloud Platform zone where your Cloud SQL database instance is
@@ -10660,7 +10660,7 @@ pub struct MappingRule {
     /// Required. The order in which the rule is applied. Lower order rules are
     /// applied before higher value rules so they may end up being overridden.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub rule_order: i64,
 
     /// Output only. The revision ID of the mapping rule.
@@ -11478,7 +11478,7 @@ pub struct SingleColumnChange {
 
     /// Optional. Column length - e.g. 50 as in varchar (50) - when relevant.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub length: i64,
 
     /// Optional. Column precision - e.g. 8 as in double (8,2) - when relevant.
@@ -11684,7 +11684,7 @@ pub struct MultiColumnDatatypeChange {
     /// Optional. Column length - e.g. varchar (50) - if not specified and relevant
     /// uses the source column length.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub override_length: i64,
 
     /// Optional. Column scale - when relevant - if not specified and relevant
@@ -11899,13 +11899,13 @@ pub struct SourceTextFilter {
     /// Optional. The filter will match columns with length greater than or equal
     /// to this number.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub source_min_length_filter: i64,
 
     /// Optional. The filter will match columns with length smaller than or equal
     /// to this number.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub source_max_length_filter: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -12901,7 +12901,7 @@ pub struct IntComparisonFilter {
 
     /// Required. Integer compare value to be used
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub value: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13986,7 +13986,7 @@ pub struct ColumnEntity {
 
     /// Column length - e.g. varchar (50).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub length: i64,
 
     /// Column precision - when relevant.
@@ -14574,7 +14574,7 @@ impl wkt::message::Message for ViewEntity {
 pub struct SequenceEntity {
     /// Increment value for the sequence.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub increment: i64,
 
     /// Start number for the sequence represented as bytes to accommodate large.
@@ -14601,7 +14601,7 @@ pub struct SequenceEntity {
 
     /// Indicates number of entries to cache / precreate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub cache: i64,
 
     /// Custom engine specific features.

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -1457,7 +1457,7 @@ pub mod parameter {
         #[non_exhaustive]
         pub enum Kind {
             /// Represents an int64 value.
-            Int64Value(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+            Int64Value(#[serde_as(as = "wkt::internal::I64")] i64),
             /// Represents a string value.
             StringValue(std::string::String),
             /// Represents a double value.

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -4432,7 +4432,7 @@ pub struct ImportStatefileRequest {
     /// Required. Lock ID of the lock file to verify that the user who is importing
     /// the state file previously locked the Deployment.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub lock_id: i64,
 
     /// Optional.
@@ -4487,7 +4487,7 @@ pub struct DeleteStatefileRequest {
     /// Required. Lock ID of the lock file to verify that the user who is deleting
     /// the state file previously locked the Deployment.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub lock_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4564,7 +4564,7 @@ pub struct UnlockDeploymentRequest {
 
     /// Required. Lock ID of the lock file to be unlocked.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub lock_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4636,7 +4636,7 @@ impl wkt::message::Message for ExportLockInfoRequest {
 pub struct LockInfo {
     /// Unique ID for the lock to be overridden with generation ID in the backend.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub lock_id: i64,
 
     /// Terraform operation, provided by the caller.

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -1462,7 +1462,7 @@ pub mod config_variable {
     #[non_exhaustive]
     pub enum Value {
         /// Value is an integer
-        IntValue(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        IntValue(#[serde_as(as = "wkt::internal::I64")] i64),
         /// Value is a bool.
         BoolValue(bool),
         /// Value is a string.

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -10062,7 +10062,7 @@ pub mod bulk_download_feedback_labels_request {
 
         /// Optional. The number of records per file. Applicable for either format.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub records_per_file_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14199,7 +14199,7 @@ pub struct IssueModel {
 
     /// Output only. Number of issues in this issue model.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub issue_count: i64,
 
     /// Output only. State of the model.
@@ -14373,7 +14373,7 @@ pub mod issue_model {
 
         /// Output only. Number of conversations used in training. Output only.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub training_conversations_count: i64,
 
         /// A filter to reduce the conversations used for training the model to a
@@ -14834,13 +14834,13 @@ impl wkt::message::Message for Issue {
 pub struct IssueModelLabelStats {
     /// Number of conversations the issue model has analyzed at this point in time.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub analyzed_conversations_count: i64,
 
     /// Number of analyzed conversations for which no issue was applicable at this
     /// point in time.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub unclassified_conversations_count: i64,
 
     /// Statistics on each issue. Key is the issue's resource name.
@@ -14912,7 +14912,7 @@ pub mod issue_model_label_stats {
 
         /// Number of conversations attached to the issue at this point in time.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub labeled_conversations_count: i64,
 
         /// Display name of the issue.
@@ -19025,7 +19025,7 @@ pub mod qa_question {
         /// Total number of valid labels provided for the question at the time of
         /// tuining.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_valid_label_count: i64,
 
         /// A list of any applicable data validation warnings about the question's

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -4960,7 +4960,7 @@ pub struct VertexDatasetSpec {
     /// The number of DataItems in this Dataset. Only apply for non-structured
     /// Dataset.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub data_item_count: i64,
 
     /// Type of the dataset.
@@ -6707,17 +6707,17 @@ impl wkt::message::Message for ReconcileTagsRequest {
 pub struct ReconcileTagsResponse {
     /// Number of tags created in the request.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub created_tags_count: i64,
 
     /// Number of tags updated in the request.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub updated_tags_count: i64,
 
     /// Number of tags deleted in the request.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub deleted_tags_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7355,12 +7355,12 @@ pub struct ImportEntriesResponse {
     /// Cumulative number of entries created and entries updated as a result of
     /// import operation.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub upserted_entries_count: std::option::Option<i64>,
 
     /// Number of entries deleted as a result of import operation.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub deleted_entries_count: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8629,7 +8629,7 @@ pub struct GcsFileSpec {
 
     /// Output only. File size in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11938,7 +11938,7 @@ pub struct BigQueryDateShardedSpec {
 
     /// Output only. Total number of shards.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub shard_count: i64,
 
     /// Output only. BigQuery resource name of the latest shard.
@@ -13349,7 +13349,7 @@ impl wkt::message::Message for UsageStats {
 pub struct CommonUsageStats {
     /// View count in source system.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub view_count: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13416,7 +13416,7 @@ pub struct UsageSignal {
 
     /// Favorite count in the source system.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub favorite_count: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -5896,27 +5896,27 @@ pub mod metadata_job {
     pub struct ImportJobResult {
         /// Output only. The total number of entries that were deleted.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub deleted_entries: i64,
 
         /// Output only. The total number of entries that were updated.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub updated_entries: i64,
 
         /// Output only. The total number of entries that were created.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub created_entries: i64,
 
         /// Output only. The total number of entries that were unchanged.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub unchanged_entries: i64,
 
         /// Output only. The total number of entries that were recreated.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub recreated_entries: i64,
 
         /// Output only. The time when the status was updated.
@@ -5997,7 +5997,7 @@ pub mod metadata_job {
     pub struct ExportJobResult {
         /// Output only. The number of entries that were exported.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub exported_entries: i64,
 
         /// Output only. The error message if the metadata export job failed.
@@ -9289,7 +9289,7 @@ pub mod data_discovery_result {
 
         /// The data processed in bytes.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub data_processed_bytes: i64,
 
         /// The number of files excluded.
@@ -9677,7 +9677,7 @@ pub mod data_profile_spec {
 pub struct DataProfileResult {
     /// The count of rows scanned.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub row_count: i64,
 
     /// The profile information per field.
@@ -10083,12 +10083,12 @@ pub mod data_profile_result {
                 pub struct StringFieldInfo {
                     /// Minimum length of non-null values in the scanned data.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                    #[serde_as(as = "serde_with::DisplayFromStr")]
+                    #[serde_as(as = "wkt::internal::I64")]
                     pub min_length: i64,
 
                     /// Maximum length of non-null values in the scanned data.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                    #[serde_as(as = "serde_with::DisplayFromStr")]
+                    #[serde_as(as = "wkt::internal::I64")]
                     pub max_length: i64,
 
                     /// Average length of non-null values in the scanned data.
@@ -10153,7 +10153,7 @@ pub mod data_profile_result {
                     /// Minimum of non-null values in the scanned data. NaN, if the field
                     /// has a NaN.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                    #[serde_as(as = "serde_with::DisplayFromStr")]
+                    #[serde_as(as = "wkt::internal::I64")]
                     pub min: i64,
 
                     /// A quartile divides the number of data points into four parts, or
@@ -10169,13 +10169,13 @@ pub mod data_profile_result {
                     /// quartile values for the scanned data, occurring in order Q1,
                     /// median, Q3.
                     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-                    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+                    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
                     pub quartiles: std::vec::Vec<i64>,
 
                     /// Maximum of non-null values in the scanned data. NaN, if the field
                     /// has a NaN.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                    #[serde_as(as = "serde_with::DisplayFromStr")]
+                    #[serde_as(as = "wkt::internal::I64")]
                     pub max: i64,
 
                     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -10347,7 +10347,7 @@ pub mod data_profile_result {
 
                     /// Count of the corresponding value in the scanned data.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                    #[serde_as(as = "serde_with::DisplayFromStr")]
+                    #[serde_as(as = "wkt::internal::I64")]
                     pub count: i64,
 
                     /// Ratio of the corresponding value in the field against the total
@@ -11167,7 +11167,7 @@ pub struct DataQualityResult {
 
     /// Output only. The count of rows processed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub row_count: i64,
 
     /// Output only. The data scanned for this result.
@@ -11568,7 +11568,7 @@ pub struct DataQualityRuleResult {
     ///
     /// This field is not set for rule SqlAssertion.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub evaluated_count: i64,
 
     /// Output only. The number of rows which passed a rule evaluation.
@@ -11577,12 +11577,12 @@ pub struct DataQualityRuleResult {
     ///
     /// This field is not set for rule SqlAssertion.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub passed_count: i64,
 
     /// Output only. The number of rows with null values in the specified column.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub null_count: i64,
 
     /// Output only. The ratio of **passed_count / evaluated_count**.
@@ -11603,7 +11603,7 @@ pub struct DataQualityRuleResult {
     ///
     /// This field is only valid for SQL assertion rules.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub assertion_row_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18965,12 +18965,12 @@ pub mod session_event {
 
         /// The size of results the query produced.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub result_size_bytes: i64,
 
         /// The data processed by the query.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub data_processed_bytes: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20243,7 +20243,7 @@ pub mod data_scan_event {
     pub struct DataProfileResult {
         /// The count of rows processed in the data scan job.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub row_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20276,7 +20276,7 @@ pub mod data_scan_event {
     pub struct DataQualityResult {
         /// The count of rows processed in the data scan job.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub row_count: i64,
 
         /// Whether the data quality result was `pass` or not.
@@ -21370,24 +21370,24 @@ pub struct DataQualityScanRuleResult {
     /// The number of rows evaluated against the data quality rule.
     /// This field is only valid for rules of PER_ROW evaluation type.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub evaluated_row_count: i64,
 
     /// The number of rows which passed a rule evaluation.
     /// This field is only valid for rules of PER_ROW evaluation type.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub passed_row_count: i64,
 
     /// The number of rows with null values in the specified column.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub null_row_count: i64,
 
     /// The number of rows returned by the SQL statement in a SQL assertion rule.
     /// This field is only valid for SQL assertion rules.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub assertion_row_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -30040,22 +30040,22 @@ pub mod asset {
         pub struct Stats {
             /// The count of data items within the referenced resource.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub data_items: i64,
 
             /// The number of stored data bytes within the referenced resource.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub data_size: i64,
 
             /// The count of table entities within the referenced resource.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub tables: i64,
 
             /// The count of fileset entities within the referenced resource.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub filesets: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -4866,7 +4866,7 @@ pub struct DiskConfig {
     /// number of I/O operations per second that the disk can handle. Note: This
     /// field is only supported if boot_disk_type is hyperdisk-balanced.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub boot_disk_provisioned_iops: std::option::Option<i64>,
 
     /// Optional. Indicates how much throughput to provision for the disk. This
@@ -4874,7 +4874,7 @@ pub struct DiskConfig {
     /// Values must be greater than or equal to 1. Note: This field is only
     /// supported if boot_disk_type is hyperdisk-balanced.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub boot_disk_provisioned_throughput: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6356,12 +6356,12 @@ impl wkt::message::Message for MetastoreConfig {
 pub struct ClusterMetrics {
     /// The HDFS metrics.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub hdfs_metrics: std::collections::HashMap<std::string::String, i64>,
 
     /// YARN metrics.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub yarn_metrics: std::collections::HashMap<std::string::String, i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -16176,21 +16176,21 @@ pub struct UsageMetrics {
     /// (see [Dataproc Serverless pricing]
     /// (<https://cloud.google.com/dataproc-serverless/pricing>)).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub milli_dcu_seconds: i64,
 
     /// Optional. Shuffle storage usage in (`GB` x `seconds`) (see
     /// [Dataproc Serverless pricing]
     /// (<https://cloud.google.com/dataproc-serverless/pricing>)).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub shuffle_storage_gb_seconds: i64,
 
     /// Optional. Accelerator usage in (`milliAccelerator` x `seconds`) (see
     /// [Dataproc Serverless pricing]
     /// (<https://cloud.google.com/dataproc-serverless/pricing>)).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub milli_accelerator_seconds: i64,
 
     /// Optional. Accelerator type being used, if any
@@ -16251,33 +16251,33 @@ pub struct UsageSnapshot {
     /// [Dataproc Serverless pricing]
     /// (<https://cloud.google.com/dataproc-serverless/pricing>)).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub milli_dcu: i64,
 
     /// Optional. Shuffle Storage in gigabytes (GB). (see [Dataproc Serverless
     /// pricing] (<https://cloud.google.com/dataproc-serverless/pricing>))
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub shuffle_storage_gb: i64,
 
     /// Optional. Milli (one-thousandth) Dataproc Compute Units (DCUs) charged at
     /// premium tier (see [Dataproc Serverless pricing]
     /// (<https://cloud.google.com/dataproc-serverless/pricing>)).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub milli_dcu_premium: i64,
 
     /// Optional. Shuffle Storage in gigabytes (GB) charged at premium tier. (see
     /// [Dataproc Serverless pricing]
     /// (<https://cloud.google.com/dataproc-serverless/pricing>))
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub shuffle_storage_gb_premium: i64,
 
     /// Optional. Milli (one-thousandth) accelerator. (see [Dataproc
     /// Serverless pricing] (<https://cloud.google.com/dataproc-serverless/pricing>))
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub milli_accelerator: i64,
 
     /// Optional. Accelerator type being used, if any
@@ -17108,7 +17108,7 @@ pub mod gke_node_pool_config {
     pub struct GkeNodePoolAcceleratorConfig {
         /// The number of accelerator cards exposed to an instance.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub accelerator_count: i64,
 
         /// The accelerator type resource namename (see GPUs on Compute Engine).

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -12387,7 +12387,7 @@ impl wkt::message::Message for SqlServerLsnPosition {
 pub struct OracleScnPosition {
     /// Required. SCN number from where Logs will be read
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub scn: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -15662,7 +15662,7 @@ pub struct Retry {
     /// Required. Total number of retries. Retry is skipped if set to 0; The
     /// minimum value is 1, and the maximum value is 10.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub attempts: i64,
 
     /// Optional. How long to wait for the first retry. Default is 0, and the
@@ -17248,7 +17248,7 @@ pub struct RepairRolloutOperation {
 
     /// Output only. The index of the current repair action in the repair sequence.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub current_repair_phase_index: i64,
 
     /// Output only. Records of the repair attempts. Each repair phase may have
@@ -17488,7 +17488,7 @@ pub mod repair_phase {
 pub struct RetryPhase {
     /// Output only. The number of attempts that have been made.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_attempts: i64,
 
     /// Output only. The pattern of how the wait time of the retry attempt is
@@ -17550,7 +17550,7 @@ impl wkt::message::Message for RetryPhase {
 pub struct RetryAttempt {
     /// Output only. The index of this retry attempt.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub attempt: i64,
 
     /// Output only. How long the operation will be paused.

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -685,7 +685,7 @@ pub struct GitHubConfig {
 
     /// Optional. GitHub App installation id.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_installation_id: i64,
 
     /// Output only. The URI to navigate to in order to manage the installation
@@ -902,7 +902,7 @@ pub struct GitHubEnterpriseConfig {
 
     /// Optional. ID of the GitHub App created from the manifest.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_id: i64,
 
     /// Output only. The URL-friendly name of the GitHub App.
@@ -921,7 +921,7 @@ pub struct GitHubEnterpriseConfig {
 
     /// Optional. ID of the installation of the GitHub App.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_installation_id: i64,
 
     /// Output only. The URI to navigate to in order to manage the installation
@@ -2988,7 +2988,7 @@ pub mod fetch_git_hub_installations_response {
     pub struct Installation {
         /// ID of the installation in GitHub.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub id: i64,
 
         /// Name of the GitHub user or organization that owns this installation.

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -8552,7 +8552,7 @@ pub struct ConversationDataset {
     /// Output only. The number of conversations this conversation dataset
     /// contains.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub conversation_count: i64,
 
     /// Output only. A read only boolean field reflecting Zone Isolation status of
@@ -10682,7 +10682,7 @@ pub struct SmartReplyMetrics {
 
     /// Total number of conversations used to generate this metric.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub conversation_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -299,14 +299,14 @@ pub mod answer {
         /// unicode). If there are multi-byte characters,such as non-ASCII
         /// characters, the index measurement is longer than the string length.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub start_index: i64,
 
         /// End of the attributed segment, exclusive. Measured in bytes (UTF-8
         /// unicode). If there are multi-byte characters,such as non-ASCII
         /// characters, the index measurement is longer than the string length.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub end_index: i64,
 
         /// Citation sources for the attributed segment.
@@ -396,12 +396,12 @@ pub mod answer {
         /// Required. Index indicates the start of the claim, measured in bytes
         /// (UTF-8 unicode).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub start_index: i64,
 
         /// Required. End of the claim, exclusive.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub end_index: i64,
 
         /// A score in the range of [0, 1] describing how grounded is a specific
@@ -3579,7 +3579,7 @@ pub mod completion_suggestion {
         GlobalScore(#[serde_as(as = "wkt::internal::F64")] f64),
         /// Frequency of this suggestion. Will be used to rank suggestions when score
         /// is not available.
-        Frequency(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        Frequency(#[serde_as(as = "wkt::internal::I64")] i64),
     }
 }
 
@@ -9826,7 +9826,7 @@ pub struct CustomTuningModel {
 
     /// The version of the model.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub model_version: i64,
 
     /// The state that the model is in (e.g.`TRAINING` or `TRAINING_FAILED`).
@@ -10418,17 +10418,17 @@ pub mod data_store {
     pub struct BillingEstimation {
         /// Data size for structured data in terms of bytes.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub structured_data_size: i64,
 
         /// Data size for unstructured data in terms of bytes.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub unstructured_data_size: i64,
 
         /// Data size for websites in terms of bytes.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub website_data_size: i64,
 
         /// Last updated timestamp for structured data.
@@ -19468,13 +19468,13 @@ pub struct ImportUserEventsResponse {
 
     /// Count of user events imported with complete existing Documents.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub joined_events_count: i64,
 
     /// Count of user events imported, but with Document information not found
     /// in the existing Branch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub unjoined_events_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -19552,12 +19552,12 @@ pub struct ImportUserEventsMetadata {
 
     /// Count of entries that were processed successfully.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of entries that encountered errors while processing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -19642,17 +19642,17 @@ pub struct ImportDocumentsMetadata {
 
     /// Count of entries that were processed successfully.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of entries that encountered errors while processing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     /// Total count of entries that were processed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20721,12 +20721,12 @@ pub struct ImportSuggestionDenyListEntriesResponse {
 
     /// Count of deny list entries successfully imported.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub imported_entries_count: i64,
 
     /// Count of deny list entries that failed to be imported.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_entries_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21161,7 +21161,7 @@ pub struct ImportCompletionSuggestionsMetadata {
     ///
     /// [google.cloud.discoveryengine.v1.CompletionSuggestion]: crate::model::CompletionSuggestion
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of
@@ -21170,7 +21170,7 @@ pub struct ImportCompletionSuggestionsMetadata {
     ///
     /// [google.cloud.discoveryengine.v1.CompletionSuggestion]: crate::model::CompletionSuggestion
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21796,7 +21796,7 @@ impl wkt::message::Message for PurgeUserEventsRequest {
 pub struct PurgeUserEventsResponse {
     /// The total count of events purged as a result of the operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub purge_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21839,12 +21839,12 @@ pub struct PurgeUserEventsMetadata {
 
     /// Count of entries that were deleted successfully.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of entries that encountered errors while processing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22237,7 +22237,7 @@ pub mod purge_documents_request {
 pub struct PurgeDocumentsResponse {
     /// The total count of documents purged as a result of the operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub purge_count: i64,
 
     /// A sample of document names that will be deleted. Only populated if `force`
@@ -22297,17 +22297,17 @@ pub struct PurgeDocumentsMetadata {
 
     /// Count of entries that were deleted successfully.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of entries that encountered errors while processing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     /// Count of entries that were ignored as entries were not found.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub ignored_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22429,7 +22429,7 @@ impl wkt::message::Message for PurgeSuggestionDenyListEntriesRequest {
 pub struct PurgeSuggestionDenyListEntriesResponse {
     /// Number of suggestion deny list entries purged.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub purge_count: i64,
 
     /// A sample of errors encountered while processing the request.
@@ -28481,7 +28481,7 @@ pub mod search_response {
         pub struct FacetValue {
             /// Number of items that have this facet value.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub count: i64,
 
             /// A facet value which contains values.
@@ -28813,12 +28813,12 @@ pub mod search_response {
         pub struct Citation {
             /// Index indicates the start of the segment, measured in bytes/unicode.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub start_index: i64,
 
             /// End of the attributed segment, exclusive.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub end_index: i64,
 
             /// Citation sources for the attributed segment.
@@ -28874,7 +28874,7 @@ pub mod search_response {
             /// It is 0-indexed and the value will be zero if the reference_index is
             /// not set explicitly.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub reference_index: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -29366,7 +29366,7 @@ pub mod search_response {
         ///
         /// [google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.pin_unexpanded_results]: crate::model::search_request::QueryExpansionSpec::pin_unexpanded_results
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub pinned_result_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -31519,7 +31519,7 @@ pub mod target_site {
             /// This number is an estimation on how much total quota this project needs
             /// to successfully complete indexing.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub total_required_quota: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -36233,7 +36233,7 @@ pub struct CollectUserEventRequest {
     /// otherwise identical get requests. The name is abbreviated to reduce the
     /// payload bytes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub ets: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -448,12 +448,12 @@ pub mod document {
     pub struct ShardInfo {
         /// The 0-based index of this shard.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub shard_index: i64,
 
         /// Total number of shards.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub shard_count: i64,
 
         /// The index of the first character in
@@ -462,7 +462,7 @@ pub mod document {
         ///
         /// [google.cloud.documentai.v1.Document.text]: crate::model::Document::text
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub text_offset: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3767,7 +3767,7 @@ pub mod document {
             /// [google.cloud.documentai.v1.Document.TextAnchor.TextSegment]: crate::model::document::text_anchor::TextSegment
             /// [google.cloud.documentai.v1.Document.text]: crate::model::Document::text
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub start_index: i64,
 
             /// [TextSegment][google.cloud.documentai.v1.Document.TextAnchor.TextSegment]
@@ -3777,7 +3777,7 @@ pub mod document {
             /// [google.cloud.documentai.v1.Document.TextAnchor.TextSegment]: crate::model::document::text_anchor::TextSegment
             /// [google.cloud.documentai.v1.Document.text]: crate::model::Document::text
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub end_index: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3871,7 +3871,7 @@ pub mod document {
             ///
             /// [google.cloud.documentai.v1.Document.pages]: crate::model::Document::pages
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub page: i64,
 
             /// Optional. The type of the layout element that is being referenced if

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -1763,35 +1763,35 @@ pub mod interconnect_diagnostics {
     pub struct PacketCounts {
         /// The number of packets that are delivered.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub inbound_unicast: i64,
 
         /// The number of inbound packets that contained errors.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub inbound_errors: i64,
 
         /// The number of inbound packets that were chosen to be discarded even
         /// though no errors had been detected to prevent their being deliverable.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub inbound_discards: i64,
 
         /// The total number of packets that are requested be transmitted.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub outbound_unicast: i64,
 
         /// The number of outbound packets that could not be transmitted because of
         /// errors.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub outbound_errors: i64,
 
         /// The number of outbound packets that were chosen to be discarded even
         /// though no errors had been detected to prevent their being transmitted.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub outbound_discards: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2276,7 +2276,7 @@ pub mod router_status {
 
         /// Time this session has been up, in seconds.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub uptime_seconds: i64,
 
         /// A collection of counts for prefixes.
@@ -2516,32 +2516,32 @@ pub mod router_status {
     pub struct PrefixCounter {
         /// Number of prefixes advertised.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub advertised: i64,
 
         /// Number of prefixes denied.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub denied: i64,
 
         /// Number of prefixes received.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub received: i64,
 
         /// Number of prefixes sent.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub sent: i64,
 
         /// Number of prefixes suppressed.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub suppressed: i64,
 
         /// Number of prefixes withdrawn.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub withdrawn: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -427,7 +427,7 @@ pub struct FileShareConfig {
     /// File share capacity in gigabytes (GB).
     /// Filestore defines 1 GB as 1024^3 bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_gb: i64,
 
     /// Nfs Export Options.
@@ -571,7 +571,7 @@ pub struct NfsExportOptions {
     /// Anon_uid may only be set with squash_mode of ROOT_SQUASH.  An error will be
     /// returned if this field is specified for other squash_mode settings.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub anon_uid: i64,
 
     /// An integer representing the anonymous group id with a default value of
@@ -579,7 +579,7 @@ pub struct NfsExportOptions {
     /// Anon_gid may only be set with squash_mode of ROOT_SQUASH.  An error will be
     /// returned if this field is specified for other squash_mode settings.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub anon_gid: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1840,7 +1840,7 @@ pub mod instance {
     pub struct IOPSPerTB {
         /// Required. Maximum IOPS per TiB.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_iops_per_tb: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1873,7 +1873,7 @@ pub mod instance {
     pub struct FixedIOPS {
         /// Required. Maximum IOPS.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_iops: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2053,27 +2053,27 @@ pub mod instance {
     pub struct PerformanceLimits {
         /// Output only. The max IOPS.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_iops: i64,
 
         /// Output only. The max read IOPS.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_read_iops: i64,
 
         /// Output only. The max write IOPS.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_write_iops: i64,
 
         /// Output only. The max read throughput in bytes per second.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_read_throughput_bps: i64,
 
         /// Output only. The max write throughput in bytes per second.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub max_write_throughput_bps: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3328,7 +3328,7 @@ pub struct Snapshot {
     /// Output only. The amount of bytes needed to allocate a full copy of the
     /// snapshot content
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub filesystem_used_bytes: i64,
 
     /// Optional. Input only. Immutable. Tag key-value pairs bound to this
@@ -3968,13 +3968,13 @@ pub struct Backup {
 
     /// Output only. Capacity of the source file share when the backup was created.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_gb: i64,
 
     /// Output only. The size of the storage used by the backup. As backups share
     /// storage, this number is expected to change with backup creation/deletion.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub storage_bytes: i64,
 
     /// The resource name of the source Filestore instance, in the format
@@ -3997,7 +3997,7 @@ pub struct Backup {
     /// restored. This may be different than storage bytes, since sequential
     /// backups of the same disk will share storage.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub download_bytes: i64,
 
     /// Output only. Reserved for future use.

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -258,7 +258,7 @@ pub mod backtest_result {
         /// investigated in an average month, based on alerts from your existing
         /// automated alerting system.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub party_investigations_per_period_hint: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2180,7 +2180,7 @@ pub mod engine_config {
         /// investigated in an average month, based on alerts from your existing
         /// automated alerting system.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub party_investigations_per_period_hint: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4436,37 +4436,37 @@ pub mod import_registered_parties_request {
 pub struct ImportRegisteredPartiesResponse {
     /// Number of parties added by this operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_added: i64,
 
     /// Number of parties removed by this operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_removed: i64,
 
     /// Total number of parties that are registered in this instance, after the
     /// update operation was completed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_total: i64,
 
     /// Number of parties that failed to be removed by this operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_failed_to_remove: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_uptiered: i64,
 
     /// Total number of parties that are downtiered in this instance
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_downtiered: i64,
 
     /// Number of parties that failed to be downtiered
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parties_failed_to_downtier: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -664,7 +664,7 @@ pub struct StorageSource {
     /// Google Cloud Storage generation for the object. If the generation is
     /// omitted, the latest generation will be used.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// When the specified storage bucket is a 1st gen function uploard url bucket,

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -184,7 +184,7 @@ pub struct Backup {
     /// Output only. The total size of the Backup in bytes = config backup size +
     /// sum(volume backup sizes)
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. `etag` is used for optimistic concurrency control as a way to
@@ -209,7 +209,7 @@ pub struct Backup {
 
     /// Output only. The size of the config backup in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub config_backup_size_bytes: i64,
 
     /// Output only. If false, Backup will fail when Backup for GKE detects
@@ -10163,13 +10163,13 @@ pub struct VolumeBackup {
     /// location. In particular, this is likely to increase in size when
     /// the immediately preceding backup of the same volume is deleted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub storage_bytes: i64,
 
     /// Output only. The minimum size of the disk to which this VolumeBackup can be
     /// restored.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_size_bytes: i64,
 
     /// Output only. The timestamp when the associated underlying volume backup

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -591,7 +591,7 @@ pub struct GitConfig {
 
     /// Period in seconds between consecutive syncs. Default: 15.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub sync_wait_secs: i64,
 
     /// Git revision (tag or hash) to check out. Default HEAD.
@@ -698,7 +698,7 @@ pub struct OciConfig {
 
     /// Period in seconds between consecutive syncs. Default: 15.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub sync_wait_secs: i64,
 
     /// Type of secret configured for access to the Git repo.
@@ -778,7 +778,7 @@ pub struct PolicyController {
     /// Sets the interval for Policy Controller Audit Scans (in seconds).
     /// When set to 0, this disables audit functionality altogether.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub audit_interval_seconds: std::option::Option<i64>,
 
     /// The set of namespaces that are excluded from Policy Controller checks.

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -11279,7 +11279,7 @@ impl wkt::message::Message for WorkloadIdentityConfig {
 pub struct MaxPodsConstraint {
     /// Required. The maximum number of pods to schedule on a single node.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_pods_per_node: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11691,7 +11691,7 @@ pub struct NodeKubeletConfig {
     /// Controls the maximum number of processes allowed to run in a pod. The value
     /// must be greater than or equal to 1024 and less than 4194304.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub pod_pids_limit: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/kms/inventory/v1/src/model.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/model.rs
@@ -212,7 +212,7 @@ pub struct ProtectedResourcesSummary {
     /// The total number of protected resources in the same Cloud organization as
     /// the key.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub resource_count: i64,
 
     /// The number of distinct Cloud projects in the same Cloud organization as the
@@ -223,17 +223,17 @@ pub struct ProtectedResourcesSummary {
 
     /// The number of resources protected by the key grouped by resource type.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub resource_types: std::collections::HashMap<std::string::String, i64>,
 
     /// The number of resources protected by the key grouped by Cloud product.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub cloud_products: std::collections::HashMap<std::string::String, i64>,
 
     /// The number of resources protected by the key grouped by region.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub locations: std::collections::HashMap<std::string::String, i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -4349,7 +4349,7 @@ pub struct ChecksummedData {
     /// [google.cloud.kms.v1.ChecksummedData.data]: crate::model::ChecksummedData::data
     #[serde(rename = "crc32cChecksum")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub crc32c_checksum: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4437,7 +4437,7 @@ pub struct PublicKey {
     /// [google.cloud.kms.v1.PublicKey.pem]: crate::model::PublicKey::pem
     #[serde(rename = "pemCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub pem_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// The [name][google.cloud.kms.v1.CryptoKeyVersion.name] of the
@@ -7462,7 +7462,7 @@ pub struct EncryptRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub plaintext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. An optional CRC32C checksum of the
@@ -7490,7 +7490,7 @@ pub struct EncryptRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub additional_authenticated_data_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7627,7 +7627,7 @@ pub struct DecryptRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub ciphertext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. An optional CRC32C checksum of the
@@ -7655,7 +7655,7 @@ pub struct DecryptRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub additional_authenticated_data_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7812,7 +7812,7 @@ pub struct RawEncryptRequest {
     /// [google.cloud.kms.v1.RawEncryptRequest.plaintext]: crate::model::RawEncryptRequest::plaintext
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub plaintext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. An optional CRC32C checksum of the
@@ -7837,7 +7837,7 @@ pub struct RawEncryptRequest {
     /// [google.cloud.kms.v1.RawEncryptRequest.additional_authenticated_data]: crate::model::RawEncryptRequest::additional_authenticated_data
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub additional_authenticated_data_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. A customer-supplied initialization vector that will be used for
@@ -7871,7 +7871,7 @@ pub struct RawEncryptRequest {
     /// [google.cloud.kms.v1.RawEncryptRequest.initialization_vector]: crate::model::RawEncryptRequest::initialization_vector
     #[serde(rename = "initializationVectorCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub initialization_vector_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8045,7 +8045,7 @@ pub struct RawDecryptRequest {
     /// [google.cloud.kms.v1.RawDecryptRequest.ciphertext]: crate::model::RawDecryptRequest::ciphertext
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub ciphertext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. An optional CRC32C checksum of the
@@ -8070,7 +8070,7 @@ pub struct RawDecryptRequest {
     /// [google.cloud.kms.v1.RawDecryptRequest.additional_authenticated_data]: crate::model::RawDecryptRequest::additional_authenticated_data
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub additional_authenticated_data_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. An optional CRC32C checksum of the
@@ -8093,7 +8093,7 @@ pub struct RawDecryptRequest {
     /// [google.cloud.kms.v1.RawDecryptRequest.initialization_vector]: crate::model::RawDecryptRequest::initialization_vector
     #[serde(rename = "initializationVectorCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub initialization_vector_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8260,7 +8260,7 @@ pub struct AsymmetricSignRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "digestCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub digest_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Optional. The data to sign.
@@ -8298,7 +8298,7 @@ pub struct AsymmetricSignRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8434,7 +8434,7 @@ pub struct AsymmetricDecryptRequest {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub ciphertext_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8529,7 +8529,7 @@ pub struct MacSignRequest {
     /// [google.cloud.kms.v1.MacSignRequest.data_crc32c]: crate::model::MacSignRequest::data_crc32c
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8628,7 +8628,7 @@ pub struct MacVerifyRequest {
     /// [google.cloud.kms.v1.MacVerifyRequest.data_crc32c]: crate::model::MacVerifyRequest::data_crc32c
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Required. The signature to verify.
@@ -8659,7 +8659,7 @@ pub struct MacVerifyRequest {
     /// [google.cloud.kms.v1.MacVerifyRequest.mac_crc32c]: crate::model::MacVerifyRequest::mac_crc32c
     #[serde(rename = "macCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub mac_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8839,7 +8839,7 @@ pub struct EncryptResponse {
     /// [google.cloud.kms.v1.EncryptResponse.ciphertext]: crate::model::EncryptResponse::ciphertext
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub ciphertext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Integrity verification field. A flag indicating whether
@@ -9005,7 +9005,7 @@ pub struct DecryptResponse {
     /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub plaintext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Whether the Decryption was performed using the primary key version.
@@ -9124,7 +9124,7 @@ pub struct RawEncryptResponse {
     /// [google.cloud.kms.v1.RawEncryptResponse.ciphertext]: crate::model::RawEncryptResponse::ciphertext
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub ciphertext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Integrity verification field. A CRC32C checksum of the returned
@@ -9141,7 +9141,7 @@ pub struct RawEncryptResponse {
     /// [google.cloud.kms.v1.RawEncryptResponse.initialization_vector]: crate::model::RawEncryptResponse::initialization_vector
     #[serde(rename = "initializationVectorCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub initialization_vector_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Integrity verification field. A flag indicating whether
@@ -9369,7 +9369,7 @@ pub struct RawDecryptResponse {
     /// [google.cloud.kms.v1.RawDecryptResponse.plaintext]: crate::model::RawDecryptResponse::plaintext
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub plaintext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// The [ProtectionLevel][google.cloud.kms.v1.ProtectionLevel] of the
@@ -9545,7 +9545,7 @@ pub struct AsymmetricSignResponse {
     /// [google.cloud.kms.v1.AsymmetricSignResponse.signature]: crate::model::AsymmetricSignResponse::signature
     #[serde(rename = "signatureCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub signature_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Integrity verification field. A flag indicating whether
@@ -9706,7 +9706,7 @@ pub struct AsymmetricDecryptResponse {
     /// [google.cloud.kms.v1.AsymmetricDecryptResponse.plaintext]: crate::model::AsymmetricDecryptResponse::plaintext
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub plaintext_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Integrity verification field. A flag indicating whether
@@ -9834,7 +9834,7 @@ pub struct MacSignResponse {
     /// [google.cloud.kms.v1.MacSignResponse.mac]: crate::model::MacSignResponse::mac
     #[serde(rename = "macCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub mac_crc32c: std::option::Option<wkt::Int64Value>,
 
     /// Integrity verification field. A flag indicating whether
@@ -10102,7 +10102,7 @@ pub struct GenerateRandomBytesResponse {
     /// [google.cloud.kms.v1.GenerateRandomBytesResponse.data]: crate::model::GenerateRandomBytesResponse::data
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_crc32c: std::option::Option<wkt::Int64Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/lustre/v1/src/model.rs
+++ b/src/generated/cloud/lustre/v1/src/model.rs
@@ -53,7 +53,7 @@ pub struct Instance {
     /// Required. The storage capacity of the instance in gibibytes (GiB). Allowed
     /// values are from `18000` to `936000`, in increments of 9000.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_gib: i64,
 
     /// Required. Immutable. The full name of the VPC network to which the instance
@@ -91,7 +91,7 @@ pub struct Instance {
     /// Valid values are 250, 500, 1000.
     /// Default value is 1000.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub per_unit_storage_throughput: i64,
 
     /// Optional. Indicates whether you want to enable support for GKE clients. By
@@ -1680,46 +1680,46 @@ pub struct TransferCounters {
     /// excluding any that are filtered based on object conditions or skipped due
     /// to sync.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub found_objects_count: i64,
 
     /// Total number of bytes found in the data source that are scheduled to be
     /// transferred, excluding any that are filtered based on object conditions or
     /// skipped due to sync.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_found_count: i64,
 
     /// Objects in the data source that are not transferred because they already
     /// exist in the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_skipped_count: i64,
 
     /// Bytes in the data source that are not transferred because they already
     /// exist in the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_skipped_count: i64,
 
     /// Objects that are copied to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_copied_count: i64,
 
     /// Bytes that are copied to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_copied_count: i64,
 
     /// Output only. Objects that are failed to write to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_failed_count: i64,
 
     /// Output only. Bytes that are failed to write to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_failed_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1847,7 +1847,7 @@ pub struct ErrorSummary {
 
     /// Required. Count of this type of error.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub error_count: i64,
 
     /// Error samples.

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -2290,7 +2290,7 @@ pub struct Backup {
 
     /// Output only. Total size of the backup in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_size_bytes: i64,
 
     /// Output only. The time when the backup will expire.
@@ -2763,7 +2763,7 @@ pub struct BackupFile {
 
     /// Output only. Size of the backup file in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. The time when the backup file was created.

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -7978,12 +7978,12 @@ pub mod network_address {
 pub struct MachineDiskDetails {
     /// Disk total Capacity.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_capacity_bytes: i64,
 
     /// Total disk free space.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_free_bytes: i64,
 
     /// List of disks.
@@ -8081,12 +8081,12 @@ impl wkt::message::Message for DiskEntryList {
 pub struct DiskEntry {
     /// Disk capacity.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_bytes: i64,
 
     /// Disk free space.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub free_bytes: i64,
 
     /// Disk label.
@@ -8466,12 +8466,12 @@ pub struct DiskPartition {
 
     /// Partition capacity.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_bytes: i64,
 
     /// Partition free space.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub free_bytes: i64,
 
     /// Partition UUID.
@@ -9969,7 +9969,7 @@ pub struct RunningService {
 
     /// Service pid.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pid: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -10373,7 +10373,7 @@ impl wkt::message::Message for RunningProcessList {
 pub struct RunningProcess {
     /// Process ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pid: i64,
 
     /// Process binary path.
@@ -10580,7 +10580,7 @@ pub struct NetworkConnection {
 
     /// Process ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pid: i64,
 
     /// Process or service name.
@@ -12424,7 +12424,7 @@ pub struct GenericInsight {
     /// this insight, can be used for localization purposes, in case message_code
     /// is not yet known by the client use default_message instead.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub message_id: i64,
 
     /// Output only. In case message_code is not yet known by the client
@@ -13428,7 +13428,7 @@ pub mod aggregation_result {
     #[non_exhaustive]
     pub struct Count {
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub value: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13552,7 +13552,7 @@ pub mod aggregation_result {
 
             /// Count of items in the bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13597,7 +13597,7 @@ pub mod aggregation_result {
     #[non_exhaustive]
     pub struct Frequency {
         #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-        #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
         pub values: std::collections::HashMap<std::string::String, i64>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -15443,12 +15443,12 @@ pub mod report_summary {
     pub struct UtilizationChartData {
         /// Aggregate value which falls into the "Used" bucket.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub used: i64,
 
         /// Aggregate value which falls into the "Free" bucket.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub free: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -15537,17 +15537,17 @@ pub mod report_summary {
         pub struct Bucket {
             /// Lower bound - inclusive.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub lower_bound: i64,
 
             /// Upper bound - exclusive.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub upper_bound: i64,
 
             /// Count of items in the bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -15593,22 +15593,22 @@ pub mod report_summary {
     pub struct AssetAggregateStats {
         /// Sum of the memory in bytes of all the assets in this collection.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_memory_bytes: i64,
 
         /// Sum of persistent storage in bytes of all the assets in this collection.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_storage_bytes: i64,
 
         /// Sum of the CPU core count of all the assets in this collection.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_cores: i64,
 
         /// Count of the number of unique assets in this collection.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_assets: i64,
 
         /// Total memory split into Used/Free buckets.
@@ -15804,7 +15804,7 @@ pub mod report_summary {
 
         /// Count of assets allocated to this machine series.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub allocated_asset_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -15859,7 +15859,7 @@ pub mod report_summary {
 
         /// Count of assets which were allocated.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub allocated_asset_count: i64,
 
         /// Distribution of assets based on the Machine Series.
@@ -15938,7 +15938,7 @@ pub mod report_summary {
 
         /// Count of assets which are allocated
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub allocated_asset_count: i64,
 
         /// Set of per-nodetype allocation records
@@ -16001,12 +16001,12 @@ pub mod report_summary {
 
         /// Count of this node type to be provisioned
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub node_count: i64,
 
         /// Count of assets allocated to these nodes
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub allocated_asset_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -16101,7 +16101,7 @@ pub mod report_summary {
 
         /// Count of assets which are allocated
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub allocated_asset_count: i64,
 
         /// Set of per-nodetype allocation records
@@ -16164,12 +16164,12 @@ pub mod report_summary {
 
         /// Count of this node type to be provisioned
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub node_count: i64,
 
         /// Count of assets allocated to these nodes
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub allocated_asset_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -16510,7 +16510,7 @@ pub mod report_summary {
 
         /// This field is deprecated, do not rely on it having a value.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         #[deprecated]
         pub overlapping_asset_count: i64,
 

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -2222,7 +2222,7 @@ pub mod sanitization_result {
     pub struct SanitizationMetadata {
         /// Error code if any.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub error_code: i64,
 
         /// Error message if any.
@@ -3255,7 +3255,7 @@ pub struct SdpDeidentifyResult {
 
     /// Total size in bytes that were transformed during deidentification.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformed_bytes: i64,
 
     /// List of Sensitive Data Protection info-types that were de-identified.
@@ -3734,7 +3734,7 @@ pub struct VirusScanFilterResult {
 
     /// Size of scanned content in bytes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub scanned_size: std::option::Option<i64>,
 
     /// List of Viruses identified.
@@ -4463,12 +4463,12 @@ pub struct RangeInfo {
     /// Ref: <https://protobuf.dev/programming-guides/proto3/#default>
     /// Index of first character (inclusive).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub start: std::option::Option<i64>,
 
     /// Index of last character (exclusive).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub end: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -875,7 +875,7 @@ pub struct Backup {
     /// creating a new volume from the backup, the volume capacity will have to be
     /// at least as big.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub volume_usage_bytes: i64,
 
     /// Output only. Type of backup, manually created or created by a backup
@@ -907,7 +907,7 @@ pub struct Backup {
     /// Output only. Total size of all backups in a chain in bytes = baseline
     /// backup size + sum(incremental backup size)
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub chain_storage_bytes: i64,
 
     /// Output only. Reserved for future use
@@ -5205,7 +5205,7 @@ pub mod quota_rule {
 pub struct TransferStats {
     /// Cumulative bytes transferred so far for the replication relationship.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub transfer_bytes: std::option::Option<i64>,
 
     /// Cumulative time taken across all transfers for the replication
@@ -5215,7 +5215,7 @@ pub struct TransferStats {
 
     /// Last transfer size in bytes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub last_transfer_bytes: std::option::Option<i64>,
 
     /// Time taken during last transfer.
@@ -8296,12 +8296,12 @@ pub struct StoragePool {
 
     /// Required. Capacity in GIB of the pool
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_gib: i64,
 
     /// Output only. Allocated size of all volumes in GIB in the storage pool
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub volume_capacity_gib: i64,
 
     /// Output only. Volume count of the storage pool
@@ -8391,13 +8391,13 @@ pub struct StoragePool {
 
     /// Optional. Custom Performance Total Throughput of the pool (in MiB/s)
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_throughput_mibps: i64,
 
     /// Optional. Custom Performance Total IOPS of the pool
     /// If not provided, it will be calculated based on the total_throughput_mibps
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_iops: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9283,7 +9283,7 @@ pub struct Volume {
 
     /// Required. Capacity in GIB of the volume
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_gib: i64,
 
     /// Optional. Export policy of the volume
@@ -9334,7 +9334,7 @@ pub struct Volume {
     /// Output only. Used capacity in GIB of the volume. This is computed
     /// periodically and it does not represent the realtime usage.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub used_gib: i64,
 
     /// Optional. Security Style of the Volume
@@ -9404,7 +9404,7 @@ pub struct Volume {
 
     /// Output only. Size of the volume cold tier data in GiB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub cold_tier_size_gib: i64,
 
     /// Optional. The Hybrid Replication parameters for the volume.
@@ -11027,7 +11027,7 @@ pub struct BackupConfig {
     /// Output only. Total size of all backups in a chain in bytes = baseline
     /// backup size + sum(incremental backup size).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub backup_chain_bytes: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -1877,7 +1877,7 @@ pub mod service_connection_policy {
 
         /// Optional. Max number of PSC connections for this policy.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub limit: std::option::Option<i64>,
 
         /// Required. ProducerInstanceLocation is used to specify which authorization
@@ -5074,7 +5074,7 @@ pub struct Route {
     /// cases where a destination matches more than one route. In these cases the
     /// route with the lowest-numbered priority value wins.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub priority: i64,
 
     /// Immutable. The next-hop VPN tunnel for packets on this route.
@@ -9152,7 +9152,7 @@ pub mod spoke_summary {
         /// Output only. The total number of spokes of this type that are
         /// associated with the hub.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9200,7 +9200,7 @@ pub mod spoke_summary {
         /// Output only. The total number of spokes that are in this state
         /// and associated with a given hub.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9244,7 +9244,7 @@ pub mod spoke_summary {
         /// Output only. The total number of spokes that are inactive for a
         /// particular reason and associated with a given hub.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -1316,7 +1316,7 @@ pub struct LatencyPercentile {
     /// Fraction of percent/100 of samples have latency lower or
     /// equal to the value of this field.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub latency_micros: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9456,7 +9456,7 @@ pub struct CloudFunctionInfo {
 
     /// Latest successfully deployed version id of the Cloud Function.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub version_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -734,7 +734,7 @@ pub struct AcceleratorConfig {
 
     /// Optional. Count of cores of this accelerator.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub core_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1086,7 +1086,7 @@ pub struct DataDisk {
     /// Optional. The size of the disk in GB attached to this VM instance, up to a
     /// maximum of 64000 GB (64 TB). If not specified, this defaults to 100.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_size_gb: i64,
 
     /// Optional. Input only. Indicates the type of the disk.
@@ -1159,7 +1159,7 @@ pub struct BootDisk {
     /// a maximum of 64000 GB (64 TB). If not specified, this defaults to the
     /// recommended value of 150GB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_size_gb: i64,
 
     /// Optional. Indicates the type of the disk.

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -3394,7 +3394,7 @@ pub mod shipment {
         /// visit will vary. Since it is an integer, users are advised to choose an
         /// appropriate unit to avoid loss of precision. Must be ≥ 0.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub amount: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4614,7 +4614,7 @@ pub mod vehicle {
     pub struct LoadLimit {
         /// The maximum acceptable amount of load.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub max_load: std::option::Option<i64>,
 
         /// A soft limit of the load. See
@@ -4622,7 +4622,7 @@ pub mod vehicle {
         ///
         /// [google.cloud.optimization.v1.Vehicle.LoadLimit.cost_per_unit_above_soft_max]: crate::model::vehicle::LoadLimit::cost_per_unit_above_soft_max
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub soft_max_load: i64,
 
         /// If the load ever exceeds
@@ -4755,7 +4755,7 @@ pub mod vehicle {
             /// [google.cloud.optimization.v1.Vehicle.LoadLimit.Interval.max]: crate::model::vehicle::load_limit::Interval::max
             /// [google.cloud.optimization.v1.Vehicle.LoadLimit.Interval.min]: crate::model::vehicle::load_limit::Interval::min
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub min: i64,
 
             /// A maximum acceptable load. Must be ≥ 0. If unspecified, the maximum
@@ -4768,7 +4768,7 @@ pub mod vehicle {
             /// [google.cloud.optimization.v1.Vehicle.LoadLimit.Interval.max]: crate::model::vehicle::load_limit::Interval::max
             /// [google.cloud.optimization.v1.Vehicle.LoadLimit.Interval.min]: crate::model::vehicle::load_limit::Interval::min
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub max: std::option::Option<i64>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5491,7 +5491,7 @@ pub struct CapacityQuantity {
     pub r#type: std::string::String,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub value: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5538,11 +5538,11 @@ pub struct CapacityQuantityInterval {
     pub r#type: std::string::String,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub min_value: std::option::Option<i64>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub max_value: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5616,7 +5616,7 @@ pub struct DistanceLimit {
     /// A hard limit constraining the distance to be at most max_meters. The limit
     /// must be nonnegative.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub max_meters: std::option::Option<i64>,
 
     /// A soft limit not enforcing a maximum distance limit, but when violated
@@ -5626,7 +5626,7 @@ pub struct DistanceLimit {
     /// If defined soft_max_meters must be less than max_meters and must be
     /// nonnegative.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub soft_max_meters: std::option::Option<i64>,
 
     /// Cost per kilometer incurred, increasing up to `soft_max_meters`, with
@@ -7464,7 +7464,7 @@ pub mod shipment_route {
         ///
         /// [google.cloud.optimization.v1.ShipmentRoute.Transition.vehicle_loads]: crate::model::shipment_route::Transition::vehicle_loads
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub amount: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -2379,7 +2379,7 @@ pub mod os_policy {
 
                 /// Generation number of the Cloud Storage object.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                #[serde_as(as = "serde_with::DisplayFromStr")]
+                #[serde_as(as = "wkt::internal::I64")]
                 pub generation: i64,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9466,7 +9466,7 @@ pub struct PatchJobInstanceDetails {
 
     /// The number of times the agent that the agent attempts to apply the patch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub attempt_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9942,79 +9942,79 @@ pub mod patch_job {
     pub struct InstanceDetailsSummary {
         /// Number of instances pending patch job.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub pending_instance_count: i64,
 
         /// Number of instances that are inactive.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub inactive_instance_count: i64,
 
         /// Number of instances notified about patch job.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub notified_instance_count: i64,
 
         /// Number of instances that have started.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub started_instance_count: i64,
 
         /// Number of instances that are downloading patches.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub downloading_patches_instance_count: i64,
 
         /// Number of instances that are applying patches.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub applying_patches_instance_count: i64,
 
         /// Number of instances rebooting.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub rebooting_instance_count: i64,
 
         /// Number of instances that have completed successfully.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub succeeded_instance_count: i64,
 
         /// Number of instances that require reboot.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub succeeded_reboot_required_instance_count: i64,
 
         /// Number of instances that failed.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub failed_instance_count: i64,
 
         /// Number of instances that have acked and will start shortly.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub acked_instance_count: i64,
 
         /// Number of instances that exceeded the time out while applying the patch.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub timed_out_instance_count: i64,
 
         /// Number of instances that are running the pre-patch step.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub pre_patch_step_instance_count: i64,
 
         /// Number of instances that are running the post-patch step.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub post_patch_step_instance_count: i64,
 
         /// Number of instances that do not appear to be running the agent. Check to
         /// ensure that the agent is installed, running, and able to communicate with
         /// the service.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub no_agent_detected_instance_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -12006,7 +12006,7 @@ pub struct GcsObject {
     /// Required. Generation number of the Cloud Storage object. This is used to
     /// ensure that the ExecStep specified by this PatchJob does not change.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation_number: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -72,7 +72,7 @@ pub struct Instance {
     /// Allowed values are between 12000 and 100000, in multiples of 4000; e.g.,
     /// 12000, 16000, 20000, ...
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub capacity_gib: i64,
 
     /// Output only. Deprecated 'daos_version' field.
@@ -1625,7 +1625,7 @@ pub struct TransferErrorSummary {
 
     /// Count of this type of error.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub error_count: i64,
 
     /// A list of messages that carry the error details.
@@ -2264,46 +2264,46 @@ pub struct TransferCounters {
     /// excluding any that are filtered based on object conditions or skipped due
     /// to sync.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_found: i64,
 
     /// Bytes found in the data source that are scheduled to be transferred,
     /// excluding any that are filtered based on object conditions or skipped due
     /// to sync.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_found: i64,
 
     /// Objects in the data source that are not transferred because they already
     /// exist in the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_skipped: i64,
 
     /// Bytes in the data source that are not transferred because they already
     /// exist in the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_skipped: i64,
 
     /// Objects that are copied to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_copied: i64,
 
     /// Bytes that are copied to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_copied: i64,
 
     /// Objects that are failed to write to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_failed: i64,
 
     /// Bytes that are failed to write to the data destination.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_failed: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -654,7 +654,7 @@ pub mod condition_context {
 
         /// The network port of the peer.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub port: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -138,7 +138,7 @@ pub struct Collector {
 
     /// User specified expected asset count.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub expected_asset_count: i64,
 
     /// Output only. State of the Collector.

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -2520,7 +2520,7 @@ pub mod transaction_data {
 
         /// Optional. The epoch milliseconds of the user's account creation.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub creation_ms: i64,
 
         /// Optional. The email address of the user.
@@ -2614,7 +2614,7 @@ pub mod transaction_data {
 
         /// Optional. The quantity of this item that is being purchased.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub quantity: i64,
 
         /// Optional. When a merchant is specified, its corresponding account_id.
@@ -6587,7 +6587,7 @@ pub struct ScoreDistribution {
     /// between [0, 1]. The maximum number of buckets is on order of a few dozen,
     /// but typically much lower (ie. 10).
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<wkt::internal::I32, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I32, wkt::internal::I64>")]
     pub score_buckets: std::collections::HashMap<i32, i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6689,25 +6689,25 @@ pub struct ChallengeMetrics {
     /// Count of reCAPTCHA checkboxes or badges rendered. This is mostly equivalent
     /// to a count of pageloads for pages that include reCAPTCHA.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pageload_count: i64,
 
     /// Count of nocaptchas (successful verification without a challenge) issued.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub nocaptcha_count: i64,
 
     /// Count of submitted challenge solutions that were incorrect or otherwise
     /// deemed suspicious such that a subsequent challenge was triggered.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_count: i64,
 
     /// Count of nocaptchas (successful verification without a challenge) plus
     /// submitted challenge solutions that were correct and resulted in
     /// verification.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub passed_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -2486,7 +2486,7 @@ pub struct Backup {
 
     /// Output only. Total size of the backup in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_size_bytes: i64,
 
     /// Output only. The time when the backup will expire.
@@ -2978,7 +2978,7 @@ pub struct BackupFile {
 
     /// Output only. Size of the backup file in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. The time when the backup file was created.

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -4160,7 +4160,7 @@ pub mod rule {
         /// The max size of this map is 120, equivalent to the max [request page
         /// size](https://cloud.google.com/retail/docs/reference/rest/v2/projects.locations.catalogs.placements/search#request-body).
         #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-        #[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]
+        #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, _>")]
         pub pin_map: std::collections::HashMap<i64, std::string::String>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5531,14 +5531,14 @@ impl wkt::message::Message for LocalInventory {
 pub struct PinControlMetadata {
     /// Map of all matched pins, keyed by pin position.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, _>")]
     pub all_matched_pins:
         std::collections::HashMap<i64, crate::model::pin_control_metadata::ProductPins>,
 
     /// Map of pins that were dropped due to overlap with other matching pins,
     /// keyed by pin position.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, _>")]
     pub dropped_pins:
         std::collections::HashMap<i64, crate::model::pin_control_metadata::ProductPins>,
 
@@ -9085,12 +9085,12 @@ pub struct ImportMetadata {
 
     /// Count of entries that were processed successfully.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of entries that encountered errors while processing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     /// Deprecated. This field is never set.
@@ -9345,13 +9345,13 @@ impl wkt::message::Message for ImportUserEventsResponse {
 pub struct UserEventImportSummary {
     /// Count of user events imported with complete existing catalog information.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub joined_events_count: i64,
 
     /// Count of user events imported, but with catalog information not found
     /// in the imported catalog.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub unjoined_events_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14578,12 +14578,12 @@ pub struct PurgeProductsMetadata {
 
     /// Count of entries that were deleted successfully.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub success_count: i64,
 
     /// Count of entries that encountered errors while processing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failure_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14758,7 +14758,7 @@ impl wkt::message::Message for PurgeProductsRequest {
 pub struct PurgeProductsResponse {
     /// The total count of products purged as a result of the operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub purge_count: i64,
 
     /// A sample of the product names that will be deleted.
@@ -14890,7 +14890,7 @@ impl wkt::message::Message for PurgeUserEventsRequest {
 pub struct PurgeUserEventsResponse {
     /// The total count of events purged as a result of the operation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub purged_events_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18256,7 +18256,7 @@ pub mod search_response {
         pub struct FacetValue {
             /// Number of items that have this facet value.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub count: i64,
 
             /// The minimum value in the
@@ -18434,7 +18434,7 @@ pub mod search_response {
         ///
         /// [google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.pin_unexpanded_results]: crate::model::search_request::QueryExpansionSpec::pin_unexpanded_results
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub pinned_result_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20851,7 +20851,7 @@ pub struct CollectUserEventRequest {
     /// otherwise identical get requests. The name is abbreviated to reduce the
     /// payload bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub ets: i64,
 
     /// An arbitrary serialized JSON string that contains necessary information
@@ -21178,7 +21178,7 @@ pub mod rejoin_user_events_request {
 pub struct RejoinUserEventsResponse {
     /// Number of user events that were joined with latest product catalog.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub rejoined_user_events_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -514,7 +514,7 @@ pub struct StorageSource {
     /// Optional. Google Cloud Storage generation for the object. If the generation
     /// is omitted, the latest generation will be used.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1966,7 +1966,7 @@ pub struct Execution {
     /// Output only. A number that monotonically increases every time the user
     /// modifies the desired state.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Output only. Unstructured key value map that can be used to organize and
@@ -2069,7 +2069,7 @@ pub struct Execution {
     /// `reconciling` for additional information on reconciliation process in Cloud
     /// Run.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub observed_generation: i64,
 
     /// Output only. The number of actively running tasks.
@@ -3139,7 +3139,7 @@ pub struct Job {
     /// Output only. A number that monotonically increases every time the user
     /// modifies the desired state.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Unstructured key value map that can be used to organize and categorize
@@ -3217,7 +3217,7 @@ pub struct Job {
     /// Output only. The generation of this Job. See comments in `reconciling` for
     /// additional information on reconciliation process in Cloud Run.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub observed_generation: i64,
 
     /// Output only. The Condition of this Job, containing its readiness status,
@@ -5903,7 +5903,7 @@ pub struct Revision {
     /// Output only. A number that monotonically increases every time the user
     /// modifies the desired state.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Output only. Unstructured key value map that can be used to organize and
@@ -6029,7 +6029,7 @@ pub struct Revision {
     /// comments in `reconciling` for additional information on reconciliation
     /// process in Cloud Run.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub observed_generation: i64,
 
     /// Output only. The Google Console URI to obtain logs for the Revision.
@@ -7255,7 +7255,7 @@ pub struct Service {
     /// Please note that unlike v1, this is an int64 value. As with most Google
     /// APIs, its JSON representation will be a `string` instead of an `integer`.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Optional. Unstructured key value map that can be used to organize and
@@ -7373,7 +7373,7 @@ pub struct Service {
     /// As with most Google APIs, its JSON representation will be a `string`
     /// instead of an `integer`.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub observed_generation: i64,
 
     /// Output only. The Condition of this Service, containing its readiness
@@ -8048,7 +8048,7 @@ pub struct Task {
     /// Output only. A number that monotonically increases every time the user
     /// modifies the desired state.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Output only. Unstructured key value map that can be used to organize and
@@ -8158,7 +8158,7 @@ pub struct Task {
     /// Output only. The generation of this Task. See comments in `Job.reconciling`
     /// for additional information on reconciliation process in Cloud Run.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub observed_generation: i64,
 
     /// Output only. Index of the Task, unique per execution, and beginning at 0.

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -116,7 +116,7 @@ pub struct Secret {
     /// UpdateSecret. Access by alias is only be supported on
     /// GetSecretVersion and AccessSecretVersion.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub version_aliases: std::collections::HashMap<std::string::String, i64>,
 
     /// Optional. Custom metadata about the secret.
@@ -1744,7 +1744,7 @@ pub struct SecretPayload {
     /// [google.cloud.secretmanager.v1.SecretPayload.data]: crate::model::SecretPayload::data
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_crc32c: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -1931,14 +1931,14 @@ pub mod ca_pool {
                 /// If this is not set, or if set to zero, the service-level min RSA
                 /// modulus size will continue to apply.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                #[serde_as(as = "serde_with::DisplayFromStr")]
+                #[serde_as(as = "wkt::internal::I64")]
                 pub min_modulus_size: i64,
 
                 /// Optional. The maximum allowed RSA modulus size (inclusive), in bits.
                 /// If this is not set, or if set to zero, the service will not enforce
                 /// an explicit upper bound on RSA modulus sizes.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                #[serde_as(as = "serde_with::DisplayFromStr")]
+                #[serde_as(as = "wkt::internal::I64")]
                 pub max_modulus_size: i64,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2410,7 +2410,7 @@ pub struct CertificateRevocationList {
 
     /// Output only. The CRL sequence number that appears in pem_crl.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub sequence_number: i64,
 
     /// Output only. The revoked serial numbers that appear in pem_crl.

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -1807,12 +1807,12 @@ impl wkt::message::Message for AdaptiveProtection {
 pub struct Attack {
     /// Total PPS (packets per second) volume of attack.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub volume_pps_long: i64,
 
     /// Total BPS (bytes per second) volume of attack.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub volume_bps_long: i64,
 
     /// Type of attack, for example, 'SYN-flood', 'NTP-udp', or 'CHARGEN-udp'.
@@ -2090,7 +2090,7 @@ pub struct CloudDlpInspection {
     /// The number of times Cloud DLP found this infoType within this job
     /// and resource.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub info_type_count: i64,
 
     /// Whether Cloud DLP scanned the complete resource or a sampled subset.
@@ -3079,7 +3079,7 @@ pub struct DataRetentionDeletionEvent {
     /// the number of objects that violated the policy is greater than or equal to
     /// 1,000, then the value of this field is 1000.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub data_object_count: i64,
 
     /// Maximum duration of retention allowed from the DRD control. This comes
@@ -3454,7 +3454,7 @@ pub struct Exfiltration {
 
     /// Total exfiltrated bytes processed for the entire job.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_exfiltrated_bytes: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3882,7 +3882,7 @@ pub struct File {
 
     /// Size of the file in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size: i64,
 
     /// SHA256 hash of the first hashed_size bytes of the file encoded as a
@@ -3895,7 +3895,7 @@ pub struct File {
     /// hashed_size == size, any hashes reported represent the entire
     /// file.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub hashed_size: i64,
 
     /// True when the hash covers only a prefix of the file.
@@ -9943,12 +9943,12 @@ pub struct Process {
 
     /// The process ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pid: i64,
 
     /// The parent process ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub parent_pid: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13126,7 +13126,7 @@ pub struct GroupResult {
 
     /// Total count of resources for the given properties.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -40,7 +40,7 @@ pub struct SqlBackupRunsDeleteRequest {
     /// [list](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/backupRuns/list)
     /// method.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub id: i64,
 
     /// Cloud SQL instance ID. This does not include the project ID.
@@ -93,7 +93,7 @@ impl wkt::message::Message for SqlBackupRunsDeleteRequest {
 pub struct SqlBackupRunsGetRequest {
     /// The ID of this backup run.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub id: i64,
 
     /// Cloud SQL instance ID. This does not include the project ID.
@@ -289,7 +289,7 @@ pub struct BackupRun {
     /// The identifier for this backup run. Unique only for a specific Cloud SQL
     /// instance.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub id: i64,
 
     /// The time the backup operation actually started in UTC timezone in
@@ -358,7 +358,7 @@ pub struct BackupRun {
 
     /// Output only. The maximum chargeable bytes for the backup.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub max_chargeable_bytes: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1622,12 +1622,12 @@ pub struct Flag {
 
     /// For `INTEGER` flags, the minimum allowed value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub min_value: std::option::Option<wkt::Int64Value>,
 
     /// For `INTEGER` flags, the maximum allowed value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub max_value: std::option::Option<wkt::Int64Value>,
 
     /// Indicates whether changing this flag will trigger a database restart. Only
@@ -1646,7 +1646,7 @@ pub struct Flag {
     /// Use this field if only certain integers are accepted. Can be combined
     /// with min_value and max_value to add additional values.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub allowed_int_values: std::vec::Vec<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4987,7 +4987,7 @@ pub struct SqlInstancesGetDiskShrinkConfigResponse {
 
     /// The minimum size to which a disk can be shrunk in GigaBytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub minimal_target_size_gb: i64,
 
     /// Additional message to customers.
@@ -5136,7 +5136,7 @@ pub struct CloneContext {
 
     /// Reserved for future use.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pitr_timestamp_ms: i64,
 
     /// Name of the Cloud SQL instance to be created as a clone.
@@ -5298,7 +5298,7 @@ pub struct BinLogCoordinates {
 
     /// Position (offset) within the binary log file.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bin_log_position: i64,
 
     /// This is always `sql#binLogCoordinates`.
@@ -5385,7 +5385,7 @@ pub struct DatabaseInstance {
 
     /// The maximum disk size of the instance in bytes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     #[deprecated]
     pub max_disk_size: std::option::Option<wkt::Int64Value>,
 
@@ -5396,7 +5396,7 @@ pub struct DatabaseInstance {
     /// announcement](https://groups.google.com/d/msg/google-cloud-sql-announce/I_7-F9EBhT0/BtvFtdFeAgAJ)
     /// for details.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     #[deprecated]
     pub current_disk_size: std::option::Option<wkt::Int64Value>,
 
@@ -7634,7 +7634,7 @@ pub struct FailoverContext {
     /// The current settings version of this instance. Request will be rejected if
     /// this version doesn't match the current settings version.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub settings_version: i64,
 
     /// This is always `sql#failoverContext`.
@@ -7682,7 +7682,7 @@ pub struct RestoreBackupContext {
 
     /// The ID of the backup run to restore from.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub backup_run_id: i64,
 
     /// The ID of the instance that the backup was taken from.
@@ -9943,7 +9943,7 @@ pub mod backup_configuration {
 pub struct PerformDiskShrinkContext {
     /// The target disk shrink size in GigaBytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub target_size_gb: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9976,7 +9976,7 @@ impl wkt::message::Message for PerformDiskShrinkContext {
 pub struct BackupContext {
     /// The identifier of the backup.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub backup_id: i64,
 
     /// This is always `sql#backupContext`.
@@ -12852,7 +12852,7 @@ pub struct MySqlReplicaConfiguration {
 
     /// Interval in milliseconds between replication heartbeats.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub master_heartbeat_period: std::option::Option<wkt::Int64Value>,
 
     /// PEM representation of the trusted CA's x509 certificate.
@@ -14551,7 +14551,7 @@ pub struct Settings {
     /// use the most recent settingsVersion value for this instance and do not try
     /// to update this value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub settings_version: std::option::Option<wkt::Int64Value>,
 
     /// The App Engine app IDs that can access this instance.
@@ -14601,7 +14601,7 @@ pub struct Settings {
     /// The maximum size to which storage capacity can be automatically increased.
     /// The default value is 0, which specifies that there is no limit.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub storage_auto_resize_limit: std::option::Option<wkt::Int64Value>,
 
     /// The activation policy specifies when the instance is activated; it is
@@ -14665,7 +14665,7 @@ pub struct Settings {
 
     /// The size of data disk, in GB. The data disk size minimum is 10GB.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_disk_size_gb: std::option::Option<wkt::Int64Value>,
 
     /// Active Directory configuration, relevant only for Cloud SQL for SQL Server.
@@ -16613,7 +16613,7 @@ pub struct Tier {
     /// The maximum RAM usage of this tier in bytes.
     #[serde(rename = "RAM")]
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub ram: i64,
 
     /// This is always `sql#tier`.
@@ -16623,7 +16623,7 @@ pub struct Tier {
     /// The maximum disk size of this tier in bytes.
     #[serde(rename = "DiskQuota")]
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_quota: i64,
 
     /// The applicable regions for this tier.

--- a/src/generated/cloud/storagebatchoperations/v1/src/model.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/model.rs
@@ -1829,7 +1829,7 @@ pub struct ErrorSummary {
 
     /// Required. Number of errors encountered per `error_code`.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub error_count: i64,
 
     /// Required. Sample error logs.
@@ -1931,17 +1931,17 @@ impl wkt::message::Message for ErrorLogEntry {
 pub struct Counters {
     /// Output only. Number of objects listed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_object_count: i64,
 
     /// Output only. Number of objects completed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub succeeded_object_count: i64,
 
     /// Output only. Number of objects failed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_object_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -482,7 +482,7 @@ pub struct ReportDetail {
 
     /// Total shards generated for the report.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub shards_count: i64,
 
     /// Status of the ReportDetail.
@@ -636,7 +636,7 @@ pub mod report_detail {
     pub struct Metrics {
         /// Count of Cloud Storage objects which are part of the report.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub processed_records_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2021,7 +2021,7 @@ pub struct DatasetConfig {
     /// to. Projects that do not belong to the provided organization are not
     /// considered when creating the dataset.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub organization_number: i64,
 
     /// If set to `true`, the request includes all the newly created buckets in the
@@ -2561,7 +2561,7 @@ pub mod dataset_config {
     #[non_exhaustive]
     pub struct SourceProjects {
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-        #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
         pub project_numbers: std::vec::Vec<i64>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2599,7 +2599,7 @@ pub mod dataset_config {
     pub struct SourceFolders {
         /// Optional. The list of folder numbers to include in the dataset.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-        #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
         pub folder_numbers: std::vec::Vec<i64>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2870,12 +2870,12 @@ pub mod dataset_config {
     pub struct BucketErrors {
         /// Optional. Count of successfully validated buckets.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub validated_count: i64,
 
         /// Optional. Count of buckets with permission denied errors.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub permission_denied_count: i64,
 
         /// Optional. Subset of bucket names that have permission denied.
@@ -2885,7 +2885,7 @@ pub mod dataset_config {
         /// Optional. Count of buckets that are not subscribed to Storage
         /// Intelligence.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         #[deprecated]
         pub non_management_hub_entitled_count: i64,
 
@@ -2893,13 +2893,13 @@ pub mod dataset_config {
         /// validation process. These buckets are automatically retried in subsequent
         /// validation attempts.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub internal_error_count: i64,
 
         /// Optional. Count of buckets that are not subscribed to Storage
         /// Intelligence.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub non_storage_intelligence_entitled_count: i64,
 
         /// Optional. Subset of bucket names that are not subscribed to Storage
@@ -2991,50 +2991,50 @@ pub mod dataset_config {
     pub struct ProjectErrors {
         /// Optional. Count of successfully validated projects.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub validated_count: std::option::Option<i64>,
 
         /// Optional. Count of projects which are not in the same organization.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub outside_org_error_count: std::option::Option<i64>,
 
         /// Optional. Subset of project numbers which are not in the same
         /// organization.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-        #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
         pub outside_org_project_numbers: std::vec::Vec<i64>,
 
         /// Optional. Count of projects that are not subscribed to Storage
         /// Intelligence.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         #[deprecated]
         pub non_management_hub_entitled_error_count: std::option::Option<i64>,
 
         /// Optional. Subset of project numbers that are not subscribed to Storage
         /// Intelligence.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-        #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
         #[deprecated]
         pub non_management_hub_entitled_project_numbers: std::vec::Vec<i64>,
 
         /// Optional. Count of projects that are not subscribed to Storage
         /// Intelligence.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub non_storage_intelligence_entitled_error_count: std::option::Option<i64>,
 
         /// Optional. Subset of project numbers that are not subscribed to Storage
         /// Intelligence.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-        #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
         pub non_storage_intelligence_entitled_project_numbers: std::vec::Vec<i64>,
 
         /// Optional. Number of projects that encountered internal errors during
         /// validation and are automatically retried.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub internal_error_count: std::option::Option<i64>,
 
         /// The destination project check result. It indicates whether the project

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -144,7 +144,7 @@ pub struct Attachment {
 
     /// Output only. The size of the attachment in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -843,7 +843,7 @@ pub struct CustomAttribute {
     /// [google.cloud.talent.v4.CustomAttribute.long_values]: crate::model::CustomAttribute::long_values
     /// [google.cloud.talent.v4.CustomAttribute.string_values]: crate::model::CustomAttribute::string_values
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub long_values: std::vec::Vec<i64>,
 
     /// If the `filterable` flag is true, the custom field values may be used for
@@ -5233,7 +5233,7 @@ pub struct HistogramQueryResult {
     /// * (for anonymous numeric bucket) range formatted as `<low>-<high>`, for
     ///   example, `0-1000`, `MIN-0`, and `0-MAX`.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub histogram: std::collections::HashMap<std::string::String, i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -627,7 +627,7 @@ pub mod event_dimension {
         /// supported.
         StringVal(std::string::String),
         /// Long representation.
-        LongVal(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        LongVal(#[serde_as(as = "wkt::internal::I64")] i64),
         /// Bool representation.
         BoolVal(bool),
         /// Double representation.
@@ -672,7 +672,7 @@ pub struct Event {
     /// **NOTE**: JSON encoding should use a string to hold a 64-bit integer value,
     /// because a native JSON number holds only 53 binary bits for an integer.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub group_id: i64,
 
     /// Event timestamp.

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -742,7 +742,7 @@ pub struct Node {
 
     /// Output only. The unique identifier for the TPU Node.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub id: i64,
 
     /// The additional data disks for the Node.

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -6221,20 +6221,20 @@ pub struct BatchTranslateMetadata {
 
     /// Number of successfully translated characters so far (Unicode codepoints).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub translated_characters: i64,
 
     /// Number of characters that have failed to process so far (Unicode
     /// codepoints).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_characters: i64,
 
     /// Total number of characters (Unicode codepoints).
     /// This is the total number of codepoints from input files times the number of
     /// target languages and appears here shortly after the call is submitted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_characters: i64,
 
     /// Time when the operation was submitted.
@@ -6478,17 +6478,17 @@ pub mod batch_translate_metadata {
 pub struct BatchTranslateResponse {
     /// Total number of characters (Unicode codepoints).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_characters: i64,
 
     /// Number of successfully translated characters (Unicode codepoints).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub translated_characters: i64,
 
     /// Number of characters that have failed to process (Unicode codepoints).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_characters: i64,
 
     /// Time when the operation was submitted.
@@ -8866,48 +8866,48 @@ pub struct BatchTranslateDocumentResponse {
     /// Total number of pages to translate in all documents. Documents without
     /// clear page definition (such as XLSX) are not counted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_pages: i64,
 
     /// Number of successfully translated pages in all documents. Documents without
     /// clear page definition (such as XLSX) are not counted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub translated_pages: i64,
 
     /// Number of pages that failed to process in all documents. Documents without
     /// clear page definition (such as XLSX) are not counted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_pages: i64,
 
     /// Number of billable pages in documents with clear page definition (such as
     /// PDF, DOCX, PPTX)
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_billable_pages: i64,
 
     /// Total number of characters (Unicode codepoints) in all documents.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_characters: i64,
 
     /// Number of successfully translated characters (Unicode codepoints) in all
     /// documents.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub translated_characters: i64,
 
     /// Number of characters that have failed to process (Unicode codepoints) in
     /// all documents.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_characters: i64,
 
     /// Number of billable characters (Unicode codepoints) in documents without
     /// clear page definition, such as XLSX.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_billable_characters: i64,
 
     /// Time when the operation was submitted.
@@ -9035,48 +9035,48 @@ pub struct BatchTranslateDocumentMetadata {
     /// Total number of pages to translate in all documents so far. Documents
     /// without clear page definition (such as XLSX) are not counted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_pages: i64,
 
     /// Number of successfully translated pages in all documents so far. Documents
     /// without clear page definition (such as XLSX) are not counted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub translated_pages: i64,
 
     /// Number of pages that failed to process in all documents so far. Documents
     /// without clear page definition (such as XLSX) are not counted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_pages: i64,
 
     /// Number of billable pages in documents with clear page definition (such as
     /// PDF, DOCX, PPTX) so far.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_billable_pages: i64,
 
     /// Total number of characters (Unicode codepoints) in all documents so far.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_characters: i64,
 
     /// Number of successfully translated characters (Unicode codepoints) in all
     /// documents so far.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub translated_characters: i64,
 
     /// Number of characters that have failed to process (Unicode codepoints) in
     /// all documents so far.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_characters: i64,
 
     /// Number of billable characters (Unicode codepoints) in documents without
     /// clear page definition (such as XLSX) so far.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_billable_characters: i64,
 
     /// Time when the operation was submitted.

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -3375,7 +3375,7 @@ pub mod slate {
 
         /// Output only. The identifier generated for the slate by GAM.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub gam_slate_id: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -3305,7 +3305,7 @@ pub mod object_tracking_annotation {
         /// Instead, we provide a unique identifiable integer track_id so that
         /// the customers can correlate the results of the ongoing
         /// ObjectTrackAnnotation of the same track_id over time.
-        TrackId(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        TrackId(#[serde_as(as = "wkt::internal::I64")] i64),
     }
 }
 

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -1396,7 +1396,7 @@ pub struct Property {
 
     /// Value of numeric properties.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub uint64_value: u64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -582,24 +582,24 @@ impl wkt::message::Message for InitializingReplicationStep {
 pub struct ReplicatingStep {
     /// Total bytes to be handled in the step.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_bytes: i64,
 
     /// Replicated bytes in the step.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub replicated_bytes: i64,
 
     /// The source disks replication rate for the last 2 minutes in bytes per
     /// second.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_two_minutes_average_bytes_per_second: i64,
 
     /// The source disks replication rate for the last 30 minutes in bytes per
     /// second.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub last_thirty_minutes_average_bytes_per_second: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5009,7 +5009,7 @@ pub struct VmwareVmDetails {
 
     /// The total size of the storage allocated to the VM in MB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub committed_storage_mb: i64,
 
     /// The VM's OS. See for example
@@ -5442,7 +5442,7 @@ pub struct AwsVmDetails {
 
     /// The total size of the storage allocated to the VM in MB.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub committed_storage_mb: i64,
 
     /// The VM's OS.
@@ -7077,24 +7077,24 @@ pub struct VmUtilizationMetrics {
 
     /// Max disk IO rate, in kilobytes per second.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_io_rate_max_kbps: i64,
 
     /// Average disk IO rate, in kilobytes per second.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_io_rate_average_kbps: i64,
 
     /// Max network throughput (combined transmit-rates and receive-rates), in
     /// kilobytes per second.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub network_throughput_max_kbps: i64,
 
     /// Average network throughput (combined transmit-rates and receive-rates), in
     /// kilobytes per second.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub network_throughput_average_kbps: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11929,7 +11929,7 @@ pub struct AwsSourceVmDetails {
 
     /// The total size of the disks being migrated in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub committed_storage_bytes: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -8497,7 +8497,7 @@ pub struct Node {
 
     /// Output only. Customized number of cores
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub custom_core_count: i64,
 
     /// Output only. The state of the appliance.
@@ -12797,7 +12797,7 @@ pub struct PeeringRoute {
 
     /// Output only. The priority of the peering route.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub priority: i64,
 
     /// Output only. True if the peering route has been imported from a peered

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -1079,7 +1079,7 @@ pub struct RiceDeltaEncoding {
     /// integer was encoded, that single integer's value. If the field is empty or
     /// missing, assume zero.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub first_value: i64,
 
     /// The Golomb-Rice parameter, which is a number between 2 and 28. This field

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -3024,7 +3024,7 @@ pub struct ScanRun {
     /// Output only. The number of URLs crawled during this ScanRun. If the scan is in progress,
     /// the value represents the number of URLs crawled up to now.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub urls_crawled_count: i64,
 
     /// Output only. The number of URLs tested during this ScanRun. If the scan is in progress,
@@ -3032,7 +3032,7 @@ pub struct ScanRun {
     /// URLs tested is usually larger than the number URLS crawled because
     /// typically a crawled URL is tested with multiple test payloads.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub urls_tested_count: i64,
 
     /// Output only. Whether the scan run has found any vulnerabilities.
@@ -3748,11 +3748,11 @@ pub struct ScanRunLog {
     pub result_state: crate::model::scan_run::ResultState,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub urls_crawled_count: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub urls_tested_count: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -373,18 +373,18 @@ pub mod execution {
         pub struct Position {
             /// The source code line number the current instruction was generated from.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub line: i64,
 
             /// The source code column position (of the line) the current instruction
             /// was generated from.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub column: i64,
 
             /// The number of bytes of source code making up this stack trace element.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub length: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -556,7 +556,7 @@ pub struct NodeKubeletConfig {
     /// Controls the maximum number of processes allowed to run in a pod. The value
     /// must be greater than or equal to 1024 and less than 4194304.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pod_pids_limit: i64,
 
     /// Enable or disable Kubelet read only port.
@@ -1802,7 +1802,7 @@ pub struct AdvancedMachineFeatures {
     /// multithreading (SMT) set this to 1. If unset, the maximum number of threads
     /// supported per core by the underlying processor is assumed.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub threads_per_core: std::option::Option<i64>,
 
     /// Whether or not to enable nested virtualization (defaults to false).
@@ -11524,7 +11524,7 @@ pub mod operation_progress {
         #[non_exhaustive]
         pub enum Value {
             /// For metrics with integer value.
-            IntValue(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+            IntValue(#[serde_as(as = "wkt::internal::I64")] i64),
             /// For metrics with floating point value.
             DoubleValue(#[serde_as(as = "wkt::internal::F64")] f64),
             /// For metrics with custom values (ratios, visual progress, etc.).
@@ -11956,7 +11956,7 @@ pub struct UpdateNodePoolRequest {
     /// Initiates an upgrade operation that migrates the nodes in the
     /// node pool to the specified disk size.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_size_gb: i64,
 
     /// Desired resource manager tag keys and values to be attached to the nodes
@@ -17544,12 +17544,12 @@ pub struct ResourceLimit {
 
     /// Minimum amount of the resource in the cluster.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub minimum: i64,
 
     /// Maximum amount of the resource in the cluster.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub maximum: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18202,7 +18202,7 @@ impl wkt::message::Message for CompleteIPRotationRequest {
 pub struct AcceleratorConfig {
     /// The number of the accelerator cards exposed to an instance.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub accelerator_count: i64,
 
     /// The accelerator type resource name. List of supported accelerators
@@ -18313,7 +18313,7 @@ impl wkt::message::Message for AcceleratorConfig {
 pub struct GPUSharingConfig {
     /// The max number of containers that can share a physical GPU.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_shared_clients_per_gpu: i64,
 
     /// The type of GPU sharing strategy to enable on the GPU node.
@@ -21359,7 +21359,7 @@ pub mod dns_config {
 pub struct MaxPodsConstraint {
     /// Constraint enforced on the max num of pods per node.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_pods_per_node: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -326,13 +326,13 @@ pub struct Progress {
     /// The amount of work that has been completed. Note that this may be greater
     /// than work_estimated.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub work_completed: i64,
 
     /// An estimate of how much work needs to be performed. May be zero if the
     /// work estimate is unavailable.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub work_estimated: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -632,7 +632,7 @@ pub struct DockerImage {
     /// This field is returned as the 'metadata.imageSizeBytes' field in the
     /// Version resource.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub image_size_bytes: i64,
 
     /// Time the image was uploaded.
@@ -2348,7 +2348,7 @@ pub struct File {
 
     /// The size of the File in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// The hashes of the file content.
@@ -6749,7 +6749,7 @@ pub struct Repository {
     /// repository. Repositories that are generally available or in public preview
     /// use this to calculate storage costs.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. If set, the repository satisfies physical zone separation.

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -184,7 +184,7 @@ pub struct StorageSource {
     /// Cloud Storage generation for the object. If the generation is
     /// omitted, the latest generation will be used.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Option to specify the tool to fetch the source file for the build.
@@ -659,7 +659,7 @@ pub struct StorageSourceManifest {
     /// Cloud Storage generation for the object. If the generation is
     /// omitted, the latest generation will be used.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1654,7 +1654,7 @@ pub struct Results {
     /// Number of non-container artifacts uploaded to Cloud Storage. Only populated
     /// when artifacts are uploaded to Cloud Storage.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub num_artifacts: i64,
 
     /// List of build step outputs, produced by builder images, in the order
@@ -3187,7 +3187,7 @@ pub mod dependency {
         /// Optional. How much history should be fetched for the build (default 1, -1
         /// for all history).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub depth: i64,
 
         /// Required. Where should the files be placed on the worker.
@@ -6878,7 +6878,7 @@ pub mod repository_event_config {
 pub struct GitHubEventsConfig {
     /// The installationID that emits the GitHub event.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     #[deprecated]
     pub installation_id: i64,
 
@@ -8277,7 +8277,7 @@ pub struct BuildOptions {
     /// requested. At present, the maximum disk size is 4000GB; builds that request
     /// more than the maximum are rejected with an error.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub disk_size_gb: i64,
 
     /// Option to specify behavior when there is an error in the substitution
@@ -9553,7 +9553,7 @@ pub struct GitHubEnterpriseConfig {
     /// Required. The GitHub app id of the Cloud Build app on the GitHub Enterprise
     /// server.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_id: i64,
 
     /// Output only. Time when the installation was associated with the project.
@@ -10273,7 +10273,7 @@ pub mod private_pool_v_1_config {
         /// Specify a value of up to 2000. If `0` is specified, Cloud Build will use
         /// a standard disk size.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub disk_size_gb: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -969,7 +969,7 @@ pub struct GitHubConfig {
 
     /// GitHub App installation id.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_installation_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1028,7 +1028,7 @@ pub struct GitHubEnterpriseConfig {
 
     /// Id of the GitHub App created from the manifest.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_id: i64,
 
     /// The URL-friendly name of the GitHub App.
@@ -1047,7 +1047,7 @@ pub struct GitHubEnterpriseConfig {
 
     /// ID of the installation of the GitHub App.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub app_installation_id: i64,
 
     /// Configuration for using Service Directory to privately connect to a GitHub

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -636,19 +636,19 @@ pub mod span {
             /// An identifier for the MessageEvent's message that can be used to match
             /// `SENT` and `RECEIVED` MessageEvents.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub id: i64,
 
             /// The number of uncompressed bytes sent or received.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub uncompressed_size_bytes: i64,
 
             /// The number of compressed bytes sent or received. If missing, the
             /// compressed size is assumed to be the same size as the uncompressed
             /// size.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub compressed_size_bytes: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1482,7 +1482,7 @@ pub mod attribute_value {
         /// A string up to 256 bytes long.
         StringValue(std::boxed::Box<crate::model::TruncatableString>),
         /// A 64-bit signed integer.
-        IntValue(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        IntValue(#[serde_as(as = "wkt::internal::I64")] i64),
         /// A Boolean value represented by `true` or `false`.
         BoolValue(bool),
     }
@@ -1508,7 +1508,7 @@ pub struct StackTrace {
     /// Subsequent spans within the same request can refer
     /// to that stack trace by only setting `stackTraceHashId`.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub stack_trace_hash_id: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1581,13 +1581,13 @@ pub mod stack_trace {
 
         /// The line number in `file_name` where the function call appears.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub line_number: i64,
 
         /// The column number where the function call appears, if available.
         /// This is important in JavaScript because of its anonymous functions.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub column_number: i64,
 
         /// The binary module from where the code was loaded.

--- a/src/generated/devtools/containeranalysis/v1/src/model.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/model.rs
@@ -305,12 +305,12 @@ pub mod vulnerability_occurrences_summary {
 
         /// The number of fixable vulnerabilities associated with this resource.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub fixable_count: i64,
 
         /// The total number of vulnerabilities associated with this resource.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -187,17 +187,17 @@ pub mod backup {
         /// Output only. Summation of the size of all documents and index entries in
         /// the backup, measured in bytes.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub size_bytes: i64,
 
         /// Output only. The total number of documents contained in the backup.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub document_count: i64,
 
         /// Output only. The total number of index entries contained in the backup.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub index_count: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7389,12 +7389,12 @@ impl wkt::message::Message for RestoreDatabaseMetadata {
 pub struct Progress {
     /// The amount of work estimated.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub estimated_work: i64,
 
     /// The amount of work completed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub completed_work: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -7268,7 +7268,7 @@ pub struct Recipe {
     /// Set to -1 if the recipe doesn't come from a material, as zero is default
     /// unset value for int64.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub defined_in_material: i64,
 
     /// String identifying the entry point into the build.
@@ -11322,7 +11322,7 @@ pub mod slsa_provenance {
         /// Set to -1 if the recipe doesn't come from a material, as zero is default
         /// unset value for int64.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub defined_in_material: i64,
 
         /// String identifying the entry point into the build.

--- a/src/generated/logging/type/src/model.rs
+++ b/src/generated/logging/type/src/model.rs
@@ -45,7 +45,7 @@ pub struct HttpRequest {
     /// The size of the HTTP request message in bytes, including the request
     /// headers and the request body.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub request_size: i64,
 
     /// The response code indicating the status of response.
@@ -57,7 +57,7 @@ pub struct HttpRequest {
     /// The size of the HTTP response message sent back to the client, in bytes,
     /// including the response headers and the response body.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub response_size: i64,
 
     /// The user agent sent by the client. Example:
@@ -107,7 +107,7 @@ pub struct HttpRequest {
     /// The number of HTTP response bytes inserted into cache. Set only when a
     /// cache fill was attempted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub cache_fill_bytes: i64,
 
     /// Protocol used for the request. Examples: "HTTP/1.1", "HTTP/2", "websocket"

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -599,7 +599,7 @@ pub struct LogEntrySourceLocation {
     /// Optional. Line within the source file. 1-based; 0 indicates no line number
     /// available.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub line: i64,
 
     /// Optional. Human-readable name of the function or method being invoked, with
@@ -5618,7 +5618,7 @@ impl wkt::message::Message for CopyLogEntriesMetadata {
 pub struct CopyLogEntriesResponse {
     /// Number of log entries copied.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub log_entries_copied_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -2422,7 +2422,7 @@ pub struct GridLayout {
     /// The number of columns into which the view's width is divided. If omitted
     /// or set to zero, a system default will be used while rendering.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub columns: i64,
 
     /// The informational elements that are arranged into the columns row-first.
@@ -2667,7 +2667,7 @@ pub mod row_layout {
         /// greater the height of the row on the screen. If omitted, a value
         /// of 1 is used while rendering.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub weight: i64,
 
         /// The display widgets arranged horizontally in this row.
@@ -2762,7 +2762,7 @@ pub mod column_layout {
         /// Greater the weight, greater the width of the column on the screen.
         /// If omitted, a value of 1 is used while rendering.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub weight: i64,
 
         /// The display widgets arranged vertically in this column.

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -2220,7 +2220,7 @@ pub mod alert_policy {
 
                 /// Required. The value against which to compare the row count.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
-                #[serde_as(as = "serde_with::DisplayFromStr")]
+                #[serde_as(as = "wkt::internal::I64")]
                 pub threshold: i64,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3757,7 +3757,7 @@ pub mod typed_value {
         /// A Boolean value: `true` or `false`.
         BoolValue(bool),
         /// A 64-bit integer. Its range is approximately &plusmn;9.2x10\<sup\>18\</sup\>.
-        Int64Value(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        Int64Value(#[serde_as(as = "wkt::internal::I64")] i64),
         /// A 64-bit double-precision floating-point number. Its magnitude
         /// is approximately &plusmn;10\<sup\>&plusmn;300\</sup\> and it has 16
         /// significant digits of precision.
@@ -6115,7 +6115,7 @@ pub mod label_value {
         /// A bool label value.
         BoolValue(bool),
         /// An int64 label value.
-        Int64Value(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        Int64Value(#[serde_as(as = "wkt::internal::I64")] i64),
         /// A string label value.
         StringValue(std::string::String),
     }

--- a/src/generated/openapi-validation/src/model.rs
+++ b/src/generated/openapi-validation/src/model.rs
@@ -408,7 +408,7 @@ pub struct Secret {
     /// UpdateSecret. Access by alias is only be supported on
     /// GetSecretVersion and AccessSecretVersion.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub version_aliases: std::collections::HashMap<std::string::String, i64>,
 
     /// Optional. Custom metadata about the secret.
@@ -1153,7 +1153,7 @@ pub struct SecretPayload {
     /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub data_crc_32_c: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/oslogin/common/src/model.rs
+++ b/src/generated/oslogin/common/src/model.rs
@@ -40,12 +40,12 @@ pub struct PosixAccount {
 
     /// The user ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub uid: i64,
 
     /// The default group ID.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub gid: i64,
 
     /// The path to the home directory for this account.
@@ -175,7 +175,7 @@ pub struct SshPublicKey {
 
     /// An expiration time in microseconds since epoch.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub expiration_time_usec: i64,
 
     /// Output only. The SHA-256 fingerprint of the SSH public key.

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -2264,7 +2264,7 @@ pub struct DocumentLocation {
     /// Offset of the line, from the beginning of the file, where the finding
     /// is located.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub file_offset: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2390,7 +2390,7 @@ pub struct TableLocation {
     /// when you store the findings the value of those columns will be stored
     /// inside of Finding.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub row_index: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2550,12 +2550,12 @@ impl wkt::message::Message for Container {
 pub struct Range {
     /// Index of the first character of the range (inclusive).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub start: i64,
 
     /// Index of the last character of the range (exclusive).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub end: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4019,7 +4019,7 @@ pub struct InfoTypeStats {
 
     /// Number of findings for this infoType.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4212,12 +4212,12 @@ pub mod inspect_data_source_details {
     pub struct Result {
         /// Total size in bytes that were processed.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub processed_bytes: i64,
 
         /// Estimate of the number of bytes to process.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub total_estimated_bytes: i64,
 
         /// Statistics of how many instances of each info type were found during
@@ -4228,7 +4228,7 @@ pub mod inspect_data_source_details {
         /// Number of rows scanned after sampling and time filtering (applicable for
         /// row based stores such as BigQuery).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub num_rows_processed: i64,
 
         /// Statistics related to the processing of hybrid inspect.
@@ -4469,13 +4469,13 @@ pub mod data_profile_big_query_row_schema {
 pub struct HybridInspectStatistics {
     /// The number of hybrid inspection requests processed within this job.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub processed_count: i64,
 
     /// The number of hybrid inspection requests aborted because the job ran
     /// out of quota or was ended before they could be processed.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub aborted_count: i64,
 
     /// The number of hybrid requests currently being processed. Only populated
@@ -4484,7 +4484,7 @@ pub struct HybridInspectStatistics {
     /// Processing will take place as quickly as possible, but resource limitations
     /// may impact how long a request is enqueued for.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub pending_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4619,17 +4619,17 @@ pub mod action_details {
 pub struct DeidentifyDataSourceStats {
     /// Total size in bytes that were transformed in some way.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformed_bytes: i64,
 
     /// Number of successfully applied transformations.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformation_count: i64,
 
     /// Number of errors encountered while trying to apply transformations.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformation_error_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7955,17 +7955,17 @@ pub mod analyze_data_source_risk_details {
         pub struct CategoricalStatsHistogramBucket {
             /// Lower bound on the value frequency of the values in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub value_frequency_lower_bound: i64,
 
             /// Upper bound on the value frequency of the values in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub value_frequency_upper_bound: i64,
 
             /// Total number of values in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_size: i64,
 
             /// Sample of value frequencies in this bucket. The total number of
@@ -7975,7 +7975,7 @@ pub mod analyze_data_source_risk_details {
 
             /// Total number of distinct values in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_value_count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8094,7 +8094,7 @@ pub mod analyze_data_source_risk_details {
             /// Size of the equivalence class, for example number of rows with the
             /// above set of values.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub equivalence_class_size: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8139,17 +8139,17 @@ pub mod analyze_data_source_risk_details {
 
             /// Lower bound on the size of the equivalence classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub equivalence_class_size_lower_bound: i64,
 
             /// Upper bound on the size of the equivalence classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub equivalence_class_size_upper_bound: i64,
 
             /// Total number of equivalence classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_size: i64,
 
             /// Sample of equivalence classes in this bucket. The total number of
@@ -8159,7 +8159,7 @@ pub mod analyze_data_source_risk_details {
 
             /// Total number of distinct equivalence classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_value_count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8277,12 +8277,12 @@ pub mod analyze_data_source_risk_details {
 
             /// Size of the k-anonymity equivalence class.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub equivalence_class_size: i64,
 
             /// Number of distinct sensitive values in this equivalence class.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub num_distinct_sensitive_values: i64,
 
             /// Estimated frequencies of top sensitive values.
@@ -8352,18 +8352,18 @@ pub mod analyze_data_source_risk_details {
             /// Lower bound on the sensitive value frequencies of the equivalence
             /// classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub sensitive_value_frequency_lower_bound: i64,
 
             /// Upper bound on the sensitive value frequencies of the equivalence
             /// classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub sensitive_value_frequency_upper_bound: i64,
 
             /// Total number of equivalence classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_size: i64,
 
             /// Sample of equivalence classes in this bucket. The total number of
@@ -8373,7 +8373,7 @@ pub mod analyze_data_source_risk_details {
 
             /// Total number of distinct equivalence classes in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_value_count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8497,7 +8497,7 @@ pub mod analyze_data_source_risk_details {
 
             /// The estimated anonymity for these quasi-identifier values.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub estimated_anonymity: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8549,17 +8549,17 @@ pub mod analyze_data_source_risk_details {
 
             /// Always positive.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub min_anonymity: i64,
 
             /// Always greater than or equal to min_anonymity.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub max_anonymity: i64,
 
             /// Number of records within these anonymity bounds.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_size: i64,
 
             /// Sample of quasi-identifier tuple values in this bucket. The total
@@ -8569,7 +8569,7 @@ pub mod analyze_data_source_risk_details {
 
             /// Total number of distinct quasi-identifier tuple values in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_value_count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8757,7 +8757,7 @@ pub mod analyze_data_source_risk_details {
 
             /// Number of records within these probability bounds.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_size: i64,
 
             /// Sample of quasi-identifier tuple values in this bucket. The total
@@ -8767,7 +8767,7 @@ pub mod analyze_data_source_risk_details {
 
             /// Total number of distinct quasi-identifier tuple values in this bucket.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
-            #[serde_as(as = "serde_with::DisplayFromStr")]
+            #[serde_as(as = "wkt::internal::I64")]
             pub bucket_value_count: i64,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8913,7 +8913,7 @@ pub struct ValueFrequency {
 
     /// How many times the value is contained in the field.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9193,7 +9193,7 @@ pub mod value {
     #[non_exhaustive]
     pub enum Type {
         /// integer
-        IntegerValue(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        IntegerValue(#[serde_as(as = "wkt::internal::I64")] i64),
         /// float
         FloatValue(#[serde_as(as = "wkt::internal::F64")] f64),
         /// string
@@ -13465,7 +13465,7 @@ pub mod record_condition {
 pub struct TransformationOverview {
     /// Total size in bytes that were transformed in some way.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformed_bytes: i64,
 
     /// Transformations applied to the dataset.
@@ -13541,7 +13541,7 @@ pub struct TransformationSummary {
 
     /// Total size in bytes that were transformed in some way.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformed_bytes: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13674,7 +13674,7 @@ pub mod transformation_summary {
     pub struct SummaryResult {
         /// Number of transformations counted by this result.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub count: i64,
 
         /// Outcome of the transformation.
@@ -13989,7 +13989,7 @@ pub struct TransformationDetails {
     /// unsuccessful or did not take place because there was no content to
     /// transform, this will be zero.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub transformed_bytes: i64,
 
     /// The precise location of the transformed content in the original container.
@@ -19577,9 +19577,9 @@ pub mod data_profile_location {
     #[non_exhaustive]
     pub enum Location {
         /// The ID of an organization to scan.
-        OrganizationId(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        OrganizationId(#[serde_as(as = "wkt::internal::I64")] i64),
         /// The ID of the folder within an organization to scan.
-        FolderId(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        FolderId(#[serde_as(as = "wkt::internal::I64")] i64),
     }
 }
 
@@ -25343,9 +25343,9 @@ pub mod discovery_starting_location {
     #[non_exhaustive]
     pub enum Location {
         /// The ID of an organization to scan.
-        OrganizationId(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        OrganizationId(#[serde_as(as = "wkt::internal::I64")] i64),
         /// The ID of the folder within an organization to be scanned.
-        FolderId(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+        FolderId(#[serde_as(as = "wkt::internal::I64")] i64),
     }
 }
 
@@ -27619,7 +27619,7 @@ pub mod large_custom_dictionary_config {
 pub struct LargeCustomDictionaryStats {
     /// Approximate number of distinct phrases in the dictionary.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub approx_num_phrases: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -28717,14 +28717,14 @@ pub struct HybridFindingDetails {
     /// bigger item, such as a shard of a file and you want to track the absolute
     /// position of the finding.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub file_offset: i64,
 
     /// Offset of the row for tables. Populate if the row(s) being scanned are
     /// part of a bigger dataset and you want to keep track of their absolute
     /// position.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub row_offset: i64,
 
     /// If the container is a table, additional information to make findings
@@ -29620,12 +29620,12 @@ pub struct ProjectDataProfile {
 
     /// The number of table data profiles generated for this project.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub table_data_profile_count: i64,
 
     /// The number of file store data profiles generated for this project.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub file_store_data_profile_count: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -29955,23 +29955,23 @@ pub struct TableDataProfile {
 
     /// The number of columns profiled in the table.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub scanned_column_count: i64,
 
     /// The number of columns skipped in the table because of an error.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub failed_column_count: i64,
 
     /// The size of the table when the profile was generated.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub table_size_bytes: i64,
 
     /// Number of rows in the table when the profile was generated.
     /// This will not be populated for BigLake tables.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub row_count: i64,
 
     /// How the table is encrypted.
@@ -36581,7 +36581,7 @@ pub struct CloudStorageOptions {
     /// on bytes scanned per
     /// file](https://cloud.google.com/sensitive-data-protection/docs/supported-file-types#max-byte-size-per-file).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_limit_per_file: i64,
 
     /// Max percentage of bytes to scan from a file. The rest are omitted. The
@@ -36985,7 +36985,7 @@ pub struct BigQueryOptions {
     /// scanned. Only one of rows_limit and rows_limit_percent can be specified.
     /// Cannot be used in conjunction with TimespanConfig.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub rows_limit: i64,
 
     /// Max percentage of rows to scan. The rest are omitted. The number of rows
@@ -37733,7 +37733,7 @@ pub struct BigQueryKey {
     /// `inspect_job.storage_config.big_query_options.identifying_fields` in
     /// `CreateDlpJobRequest`.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub row_number: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -38011,7 +38011,7 @@ pub mod key {
             /// The auto-allocated ID of the entity.
             /// Never equal to zero. Values less than zero are discouraged and may not
             /// be supported in the future.
-            Id(#[serde_as(as = "serde_with::DisplayFromStr")] i64),
+            Id(#[serde_as(as = "wkt::internal::I64")] i64),
             /// The name of the entity.
             /// A name matching regex `__.*__` is reserved/read-only.
             /// A name must not be more than 1500 bytes when UTF-8 encoded.

--- a/src/generated/rpc/context/src/model.rs
+++ b/src/generated/rpc/context/src/model.rs
@@ -259,7 +259,7 @@ pub mod attribute_context {
 
         /// The network port of the peer.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub port: i64,
 
         /// The labels associated with the peer.
@@ -584,7 +584,7 @@ pub mod attribute_context {
 
         /// The HTTP request size in bytes. If unknown, it must be -1.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub size: i64,
 
         /// The network protocol used with the request, such as "http/1.1",
@@ -731,12 +731,12 @@ pub mod attribute_context {
     pub struct Response {
         /// The HTTP response status code, such as `200` and `404`.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub code: i64,
 
         /// The HTTP response size in bytes. If unknown, it must be -1.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub size: i64,
 
         /// The HTTP response headers. If multiple headers share the same key, they

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -362,7 +362,7 @@ pub mod quota_failure {
         /// `QuotaFailure` on the number of CPUs is "10", then the value of this
         /// field would reflect this quantity.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub quota_value: i64,
 
         /// The new quota value being rolled out at the time of the violation. At the
@@ -374,7 +374,7 @@ pub mod quota_failure {
         /// changing the number of CPUs quota from 10 to 20, 20 would be the value of
         /// this field.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
-        #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+        #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
         pub future_quota_value: std::option::Option<i64>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -62,7 +62,7 @@ pub struct RepeatRequest {
     pub f_int32: i32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub f_int64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -74,7 +74,7 @@ pub struct RepeatRequest {
     pub p_int32: std::option::Option<i32>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub p_int64: std::option::Option<i64>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -399,23 +399,23 @@ pub struct ComplianceData {
     pub f_fixed32: u32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub f_int64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub f_sint64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub f_sfixed64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub f_uint64: u64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub f_fixed64: u64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -102,7 +102,7 @@ pub struct Backup {
 
     /// Output only. Size of the backup in bytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size_bytes: i64,
 
     /// Output only. The number of bytes that will be freed by deleting this
@@ -112,7 +112,7 @@ pub struct Backup {
     /// always the size of the backup. This value may change if backups on the same
     /// chain get created, deleted or expired.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub freeable_size_bytes: i64,
 
     /// Output only. For a backup in an incremental backup chain, this is the
@@ -124,7 +124,7 @@ pub struct Backup {
     /// of backups. For example, the total space used by all backups of a database
     /// can be computed by summing up this field.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub exclusive_size_bytes: i64,
 
     /// Output only. The current state of the backup.

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -478,7 +478,7 @@ pub struct InstanceConfig {
 
     /// Output only. The storage limit in bytes per processing unit.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub storage_limit_per_processing_unit: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -2747,7 +2747,7 @@ pub mod agent_pool {
         /// Bandwidth rate in megabytes per second, distributed across all the agents
         /// in the pool.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub limit_mbps: i64,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6180,7 +6180,7 @@ pub struct ErrorSummary {
 
     /// Required. Count of this type of error.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub error_count: i64,
 
     /// Error samples.
@@ -6239,88 +6239,88 @@ pub struct TransferCounters {
     /// excluding any that are filtered based on object conditions or skipped due
     /// to sync.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_found_from_source: i64,
 
     /// Bytes found in the data source that are scheduled to be transferred,
     /// excluding any that are filtered based on object conditions or skipped due
     /// to sync.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_found_from_source: i64,
 
     /// Objects found only in the data sink that are scheduled to be deleted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_found_only_from_sink: i64,
 
     /// Bytes found only in the data sink that are scheduled to be deleted.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_found_only_from_sink: i64,
 
     /// Objects in the data source that are not transferred because they already
     /// exist in the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_from_source_skipped_by_sync: i64,
 
     /// Bytes in the data source that are not transferred because they already
     /// exist in the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_from_source_skipped_by_sync: i64,
 
     /// Objects that are copied to the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_copied_to_sink: i64,
 
     /// Bytes that are copied to the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_copied_to_sink: i64,
 
     /// Objects that are deleted from the data source.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_deleted_from_source: i64,
 
     /// Bytes that are deleted from the data source.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_deleted_from_source: i64,
 
     /// Objects that are deleted from the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_deleted_from_sink: i64,
 
     /// Bytes that are deleted from the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_deleted_from_sink: i64,
 
     /// Objects in the data source that failed to be transferred or that failed
     /// to be deleted after being transferred.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_from_source_failed: i64,
 
     /// Bytes in the data source that failed to be transferred or that failed to
     /// be deleted after being transferred.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_from_source_failed: i64,
 
     /// Objects that failed to be deleted from the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub objects_failed_to_delete_from_sink: i64,
 
     /// Bytes that failed to be deleted from the data sink.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub bytes_failed_to_delete_from_sink: i64,
 
     /// For transfers involving PosixFilesystem only.
@@ -6330,7 +6330,7 @@ pub struct TransferCounters {
     /// `a/` and `b/` under this directory, the count after listing `base/`,
     /// `base/a/` and `base/b/` is 3.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub directories_found_from_source: i64,
 
     /// For transfers involving PosixFilesystem only.
@@ -6340,24 +6340,24 @@ pub struct TransferCounters {
     /// block failure. If listing a directory fails, no files in the directory are
     /// transferred.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub directories_failed_to_list_from_source: i64,
 
     /// For transfers involving PosixFilesystem only.
     ///
     /// Number of successful listings for each directory found at the source.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub directories_successfully_listed_from_source: i64,
 
     /// Number of successfully cleaned up intermediate objects.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub intermediate_objects_cleaned_up: i64,
 
     /// Number of intermediate objects failed cleaned up.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub intermediate_objects_failed_cleaned_up: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -794,13 +794,13 @@ impl wkt::message::Message for Expr {
 pub struct Fraction {
     /// The numerator in the fraction, e.g. 2 in 2/3.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub numerator: i64,
 
     /// The value by which the numerator is divided, e.g. 3 in 2/3. Must be
     /// positive.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub denominator: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1014,7 +1014,7 @@ pub struct Money {
     /// The whole units of the amount.
     /// For example if `currencyCode` is `"USD"`, then 1 unit is one US dollar.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub units: i64,
 
     /// Number of nano (10^-9) units of the amount.

--- a/src/protojson-conformance/src/generated/test_protos/mod.rs
+++ b/src/protojson-conformance/src/generated/test_protos/mod.rs
@@ -35,7 +35,7 @@ pub struct TestAllTypesProto3 {
     pub optional_int32: i32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub optional_int64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -43,7 +43,7 @@ pub struct TestAllTypesProto3 {
     pub optional_uint32: u32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub optional_uint64: u64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -51,7 +51,7 @@ pub struct TestAllTypesProto3 {
     pub optional_sint32: i32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub optional_sint64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -59,7 +59,7 @@ pub struct TestAllTypesProto3 {
     pub optional_fixed32: u32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub optional_fixed64: u64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -67,7 +67,7 @@ pub struct TestAllTypesProto3 {
     pub optional_sfixed32: i32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub optional_sfixed64: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -122,7 +122,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_int32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub repeated_int64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -130,7 +130,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_uint32: std::vec::Vec<u32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub repeated_uint64: std::vec::Vec<u64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -138,7 +138,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_sint32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub repeated_sint64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -146,7 +146,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_fixed32: std::vec::Vec<u32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub repeated_fixed64: std::vec::Vec<u64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -154,7 +154,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_sfixed32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub repeated_sfixed64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -201,7 +201,7 @@ pub struct TestAllTypesProto3 {
     pub packed_int32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub packed_int64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -209,7 +209,7 @@ pub struct TestAllTypesProto3 {
     pub packed_uint32: std::vec::Vec<u32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub packed_uint64: std::vec::Vec<u64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -217,7 +217,7 @@ pub struct TestAllTypesProto3 {
     pub packed_sint32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub packed_sint64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -225,7 +225,7 @@ pub struct TestAllTypesProto3 {
     pub packed_fixed32: std::vec::Vec<u32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub packed_fixed64: std::vec::Vec<u64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -233,7 +233,7 @@ pub struct TestAllTypesProto3 {
     pub packed_sfixed32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub packed_sfixed64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -257,7 +257,7 @@ pub struct TestAllTypesProto3 {
     pub unpacked_int32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub unpacked_int64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -265,7 +265,7 @@ pub struct TestAllTypesProto3 {
     pub unpacked_uint32: std::vec::Vec<u32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub unpacked_uint64: std::vec::Vec<u64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -273,7 +273,7 @@ pub struct TestAllTypesProto3 {
     pub unpacked_sint32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub unpacked_sint64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -281,7 +281,7 @@ pub struct TestAllTypesProto3 {
     pub unpacked_fixed32: std::vec::Vec<u32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub unpacked_fixed64: std::vec::Vec<u64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -289,7 +289,7 @@ pub struct TestAllTypesProto3 {
     pub unpacked_sfixed32: std::vec::Vec<i32>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub unpacked_sfixed64: std::vec::Vec<i64>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -313,9 +313,7 @@ pub struct TestAllTypesProto3 {
     pub map_int32_int32: std::collections::HashMap<i32, i32>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "std::collections::HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>"
-    )]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>")]
     pub map_int64_int64: std::collections::HashMap<i64, i64>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -323,9 +321,7 @@ pub struct TestAllTypesProto3 {
     pub map_uint32_uint32: std::collections::HashMap<u32, u32>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "std::collections::HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>"
-    )]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>")]
     pub map_uint64_uint64: std::collections::HashMap<u64, u64>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -333,9 +329,7 @@ pub struct TestAllTypesProto3 {
     pub map_sint32_sint32: std::collections::HashMap<i32, i32>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "std::collections::HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>"
-    )]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>")]
     pub map_sint64_sint64: std::collections::HashMap<i64, i64>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -343,9 +337,7 @@ pub struct TestAllTypesProto3 {
     pub map_fixed32_fixed32: std::collections::HashMap<u32, u32>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "std::collections::HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>"
-    )]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>")]
     pub map_fixed64_fixed64: std::collections::HashMap<u64, u64>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -353,9 +345,7 @@ pub struct TestAllTypesProto3 {
     pub map_sfixed32_sfixed32: std::collections::HashMap<i32, i32>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "std::collections::HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>"
-    )]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>")]
     pub map_sfixed64_sfixed64: std::collections::HashMap<i64, i64>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -408,7 +398,7 @@ pub struct TestAllTypesProto3 {
     pub optional_int32_wrapper: std::option::Option<wkt::Int32Value>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub optional_int64_wrapper: std::option::Option<wkt::Int64Value>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -416,7 +406,7 @@ pub struct TestAllTypesProto3 {
     pub optional_uint32_wrapper: std::option::Option<wkt::UInt32Value>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::U64>")]
     pub optional_uint64_wrapper: std::option::Option<wkt::UInt64Value>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -442,7 +432,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_int32_wrapper: std::vec::Vec<wkt::Int32Value>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub repeated_int64_wrapper: std::vec::Vec<wkt::Int64Value>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -450,7 +440,7 @@ pub struct TestAllTypesProto3 {
     pub repeated_uint32_wrapper: std::vec::Vec<wkt::UInt32Value>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
     pub repeated_uint64_wrapper: std::vec::Vec<wkt::UInt64Value>,
 
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -2772,7 +2762,7 @@ pub mod test_all_types_proto_3 {
         OneofString(std::string::String),
         OneofBytes(#[serde_as(as = "serde_with::base64::Base64")] ::bytes::Bytes),
         OneofBool(bool),
-        OneofUint64(#[serde_as(as = "serde_with::DisplayFromStr")] u64),
+        OneofUint64(#[serde_as(as = "wkt::internal::U64")] u64),
         OneofFloat(#[serde_as(as = "wkt::internal::F32")] f32),
         OneofDouble(#[serde_as(as = "wkt::internal::F64")] f64),
         OneofEnum(crate::generated::test_protos::test_all_types_proto_3::NestedEnum),

--- a/src/storage-control/src/generated/gapic/model.rs
+++ b/src/storage-control/src/generated/gapic/model.rs
@@ -29,13 +29,13 @@ pub struct DeleteBucketRequest {
 
     /// If set, only deletes the bucket if its metageneration matches this value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// If set, only deletes the bucket if its metageneration does not match this
     /// value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -109,13 +109,13 @@ pub struct GetBucketRequest {
     /// If set, and if the bucket's current metageneration does not match the
     /// specified value, the request will return an error.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// If set, and if the bucket's current metageneration matches the specified
     /// value, the request will return an error.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Mask specifying which fields to read.
@@ -469,7 +469,7 @@ pub struct LockBucketRetentionPolicyRequest {
     /// Required. Makes the operation conditional on whether bucket's current
     /// metageneration matches the given value. Must be positive.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub if_metageneration_match: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -514,13 +514,13 @@ pub struct UpdateBucketRequest {
     /// If set, will only modify the bucket if its metageneration matches this
     /// value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// If set, will only modify the bucket if its metageneration does not match
     /// this value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. Apply a predefined set of access controls to this bucket.
@@ -674,13 +674,13 @@ pub struct ComposeObjectRequest {
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Optional. Resource name of the Cloud KMS key, of the form
@@ -850,7 +850,7 @@ pub mod compose_object_request {
 
         /// Optional. The generation of this object to use as the source.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[serde_as(as = "wkt::internal::I64")]
         pub generation: i64,
 
         /// Optional. Conditions that must be met for this operation to execute.
@@ -924,7 +924,7 @@ pub mod compose_object_request {
             /// that would be used matches this value.  If this value and a generation
             /// are both specified, they must be the same value or the call will fail.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
-            #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+            #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
             pub if_generation_match: std::option::Option<i64>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -983,14 +983,14 @@ pub struct DeleteObjectRequest {
     /// Optional. If present, permanently deletes a specific revision of this
     /// object (as opposed to the latest version, the default).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Makes the operation conditional on whether the object's current generation
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live generation
@@ -998,19 +998,19 @@ pub struct DeleteObjectRequest {
     /// fails. Setting to 0 makes the operation succeed only if there is a live
     /// version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A set of parameters common to Storage API requests concerning an
@@ -1159,7 +1159,7 @@ pub struct RestoreObjectRequest {
 
     /// Required. The specific revision of the object to restore.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Optional. Restore token used to differentiate soft-deleted objects with the
@@ -1174,7 +1174,7 @@ pub struct RestoreObjectRequest {
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live generation
@@ -1182,19 +1182,19 @@ pub struct RestoreObjectRequest {
     /// fails. Setting to 0 makes the operation succeed only if there is a live
     /// version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// If false or unset, the bucket's default object ACL will be used.
@@ -1407,7 +1407,7 @@ pub struct ReadObjectRequest {
     /// Optional. If present, selects a specific revision of this object (as
     /// opposed to the latest version, the default).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Optional. The offset for the first byte to return in the read, relative to
@@ -1420,7 +1420,7 @@ pub struct ReadObjectRequest {
     /// a negative offset with magnitude larger than the size of the object will
     /// return the entire object.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub read_offset: i64,
 
     /// Optional. The maximum number of `data` bytes the server is allowed to
@@ -1432,14 +1432,14 @@ pub struct ReadObjectRequest {
     /// error occurred, the stream includes all data from the `read_offset` to the
     /// end of the resource.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub read_limit: i64,
 
     /// Makes the operation conditional on whether the object's current generation
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live generation
@@ -1447,19 +1447,19 @@ pub struct ReadObjectRequest {
     /// fails. Setting to 0 makes the operation succeed only if there is a live
     /// version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A set of parameters common to Storage API requests concerning an
@@ -1647,7 +1647,7 @@ pub struct GetObjectRequest {
     /// Optional. If present, selects a specific revision of this object (as
     /// opposed to the latest version, the default).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// If true, return the soft-deleted version of this object.
@@ -1658,7 +1658,7 @@ pub struct GetObjectRequest {
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live generation
@@ -1666,19 +1666,19 @@ pub struct GetObjectRequest {
     /// fails. Setting to 0 makes the operation succeed only if there is a live
     /// version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A set of parameters common to Storage API requests concerning an
@@ -1888,7 +1888,7 @@ pub struct WriteObjectSpec {
     /// generation matches the given value. Setting to 0 makes the operation
     /// succeed only if there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live
@@ -1896,19 +1896,19 @@ pub struct WriteObjectSpec {
     /// precondition fails. Setting to 0 makes the operation succeed only if
     /// there is a live version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// The expected final object size being uploaded.
@@ -1919,7 +1919,7 @@ pub struct WriteObjectSpec {
     /// you must start the upload over from scratch, this time sending the correct
     /// number of bytes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub object_size: std::option::Option<i64>,
 
     /// If true, the object will be created in appendable mode.
@@ -2387,7 +2387,7 @@ pub struct RewriteObjectRequest {
     /// Optional. If present, selects a specific revision of the source object (as
     /// opposed to the latest version, the default).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub source_generation: i64,
 
     /// Optional. Include this field (from the previous rewrite response) on each
@@ -2408,7 +2408,7 @@ pub struct RewriteObjectRequest {
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live generation
@@ -2416,43 +2416,43 @@ pub struct RewriteObjectRequest {
     /// fails. Setting to 0 makes the operation succeed only if there is a live
     /// version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the destination object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the destination object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the source object's live
     /// generation matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the source object's live
     /// generation does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the source object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the source object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. The maximum number of bytes that will be rewritten per rewrite
@@ -2463,7 +2463,7 @@ pub struct RewriteObjectRequest {
     /// Finally, this value must not change across rewrite calls else you'll get an
     /// error that the `rewriteToken` is invalid.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub max_bytes_rewritten_per_call: i64,
 
     /// Optional. The algorithm used to encrypt the source object, if any. Used if
@@ -2820,13 +2820,13 @@ pub struct RewriteResponse {
     /// The total bytes written so far, which can be used to provide a waiting user
     /// with a progress indicator. This property is always present in the response.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub total_bytes_rewritten: i64,
 
     /// The total size of the object being copied in bytes. This property is always
     /// present in the response.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub object_size: i64,
 
     /// `true` if the copy is finished; otherwise, `false` if
@@ -2925,7 +2925,7 @@ pub struct MoveObjectRequest {
     /// and `if_source_generation_not_match` conditions are mutually exclusive:
     /// it's an error for both of them to be set in the request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_generation_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the source object's
@@ -2934,7 +2934,7 @@ pub struct MoveObjectRequest {
     /// conditions are mutually exclusive: it's an error for both of them to be set
     /// in the request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_generation_not_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the source object's
@@ -2943,7 +2943,7 @@ pub struct MoveObjectRequest {
     /// conditions are mutually exclusive: it's an error for both of them to be set
     /// in the request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_metageneration_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the source object's
@@ -2952,7 +2952,7 @@ pub struct MoveObjectRequest {
     /// conditions are mutually exclusive: it's an error for both of them to be set
     /// in the request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_source_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the destination
@@ -2961,7 +2961,7 @@ pub struct MoveObjectRequest {
     /// `if_generation_match` and `if_generation_not_match` conditions are mutually
     /// exclusive: it's an error for both of them to be set in the request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the destination
@@ -2971,7 +2971,7 @@ pub struct MoveObjectRequest {
     /// `if_generation_match` and `if_generation_not_match` conditions are mutually
     /// exclusive: it's an error for both of them to be set in the request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the destination
@@ -2980,7 +2980,7 @@ pub struct MoveObjectRequest {
     /// mutually exclusive: it's an error for both of them to be set in the
     /// request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Optional. Makes the operation conditional on whether the destination
@@ -2989,7 +2989,7 @@ pub struct MoveObjectRequest {
     /// mutually exclusive: it's an error for both of them to be set in the
     /// request.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3293,7 +3293,7 @@ pub struct UpdateObjectRequest {
     /// matches the given value. Setting to 0 makes the operation succeed only if
     /// there are no live versions of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's live generation
@@ -3301,19 +3301,19 @@ pub struct UpdateObjectRequest {
     /// fails. Setting to 0 makes the operation succeed only if there is a live
     /// version of the object.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_generation_not_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation conditional on whether the object's current
     /// metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. Apply a predefined set of access controls to this object.
@@ -3898,7 +3898,7 @@ pub struct Bucket {
 
     /// Output only. The metadata generation of this bucket.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub metageneration: i64,
 
     /// Immutable. The location of the bucket. Object data for objects in the
@@ -6190,7 +6190,7 @@ pub struct Object {
     /// Immutable. The content generation of this object. Used for object
     /// versioning.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub generation: i64,
 
     /// Output only. Restore token used to differentiate deleted objects with the
@@ -6204,7 +6204,7 @@ pub struct Object {
     /// metageneration number is only meaningful in the context of a particular
     /// generation of a particular object.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub metageneration: i64,
 
     /// Optional. Storage class of the object.
@@ -6214,7 +6214,7 @@ pub struct Object {
     /// Output only. Content-Length of the object data in bytes, matching
     /// [<https://tools.ietf.org/html/rfc7230#section-3.3.2>][RFC 7230 §3.3.2].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub size: i64,
 
     /// Optional. Content-Encoding of the object data, matching
@@ -7306,17 +7306,17 @@ impl wkt::message::Message for Owner {
 pub struct ContentRange {
     /// The starting offset of the object data. This value is inclusive.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub start: i64,
 
     /// The ending offset of the object data. This value is exclusive.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub end: i64,
 
     /// The complete length of the object data.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub complete_length: i64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/storage-control/src/generated/gapic_control/model.rs
+++ b/src/storage-control/src/generated/gapic_control/model.rs
@@ -64,7 +64,7 @@ pub struct Folder {
     /// Output only. The version of the metadata for this folder. Used for
     /// preconditions and for detecting changes in metadata.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub metageneration: i64,
 
     /// Output only. The creation time of the folder.
@@ -180,13 +180,13 @@ pub struct GetFolderRequest {
     /// Makes the operation only succeed conditional on whether the folder's
     /// current metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation only succeed conditional on whether the folder's
     /// current metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A unique identifier for this request. UUID is the recommended
@@ -368,13 +368,13 @@ pub struct DeleteFolderRequest {
     /// Makes the operation only succeed conditional on whether the folder's
     /// current metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation only succeed conditional on whether the folder's
     /// current metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A unique identifier for this request. UUID is the recommended
@@ -650,13 +650,13 @@ pub struct RenameFolderRequest {
     /// Makes the operation only succeed conditional on whether the source
     /// folder's current metageneration matches the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// Makes the operation only succeed conditional on whether the source
     /// folder's current metageneration does not match the given value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A unique identifier for this request. UUID is the recommended
@@ -1182,7 +1182,7 @@ pub struct ManagedFolder {
     /// whenever the metadata is updated. Used for preconditions and for detecting
     /// changes in metadata. Managed folders don't have a generation number.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub metageneration: i64,
 
     /// Output only. The creation time of the managed folder.
@@ -1272,13 +1272,13 @@ pub struct GetManagedFolderRequest {
     /// The operation succeeds conditional on the managed folder's current
     /// metageneration matching the value here specified.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// The operation succeeds conditional on the managed folder's current
     /// metageneration NOT matching the value here specified.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Optional. A unique identifier for this request. UUID is the recommended
@@ -1447,13 +1447,13 @@ pub struct DeleteManagedFolderRequest {
     /// The operation succeeds conditional on the managed folder's current
     /// metageneration matching the value here specified.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_match: std::option::Option<i64>,
 
     /// The operation succeeds conditional on the managed folder's current
     /// metageneration NOT matching the value here specified.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub if_metageneration_not_match: std::option::Option<i64>,
 
     /// Allows deletion of a managed folder even if it is not empty.

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -4342,11 +4342,11 @@ pub struct UninterpretedOption {
     pub identifier_value: std::string::String,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::U64")]
     pub positive_int_value: u64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub negative_int_value: i64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]

--- a/src/wkt/tests/generated/mod.rs
+++ b/src/wkt/tests/generated/mod.rs
@@ -446,32 +446,32 @@ pub struct MessageWithI64 {
 
     /// A singular field.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "wkt::internal::I64")]
     pub singular: i64,
 
     /// An optional field.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub optional: std::option::Option<i64>,
 
     /// A repeated field.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::I64>")]
     pub repeated: std::vec::Vec<i64>,
 
     /// Test i64 as values.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::I64>")]
     pub map_value: std::collections::HashMap<std::string::String,i64>,
 
     /// Test i64 as keys.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, _>")]
     pub map_key: std::collections::HashMap<i64,std::string::String>,
 
     /// Test i64 as both keys and values.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>")]
     pub map_key_value: std::collections::HashMap<i64,i64>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -556,6 +556,128 @@ impl MessageWithI64 {
 impl wkt::message::Message for MessageWithI64 {
     fn typename() -> &'static str {
         "type.googleapis.com/google.rust.sdk.test.MessageWithI64"
+    }
+}
+
+/// A test message for u64.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct MessageWithU64 {
+
+    /// A singular field.
+    #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::U64")]
+    pub singular: u64,
+
+    /// An optional field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::U64>")]
+    pub optional: std::option::Option<u64>,
+
+    /// A repeated field.
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::U64>")]
+    pub repeated: std::vec::Vec<u64>,
+
+    /// Test u64 as values.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "std::collections::HashMap<_, wkt::internal::U64>")]
+    pub map_value: std::collections::HashMap<std::string::String,u64>,
+
+    /// Test u64 as keys.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::U64, _>")]
+    pub map_key: std::collections::HashMap<u64,std::string::String>,
+
+    /// Test u64 as both keys and values.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>")]
+    pub map_key_value: std::collections::HashMap<u64,u64>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl MessageWithU64 {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [singular][crate::protos::MessageWithU64::singular].
+    pub fn set_singular<T: std::convert::Into<u64>>(mut self, v: T) -> Self {
+        self.singular = v.into();
+        self
+    }
+
+    /// Sets the value of [optional][crate::protos::MessageWithU64::optional].
+    pub fn set_optional<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<u64>
+    {
+        self.optional = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [optional][crate::protos::MessageWithU64::optional].
+    pub fn set_or_clear_optional<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<u64>
+    {
+        self.optional = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [repeated][crate::protos::MessageWithU64::repeated].
+    pub fn set_repeated<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<u64>
+    {
+        use std::iter::Iterator;
+        self.repeated = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [map_value][crate::protos::MessageWithU64::map_value].
+    pub fn set_map_value<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<u64>,
+    {
+        use std::iter::Iterator;
+        self.map_value = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [map_key][crate::protos::MessageWithU64::map_key].
+    pub fn set_map_key<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<u64>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.map_key = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [map_key_value][crate::protos::MessageWithU64::map_key_value].
+    pub fn set_map_key_value<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<u64>,
+        V: std::convert::Into<u64>,
+    {
+        use std::iter::Iterator;
+        self.map_key_value = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+impl wkt::message::Message for MessageWithU64 {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.rust.sdk.test.MessageWithU64"
     }
 }
 

--- a/src/wkt/tests/generated/primitive_types.proto
+++ b/src/wkt/tests/generated/primitive_types.proto
@@ -89,6 +89,22 @@ message MessageWithI64 {
     map<int64, int64> map_key_value = 6;
 }
 
+// A test message for u64.
+message MessageWithU64 {
+    // A singular field.
+    uint64 singular = 1;
+    // An optional field.
+    optional uint64 optional = 2;
+    // A repeated field.
+    repeated uint64 repeated = 3;
+    // Test u64 as values.
+    map<string, uint64> map_value = 4;
+    // Test u64 as keys.
+    map<uint64, string> map_key = 5;
+    // Test u64 as both keys and values.
+    map<uint64, uint64> map_key_value = 6;
+}
+
 // A test message for bytes.
 message MessageWithBytes {
     // A singular field.

--- a/src/wkt/tests/message_with_u64.rs
+++ b/src/wkt/tests/message_with_u64.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,22 +24,19 @@ mod test {
         use google_cloud_wkt as wkt;
         include!("generated/mod.rs");
     }
-    use protos::MessageWithI64;
+    use protos::MessageWithU64;
 
     #[test_case(123, 123)]
-    #[test_case(-234, -234)]
     #[test_case("345", 345)]
-    #[test_case("-456", -456)]
     #[test_case("567.0", 567)]
-    #[test_case("-789.0", -789)]
-    fn test_singular<T>(input: T, want: i64) -> Result
+    fn test_singular<T>(input: T, want: u64) -> Result
     where
         T: serde::ser::Serialize,
     {
         let value = json!({"singular": input});
-        let got = serde_json::from_value::<MessageWithI64>(value)?;
+        let got = serde_json::from_value::<MessageWithU64>(value)?;
         let output = json!({"singular": want.to_string()});
-        assert_eq!(got, MessageWithI64::new().set_singular(want));
+        assert_eq!(got, MessageWithU64::new().set_singular(want));
         let trip = serde_json::to_value(&got)?;
         assert_eq!(trip, output);
         Ok(())
@@ -48,8 +45,8 @@ mod test {
     #[test_case(json!({}))]
     #[test_case(json!({"singular": 0}))]
     fn test_singular_default(input: Value) -> Result {
-        let want = MessageWithI64::new().set_singular(0);
-        let got = serde_json::from_value::<MessageWithI64>(input)?;
+        let want = MessageWithU64::new().set_singular(0_u64);
+        let got = serde_json::from_value::<MessageWithU64>(input)?;
         assert_eq!(got, want);
         let output = serde_json::to_value(&got)?;
         assert_eq!(output, json!({}));
@@ -58,19 +55,16 @@ mod test {
 
     #[test_case(0, 0)]
     #[test_case(123, 123)]
-    #[test_case(-234, -234)]
     #[test_case("345", 345)]
-    #[test_case("-456", -456)]
     #[test_case("567.0", 567)]
-    #[test_case("-789.0", -789)]
-    fn test_optional<T>(input: T, want: i64) -> Result
+    fn test_optional<T>(input: T, want: u64) -> Result
     where
         T: serde::ser::Serialize,
     {
         let value = json!({"optional": input});
-        let got = serde_json::from_value::<MessageWithI64>(value)?;
+        let got = serde_json::from_value::<MessageWithU64>(value)?;
         let output = json!({"optional": want.to_string()});
-        assert_eq!(got, MessageWithI64::new().set_optional(want));
+        assert_eq!(got, MessageWithU64::new().set_optional(want));
         let trip = serde_json::to_value(&got)?;
         assert_eq!(trip, output);
         Ok(())
@@ -79,27 +73,24 @@ mod test {
     #[test_case(json!({}))]
     #[test_case(json!({"optional": null}))]
     fn test_optional_none(input: Value) -> Result {
-        let want = MessageWithI64::new().set_or_clear_optional(None::<i64>);
-        let got = serde_json::from_value::<MessageWithI64>(input)?;
+        let want = MessageWithU64::new().set_or_clear_optional(None::<u64>);
+        let got = serde_json::from_value::<MessageWithU64>(input)?;
         assert_eq!(got, want);
         Ok(())
     }
 
     #[test_case(0, 0)]
     #[test_case(123, 123)]
-    #[test_case(-234, -234)]
     #[test_case("345", 345)]
-    #[test_case("-456", -456)]
     #[test_case("567.0", 567)]
-    #[test_case("-789.0", -789)]
-    fn test_repeated<T>(input: T, want: i64) -> Result
+    fn test_repeated<T>(input: T, want: u64) -> Result
     where
         T: serde::ser::Serialize,
     {
         let value = json!({"repeated": [input]});
-        let got = serde_json::from_value::<MessageWithI64>(value)?;
+        let got = serde_json::from_value::<MessageWithU64>(value)?;
         let output = json!({"repeated": [want.to_string()]});
-        assert_eq!(got, MessageWithI64::new().set_repeated([want]));
+        assert_eq!(got, MessageWithU64::new().set_repeated([want]));
         let trip = serde_json::to_value(&got)?;
         assert_eq!(trip, output);
         Ok(())
@@ -108,8 +99,8 @@ mod test {
     #[test_case(json!({}))]
     #[test_case(json!({"repeated": []}))]
     fn test_repeated_default(input: Value) -> Result {
-        let want = MessageWithI64::new();
-        let got = serde_json::from_value::<MessageWithI64>(input)?;
+        let want = MessageWithU64::new();
+        let got = serde_json::from_value::<MessageWithU64>(input)?;
         assert_eq!(got, want);
         let output = serde_json::to_value(&got)?;
         assert_eq!(output, json!({}));
@@ -118,21 +109,18 @@ mod test {
 
     #[test_case(0, 0)]
     #[test_case(123, 123)]
-    #[test_case(-234, -234)]
     #[test_case("345", 345)]
-    #[test_case("-456", -456)]
     #[test_case("567.0", 567)]
-    #[test_case("-789.0", -789)]
-    fn test_map_value<T>(input: T, want: i64) -> Result
+    fn test_map_value<T>(input: T, want: u64) -> Result
     where
         T: serde::ser::Serialize,
     {
         let value = json!({"mapValue": {"test": input}});
-        let got = serde_json::from_value::<MessageWithI64>(value)?;
+        let got = serde_json::from_value::<MessageWithU64>(value)?;
         let output = json!({"mapValue": {"test": want.to_string()}});
         assert_eq!(
             got,
-            MessageWithI64::new().set_map_value([("test".to_string(), want)])
+            MessageWithU64::new().set_map_value([("test".to_string(), want)])
         );
         let trip = serde_json::to_value(&got)?;
         assert_eq!(trip, output);
@@ -142,8 +130,8 @@ mod test {
     #[test_case(json!({}))]
     #[test_case(json!({"mapValue": {}}))]
     fn test_map_value_default(input: Value) -> Result {
-        let want = MessageWithI64::default();
-        let got = serde_json::from_value::<MessageWithI64>(input)?;
+        let want = MessageWithU64::default();
+        let got = serde_json::from_value::<MessageWithU64>(input)?;
         assert_eq!(got, want);
         let output = serde_json::to_value(&got)?;
         assert_eq!(output, json!({}));
@@ -152,21 +140,18 @@ mod test {
 
     #[test_case("0", 0)]
     #[test_case("123", 123)]
-    #[test_case("-234", -234)]
     #[test_case("345", 345)]
-    #[test_case("-456", -456)]
     #[test_case("567.0", 567)]
-    #[test_case("-789.0", -789)]
-    fn test_map_key<T>(input: T, want: i64) -> Result
+    fn test_map_key<T>(input: T, want: u64) -> Result
     where
         T: Into<String>,
     {
         let value = json!({"mapKey": {input: "test"}});
-        let got = serde_json::from_value::<MessageWithI64>(value)?;
+        let got = serde_json::from_value::<MessageWithU64>(value)?;
         let output = json!({"mapKey": {want.to_string(): "test"}});
         assert_eq!(
             got,
-            MessageWithI64::new().set_map_key([(want, "test".to_string())])
+            MessageWithU64::new().set_map_key([(want, "test".to_string())])
         );
         let trip = serde_json::to_value(&got)?;
         assert_eq!(trip, output);
@@ -176,8 +161,8 @@ mod test {
     #[test_case(json!({}))]
     #[test_case(json!({"mapKey": {}}))]
     fn test_map_key_default(input: Value) -> Result {
-        let want = MessageWithI64::default();
-        let got = serde_json::from_value::<MessageWithI64>(input)?;
+        let want = MessageWithU64::default();
+        let got = serde_json::from_value::<MessageWithU64>(input)?;
         assert_eq!(got, want);
         let output = serde_json::to_value(&got)?;
         assert_eq!(output, json!({}));
@@ -189,19 +174,17 @@ mod test {
     #[test_case("0.0", 0, 0, 0)]
     #[test_case("123", 234, 123, 234)]
     #[test_case("123.0", "345", 123, 345)]
-    #[test_case("-789", 456, -789, 456)]
-    #[test_case("-789.0", "567", -789, 567)]
-    fn test_map_key_value<K, V>(key: K, value: V, want_key: i64, want_value: i64) -> Result
+    fn test_map_key_value<K, V>(key: K, value: V, want_key: u64, want_value: u64) -> Result
     where
         K: ToString,
         V: ToString,
     {
         let value = json!({"mapKeyValue": {key.to_string(): value.to_string()}});
-        let got = serde_json::from_value::<MessageWithI64>(value)?;
+        let got = serde_json::from_value::<MessageWithU64>(value)?;
         let output = json!({"mapKeyValue": {want_key.to_string(): want_value.to_string()}});
         assert_eq!(
             got,
-            MessageWithI64::new().set_map_key_value([(want_key, want_value)])
+            MessageWithU64::new().set_map_key_value([(want_key, want_value)])
         );
         let trip = serde_json::to_value(&got)?;
         assert_eq!(trip, output);
@@ -211,8 +194,8 @@ mod test {
     #[test_case(json!({}))]
     #[test_case(json!({"mapKeyValue": {}}))]
     fn test_map_key_value_default(input: Value) -> Result {
-        let want = MessageWithI64::default();
-        let got = serde_json::from_value::<MessageWithI64>(input)?;
+        let want = MessageWithU64::default();
+        let got = serde_json::from_value::<MessageWithU64>(input)?;
         assert_eq!(got, want);
         let output = serde_json::to_value(&got)?;
         assert_eq!(output, json!({}));


### PR DESCRIPTION
Use the custom serialization / deserialization from `wkt::internal`
instead of `DisplayFromStr`. We need to support deserializing from
numbers as well as strings.

Fixes #2324
