### PR TITLE
cleanup: use specific errors in tests

### DIFF
--- a/src/gax/src/loop_state.rs
+++ b/src/gax/src/loop_state.rs
@@ -63,19 +63,29 @@ mod tests {
 
     #[test]
     fn loop_state() {
-        let flow = LoopState::Permanent(Error::other("err"));
+        let flow = LoopState::Permanent(permanent_error());
         assert!(flow.is_permanent(), "{flow:?}");
         assert!(!flow.is_exhausted(), "{flow:?}");
         assert!(!flow.is_continue(), "{flow:?}");
 
-        let flow = LoopState::Exhausted(Error::other("err"));
+        let flow = LoopState::Exhausted(transient_error());
         assert!(!flow.is_permanent(), "{flow:?}");
         assert!(flow.is_exhausted(), "{flow:?}");
         assert!(!flow.is_continue(), "{flow:?}");
 
-        let flow = LoopState::Continue(Error::other("err"));
+        let flow = LoopState::Continue(transient_error());
         assert!(!flow.is_permanent(), "{flow:?}");
         assert!(!flow.is_exhausted(), "{flow:?}");
         assert!(flow.is_continue(), "{flow:?}");
+    }
+
+    fn permanent_error() -> Error {
+        use crate::error::rpc::*;
+        Error::service(Status::default().set_code(Code::PermissionDenied))
+    }
+
+    fn transient_error() -> Error {
+        use crate::error::rpc::*;
+        Error::service(Status::default().set_code(Code::Unavailable))
     }
 }

--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -618,7 +618,7 @@ mod test {
             .expect_on_throttle()
             .once()
             .in_sequence(&mut retry_seq)
-            .returning(|_, _| Some(Error::other("retry-policy-on-throttle")));
+            .returning(|_, _| Some(permanent().unwrap_err()));
 
         let mut backoff_policy = MockBackoffPolicy::new();
         backoff_policy
@@ -643,7 +643,7 @@ mod test {
         )
         .await;
         assert!(
-            matches!(&response, Err(e) if format!("{e}").contains("retry-policy-on-throttle")),
+            matches!(&response, Err(e) if matches!(e.status(), Some(s) if s.message == "uh-oh")),
             "{response:?}"
         );
         Ok(())

--- a/src/gax/src/retry_throttler.rs
+++ b/src/gax/src/retry_throttler.rs
@@ -423,7 +423,11 @@ mod test {
     }
 
     fn test_error() -> crate::error::Error {
-        crate::error::Error::other("test only".to_string())
+        use crate::error::{
+            Error,
+            rpc::{Code, Status},
+        };
+        Error::service(Status::default().set_code(Code::Aborted))
     }
 
     #[test]

--- a/src/integration-tests/src/bigquery.rs
+++ b/src/integration-tests/src/bigquery.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::Result;
-use gax::error::Error;
 use rand::{Rng, distr::Alphanumeric};
 
 pub async fn dataset_admin(
@@ -83,9 +82,7 @@ async fn cleanup_stale_datasets(
     project_id: &str,
 ) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    let stale_deadline = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(Error::other)?;
+    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = stale_deadline.as_millis() as i64;
 

--- a/src/integration-tests/src/firestore.rs
+++ b/src/integration-tests/src/firestore.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::Result;
-use firestore::Error;
 use firestore::client::Firestore;
 use firestore::model;
 use gax::paginator::ItemPaginator as _;
@@ -118,9 +117,7 @@ async fn cleanup_stale_documents() -> Result<()> {
     use gax::retry_policy::RetryPolicyExt;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    let stale_deadline = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(Error::other)?;
+    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::Result;
-use gax::error::Error;
 use rand::{Rng, distr::Alphanumeric};
 
 pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -> Result<()> {
@@ -347,9 +346,7 @@ async fn cleanup_stale_secrets(
     location_id: &str,
 ) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    let stale_deadline = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(Error::other)?;
+    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::Result;
-use gax::error::Error;
 use gax::paginator::{ItemPaginator, Paginator};
 use rand::{Rng, distr::Alphanumeric};
 
@@ -423,9 +422,7 @@ async fn cleanup_stale_secrets(
     secret_id: &str,
 ) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    let stale_deadline = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(Error::other)?;
+    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -14,8 +14,8 @@
 
 use crate::Result;
 use gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
+use gax::options::RequestOptionsBuilder;
 use gax::paginator::ItemPaginator as _;
-use gax::{error::Error, options::RequestOptionsBuilder};
 use lro::Poller;
 use std::time::Duration;
 
@@ -192,9 +192,7 @@ async fn cleanup_stale_workflows(
     location_id: &str,
 ) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    let stale_deadline = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(Error::other)?;
+    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
@@ -260,7 +258,7 @@ pub async fn manual(
             }
             LR::Response(any) => {
                 println!("LRO completed successfully {any:?}");
-                let response = any.to_msg::<wf::model::Workflow>().map_err(Error::other);
+                let response = any.to_msg::<wf::model::Workflow>();
                 println!("LRO completed response={response:?}");
                 return Ok(());
             }
@@ -297,7 +295,7 @@ pub async fn manual(
             }
             LR::Response(any) => {
                 println!("LRO completed successfully {any:?}");
-                let response = any.to_msg::<wf::model::Workflow>().map_err(Error::other);
+                let response = any.to_msg::<wf::model::Workflow>();
                 println!("LRO completed response={response:?}");
                 return Ok(());
             }

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -193,7 +193,7 @@ mod test {
             .metadata()
             .unwrap()
             .to_msg::<wkt::Timestamp>()
-            .map_err(Error::other)?;
+            .expect("Any::from_msg should succeed");
         assert_eq!(got, wkt::Timestamp::clamp(123, 0));
 
         Ok(())
@@ -202,7 +202,7 @@ mod test {
     #[test]
     fn typed_operation_with_response() -> Result<()> {
         let any = wkt::Any::from_msg(&wkt::Duration::clamp(23, 0))
-            .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+            .expect("successful deserialization via Any::from_msg");
         let op = longrunning::model::Operation::default()
             .set_name("test-only-name")
             .set_result(longrunning::model::operation::Result::Response(any.into()));
@@ -216,7 +216,7 @@ mod test {
             .response()
             .unwrap()
             .to_msg::<wkt::Duration>()
-            .map_err(Error::other)?;
+            .expect("successful deserialization via Any::from_msg");
         assert_eq!(got, wkt::Duration::clamp(23, 0));
 
         Ok(())

--- a/src/lro/src/internal.rs
+++ b/src/lro/src/internal.rs
@@ -378,7 +378,7 @@ mod test {
     async fn poll_basic_flow() {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -388,7 +388,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Duration::clamp(234, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -433,7 +433,7 @@ mod test {
     async fn poll_basic_stream() {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -443,7 +443,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Duration::clamp(234, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -491,7 +491,7 @@ mod test {
     async fn until_done_basic_flow() -> Result<()> {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -501,7 +501,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Duration::clamp(234, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -531,7 +531,7 @@ mod test {
     async fn unit_poll_basic_flow() {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -541,7 +541,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -586,7 +586,7 @@ mod test {
     async fn unit_poll_basic_stream() {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -596,7 +596,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -644,7 +644,7 @@ mod test {
     async fn unit_until_done_basic_flow() -> Result<()> {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -654,7 +654,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -682,7 +682,7 @@ mod test {
     async fn unit_metadata_poll_basic_flow() {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -692,7 +692,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Duration::clamp(123, 456))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -737,7 +737,7 @@ mod test {
     async fn unit_metadata_poll_basic_stream() {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -747,7 +747,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Duration::clamp(123, 456))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -797,7 +797,7 @@ mod test {
     async fn unit_metadata_until_done_basic_flow() -> Result<()> {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -807,7 +807,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Duration::clamp(123, 456))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -859,7 +859,7 @@ mod test {
         type EmptyOperation = Operation<wkt::Empty, wkt::Empty>;
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -869,7 +869,7 @@ mod test {
 
         let query = |_: String| async move {
             let any = wkt::Any::from_msg(&wkt::Empty::default())
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
@@ -916,7 +916,7 @@ mod test {
     async fn until_done_with_recoverable_polling_error() -> Result<()> {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -932,12 +932,10 @@ mod test {
             drop(guard);
             async move {
                 if c == 0 {
-                    return Err::<TestOperation, Error>(Error::other(
-                        "recoverable (see policy below)",
-                    ));
+                    return Err::<TestOperation, Error>(polling_error());
                 }
                 let any = wkt::Any::from_msg(&wkt::Duration::clamp(234, 0))
-                    .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                    .expect("test message deserializes via Any::from_msg");
                 let result = longrunning::model::operation::Result::Response(any.into());
                 let op = longrunning::model::Operation::default()
                     .set_done(true)
@@ -968,7 +966,7 @@ mod test {
     async fn until_done_with_unrecoverable_polling_error() -> Result<()> {
         let start = || async move {
             let any = wkt::Any::from_msg(&wkt::Timestamp::clamp(123, 0))
-                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+                .expect("test message deserializes via Any::from_msg");
             let op = longrunning::model::Operation::default()
                 .set_name("test-only-name")
                 .set_metadata(any);
@@ -976,9 +974,7 @@ mod test {
             Ok::<TestOperation, Error>(op)
         };
 
-        let query = move |_: String| async move {
-            Err::<TestOperation, Error>(Error::other("unrecoverable (see policy below)"))
-        };
+        let query = move |_: String| async move { Err::<TestOperation, Error>(unrecoverable()) };
 
         let poller = PollerImpl::new(
             Arc::new(Aip194Strict),
@@ -1005,6 +1001,14 @@ mod test {
             Status::default()
                 .set_code(Code::ResourceExhausted)
                 .set_message("too many things"),
+        )
+    }
+
+    fn unrecoverable() -> gax::error::Error {
+        gax::error::Error::service(
+            Status::default()
+                .set_code(Code::Aborted)
+                .set_message("unrecoverable"),
         )
     }
 

--- a/src/storage-control/tests/mocking.rs
+++ b/src/storage-control/tests/mocking.rs
@@ -75,10 +75,11 @@ mod test {
             $( paste! {
                 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
                 async fn [<mock_stub_$method>]() {
+                    use gax::error::{Error, rpc::{Code, Status}};
                     let mut mock = MockStorageControl::new();
                     mock.[<expect_$method>]()
                         .times(1)
-                        .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+                        .returning(|_, _| Err(Error::service(Status::default().set_code(Code::Aborted))));
                     let client = gcs::client::StorageControl::from_stub(mock);
                     let _ = client.$method().send().await.unwrap_err();
                 }


### PR DESCRIPTION
Prefer `Error::service` over `Error::other`. We want to remove
`Error::other` altogether.

Part of the work for #2312
