### PR TITLE
impl(storage): prefer `Error::binding()`

### DIFF
--- a/src/storage/src/client.rs
+++ b/src/storage/src/client.rs
@@ -323,7 +323,7 @@ impl InsertObject {
             .as_str()
             .strip_prefix("projects/_/buckets/")
             .ok_or_else(|| {
-                Error::other(format!(
+                Error::binding(format!(
                     "malformed bucket name, it must start with `projects/_/buckets/`: {bucket}"
                 ))
             })?;
@@ -479,7 +479,7 @@ impl ReadObject {
             .as_str()
             .strip_prefix("projects/_/buckets/")
             .ok_or_else(|| {
-                Error::other(format!(
+                Error::binding(format!(
                     "malformed bucket name, it must start with `projects/_/buckets/`: {bucket}"
                 ))
             })?;


### PR DESCRIPTION
This is more specific than `Error::other()`, and sufficiently consistent
with other uses of `Error::binding()`.

Part of the work for #2312
