### PR TITLE
impl: custom serializer for `wkt::Value` fields

### DIFF
--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -1155,6 +1155,7 @@ pub mod terraform_blueprint {
 pub struct TerraformVariable {
     /// Input variable value.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
     pub input_value: std::option::Option<wkt::Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1268,6 +1269,7 @@ pub struct TerraformOutput {
 
     /// Value of output.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
     pub value: std::option::Option<wkt::Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -2756,6 +2756,7 @@ pub mod runtime_entity_schema {
         /// The following field specifies the default value of the Field provided
         /// by the external system if a value is not provided.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "wkt::internal::OptionalValue")]
         pub default_value: std::option::Option<wkt::Value>,
 
         /// The following map contains fields that are not explicitly mentioned
@@ -2955,6 +2956,7 @@ pub mod runtime_action_schema {
         /// The following field specifies the default value of the Parameter
         /// provided by the external system if a value is not provided.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "wkt::internal::OptionalValue")]
         pub default_value: std::option::Option<wkt::Value>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -13128,6 +13128,7 @@ pub mod fulfillment {
 
         /// The new value of the parameter. A null value clears the parameter.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "wkt::internal::OptionalValue")]
         pub value: std::option::Option<wkt::Value>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -16705,6 +16706,7 @@ pub mod form {
         /// The default value of an optional parameter. If the parameter is required,
         /// the default value will be ignored.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "wkt::internal::OptionalValue")]
         pub default_value: std::option::Option<wkt::Value>,
 
         /// Indicates whether the parameter content should be redacted in log.  If
@@ -33740,6 +33742,7 @@ pub mod webhook_request {
             /// Always present. Structured value for the parameter extracted from user
             /// utterance.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[serde_as(as = "wkt::internal::OptionalValue")]
             pub resolved_value: std::option::Option<wkt::Value>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -34473,6 +34476,7 @@ pub mod page_info {
             /// [google.cloud.dialogflow.cx.v3.WebhookRequest]: crate::model::WebhookRequest
             /// [google.cloud.dialogflow.cx.v3.WebhookResponse]: crate::model::WebhookResponse
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[serde_as(as = "wkt::internal::OptionalValue")]
             pub value: std::option::Option<wkt::Value>,
 
             /// Optional for

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -31590,6 +31590,7 @@ pub struct AnnotatedMessagePart {
     /// this message part. For example for a system entity of type
     /// `@sys.unit-currency`, this may contain:
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
     pub formatted_value: std::option::Option<wkt::Value>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -445,6 +445,7 @@ pub mod constraint {
 
             /// Sets the value of the parameter in an assignment if no value is given.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[serde_as(as = "wkt::internal::OptionalValue")]
             pub default_value: std::option::Option<wkt::Value>,
 
             /// Provides a CEL expression to specify the acceptable parameter values

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -2088,6 +2088,7 @@ pub mod deny_rule_explanation {
 pub struct ConditionExplanation {
     /// Value of the condition.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
     pub value: std::option::Option<wkt::Value>,
 
     /// Any errors that prevented complete evaluation of the condition expression.
@@ -2183,6 +2184,7 @@ pub mod condition_explanation {
 
         /// Value of this expression.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "wkt::internal::OptionalValue")]
         pub value: std::option::Option<wkt::Value>,
 
         /// Any errors that prevented complete evaluation of the condition

--- a/src/protojson-conformance/src/generated/test_protos/mod.rs
+++ b/src/protojson-conformance/src/generated/test_protos/mod.rs
@@ -528,6 +528,7 @@ pub struct TestAllTypesProto3 {
     pub optional_any: std::option::Option<wkt::Any>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
     pub optional_value: std::option::Option<wkt::Value>,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]

--- a/src/wkt/src/internal.rs
+++ b/src/wkt/src/internal.rs
@@ -31,6 +31,9 @@ pub use int64::I64;
 mod uint64;
 pub use uint64::U64;
 
+mod value;
+pub use value::OptionalValue;
+
 pub struct F32;
 pub struct F64;
 

--- a/src/wkt/src/internal/value.rs
+++ b/src/wkt/src/internal/value.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Value;
+use serde::Deserialize;
+
+pub struct OptionalValue;
+
+impl<'de> serde_with::DeserializeAs<'de, Option<Value>> for OptionalValue {
+    fn deserialize_as<D>(deserializer: D) -> Result<Option<Value>, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        Ok(Option::<Value>::deserialize(deserializer)?.or(Some(Value::Null)))
+    }
+}
+
+impl serde_with::SerializeAs<Option<Value>> for OptionalValue {
+    fn serialize_as<S>(source: &Option<Value>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Serialize;
+        match source {
+            None => serializer.serialize_none(),
+            Some(v) => v.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+    use serde_json::{Value, json};
+    use serde_with::{DeserializeAs, SerializeAs};
+    use test_case::test_case;
+
+    #[test_case(json!(null))]
+    #[test_case(json!("abc"))]
+    #[test_case(json!(1))]
+    #[test_case(json!([1, 2, "a"]))]
+    #[test_case(json!({"a": [1, 2, "a"], "b": null}))]
+    fn deser_and_ser(input: Value) -> Result<()> {
+        let got = OptionalValue::deserialize_as(input.clone())?;
+        assert_eq!(got, Some(input));
+
+        let serialized = OptionalValue::serialize_as(&got, serde_json::value::Serializer)?;
+        assert_eq!(serialized, json!(got));
+        Ok(())
+    }
+}

--- a/src/wkt/tests/generated/mod.rs
+++ b/src/wkt/tests/generated/mod.rs
@@ -1012,6 +1012,383 @@ impl wkt::message::Message for MessageWithString {
     }
 }
 
+/// A test message for Value.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct MessageWithValue {
+
+    /// A singular field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
+    pub singular: std::option::Option<wkt::Value>,
+
+    /// An optional field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "wkt::internal::OptionalValue")]
+    pub optional: std::option::Option<wkt::Value>,
+
+    /// A repeated field.
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
+    pub repeated: std::vec::Vec<wkt::Value>,
+
+    /// A map field, messages cannot be keys.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
+    pub map: std::collections::HashMap<std::string::String,wkt::Value>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl MessageWithValue {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [singular][crate::protos::MessageWithValue::singular].
+    pub fn set_singular<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::Value>
+    {
+        self.singular = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [singular][crate::protos::MessageWithValue::singular].
+    pub fn set_or_clear_singular<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::Value>
+    {
+        self.singular = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [optional][crate::protos::MessageWithValue::optional].
+    pub fn set_optional<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::Value>
+    {
+        self.optional = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [optional][crate::protos::MessageWithValue::optional].
+    pub fn set_or_clear_optional<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::Value>
+    {
+        self.optional = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [repeated][crate::protos::MessageWithValue::repeated].
+    pub fn set_repeated<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Value>
+    {
+        use std::iter::Iterator;
+        self.repeated = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [map][crate::protos::MessageWithValue::map].
+    pub fn set_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+impl wkt::message::Message for MessageWithValue {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.rust.sdk.test.MessageWithValue"
+    }
+}
+
+/// A test message for Struct.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct MessageWithStruct {
+
+    /// A singular field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub singular: std::option::Option<wkt::Struct>,
+
+    /// An optional field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub optional: std::option::Option<wkt::Struct>,
+
+    /// A repeated field.
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
+    pub repeated: std::vec::Vec<wkt::Struct>,
+
+    /// A map field, messages cannot be keys.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
+    pub map: std::collections::HashMap<std::string::String,wkt::Struct>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl MessageWithStruct {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [singular][crate::protos::MessageWithStruct::singular].
+    pub fn set_singular<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::Struct>
+    {
+        self.singular = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [singular][crate::protos::MessageWithStruct::singular].
+    pub fn set_or_clear_singular<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::Struct>
+    {
+        self.singular = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [optional][crate::protos::MessageWithStruct::optional].
+    pub fn set_optional<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::Struct>
+    {
+        self.optional = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [optional][crate::protos::MessageWithStruct::optional].
+    pub fn set_or_clear_optional<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::Struct>
+    {
+        self.optional = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [repeated][crate::protos::MessageWithStruct::repeated].
+    pub fn set_repeated<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Struct>
+    {
+        use std::iter::Iterator;
+        self.repeated = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [map][crate::protos::MessageWithStruct::map].
+    pub fn set_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::Struct>,
+    {
+        use std::iter::Iterator;
+        self.map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+impl wkt::message::Message for MessageWithStruct {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.rust.sdk.test.MessageWithStruct"
+    }
+}
+
+/// A test message for ListValue.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct MessageWithListValue {
+
+    /// A singular field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub singular: std::option::Option<wkt::ListValue>,
+
+    /// An optional field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub optional: std::option::Option<wkt::ListValue>,
+
+    /// A repeated field.
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
+    pub repeated: std::vec::Vec<wkt::ListValue>,
+
+    /// A map field, messages cannot be keys.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
+    pub map: std::collections::HashMap<std::string::String,wkt::ListValue>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl MessageWithListValue {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [singular][crate::protos::MessageWithListValue::singular].
+    pub fn set_singular<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::ListValue>
+    {
+        self.singular = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [singular][crate::protos::MessageWithListValue::singular].
+    pub fn set_or_clear_singular<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::ListValue>
+    {
+        self.singular = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [optional][crate::protos::MessageWithListValue::optional].
+    pub fn set_optional<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::ListValue>
+    {
+        self.optional = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [optional][crate::protos::MessageWithListValue::optional].
+    pub fn set_or_clear_optional<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::ListValue>
+    {
+        self.optional = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [repeated][crate::protos::MessageWithListValue::repeated].
+    pub fn set_repeated<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::ListValue>
+    {
+        use std::iter::Iterator;
+        self.repeated = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [map][crate::protos::MessageWithListValue::map].
+    pub fn set_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::ListValue>,
+    {
+        use std::iter::Iterator;
+        self.map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+impl wkt::message::Message for MessageWithListValue {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.rust.sdk.test.MessageWithListValue"
+    }
+}
+
+/// A test message for NullValue.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct MessageWithNullValue {
+
+    /// A singular field.
+    #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
+    pub singular: wkt::NullValue,
+
+    /// An optional field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub optional: std::option::Option<wkt::NullValue>,
+
+    /// A repeated field.
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
+    pub repeated: std::vec::Vec<wkt::NullValue>,
+
+    /// A map field, messages cannot be keys.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
+    pub map: std::collections::HashMap<std::string::String,wkt::NullValue>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl MessageWithNullValue {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [singular][crate::protos::MessageWithNullValue::singular].
+    pub fn set_singular<T: std::convert::Into<wkt::NullValue>>(mut self, v: T) -> Self {
+        self.singular = v.into();
+        self
+    }
+
+    /// Sets the value of [optional][crate::protos::MessageWithNullValue::optional].
+    pub fn set_optional<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<wkt::NullValue>
+    {
+        self.optional = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [optional][crate::protos::MessageWithNullValue::optional].
+    pub fn set_or_clear_optional<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<wkt::NullValue>
+    {
+        self.optional = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [repeated][crate::protos::MessageWithNullValue::repeated].
+    pub fn set_repeated<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::NullValue>
+    {
+        use std::iter::Iterator;
+        self.repeated = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [map][crate::protos::MessageWithNullValue::map].
+    pub fn set_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::NullValue>,
+    {
+        use std::iter::Iterator;
+        self.map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+impl wkt::message::Message for MessageWithNullValue {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.rust.sdk.test.MessageWithNullValue"
+    }
+}
+
 /// A test message for FieldMask.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/src/wkt/tests/generated/struct_types.proto
+++ b/src/wkt/tests/generated/struct_types.proto
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package google.rust.sdk.test;
+
+import "google/protobuf/struct.proto";
+
+// A test message for Value.
+message MessageWithValue {
+    // A singular field.
+    google.protobuf.Value singular = 1;
+    // An optional field.
+    optional google.protobuf.Value optional = 2;
+    // A repeated field.
+    repeated google.protobuf.Value repeated = 3;
+    // A map field, messages cannot be keys.
+    map<string, google.protobuf.Value> map = 4;
+}
+
+// A test message for Struct.
+message MessageWithStruct {
+    // A singular field.
+    google.protobuf.Struct singular = 1;
+    // An optional field.
+    optional google.protobuf.Struct optional = 2;
+    // A repeated field.
+    repeated google.protobuf.Struct repeated = 3;
+    // A map field, messages cannot be keys.
+    map<string, google.protobuf.Struct> map = 4;
+}
+
+// A test message for ListValue.
+message MessageWithListValue {
+    // A singular field.
+    google.protobuf.ListValue singular = 1;
+    // An optional field.
+    optional google.protobuf.ListValue optional = 2;
+    // A repeated field.
+    repeated google.protobuf.ListValue repeated = 3;
+    // A map field, messages cannot be keys.
+    map<string, google.protobuf.ListValue> map = 4;
+}
+
+// A test message for NullValue.
+message MessageWithNullValue {
+    // A singular field.
+    google.protobuf.NullValue singular = 1;
+    // An optional field.
+    optional google.protobuf.NullValue optional = 2;
+    // A repeated field.
+    repeated google.protobuf.NullValue repeated = 3;
+    // A map field, messages cannot be keys.
+    map<string, google.protobuf.NullValue> map = 4;
+}

--- a/src/wkt/tests/message_with_value.rs
+++ b/src/wkt/tests/message_with_value.rs
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod test {
+    use google_cloud_wkt::Value;
+    use serde_json::json;
+    use test_case::test_case;
+
+    type Result = anyhow::Result<()>;
+
+    #[allow(dead_code)]
+    mod protos {
+        use google_cloud_wkt as wkt;
+        include!("generated/mod.rs");
+    }
+    use protos::MessageWithValue;
+
+    #[test_case(json!({"singular": null}), Value::Null)]
+    #[test_case(json!({"singular": "abc"}), json!("abc"))]
+    #[test_case(json!({"singular": 1}), json!(1))]
+    #[test_case(json!({"singular": true}), json!(true))]
+    #[test_case(json!({"singular": [1, 2, "a"]}), json!([1, 2, "a"]))]
+    #[test_case(json!({"singular": {"a": 1}}), json!({"a": 1}))]
+    fn test_singular(value: Value, want: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(value.clone())?;
+        assert_eq!(got.singular, Some(want));
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    fn test_singular_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(input)?;
+        let want = MessageWithValue::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+
+    #[test_case(json!({"optional": ""}), json!(""))]
+    #[test_case(json!({"optional": null}), json!(null))]
+    fn test_optional(value: Value, want: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(value.clone())?;
+        assert_eq!(got.optional, Some(want));
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    fn test_optional_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(input)?;
+        let want = MessageWithValue::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+
+    #[test_case(json!({"repeated": [""]}), MessageWithValue::new().set_repeated([json!("")]))]
+    #[test_case(json!({"repeated": [1, 2, "a"]}), MessageWithValue::new().set_repeated([json!(1), json!(2), json!("a")]))]
+    fn test_repeated(value: Value, want: MessageWithValue) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(value.clone())?;
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    #[test_case(json!({"repeated": []}))]
+    #[test_case(json!({"repeated": null}))]
+    fn test_repeated_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(input)?;
+        let want = MessageWithValue::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+
+    #[test_case(json!({"map": {"key": ""}}), MessageWithValue::new().set_map([("key", json!(""))]))]
+    #[test_case(json!({"map": {"key": [1, 2, "a"]}}), MessageWithValue::new().set_map([("key", json!([1, 2, "a"]))]))]
+    fn test_map(value: Value, want: MessageWithValue) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(value.clone())?;
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    #[test_case(json!({"map": {}}))]
+    #[test_case(json!({"map": null}))]
+    fn test_map_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithValue>(input)?;
+        let want = MessageWithValue::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+}


### PR DESCRIPTION
Only for this message type, ProtoJSON requires handling `null` as "set the
value to `Some(Value::Null)`" as opposed to "set the value to `None`".

Fixes #2375
