### PR TITLE
fix(generator/rust): JSON for some field names

### DIFF
--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -473,7 +473,8 @@ func fieldSkipAttributes(f *api.Field) []string {
 }
 
 func fieldBaseAttributes(f *api.Field) []string {
-	if toCamel(toSnake(f.Name)) != f.JSONName {
+	// Names starting with `_` are not handled quite right by serde.
+	if toCamel(f.Name) != f.JSONName || strings.HasPrefix(f.Name, "_") {
 		return []string{fmt.Sprintf(`#[serde(rename = "%s")]`, f.JSONName)}
 	}
 	return []string{}

--- a/src/protojson-conformance/src/generated/test_protos/mod.rs
+++ b/src/protojson-conformance/src/generated/test_protos/mod.rs
@@ -510,6 +510,7 @@ pub struct TestAllTypesProto3 {
     #[serde_as(as = "wkt::internal::I32")]
     pub field_name2: i32,
 
+    #[serde(rename = "FieldName3")]
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "wkt::internal::I32")]
     pub _field_name3: i32,
@@ -555,10 +556,12 @@ pub struct TestAllTypesProto3 {
     #[serde_as(as = "wkt::internal::I32")]
     pub field_name_12: i32,
 
+    #[serde(rename = "FieldName13")]
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "wkt::internal::I32")]
     pub __field_name13: i32,
 
+    #[serde(rename = "FieldName14")]
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "wkt::internal::I32")]
     pub __field_name_14: i32,

--- a/src/protojson-conformance/src/lib.rs
+++ b/src/protojson-conformance/src/lib.rs
@@ -18,3 +18,19 @@ pub mod conformance {
     include!("generated/protos/conformance.rs");
     include!("generated/convert/convert.rs");
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use generated::test_protos::TestAllTypesProto3;
+    use serde_json::json;
+
+    #[test]
+    fn field13() -> anyhow::Result<()> {
+        let input = json!({"FieldName13": 0});
+        let message = serde_json::from_value::<TestAllTypesProto3>(input)?;
+        let value = serde_json::to_value(message)?;
+        assert_eq!(value, json!({}));
+        Ok(())
+    }
+}


### PR DESCRIPTION
Field names starting with `_` were not mapped correctly to JSON.
Fortunately only the ProtoJSON conformance test uses such names.

Fixes #2368 
