### PR TITLE
test(wkt): add test for messages with recursion

### DIFF
--- a/src/wkt/tests/generated/mod.rs
+++ b/src/wkt/tests/generated/mod.rs
@@ -2056,6 +2056,242 @@ impl wkt::message::Message for MessageWithString {
     }
 }
 
+/// A test message for FieldMask.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct MessageWithRecursion {
+
+    /// A singular field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub singular: std::option::Option<std::boxed::Box<crate::test::protos::message_with_recursion::Level0>>,
+
+    /// An optional field.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub optional: std::option::Option<std::boxed::Box<crate::test::protos::message_with_recursion::Level0>>,
+
+    /// A repeated field.
+    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
+    pub repeated: std::vec::Vec<crate::test::protos::message_with_recursion::Level0>,
+
+    /// A map field, messages cannot be keys.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
+    pub map: std::collections::HashMap<std::string::String,crate::test::protos::message_with_recursion::Level0>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl MessageWithRecursion {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [singular][crate::test::protos::MessageWithRecursion::singular].
+    pub fn set_singular<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<crate::test::protos::message_with_recursion::Level0>
+    {
+        self.singular = std::option::Option::Some(std::boxed::Box::new(v.into()));
+        self
+    }
+
+    /// Sets or clears the value of [singular][crate::test::protos::MessageWithRecursion::singular].
+    pub fn set_or_clear_singular<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<crate::test::protos::message_with_recursion::Level0>
+    {
+        self.singular = v.map(|x| std::boxed::Box::new(x.into()));
+        self
+    }
+
+    /// Sets the value of [optional][crate::test::protos::MessageWithRecursion::optional].
+    pub fn set_optional<T>(mut self, v: T) -> Self
+    where T: std::convert::Into<crate::test::protos::message_with_recursion::Level0>
+    {
+        self.optional = std::option::Option::Some(std::boxed::Box::new(v.into()));
+        self
+    }
+
+    /// Sets or clears the value of [optional][crate::test::protos::MessageWithRecursion::optional].
+    pub fn set_or_clear_optional<T>(mut self, v: std::option::Option<T>) -> Self
+    where T: std::convert::Into<crate::test::protos::message_with_recursion::Level0>
+    {
+        self.optional = v.map(|x| std::boxed::Box::new(x.into()));
+        self
+    }
+
+    /// Sets the value of [repeated][crate::test::protos::MessageWithRecursion::repeated].
+    pub fn set_repeated<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::test::protos::message_with_recursion::Level0>
+    {
+        use std::iter::Iterator;
+        self.repeated = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [map][crate::test::protos::MessageWithRecursion::map].
+    pub fn set_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::test::protos::message_with_recursion::Level0>,
+    {
+        use std::iter::Iterator;
+        self.map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+}
+
+impl wkt::message::Message for MessageWithRecursion {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.rust.sdk.test.MessageWithRecursion"
+    }
+}
+
+/// Defines additional types related to [MessageWithRecursion].
+pub mod message_with_recursion {
+    #[allow(unused_imports)]
+    use super::*;
+
+
+    #[serde_with::serde_as]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(default, rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct Level0 {
+
+        #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        pub level_1: std::option::Option<std::boxed::Box<crate::test::protos::message_with_recursion::Level1>>,
+
+        #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        pub side: std::option::Option<crate::test::protos::message_with_recursion::NonRecursive>,
+
+        #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+        _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+    }
+
+    impl Level0 {
+        pub fn new() -> Self {
+            std::default::Default::default()
+        }
+
+        /// Sets the value of [level_1][crate::test::protos::message_with_recursion::Level0::level_1].
+        pub fn set_level_1<T>(mut self, v: T) -> Self
+        where T: std::convert::Into<crate::test::protos::message_with_recursion::Level1>
+        {
+            self.level_1 = std::option::Option::Some(std::boxed::Box::new(v.into()));
+            self
+        }
+
+        /// Sets or clears the value of [level_1][crate::test::protos::message_with_recursion::Level0::level_1].
+        pub fn set_or_clear_level_1<T>(mut self, v: std::option::Option<T>) -> Self
+        where T: std::convert::Into<crate::test::protos::message_with_recursion::Level1>
+        {
+            self.level_1 = v.map(|x| std::boxed::Box::new(x.into()));
+            self
+        }
+
+        /// Sets the value of [side][crate::test::protos::message_with_recursion::Level0::side].
+        pub fn set_side<T>(mut self, v: T) -> Self
+        where T: std::convert::Into<crate::test::protos::message_with_recursion::NonRecursive>
+        {
+            self.side = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [side][crate::test::protos::message_with_recursion::Level0::side].
+        pub fn set_or_clear_side<T>(mut self, v: std::option::Option<T>) -> Self
+        where T: std::convert::Into<crate::test::protos::message_with_recursion::NonRecursive>
+        {
+            self.side = v.map(|x| x.into());
+            self
+        }
+    }
+
+    impl wkt::message::Message for Level0 {
+        fn typename() -> &'static str {
+            "type.googleapis.com/google.rust.sdk.test.MessageWithRecursion.Level0"
+        }
+    }
+
+    #[serde_with::serde_as]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(default, rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct Level1 {
+
+        #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        pub recurse: std::option::Option<std::boxed::Box<crate::test::protos::MessageWithRecursion>>,
+
+        #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+        _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+    }
+
+    impl Level1 {
+        pub fn new() -> Self {
+            std::default::Default::default()
+        }
+
+        /// Sets the value of [recurse][crate::test::protos::message_with_recursion::Level1::recurse].
+        pub fn set_recurse<T>(mut self, v: T) -> Self
+        where T: std::convert::Into<crate::test::protos::MessageWithRecursion>
+        {
+            self.recurse = std::option::Option::Some(std::boxed::Box::new(v.into()));
+            self
+        }
+
+        /// Sets or clears the value of [recurse][crate::test::protos::message_with_recursion::Level1::recurse].
+        pub fn set_or_clear_recurse<T>(mut self, v: std::option::Option<T>) -> Self
+        where T: std::convert::Into<crate::test::protos::MessageWithRecursion>
+        {
+            self.recurse = v.map(|x| std::boxed::Box::new(x.into()));
+            self
+        }
+    }
+
+    impl wkt::message::Message for Level1 {
+        fn typename() -> &'static str {
+            "type.googleapis.com/google.rust.sdk.test.MessageWithRecursion.Level1"
+        }
+    }
+
+    #[serde_with::serde_as]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(default, rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct NonRecursive {
+
+        #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[serde_as(as = "serde_with::DefaultOnNull<_>")]
+        pub value: std::string::String,
+
+        #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+        _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+    }
+
+    impl NonRecursive {
+        pub fn new() -> Self {
+            std::default::Default::default()
+        }
+
+        /// Sets the value of [value][crate::test::protos::message_with_recursion::NonRecursive::value].
+        pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.value = v.into();
+            self
+        }
+    }
+
+    impl wkt::message::Message for NonRecursive {
+        fn typename() -> &'static str {
+            "type.googleapis.com/google.rust.sdk.test.MessageWithRecursion.NonRecursive"
+        }
+    }
+}
+
 /// A test message for Value.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/src/wkt/tests/generated/recursive_types.proto
+++ b/src/wkt/tests/generated/recursive_types.proto
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package google.rust.sdk.test;
+
+// A test message for FieldMask.
+message MessageWithRecursion {
+    message Level0 {
+        Level1 level_1 = 1;
+        NonRecursive side = 2;
+    }
+    message Level1 {
+        MessageWithRecursion recurse = 1;
+    }
+    message NonRecursive {
+        string value = 1; 
+    }
+
+    // A singular field.
+    Level0 singular = 1;
+    // An optional field.
+    optional Level0 optional = 2;
+    // A repeated field.
+    repeated Level0 repeated = 3;
+    // A map field, messages cannot be keys.
+    map<string, Level0> map = 4;
+}

--- a/src/wkt/tests/message_with_recursion.rs
+++ b/src/wkt/tests/message_with_recursion.rs
@@ -1,0 +1,121 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod test {
+    use serde_json::{Value, json};
+    use test_case::test_case;
+
+    type Result = anyhow::Result<()>;
+
+    #[allow(dead_code)]
+    mod protos {
+        use google_cloud_wkt as wkt;
+        include!("generated/mod.rs");
+    }
+    use protos::{
+        MessageWithRecursion,
+        message_with_recursion::{Level0, NonRecursive},
+    };
+
+    fn test_level_0() -> Level0 {
+        Level0::new().set_side(NonRecursive::new().set_value("abc"))
+    }
+
+    #[test_case(json!({"singular": {}}), Level0::default())]
+    #[test_case(json!({"singular": {"side": {"value": "abc"}}}), test_level_0())]
+    fn test_singular(value: Value, want: Level0) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(value.clone())?;
+        assert_eq!(got.singular, Some(Box::new(want)));
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    #[test_case(json!({"singular": null}))]
+    fn test_singular_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(input)?;
+        let want = MessageWithRecursion::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+
+    #[test_case(json!({"optional": {}}), Level0::default())]
+    #[test_case(json!({"optional": {"side": {"value": "abc"}}}), test_level_0())]
+    fn test_optional(value: Value, want: Level0) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(value.clone())?;
+        assert_eq!(got.optional, Some(Box::new(want)));
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    #[test_case(json!({"optional": null}))]
+    fn test_optional_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(input)?;
+        let want = MessageWithRecursion::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+
+    #[test_case(json!({"repeated": [{}]}), MessageWithRecursion::new().set_repeated([Level0::default()]))]
+    #[test_case(json!({"repeated": [{"side": {"value": "abc"}}]}), MessageWithRecursion::new().set_repeated([test_level_0()]))]
+    fn test_repeated(value: Value, want: MessageWithRecursion) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(value.clone())?;
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    #[test_case(json!({"repeated": []}))]
+    #[test_case(json!({"repeated": null}))]
+    fn test_repeated_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(input)?;
+        let want = MessageWithRecursion::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+
+    #[test_case(json!({"map": {"key": {}}}), MessageWithRecursion::new().set_map([("key", Level0::default())]))]
+    #[test_case(json!({"map": {"key": {"side": {"value": "abc"}}}}), MessageWithRecursion::new().set_map([("key", test_level_0())]))]
+    fn test_map(value: Value, want: MessageWithRecursion) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(value.clone())?;
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, value);
+        Ok(())
+    }
+
+    #[test_case(json!({}))]
+    #[test_case(json!({"map": {}}))]
+    #[test_case(json!({"map": null}))]
+    fn test_map_default(input: Value) -> Result {
+        let got = serde_json::from_value::<MessageWithRecursion>(input)?;
+        let want = MessageWithRecursion::default();
+        assert_eq!(got, want);
+        let output = serde_json::to_value(&got)?;
+        assert_eq!(output, json!({}));
+        Ok(())
+    }
+}


### PR DESCRIPTION
Messages can "recurse", with fields that refer back to the same message,
maybe indirectly. The mapping for these is different: we box such
messages and they need different testing.

Part of the work for #2376
