### PR TITLE
impl(generator): alternative field names

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -541,6 +541,10 @@ func (f *Field) Singular() bool {
 	return !f.Map && !f.Repeated
 }
 
+func (f *Field) NameEqualJSONName() bool {
+	return f.JSONName == f.Name
+}
+
 // Pair is a key-value pair.
 type Pair struct {
 	// Key of the pair.

--- a/generator/internal/rust/templates/common/deser_field_tag.mustache
+++ b/generator/internal/rust/templates/common/deser_field_tag.mustache
@@ -51,6 +51,17 @@ impl<'de> serde::de::Deserialize<'de> for __FieldTag {
                 match value {
                     {{#Fields}}
                     "{{JSONName}}" => Ok(__FieldTag::__{{Codec.SetterName}}),
+                    {{^NameEqualJSONName}}
+                    {{!
+                        The [ProtoJSON spec] reads:
+
+                        Parsers accept both the lowerCamelCase name (or the one
+                        specified by the json_name option) and the original proto field name.
+
+                        [ProtoJSON spec]: https://protobuf.dev/programming-guides/json/
+                    }}
+                    "{{Name}}" => Ok(__FieldTag::__{{Codec.SetterName}}),
+                    {{/NameEqualJSONName}}
                     {{/Fields}}
                     _ => Ok(__FieldTag::Unknown(value.to_string())),
                 }

--- a/src/wkt/tests/common/src/generated/mod.rs
+++ b/src/wkt/tests/common/src/generated/mod.rs
@@ -701,10 +701,15 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                         use std::result::Result::Ok;
                         match value {
                             "stringContents" => Ok(__FieldTag::__string_contents),
+                            "string_contents" => Ok(__FieldTag::__string_contents),
                             "stringContentsOne" => Ok(__FieldTag::__string_contents_one),
+                            "string_contents_one" => Ok(__FieldTag::__string_contents_one),
                             "stringContentsTwo" => Ok(__FieldTag::__string_contents_two),
+                            "string_contents_two" => Ok(__FieldTag::__string_contents_two),
                             "messageValue" => Ok(__FieldTag::__message_value),
+                            "message_value" => Ok(__FieldTag::__message_value),
                             "anotherMessage" => Ok(__FieldTag::__another_message),
+                            "another_message" => Ok(__FieldTag::__another_message),
                             "string" => Ok(__FieldTag::__string),
                             "duration" => Ok(__FieldTag::__duration),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
@@ -1414,10 +1419,15 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                         match value {
                             "null" => Ok(__FieldTag::__null),
                             "boolValue" => Ok(__FieldTag::__bool_value),
+                            "bool_value" => Ok(__FieldTag::__bool_value),
                             "bytesValue" => Ok(__FieldTag::__bytes_value),
+                            "bytes_value" => Ok(__FieldTag::__bytes_value),
                             "stringValue" => Ok(__FieldTag::__string_value),
+                            "string_value" => Ok(__FieldTag::__string_value),
                             "floatValue" => Ok(__FieldTag::__float_value),
+                            "float_value" => Ok(__FieldTag::__float_value),
                             "doubleValue" => Ok(__FieldTag::__double_value),
+                            "double_value" => Ok(__FieldTag::__double_value),
                             "int" => Ok(__FieldTag::__int),
                             "long" => Ok(__FieldTag::__long),
                             "enum" => Ok(__FieldTag::__enum),
@@ -2811,8 +2821,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithI32 {
                             "optional" => Ok(__FieldTag::__optional),
                             "repeated" => Ok(__FieldTag::__repeated),
                             "mapValue" => Ok(__FieldTag::__map_value),
+                            "map_value" => Ok(__FieldTag::__map_value),
                             "mapKey" => Ok(__FieldTag::__map_key),
+                            "map_key" => Ok(__FieldTag::__map_key),
                             "mapKeyValue" => Ok(__FieldTag::__map_key_value),
+                            "map_key_value" => Ok(__FieldTag::__map_key_value),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -3229,8 +3242,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithU32 {
                             "optional" => Ok(__FieldTag::__optional),
                             "repeated" => Ok(__FieldTag::__repeated),
                             "mapValue" => Ok(__FieldTag::__map_value),
+                            "map_value" => Ok(__FieldTag::__map_value),
                             "mapKey" => Ok(__FieldTag::__map_key),
+                            "map_key" => Ok(__FieldTag::__map_key),
                             "mapKeyValue" => Ok(__FieldTag::__map_key_value),
+                            "map_key_value" => Ok(__FieldTag::__map_key_value),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -3647,8 +3663,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithI64 {
                             "optional" => Ok(__FieldTag::__optional),
                             "repeated" => Ok(__FieldTag::__repeated),
                             "mapValue" => Ok(__FieldTag::__map_value),
+                            "map_value" => Ok(__FieldTag::__map_value),
                             "mapKey" => Ok(__FieldTag::__map_key),
+                            "map_key" => Ok(__FieldTag::__map_key),
                             "mapKeyValue" => Ok(__FieldTag::__map_key_value),
+                            "map_key_value" => Ok(__FieldTag::__map_key_value),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -4065,8 +4084,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithU64 {
                             "optional" => Ok(__FieldTag::__optional),
                             "repeated" => Ok(__FieldTag::__repeated),
                             "mapValue" => Ok(__FieldTag::__map_value),
+                            "map_value" => Ok(__FieldTag::__map_value),
                             "mapKey" => Ok(__FieldTag::__map_key),
+                            "map_key" => Ok(__FieldTag::__map_key),
                             "mapKeyValue" => Ok(__FieldTag::__map_key_value),
+                            "map_key_value" => Ok(__FieldTag::__map_key_value),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -4796,8 +4818,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithBool {
                             "optional" => Ok(__FieldTag::__optional),
                             "repeated" => Ok(__FieldTag::__repeated),
                             "mapValue" => Ok(__FieldTag::__map_value),
+                            "map_value" => Ok(__FieldTag::__map_value),
                             "mapKey" => Ok(__FieldTag::__map_key),
+                            "map_key" => Ok(__FieldTag::__map_key),
                             "mapKeyValue" => Ok(__FieldTag::__map_key_value),
+                            "map_key_value" => Ok(__FieldTag::__map_key_value),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -5054,8 +5079,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithString {
                             "optional" => Ok(__FieldTag::__optional),
                             "repeated" => Ok(__FieldTag::__repeated),
                             "mapValue" => Ok(__FieldTag::__map_value),
+                            "map_value" => Ok(__FieldTag::__map_value),
                             "mapKey" => Ok(__FieldTag::__map_key),
+                            "map_key" => Ok(__FieldTag::__map_key),
                             "mapKeyValue" => Ok(__FieldTag::__map_key_value),
+                            "map_key_value" => Ok(__FieldTag::__map_key_value),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -5549,6 +5577,7 @@ pub mod message_with_recursion {
                             use std::result::Result::Ok;
                             match value {
                                 "level1" => Ok(__FieldTag::__level_1),
+                                "level_1" => Ok(__FieldTag::__level_1),
                                 "side" => Ok(__FieldTag::__side),
                                 _ => Ok(__FieldTag::Unknown(value.to_string())),
                             }

--- a/src/wkt/tests/complex_oneofs.rs
+++ b/src/wkt/tests/complex_oneofs.rs
@@ -24,14 +24,15 @@ mod test {
     use wkt::Duration;
     type Result = anyhow::Result<()>;
 
-    const LAZY: &[u8] = b"the quick brown fox jumps over the lazy dog";
+    const LAZY: &str = "the quick brown fox jumps over the lazy dog";
+    const LAZY_BYTES: &[u8] = b"the quick brown fox jumps over the lazy dog";
     const LAZY_BASE64: &str = "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==";
 
     #[test_case(MessageWithComplexOneOf::new(), json!({}))]
     #[test_case(MessageWithComplexOneOf::new().set_null(wkt::NullValue), json!({"null": null}))]
     #[test_case(MessageWithComplexOneOf::new().set_bool_value(false), json!({"boolValue": false}))]
     #[test_case(MessageWithComplexOneOf::new().set_bytes_value(""), json!({"bytesValue": ""}))]
-    #[test_case(MessageWithComplexOneOf::new().set_bytes_value(LAZY), json!({"bytesValue": LAZY_BASE64}))]
+    #[test_case(MessageWithComplexOneOf::new().set_bytes_value(LAZY_BYTES), json!({"bytesValue": LAZY_BASE64}))]
     #[test_case(MessageWithComplexOneOf::new().set_string_value(""), json!({"stringValue": ""}))]
     #[test_case(MessageWithComplexOneOf::new().set_float_value(0.0), json!({"floatValue": 0.0}))]
     #[test_case(MessageWithComplexOneOf::new().set_float_value(1.5), json!({"floatValue": 1.5}))]
@@ -83,6 +84,11 @@ mod test {
     #[test_case(MessageWithComplexOneOf::new().set_enum(TestEnum::default()), json!({"enum": 0}))]
     #[test_case(MessageWithComplexOneOf::new().set_inner(Inner::default().set_strings(["a", "b"])), json!({"inner": {"strings": ["a", "b"]}}))]
     #[test_case(MessageWithComplexOneOf::new().set_duration(Duration::clamp(-1, -750_000_000)), json!({"duration": "-1.75s"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_bool_value(false), json!({"bool_value": false}))]
+    #[test_case(MessageWithComplexOneOf::new().set_bytes_value(LAZY_BYTES), json!({"bytes_value": LAZY_BASE64}))]
+    #[test_case(MessageWithComplexOneOf::new().set_string_value(LAZY), json!({"string_value": LAZY}))]
+    #[test_case(MessageWithComplexOneOf::new().set_float_value(1.5), json!({"float_value": 1.5}))]
+    #[test_case(MessageWithComplexOneOf::new().set_double_value(2.5), json!({"double_value": 2.5}))]
     fn test_de(want: MessageWithComplexOneOf, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithComplexOneOf>(input)?;
         assert_eq!(got.0, want);

--- a/src/wkt/tests/message_with_bool.rs
+++ b/src/wkt/tests/message_with_bool.rs
@@ -43,6 +43,8 @@ mod test {
     #[test_case(MessageWithBool::new().set_map_key([(true, "trueValue"), (false, "falseValue")]), json!({"mapKey": {"true": "trueValue", "false": "falseValue"}}))]
     #[test_case(MessageWithBool::new().set_map_value([("k0", true), ("k1", false)]), json!({"mapValue": {"k0": true, "k1": false}}))]
     #[test_case(MessageWithBool::new().set_map_key_value([(false, true), (true, false)]), json!({"mapKeyValue": {"false": true, "true": false}}))]
+    #[test_case(MessageWithBool::new().set_map_key_value([(false, true), (true, false)]), json!({"map_key_value": {"false": true, "true": false}}))]
+    #[test_case(MessageWithBool::new().set_map_key_value([(true, true)]), json!({"mapKeyValue": {"tr\u{0075}e": true}}))]
     fn test_de(want: MessageWithBool, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithBool>(input)?;
         assert_eq!(got.0, want);

--- a/src/wkt/tests/message_with_i32.rs
+++ b/src/wkt/tests/message_with_i32.rs
@@ -55,6 +55,7 @@ mod test {
     #[test_case(MessageWithI32::new().set_map_key([(0_i32, "")]), json!({"mapKey": {"0": ""}}))]
     #[test_case(MessageWithI32::new().set_map_key_value([(0_i32, 0_i32);0]), json!({}))]
     #[test_case(MessageWithI32::new().set_map_key_value([(0_i32, 0_i32)]), json!({"mapKeyValue": {"0": 0}}))]
+    #[test_case(MessageWithI32::new().set_map_key_value([(0_i32, 0_i32)]), json!({"map_key_value": {"0": 0}}))]
     fn test_de(want: MessageWithI32, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithI32>(input)?;
         assert_eq!(got.0, want);

--- a/src/wkt/tests/message_with_i64.rs
+++ b/src/wkt/tests/message_with_i64.rs
@@ -55,6 +55,7 @@ mod test {
     #[test_case(MessageWithI64::new().set_map_key([(0_i64, "")]), json!({"mapKey": {"0": ""}}))]
     #[test_case(MessageWithI64::new().set_map_key_value([(0_i64, 0_i64);0]), json!({}))]
     #[test_case(MessageWithI64::new().set_map_key_value([(0_i64, 0_i64)]), json!({"mapKeyValue": {"0": "0"}}))]
+    #[test_case(MessageWithI64::new().set_map_key_value([(0_i64, 0_i64)]), json!({"map_key_value": {"0": "0"}}))]
     fn test_de(want: MessageWithI64, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithI64>(input)?;
         assert_eq!(got.0, want);

--- a/src/wkt/tests/message_with_string.rs
+++ b/src/wkt/tests/message_with_string.rs
@@ -41,6 +41,7 @@ mod test {
     #[test_case(MessageWithString::new().set_or_clear_optional(None::<String>), json!({}))]
     #[test_case(MessageWithString::new().set_repeated(["a", "b", "c"]), json!({"repeated": ["a", "b", "c"]}))]
     #[test_case(MessageWithString::new().set_map_key_value([("a", "1"), ("b", "2")]), json!({"mapKeyValue": {"a": "1", "b": "2"}}))]
+    #[test_case(MessageWithString::new().set_map_key_value([("a", "1"), ("b", "2")]), json!({"map_key_value": {"a": "1", "b": "2"}}))]
     fn test_de(want: MessageWithString, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithString>(input)?;
         assert_eq!(got.0, want);

--- a/src/wkt/tests/message_with_u32.rs
+++ b/src/wkt/tests/message_with_u32.rs
@@ -54,6 +54,7 @@ mod test {
     #[test_case(MessageWithU32::new().set_map_key([(0_u32, "")]), json!({"mapKey": {"0": ""}}))]
     #[test_case(MessageWithU32::new().set_map_key_value([(0_u32, 0_u32);0]), json!({}))]
     #[test_case(MessageWithU32::new().set_map_key_value([(0_u32, 0_u32)]), json!({"mapKeyValue": {"0": 0}}))]
+    #[test_case(MessageWithU32::new().set_map_key_value([(0_u32, 0_u32)]), json!({"map_key_value": {"0": 0}}))]
     fn test_de(want: MessageWithU32, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithU32>(input)?;
         assert_eq!(got.0, want);

--- a/src/wkt/tests/message_with_u64.rs
+++ b/src/wkt/tests/message_with_u64.rs
@@ -55,6 +55,7 @@ mod test {
     #[test_case(MessageWithU64::new().set_map_key([(0_u64, "")]), json!({"mapKey": {"0": ""}}))]
     #[test_case(MessageWithU64::new().set_map_key_value([(0_u64, 0_u64);0]), json!({}))]
     #[test_case(MessageWithU64::new().set_map_key_value([(0_u64, 0_u64)]), json!({"mapKeyValue": {"0": "0"}}))]
+    #[test_case(MessageWithU64::new().set_map_key_value([(0_u64, 0_u64)]), json!({"map_key_value": {"0": "0"}}))]
     fn test_de(want: MessageWithU64, input: Value) -> Result {
         let got = serde_json::from_value::<__MessageWithU64>(input)?;
         assert_eq!(got.0, want);


### PR DESCRIPTION
ProtoJSON allows deserialization from the original field name as well as
the "JSONName".

Part of the work for #2376
