### PR TITLE
impl(generator): deserialize `null` as default

### DIFF
--- a/generator/internal/rust/templates/common/deser_plain_message_field.mustache
+++ b/generator/internal/rust/templates/common/deser_plain_message_field.mustache
@@ -17,26 +17,19 @@ limitations under the License.
 {{#Singular}}
 {{! First deal with all the fields that are not part of a oneof }}
 {{^IsOneOf}}
-{{^Codec.IsWktNullValue}}
+{{#Optional}}
 result.{{Codec.FieldName}} = map.next_value::<{{{Codec.FieldType}}}>()?
+    {{#Codec.IsWktNullValue}}
+    .or(Some(wkt::NullValue))
+    {{/Codec.IsWktNullValue}}
     {{#Codec.IsWktValue}}
-    {{! If Codec.IsWktValue, then the field is always optional, as it is a message }}
     .or(Some(wkt::Value::Null))
     {{/Codec.IsWktValue}}
     ;
-{{/Codec.IsWktNullValue}}
-{{#Codec.IsWktNullValue}}
-{{#Optional}}
-result.{{Codec.FieldName}} = map.next_value::<{{{Codec.FieldType}}}>()?.or(Some(wkt::NullValue));
 {{/Optional}}
 {{^Optional}}
-result.{{Codec.FieldName}} =
-    map.next_value::<std::option::Option<
-        {{{Codec.PrimitiveFieldType}}}
-    >>()?
-    .unwrap_or_default();
+result.{{Codec.FieldName}} = map.next_value::<std::option::Option<{{{Codec.FieldType}}}>>()?.unwrap_or_default();
 {{/Optional}}
-{{/Codec.IsWktNullValue}}
 {{/IsOneOf}}
 {{#IsOneOf}}
 if result.{{Group.Codec.FieldName}}.is_some() {
@@ -44,15 +37,15 @@ if result.{{Group.Codec.FieldName}}.is_some() {
 }
 result.{{Group.Codec.FieldName}} = std::option::Option::Some(
     {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-        map.next_value::<{{{Codec.FieldType}}}>()?
+        map.next_value::<std::option::Option<{{{Codec.FieldType}}}>>()?.unwrap_or_default()
     ),
 );
 {{/IsOneOf}}
 {{/Singular}}
 {{! repeated and map fields are never part of a oneof }}
 {{#Repeated}}
-result.{{Codec.FieldName}} = map.next_value::<{{{Codec.FieldType}}}>()?;
+result.{{Codec.FieldName}} = map.next_value::<std::option::Option<{{{Codec.FieldType}}}>>()?.unwrap_or_default();
 {{/Repeated}}
 {{#Map}}
-result.{{Codec.FieldName}} = map.next_value::<{{{Codec.FieldType}}}>()?;
+result.{{Codec.FieldName}} = map.next_value::<std::option::Option<{{{Codec.FieldType}}}>>()?.unwrap_or_default();
 {{/Map}}

--- a/generator/internal/rust/templates/common/deser_with_message_field.mustache
+++ b/generator/internal/rust/templates/common/deser_with_message_field.mustache
@@ -43,13 +43,13 @@ result.{{Codec.FieldName}} = map.next_value::< __With >()?.0.unwrap_or_default()
 {{/Optional}}
 {{/IsOneOf}}
 {{#IsOneOf}}
-struct __With( {{{Codec.FieldType}}} );
+struct __With( std::option::Option<{{{Codec.FieldType}}}> );
 impl<'de> serde::de::Deserialize<'de> for __With {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::de::Deserializer<'de>,
     {
-        serde_with::As::< {{{Codec.SerdeAs}}} >::deserialize(deserializer).map(__With)
+        serde_with::As::< std::option::Option<{{{Codec.SerdeAs}}}> >::deserialize(deserializer).map(__With)
     }
 }
 if result.{{Group.Codec.FieldName}}.is_some() {
@@ -57,7 +57,7 @@ if result.{{Group.Codec.FieldName}}.is_some() {
 }
 result.{{Group.Codec.FieldName}} = std::option::Option::Some(
     {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-        map.next_value::<__With>()?.0,
+        map.next_value::<__With>()?.0.unwrap_or_default()
     ),
 );
 {{/IsOneOf}}

--- a/src/wkt/tests/common/src/generated/mod.rs
+++ b/src/wkt/tests/common/src/generated/mod.rs
@@ -179,7 +179,10 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithEnum {
                                 ));
                             }
                             result.singular =
-                                map.next_value::<crate::generated::message_with_enum::TestEnum>()?;
+                                map.next_value::<std::option::Option<
+                                    crate::generated::message_with_enum::TestEnum,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__optional => {
                             if !fields.insert(__FieldTag::__optional) {
@@ -197,7 +200,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithEnum {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<crate::generated::message_with_enum::TestEnum>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<
+                                    std::vec::Vec<crate::generated::message_with_enum::TestEnum>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -205,10 +212,14 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithEnum {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<
-                                std::string::String,
-                                crate::generated::message_with_enum::TestEnum,
-                            >>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        crate::generated::message_with_enum::TestEnum,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -772,7 +783,8 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.single_string = std::option::Option::Some(
                                 crate::generated::message_with_one_of::SingleString::StringContents(
-                                    map.next_value::<std::string::String>()?,
+                                    map.next_value::<std::option::Option<std::string::String>>()?
+                                        .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -789,7 +801,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.two_strings = std::option::Option::Some(
                                 crate::generated::message_with_one_of::TwoStrings::StringContentsOne(
-                                    map.next_value::<std::string::String>()?
+                                    map.next_value::<std::option::Option<std::string::String>>()?.unwrap_or_default()
                                 ),
                             );
                         }
@@ -806,7 +818,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.two_strings = std::option::Option::Some(
                                 crate::generated::message_with_one_of::TwoStrings::StringContentsTwo(
-                                    map.next_value::<std::string::String>()?
+                                    map.next_value::<std::option::Option<std::string::String>>()?.unwrap_or_default()
                                 ),
                             );
                         }
@@ -823,9 +835,12 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.one_message = std::option::Option::Some(
                                 crate::generated::message_with_one_of::OneMessage::MessageValue(
-                                    map.next_value::<std::boxed::Box<
-                                        crate::generated::message_with_one_of::Message,
-                                    >>()?,
+                                    map.next_value::<std::option::Option<
+                                        std::boxed::Box<
+                                            crate::generated::message_with_one_of::Message,
+                                        >,
+                                    >>()?
+                                    .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -842,9 +857,12 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.mixed = std::option::Option::Some(
                                 crate::generated::message_with_one_of::Mixed::AnotherMessage(
-                                    map.next_value::<std::boxed::Box<
-                                        crate::generated::message_with_one_of::Message,
-                                    >>()?,
+                                    map.next_value::<std::option::Option<
+                                        std::boxed::Box<
+                                            crate::generated::message_with_one_of::Message,
+                                        >,
+                                    >>()?
+                                    .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -861,7 +879,8 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.mixed = std::option::Option::Some(
                                 crate::generated::message_with_one_of::Mixed::String(
-                                    map.next_value::<std::string::String>()?,
+                                    map.next_value::<std::option::Option<std::string::String>>()?
+                                        .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -878,7 +897,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithOneOf {
                             }
                             result.mixed = std::option::Option::Some(
                                 crate::generated::message_with_one_of::Mixed::Duration(
-                                    map.next_value::<std::boxed::Box<wkt::Duration>>()?,
+                                    map.next_value::<std::option::Option<std::boxed::Box<wkt::Duration>>>()?.unwrap_or_default()
                                 ),
                             );
                         }
@@ -1037,7 +1056,9 @@ pub mod message_with_one_of {
                                         "multiple values for parent",
                                     ));
                                 }
-                                result.parent = map.next_value::<std::string::String>()?;
+                                result.parent = map
+                                    .next_value::<std::option::Option<std::string::String>>()?
+                                    .unwrap_or_default();
                             }
                             __FieldTag::Unknown(key) => {
                                 let value = map.next_value::<serde_json::Value>()?;
@@ -1564,7 +1585,8 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Null(
-                                    map.next_value::<wkt::NullValue>()?,
+                                    map.next_value::<std::option::Option<wkt::NullValue>>()?
+                                        .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1581,7 +1603,8 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::BoolValue(
-                                    map.next_value::<bool>()?,
+                                    map.next_value::<std::option::Option<bool>>()?
+                                        .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1591,7 +1614,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                     "multiple values for bytes_value",
                                 ));
                             }
-                            struct __With(::bytes::Bytes);
+                            struct __With(std::option::Option<::bytes::Bytes>);
                             impl<'de> serde::de::Deserialize<'de> for __With {
                                 fn deserialize<D>(
                                     deserializer: D,
@@ -1599,10 +1622,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                 where
                                     D: serde::de::Deserializer<'de>,
                                 {
-                                    serde_with::As::<serde_with::base64::Base64>::deserialize(
-                                        deserializer,
-                                    )
-                                    .map(__With)
+                                    serde_with::As::< std::option::Option<serde_with::base64::Base64> >::deserialize(deserializer).map(__With)
                                 }
                             }
                             if result.complex.is_some() {
@@ -1612,7 +1632,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::BytesValue(
-                                    map.next_value::<__With>()?.0,
+                                    map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1629,7 +1649,8 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::StringValue(
-                                    map.next_value::<std::string::String>()?,
+                                    map.next_value::<std::option::Option<std::string::String>>()?
+                                        .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1639,7 +1660,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                     "multiple values for float_value",
                                 ));
                             }
-                            struct __With(f32);
+                            struct __With(std::option::Option<f32>);
                             impl<'de> serde::de::Deserialize<'de> for __With {
                                 fn deserialize<D>(
                                     deserializer: D,
@@ -1647,8 +1668,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                 where
                                     D: serde::de::Deserializer<'de>,
                                 {
-                                    serde_with::As::<wkt::internal::F32>::deserialize(deserializer)
-                                        .map(__With)
+                                    serde_with::As::< std::option::Option<wkt::internal::F32> >::deserialize(deserializer).map(__With)
                                 }
                             }
                             if result.complex.is_some() {
@@ -1658,7 +1678,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::FloatValue(
-                                    map.next_value::<__With>()?.0,
+                                    map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1668,7 +1688,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                     "multiple values for double_value",
                                 ));
                             }
-                            struct __With(f64);
+                            struct __With(std::option::Option<f64>);
                             impl<'de> serde::de::Deserialize<'de> for __With {
                                 fn deserialize<D>(
                                     deserializer: D,
@@ -1676,8 +1696,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                 where
                                     D: serde::de::Deserializer<'de>,
                                 {
-                                    serde_with::As::<wkt::internal::F64>::deserialize(deserializer)
-                                        .map(__With)
+                                    serde_with::As::< std::option::Option<wkt::internal::F64> >::deserialize(deserializer).map(__With)
                                 }
                             }
                             if result.complex.is_some() {
@@ -1687,7 +1706,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::DoubleValue(
-                                    map.next_value::<__With>()?.0,
+                                    map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1697,7 +1716,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                     "multiple values for int",
                                 ));
                             }
-                            struct __With(i32);
+                            struct __With(std::option::Option<i32>);
                             impl<'de> serde::de::Deserialize<'de> for __With {
                                 fn deserialize<D>(
                                     deserializer: D,
@@ -1705,8 +1724,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                 where
                                     D: serde::de::Deserializer<'de>,
                                 {
-                                    serde_with::As::<wkt::internal::I32>::deserialize(deserializer)
-                                        .map(__With)
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
                                 }
                             }
                             if result.complex.is_some() {
@@ -1716,7 +1734,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Int(
-                                    map.next_value::<__With>()?.0,
+                                    map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1726,7 +1744,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                     "multiple values for long",
                                 ));
                             }
-                            struct __With(i64);
+                            struct __With(std::option::Option<i64>);
                             impl<'de> serde::de::Deserialize<'de> for __With {
                                 fn deserialize<D>(
                                     deserializer: D,
@@ -1734,8 +1752,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                                 where
                                     D: serde::de::Deserializer<'de>,
                                 {
-                                    serde_with::As::<wkt::internal::I64>::deserialize(deserializer)
-                                        .map(__With)
+                                    serde_with::As::< std::option::Option<wkt::internal::I64> >::deserialize(deserializer).map(__With)
                                 }
                             }
                             if result.complex.is_some() {
@@ -1745,7 +1762,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Long(
-                                    map.next_value::<__With>()?.0,
+                                    map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1762,7 +1779,10 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Enum(
-                                    map.next_value::<crate::generated::message_with_complex_one_of::TestEnum>()?
+                                    map.next_value::<std::option::Option<
+                                        crate::generated::message_with_complex_one_of::TestEnum,
+                                    >>()?
+                                    .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1779,9 +1799,12 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Inner(
-                                    map.next_value::<std::boxed::Box<
-                                        crate::generated::message_with_complex_one_of::Inner,
-                                    >>()?,
+                                    map.next_value::<std::option::Option<
+                                        std::boxed::Box<
+                                            crate::generated::message_with_complex_one_of::Inner,
+                                        >,
+                                    >>()?
+                                    .unwrap_or_default(),
                                 ),
                             );
                         }
@@ -1798,7 +1821,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Duration(
-                                    map.next_value::<std::boxed::Box<wkt::Duration>>()?,
+                                    map.next_value::<std::option::Option<std::boxed::Box<wkt::Duration>>>()?.unwrap_or_default()
                                 ),
                             );
                         }
@@ -1815,7 +1838,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithComplexOneOf {
                             }
                             result.complex = std::option::Option::Some(
                                 crate::generated::message_with_complex_one_of::Complex::Value(
-                                    map.next_value::<std::boxed::Box<wkt::Value>>()?,
+                                    map.next_value::<std::option::Option<std::boxed::Box<wkt::Value>>>()?.unwrap_or_default()
                                 ),
                             );
                         }
@@ -2039,8 +2062,7 @@ pub mod message_with_complex_one_of {
                                         "multiple values for strings",
                                     ));
                                 }
-                                result.strings =
-                                    map.next_value::<std::vec::Vec<std::string::String>>()?;
+                                result.strings = map.next_value::<std::option::Option<std::vec::Vec<std::string::String>>>()?.unwrap_or_default();
                             }
                             __FieldTag::Unknown(key) => {
                                 let value = map.next_value::<serde_json::Value>()?;
@@ -5226,7 +5248,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithBool {
                                     "multiple values for singular",
                                 ));
                             }
-                            result.singular = map.next_value::<bool>()?;
+                            result.singular = map
+                                .next_value::<std::option::Option<bool>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__optional => {
                             if !fields.insert(__FieldTag::__optional) {
@@ -5242,7 +5266,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithBool {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<bool>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<bool>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map_value => {
                             if !fields.insert(__FieldTag::__map_value) {
@@ -5251,8 +5277,10 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithBool {
                                 ));
                             }
                             result.map_value = map
-                                .next_value::<std::collections::HashMap<std::string::String, bool>>(
-                                )?;
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, bool>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map_key => {
                             if !fields.insert(__FieldTag::__map_key) {
@@ -5583,7 +5611,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithString {
                                     "multiple values for singular",
                                 ));
                             }
-                            result.singular = map.next_value::<std::string::String>()?;
+                            result.singular = map
+                                .next_value::<std::option::Option<std::string::String>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__optional => {
                             if !fields.insert(__FieldTag::__optional) {
@@ -5600,8 +5630,7 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithString {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated =
-                                map.next_value::<std::vec::Vec<std::string::String>>()?;
+                            result.repeated = map.next_value::<std::option::Option<std::vec::Vec<std::string::String>>>()?.unwrap_or_default();
                         }
                         __FieldTag::__map_value => {
                             if !fields.insert(__FieldTag::__map_value) {
@@ -5671,10 +5700,14 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithString {
                                     "multiple values for map_key_value",
                                 ));
                             }
-                            result.map_key_value = map.next_value::<std::collections::HashMap<
-                                std::string::String,
-                                std::string::String,
-                            >>()?;
+                            result.map_key_value = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        std::string::String,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -5937,7 +5970,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithRecursion {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<crate::generated::message_with_recursion::Level0>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<
+                                    std::vec::Vec<crate::generated::message_with_recursion::Level0>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -5945,10 +5982,14 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithRecursion {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<
-                                std::string::String,
-                                crate::generated::message_with_recursion::Level0,
-                            >>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        crate::generated::message_with_recursion::Level0,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -6426,7 +6467,9 @@ pub mod message_with_recursion {
                                         "multiple values for value",
                                     ));
                                 }
-                                result.value = map.next_value::<std::string::String>()?;
+                                result.value = map
+                                    .next_value::<std::option::Option<std::string::String>>()?
+                                    .unwrap_or_default();
                             }
                             __FieldTag::Unknown(key) => {
                                 let value = map.next_value::<serde_json::Value>()?;
@@ -6652,7 +6695,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithValue {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<wkt::Value>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Value>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -6660,7 +6705,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithValue {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<std::string::String,wkt::Value>>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, wkt::Value>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -6892,7 +6941,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithStruct {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<wkt::Struct>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Struct>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -6900,7 +6951,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithStruct {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<std::string::String,wkt::Struct>>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, wkt::Struct>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -7132,7 +7187,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithListValue {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<wkt::ListValue>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::ListValue>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -7140,7 +7197,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithListValue {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<std::string::String,wkt::ListValue>>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, wkt::ListValue>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -7363,7 +7424,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithNullValue {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<wkt::NullValue>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::NullValue>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -7371,7 +7434,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithNullValue {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<std::string::String,wkt::NullValue>>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, wkt::NullValue>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -7603,7 +7670,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithFieldMask {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<wkt::FieldMask>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::FieldMask>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -7611,7 +7680,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithFieldMask {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<std::string::String,wkt::FieldMask>>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, wkt::FieldMask>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -9802,7 +9875,9 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithBoolValue {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated = map.next_value::<std::vec::Vec<wkt::BoolValue>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::BoolValue>>>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -9810,7 +9885,11 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithBoolValue {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map = map.next_value::<std::collections::HashMap<std::string::String,wkt::BoolValue>>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<std::string::String, wkt::BoolValue>,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;
@@ -10006,8 +10085,10 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithStringValue {
                                     "multiple values for repeated",
                                 ));
                             }
-                            result.repeated =
-                                map.next_value::<std::vec::Vec<wkt::StringValue>>()?;
+                            result.repeated = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::StringValue>>>(
+                                )?
+                                .unwrap_or_default();
                         }
                         __FieldTag::__map => {
                             if !fields.insert(__FieldTag::__map) {
@@ -10015,11 +10096,14 @@ impl<'de> serde::de::Deserialize<'de> for __MessageWithStringValue {
                                     "multiple values for map",
                                 ));
                             }
-                            result.map =
-                                map.next_value::<std::collections::HashMap<
-                                    std::string::String,
-                                    wkt::StringValue,
-                                >>()?;
+                            result.map = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        wkt::StringValue,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;

--- a/src/wkt/tests/complex_oneofs.rs
+++ b/src/wkt/tests/complex_oneofs.rs
@@ -99,6 +99,24 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"null":         null}"#, MessageWithComplexOneOf::new().set_null(wkt::NullValue))]
+    #[test_case(r#"{"bool_value":   null}"#, MessageWithComplexOneOf::new().set_bool_value(false))]
+    #[test_case(r#"{"bytes_value":  null}"#, MessageWithComplexOneOf::new().set_bytes_value(""))]
+    #[test_case(r#"{"string_value": null}"#, MessageWithComplexOneOf::new().set_string_value(""))]
+    #[test_case(r#"{"float_value":  null}"#, MessageWithComplexOneOf::new().set_float_value(0_f32))]
+    #[test_case(r#"{"double_value": null}"#, MessageWithComplexOneOf::new().set_double_value(0_f64))]
+    #[test_case(r#"{"int":          null}"#, MessageWithComplexOneOf::new().set_int(0))]
+    #[test_case(r#"{"long":         null}"#, MessageWithComplexOneOf::new().set_long(0_i64))]
+    #[test_case(r#"{"enum":         null}"#, MessageWithComplexOneOf::new().set_enum(TestEnum::default()))]
+    #[test_case(r#"{"inner":        null}"#, MessageWithComplexOneOf::new().set_inner(Inner::default()))]
+    #[test_case(r#"{"duration":     null}"#, MessageWithComplexOneOf::new().set_duration(Duration::default()))]
+    // wkt::Value is special #[test_case(r#"{"value": null}"#, MessageWithComplexOneOf::new().set_value(/* no default */))]
+    fn test_null_is_default(input: &str, want: MessageWithComplexOneOf) -> Result {
+        let got = serde_json::from_str::<__MessageWithComplexOneOf>(input)?;
+        assert_eq!(got.0, want);
+        Ok(())
+    }
+
     #[test_case(r#"{"null":        null,         "null":        null}"#)]
     #[test_case(r#"{"null":        null,         "boolValue":   true}"#)]
     #[test_case(r#"{"boolValue":   true,         "boolValue":   true}"#)]

--- a/src/wkt/tests/message_with_bool.rs
+++ b/src/wkt/tests/message_with_bool.rs
@@ -59,6 +59,18 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":      null}"#)]
+    #[test_case(r#"{"optional":      null}"#)]
+    #[test_case(r#"{"repeated":      null}"#)]
+    #[test_case(r#"{"map_key":       null}"#)]
+    #[test_case(r#"{"map_value":     null}"#)]
+    #[test_case(r#"{"map_key_value": null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithBool>(input)?;
+        assert_eq!(got.0, MessageWithBool::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular":    true,  "singular":      true}"#)]
     #[test_case(r#"{"optional":    false, "optional":      false}"#)]
     #[test_case(r#"{"repeated":    [],    "repeated":      []}"#)]

--- a/src/wkt/tests/message_with_bytes.rs
+++ b/src/wkt/tests/message_with_bytes.rs
@@ -55,6 +55,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular": null}"#)]
+    #[test_case(r#"{"optional": null}"#)]
+    #[test_case(r#"{"repeated": null}"#)]
+    #[test_case(r#"{"map":       null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithBytes>(input)?;
+        assert_eq!(got.0, MessageWithBytes::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": "", "singular": ""}"#)]
     #[test_case(r#"{"optional": "", "optional": ""}"#)]
     #[test_case(r#"{"repeated": [], "repeated": []}"#)]

--- a/src/wkt/tests/message_with_enum.rs
+++ b/src/wkt/tests/message_with_enum.rs
@@ -47,6 +47,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":  null}"#)]
+    #[test_case(r#"{"optional":  null}"#)]
+    #[test_case(r#"{"repeated":  null}"#)]
+    #[test_case(r#"{"map":       null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithEnum>(input)?;
+        assert_eq!(got.0, MessageWithEnum::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": 0,  "singular": 0}"#)]
     #[test_case(r#"{"optional": 0,  "optional": 0}"#)]
     #[test_case(r#"{"repeated": [], "repeated": []}"#)]

--- a/src/wkt/tests/message_with_f32.rs
+++ b/src/wkt/tests/message_with_f32.rs
@@ -88,6 +88,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":  null}"#)]
+    #[test_case(r#"{"optional":  null}"#)]
+    #[test_case(r#"{"repeated":  null}"#)]
+    #[test_case(r#"{"map":       null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithF32>(input)?;
+        assert_eq!(got.0, MessageWithF32::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": 0,  "singular": 0}"#)]
     #[test_case(r#"{"optional": 0,  "optional": 0}"#)]
     #[test_case(r#"{"repeated": [], "repeated": []}"#)]

--- a/src/wkt/tests/message_with_f64.rs
+++ b/src/wkt/tests/message_with_f64.rs
@@ -88,6 +88,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":  null}"#)]
+    #[test_case(r#"{"optional":  null}"#)]
+    #[test_case(r#"{"repeated":  null}"#)]
+    #[test_case(r#"{"map":       null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithF64>(input)?;
+        assert_eq!(got.0, MessageWithF64::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": 0,  "singular": 0}"#)]
     #[test_case(r#"{"optional": 0,  "optional": 0}"#)]
     #[test_case(r#"{"repeated": [], "repeated": []}"#)]

--- a/src/wkt/tests/message_with_field_mask.rs
+++ b/src/wkt/tests/message_with_field_mask.rs
@@ -50,6 +50,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":  null}"#)]
+    #[test_case(r#"{"optional":  null}"#)]
+    #[test_case(r#"{"repeated":  null}"#)]
+    #[test_case(r#"{"map":       null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithFieldMask>(input)?;
+        assert_eq!(got.0, MessageWithFieldMask::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": "a,b,c", "singular": "a,b,c"}"#)]
     #[test_case(r#"{"optional": "a,b,c", "optional": "a,b,c"}"#)]
     #[test_case(r#"{"repeated": [],      "repeated": []}"#)]

--- a/src/wkt/tests/message_with_i32.rs
+++ b/src/wkt/tests/message_with_i32.rs
@@ -62,6 +62,18 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":      null}"#)]
+    #[test_case(r#"{"optional":      null}"#)]
+    #[test_case(r#"{"repeated":      null}"#)]
+    #[test_case(r#"{"map_key":       null}"#)]
+    #[test_case(r#"{"map_value":     null}"#)]
+    #[test_case(r#"{"map_key_value": null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithI32>(input)?;
+        assert_eq!(got.0, MessageWithI32::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular":    0,  "singular":      0}"#)]
     #[test_case(r#"{"optional":    0,  "optional":      0}"#)]
     #[test_case(r#"{"repeated":    [], "repeated":      []}"#)]

--- a/src/wkt/tests/message_with_i64.rs
+++ b/src/wkt/tests/message_with_i64.rs
@@ -62,6 +62,18 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":      null}"#)]
+    #[test_case(r#"{"optional":      null}"#)]
+    #[test_case(r#"{"repeated":      null}"#)]
+    #[test_case(r#"{"map_key":       null}"#)]
+    #[test_case(r#"{"map_value":     null}"#)]
+    #[test_case(r#"{"map_key_value": null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithI64>(input)?;
+        assert_eq!(got.0, MessageWithI64::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular":    0,  "singular":      0}"#)]
     #[test_case(r#"{"optional":    0,  "optional":      0}"#)]
     #[test_case(r#"{"repeated":    [], "repeated":      []}"#)]

--- a/src/wkt/tests/message_with_null_value.rs
+++ b/src/wkt/tests/message_with_null_value.rs
@@ -42,6 +42,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular": null}"#)]
+    // This is special: #[test_case(r#"{"optional": null}"#)]
+    #[test_case(r#"{"repeated": null}"#)]
+    #[test_case(r#"{"map":      null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithNullValue>(input)?;
+        assert_eq!(got.0, MessageWithNullValue::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": null, "singular": null}"#)]
     #[test_case(r#"{"optional": null, "optional": null}"#)]
     #[test_case(r#"{"repeated": [],   "repeated": []}"#)]

--- a/src/wkt/tests/message_with_recursion.rs
+++ b/src/wkt/tests/message_with_recursion.rs
@@ -52,6 +52,16 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":  null}"#)]
+    #[test_case(r#"{"optional":  null}"#)]
+    #[test_case(r#"{"repeated":  null}"#)]
+    #[test_case(r#"{"map":       null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithRecursion>(input)?;
+        assert_eq!(got.0, MessageWithRecursion::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": {}, "singular": {}}"#)]
     #[test_case(r#"{"optional": {}, "optional": {}}"#)]
     #[test_case(r#"{"repeated": [], "repeated": []}"#)]

--- a/src/wkt/tests/message_with_string.rs
+++ b/src/wkt/tests/message_with_string.rs
@@ -48,6 +48,18 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":      null}"#)]
+    #[test_case(r#"{"optional":      null}"#)]
+    #[test_case(r#"{"repeated":      null}"#)]
+    #[test_case(r#"{"map_key":       null}"#)]
+    #[test_case(r#"{"map_value":     null}"#)]
+    #[test_case(r#"{"map_key_value": null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithString>(input)?;
+        assert_eq!(got.0, MessageWithString::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular":    "", "singular":      ""}"#)]
     #[test_case(r#"{"optional":    "", "optional":      ""}"#)]
     #[test_case(r#"{"repeated":    [], "repeated":      []}"#)]

--- a/src/wkt/tests/message_with_u32.rs
+++ b/src/wkt/tests/message_with_u32.rs
@@ -61,6 +61,18 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":      null}"#)]
+    #[test_case(r#"{"optional":      null}"#)]
+    #[test_case(r#"{"repeated":      null}"#)]
+    #[test_case(r#"{"map_key":       null}"#)]
+    #[test_case(r#"{"map_value":     null}"#)]
+    #[test_case(r#"{"map_key_value": null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithU32>(input)?;
+        assert_eq!(got.0, MessageWithU32::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular":    0,  "singular":      0}"#)]
     #[test_case(r#"{"optional":    0,  "optional":      0}"#)]
     #[test_case(r#"{"repeated":    [], "repeated":      []}"#)]

--- a/src/wkt/tests/message_with_u64.rs
+++ b/src/wkt/tests/message_with_u64.rs
@@ -62,6 +62,18 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"singular":      null}"#)]
+    #[test_case(r#"{"optional":      null}"#)]
+    #[test_case(r#"{"repeated":      null}"#)]
+    #[test_case(r#"{"map_key":       null}"#)]
+    #[test_case(r#"{"map_value":     null}"#)]
+    #[test_case(r#"{"map_key_value": null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithU64>(input)?;
+        assert_eq!(got.0, MessageWithU64::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular":    0,  "singular":      0}"#)]
     #[test_case(r#"{"optional":    0,  "optional":      0}"#)]
     #[test_case(r#"{"repeated":    [], "repeated":      []}"#)]

--- a/src/wkt/tests/message_with_value.rs
+++ b/src/wkt/tests/message_with_value.rs
@@ -54,6 +54,17 @@ mod test {
         Ok(())
     }
 
+    // This type handles null in a weird way
+    //    #[test_case(r#"{"singular": null}"#)]
+    //    #[test_case(r#"{"optional": null}"#)]
+    #[test_case(r#"{"repeated": null}"#)]
+    #[test_case(r#"{"map":      null}"#)]
+    fn test_null_is_default(input: &str) -> Result {
+        let got = serde_json::from_str::<__MessageWithValue>(input)?;
+        assert_eq!(got.0, MessageWithValue::default());
+        Ok(())
+    }
+
     #[test_case(r#"{"singular": "abc", "singular": "abc"}"#)]
     #[test_case(r#"{"optional": "abc", "optional": "abc"}"#)]
     #[test_case(r#"{"repeated": [],    "repeated": []}"#)]

--- a/src/wkt/tests/oneofs.rs
+++ b/src/wkt/tests/oneofs.rs
@@ -58,6 +58,19 @@ mod test {
         Ok(())
     }
 
+    #[test_case(r#"{"string_contents":      null}"#, MessageWithOneOf::new().set_string_contents(""))]
+    #[test_case(r#"{"string_contents_one":  null}"#, MessageWithOneOf::new().set_string_contents_one(""))]
+    #[test_case(r#"{"string_contents_two":  null}"#, MessageWithOneOf::new().set_string_contents_two(""))]
+    #[test_case(r#"{"message_value":        null}"#, MessageWithOneOf::new().set_message_value(Message::default()))]
+    #[test_case(r#"{"another_message":      null}"#, MessageWithOneOf::new().set_another_message(Message::default()))]
+    #[test_case(r#"{"string":               null}"#, MessageWithOneOf::new().set_string(""))]
+    #[test_case(r#"{"duration":             null}"#, MessageWithOneOf::new().set_duration(Duration::default()))]
+    fn test_null_is_default(input: &str, want: MessageWithOneOf) -> Result {
+        let got = serde_json::from_str::<__MessageWithOneOf>(input)?;
+        assert_eq!(got.0, want);
+        Ok(())
+    }
+
     #[test_case(json!({"stringContentsOne": "abc", "stringContentsTwo": "cde"}))]
     #[test_case(json!({"stringContentsTwo": "abc", "stringContentsOne": "cde"}))]
     #[test_case(json!({"anotherMessage": {}, "string": "cde"}))]


### PR DESCRIPTION
For most types, `null` deserializes as the default value. For optional fields
that is `None`. The exception are `wkt::NullValue` and `wkt::Value`.

Part of the work for #2376
