### PR TITLE
test: use generated serde for protojson conformance

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -237,10 +237,10 @@ jobs:
         env:
           USE_BAZEL_VERSION: '8.2.1'
         run: |
-           bazelisk run --enable_bzlmod -- \
-                //conformance:conformance_test_runner \
-                --failure_list ${GITHUB_WORKSPACE}/main/src/protojson-conformance/expected_failures.txt \
-                ${GITHUB_WORKSPACE}/main/target/debug/protojson-conformance
+          bazelisk run --enable_bzlmod -- \
+               //conformance:conformance_test_runner \
+               --failure_list ${GITHUB_WORKSPACE}/main/src/protojson-conformance/expected_failures.txt \
+               ${GITHUB_WORKSPACE}/main/target/debug/protojson-conformance
 
   docs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -200,6 +200,48 @@ jobs:
       - run: |
           cargo test --features run-showcase-tests -p integration-tests
 
+  protojson-conformance:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        rust-version: ['rust:current']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'protocolbuffers/protobuf'
+          ref: '31.x'
+          path: 'protobuf'
+      - uses: actions/checkout@v4
+        with:
+          path: 'main'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('main/Cargo.lock', 'main/.github/workflows/sdk.yaml') }}
+      - name: Setup Rust ${{ matrix.rust-version }}
+        run: |
+          set -e
+          rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+      - name: Display Cargo version
+        run: cargo version
+      - name: Display rustc version
+        run: rustup show active-toolchain -v
+      - name: Build conformance testee
+        working-directory: main
+        run: |
+          cargo build -p protojson-conformance
+      - name: Run conformance test
+        working-directory: protobuf
+        env:
+          USE_BAZEL_VERSION: '8.2.1'
+        run: |
+           bazelisk run --enable_bzlmod -- \
+                //conformance:conformance_test_runner \
+                --failure_list ${GITHUB_WORKSPACE}/main/src/protojson-conformance/expected_failures.txt \
+                ${GITHUB_WORKSPACE}/main/target/debug/protojson-conformance
+
   docs:
     runs-on: ubuntu-24.04
     strategy:

--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -420,6 +420,10 @@ type Message struct {
 	Codec any
 }
 
+func (m *Message) HasFields() bool {
+	return len(m.Fields) != 0
+}
+
 // Information related to pagination aka [AIP-4233](https://google.aip.dev/client-libraries/4233).
 type PaginationInfo struct {
 	// The field that gives us the next page token.

--- a/generator/internal/rust/templates/common/deser_field_tag.mustache
+++ b/generator/internal/rust/templates/common/deser_field_tag.mustache
@@ -49,6 +49,10 @@ impl<'de> serde::de::Deserialize<'de> for __FieldTag {
                 E: serde::de::Error,
             {
                 use std::result::Result::Ok;
+                {{^HasFields}}
+                Ok(__FieldTag::Unknown(value.to_string()))
+                {{/HasFields}}
+                {{#HasFields}}
                 match value {
                     {{#Fields}}
                     "{{JSONName}}" => Ok(__FieldTag::__{{Codec.SetterName}}),
@@ -66,6 +70,7 @@ impl<'de> serde::de::Deserialize<'de> for __FieldTag {
                     {{/Fields}}
                     _ => Ok(__FieldTag::Unknown(value.to_string())),
                 }
+                {{/HasFields}}
             }
         }
         {{! Deserialize the field tag. }}

--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -283,7 +283,9 @@ impl<'de> serde::de::Deserialize<'de> for {{Codec.Name}} {
             {
                 #[allow(unused_imports)]
                 use serde::de::Error;
+                {{#HasFields}}
                 let mut fields = std::collections::HashSet::new();
+                {{/HasFields}}
                 let mut result = Self::Value::new();
                 while let Some(tag) = map.next_key::<__FieldTag>()? {
                     #[allow(clippy::match_single_binding)]

--- a/src/protojson-conformance/Cargo.toml
+++ b/src/protojson-conformance/Cargo.toml
@@ -27,7 +27,7 @@ futures.workspace     = true
 prost.workspace       = true
 prost-types.workspace = true
 serde.workspace       = true
-serde_json            = { workspace  = true, features = ["float_roundtrip"] }
+serde_json            = { workspace = true, features = ["float_roundtrip"] }
 serde_with.workspace  = true
 tokio.workspace       = true
 # Local dependencies

--- a/src/protojson-conformance/Cargo.toml
+++ b/src/protojson-conformance/Cargo.toml
@@ -27,7 +27,7 @@ futures.workspace     = true
 prost.workspace       = true
 prost-types.workspace = true
 serde.workspace       = true
-serde_json.workspace  = true
+serde_json            = { workspace  = true, features = ["float_roundtrip"] }
 serde_with.workspace  = true
 tokio.workspace       = true
 # Local dependencies

--- a/src/protojson-conformance/README.md
+++ b/src/protojson-conformance/README.md
@@ -47,7 +47,11 @@ USE_BAZEL_VERSION=8.2.1 ./bazelisk build --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN
 Use bazelisk to compile and run the test program:
 
 ```shell
-USE_BAZEL_VERSION=8.2.1 ./bazelisk run --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1 --enable_bzlmod  //conformance:conformance_test_runner $HOME/rust-conformance/target/debug/protojson-conformance
+USE_BAZEL_VERSION=8.2.1 ./bazelisk run \
+    --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1 --enable_bzlmod  -- \
+    //conformance:conformance_test_runner \
+    --failure_list $HOME/rust-conformance/src/protojson-conformance/expected_failures.txt \
+    $HOME/rust-conformance/target/debug/protojson-conformance
 ```
 
 [protocol buffers repository]: https://github.com/protocolbuffers/protobuf/blob/main/conformance/README.md

--- a/src/protojson-conformance/expected_failures.txt
+++ b/src/protojson-conformance/expected_failures.txt
@@ -1,0 +1,22 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We believe Rust correctly accepts `t` and `z` and spaces for RFC 3339 dates.
+Required.Proto3.JsonInput.TimestampJsonInputLowercaseT # Should have failed to parse, but didn't.
+Required.Proto3.JsonInput.TimestampJsonInputLowercaseZ # Should have failed to parse, but didn't.
+Required.Proto3.JsonInput.TimestampJsonInputMissingT # Should have failed to parse, but didn't.
+
+# We reject overlapping `oneof` fields, even if set to `null`:
+Required.Proto3.JsonInput.OneofFieldNullFirst.JsonOutput # Failed to parse input or produce output.
+Required.Proto3.JsonInput.OneofFieldNullSecond.JsonOutput # Failed to parse input or produce output.

--- a/src/protojson-conformance/src/generated/test_protos/.sidekick.toml
+++ b/src/protojson-conformance/src/generated/test_protos/.sidekick.toml
@@ -21,6 +21,7 @@ roots        = 'conformance'
 include-list = 'test_messages_proto3.proto'
 
 [codec]
-copyright-year    = '2025'
-template-override = 'templates/mod'
-module-path       = 'crate::generated::test_protos'
+copyright-year        = '2025'
+template-override     = 'templates/mod'
+module-path           = 'crate::generated::test_protos'
+with-generated-serde  = 'true'

--- a/src/protojson-conformance/src/generated/test_protos/mod.rs
+++ b/src/protojson-conformance/src/generated/test_protos/mod.rs
@@ -24,633 +24,320 @@
 /// submessages of this message.  So for example, a fuzz test of TestAllTypes
 /// could trigger bugs that occur in any message type in this file.  We verify
 /// this stays true in a unit test.
-#[serde_with::serde_as]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct TestAllTypesProto3 {
     /// Singular
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub optional_int32: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I64>")]
     pub optional_int64: i64,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::U32>")]
     pub optional_uint32: u32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::U64>")]
     pub optional_uint64: u64,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub optional_sint32: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I64>")]
     pub optional_sint64: i64,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::U32>")]
     pub optional_fixed32: u32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::U64>")]
     pub optional_fixed64: u64,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub optional_sfixed32: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I64>")]
     pub optional_sfixed64: i64,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::F32>")]
     pub optional_float: f32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::F64>")]
     pub optional_double: f64,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_bool: bool,
 
-    #[serde(skip_serializing_if = "std::string::String::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_string: std::string::String,
 
-    #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<serde_with::base64::Base64>")]
     pub optional_bytes: ::bytes::Bytes,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_nested_message: std::option::Option<
         std::boxed::Box<crate::generated::test_protos::test_all_types_proto_3::NestedMessage>,
     >,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_foreign_message:
         std::option::Option<crate::generated::test_protos::ForeignMessage>,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_nested_enum: crate::generated::test_protos::test_all_types_proto_3::NestedEnum,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_foreign_enum: crate::generated::test_protos::ForeignEnum,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_aliased_enum: crate::generated::test_protos::test_all_types_proto_3::AliasedEnum,
 
-    #[serde(skip_serializing_if = "std::string::String::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_string_piece: std::string::String,
 
-    #[serde(skip_serializing_if = "std::string::String::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_cord: std::string::String,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub recursive_message:
         std::option::Option<std::boxed::Box<crate::generated::test_protos::TestAllTypesProto3>>,
 
     /// Repeated
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub repeated_int32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub repeated_int64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub repeated_uint32: std::vec::Vec<u32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub repeated_uint64: std::vec::Vec<u64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub repeated_sint32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub repeated_sint64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub repeated_fixed32: std::vec::Vec<u32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub repeated_fixed64: std::vec::Vec<u64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub repeated_sfixed32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub repeated_sfixed64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F32>>")]
     pub repeated_float: std::vec::Vec<f32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F64>>")]
     pub repeated_double: std::vec::Vec<f64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_bool: std::vec::Vec<bool>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_string: std::vec::Vec<std::string::String>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<serde_with::base64::Base64>>")]
     pub repeated_bytes: std::vec::Vec<::bytes::Bytes>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_nested_message:
         std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedMessage>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_foreign_message: std::vec::Vec<crate::generated::test_protos::ForeignMessage>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_nested_enum:
         std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_foreign_enum: std::vec::Vec<crate::generated::test_protos::ForeignEnum>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_string_piece: std::vec::Vec<std::string::String>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_cord: std::vec::Vec<std::string::String>,
 
     /// Packed
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub packed_int32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub packed_int64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub packed_uint32: std::vec::Vec<u32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub packed_uint64: std::vec::Vec<u64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub packed_sint32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub packed_sint64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub packed_fixed32: std::vec::Vec<u32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub packed_fixed64: std::vec::Vec<u64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub packed_sfixed32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub packed_sfixed64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F32>>")]
     pub packed_float: std::vec::Vec<f32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F64>>")]
     pub packed_double: std::vec::Vec<f64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub packed_bool: std::vec::Vec<bool>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub packed_nested_enum:
         std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>,
 
     /// Unpacked
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub unpacked_int32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub unpacked_int64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub unpacked_uint32: std::vec::Vec<u32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub unpacked_uint64: std::vec::Vec<u64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub unpacked_sint32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub unpacked_sint64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub unpacked_fixed32: std::vec::Vec<u32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub unpacked_fixed64: std::vec::Vec<u64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub unpacked_sfixed32: std::vec::Vec<i32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub unpacked_sfixed64: std::vec::Vec<i64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F32>>")]
     pub unpacked_float: std::vec::Vec<f32>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F64>>")]
     pub unpacked_double: std::vec::Vec<f64>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub unpacked_bool: std::vec::Vec<bool>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub unpacked_nested_enum:
         std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>,
 
     /// Map
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I32, wkt::internal::I32>>"
-    )]
     pub map_int32_int32: std::collections::HashMap<i32, i32>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>>"
-    )]
     pub map_int64_int64: std::collections::HashMap<i64, i64>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::U32, wkt::internal::U32>>"
-    )]
     pub map_uint32_uint32: std::collections::HashMap<u32, u32>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>>"
-    )]
     pub map_uint64_uint64: std::collections::HashMap<u64, u64>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I32, wkt::internal::I32>>"
-    )]
     pub map_sint32_sint32: std::collections::HashMap<i32, i32>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>>"
-    )]
     pub map_sint64_sint64: std::collections::HashMap<i64, i64>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::U32, wkt::internal::U32>>"
-    )]
     pub map_fixed32_fixed32: std::collections::HashMap<u32, u32>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>>"
-    )]
     pub map_fixed64_fixed64: std::collections::HashMap<u64, u64>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I32, wkt::internal::I32>>"
-    )]
     pub map_sfixed32_sfixed32: std::collections::HashMap<i32, i32>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>>"
-    )]
     pub map_sfixed64_sfixed64: std::collections::HashMap<i64, i64>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I32, wkt::internal::F32>>"
-    )]
     pub map_int32_float: std::collections::HashMap<i32, f32>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<wkt::internal::I32, wkt::internal::F64>>"
-    )]
     pub map_int32_double: std::collections::HashMap<i32, f64>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<serde_with::DisplayFromStr, _>>"
-    )]
     pub map_bool_bool: std::collections::HashMap<bool, bool>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub map_string_string: std::collections::HashMap<std::string::String, std::string::String>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(
-        as = "serde_with::DefaultOnNull<std::collections::HashMap<_, serde_with::base64::Base64>>"
-    )]
     pub map_string_bytes: std::collections::HashMap<std::string::String, ::bytes::Bytes>,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub map_string_nested_message: std::collections::HashMap<
         std::string::String,
         crate::generated::test_protos::test_all_types_proto_3::NestedMessage,
     >,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub map_string_foreign_message: std::collections::HashMap<
         std::string::String,
         crate::generated::test_protos::ForeignMessage,
     >,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub map_string_nested_enum: std::collections::HashMap<
         std::string::String,
         crate::generated::test_protos::test_all_types_proto_3::NestedEnum,
     >,
 
-    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub map_string_foreign_enum:
         std::collections::HashMap<std::string::String, crate::generated::test_protos::ForeignEnum>,
 
     /// Well-known types
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_bool_wrapper: std::option::Option<wkt::BoolValue>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<wkt::internal::I32>")]
     pub optional_int32_wrapper: std::option::Option<wkt::Int32Value>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<wkt::internal::I64>")]
     pub optional_int64_wrapper: std::option::Option<wkt::Int64Value>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<wkt::internal::U32>")]
     pub optional_uint32_wrapper: std::option::Option<wkt::UInt32Value>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<wkt::internal::U64>")]
     pub optional_uint64_wrapper: std::option::Option<wkt::UInt64Value>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub optional_float_wrapper: std::option::Option<wkt::FloatValue>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<wkt::internal::F64>")]
     pub optional_double_wrapper: std::option::Option<wkt::DoubleValue>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_string_wrapper: std::option::Option<wkt::StringValue>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "std::option::Option<serde_with::base64::Base64>")]
     pub optional_bytes_wrapper: std::option::Option<wkt::BytesValue>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_bool_wrapper: std::vec::Vec<wkt::BoolValue>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I32>>")]
     pub repeated_int32_wrapper: std::vec::Vec<wkt::Int32Value>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::I64>>")]
     pub repeated_int64_wrapper: std::vec::Vec<wkt::Int64Value>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U32>>")]
     pub repeated_uint32_wrapper: std::vec::Vec<wkt::UInt32Value>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::U64>>")]
     pub repeated_uint64_wrapper: std::vec::Vec<wkt::UInt64Value>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F32>>")]
     pub repeated_float_wrapper: std::vec::Vec<wkt::FloatValue>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<wkt::internal::F64>>")]
     pub repeated_double_wrapper: std::vec::Vec<wkt::DoubleValue>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_string_wrapper: std::vec::Vec<wkt::StringValue>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<serde_with::base64::Base64>>")]
     pub repeated_bytes_wrapper: std::vec::Vec<wkt::BytesValue>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_duration: std::option::Option<wkt::Duration>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_timestamp: std::option::Option<wkt::Timestamp>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_field_mask: std::option::Option<wkt::FieldMask>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_struct: std::option::Option<wkt::Struct>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub optional_any: std::option::Option<wkt::Any>,
 
-    #[serde(skip_serializing_if = "std::option::Option::is_none")]
-    #[serde_as(as = "wkt::internal::OptionalValue")]
     pub optional_value: std::option::Option<wkt::Value>,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub optional_null_value: wkt::NullValue,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_duration: std::vec::Vec<wkt::Duration>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_timestamp: std::vec::Vec<wkt::Timestamp>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_fieldmask: std::vec::Vec<wkt::FieldMask>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_struct: std::vec::Vec<wkt::Struct>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_any: std::vec::Vec<wkt::Any>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_value: std::vec::Vec<wkt::Value>,
 
-    #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
-    #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub repeated_list_value: std::vec::Vec<wkt::ListValue>,
 
     /// Test field-name-to-JSON-name convention.
     /// (protobuf says names can be any valid C/C++ identifier.)
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub fieldname1: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name2: i32,
 
-    #[serde(rename = "FieldName3")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub _field_name3: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field__name4_: i32,
 
-    #[serde(rename = "field0name5")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field0name5: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_0_name6: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_7: i32,
 
-    #[serde(rename = "FieldName8")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_8: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_9: i32,
 
-    #[serde(rename = "FieldName10")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_10: i32,
 
-    #[serde(rename = "FIELDNAME11")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_11: i32,
 
-    #[serde(rename = "FIELDName12")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_12: i32,
 
-    #[serde(rename = "FieldName13")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub __field_name13: i32,
 
-    #[serde(rename = "FieldName14")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub __field_name_14: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field__name15: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field__name_16: i32,
 
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name17__: i32,
 
-    #[serde(rename = "FieldName18")]
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub field_name_18__: i32,
 
-    #[serde(flatten, skip_serializing_if = "std::option::Option::is_none")]
     pub oneof_field:
         std::option::Option<crate::generated::test_protos::test_all_types_proto_3::OneofField>,
 
-    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
     _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
@@ -2485,25 +2172,4916 @@ impl wkt::message::Message for TestAllTypesProto3 {
     }
 }
 
+#[doc(hidden)]
+impl<'de> serde::de::Deserialize<'de> for TestAllTypesProto3 {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        #[derive(PartialEq, Eq, Hash)]
+        enum __FieldTag {
+            __optional_int32,
+            __optional_int64,
+            __optional_uint32,
+            __optional_uint64,
+            __optional_sint32,
+            __optional_sint64,
+            __optional_fixed32,
+            __optional_fixed64,
+            __optional_sfixed32,
+            __optional_sfixed64,
+            __optional_float,
+            __optional_double,
+            __optional_bool,
+            __optional_string,
+            __optional_bytes,
+            __optional_nested_message,
+            __optional_foreign_message,
+            __optional_nested_enum,
+            __optional_foreign_enum,
+            __optional_aliased_enum,
+            __optional_string_piece,
+            __optional_cord,
+            __recursive_message,
+            __repeated_int32,
+            __repeated_int64,
+            __repeated_uint32,
+            __repeated_uint64,
+            __repeated_sint32,
+            __repeated_sint64,
+            __repeated_fixed32,
+            __repeated_fixed64,
+            __repeated_sfixed32,
+            __repeated_sfixed64,
+            __repeated_float,
+            __repeated_double,
+            __repeated_bool,
+            __repeated_string,
+            __repeated_bytes,
+            __repeated_nested_message,
+            __repeated_foreign_message,
+            __repeated_nested_enum,
+            __repeated_foreign_enum,
+            __repeated_string_piece,
+            __repeated_cord,
+            __packed_int32,
+            __packed_int64,
+            __packed_uint32,
+            __packed_uint64,
+            __packed_sint32,
+            __packed_sint64,
+            __packed_fixed32,
+            __packed_fixed64,
+            __packed_sfixed32,
+            __packed_sfixed64,
+            __packed_float,
+            __packed_double,
+            __packed_bool,
+            __packed_nested_enum,
+            __unpacked_int32,
+            __unpacked_int64,
+            __unpacked_uint32,
+            __unpacked_uint64,
+            __unpacked_sint32,
+            __unpacked_sint64,
+            __unpacked_fixed32,
+            __unpacked_fixed64,
+            __unpacked_sfixed32,
+            __unpacked_sfixed64,
+            __unpacked_float,
+            __unpacked_double,
+            __unpacked_bool,
+            __unpacked_nested_enum,
+            __map_int32_int32,
+            __map_int64_int64,
+            __map_uint32_uint32,
+            __map_uint64_uint64,
+            __map_sint32_sint32,
+            __map_sint64_sint64,
+            __map_fixed32_fixed32,
+            __map_fixed64_fixed64,
+            __map_sfixed32_sfixed32,
+            __map_sfixed64_sfixed64,
+            __map_int32_float,
+            __map_int32_double,
+            __map_bool_bool,
+            __map_string_string,
+            __map_string_bytes,
+            __map_string_nested_message,
+            __map_string_foreign_message,
+            __map_string_nested_enum,
+            __map_string_foreign_enum,
+            __oneof_uint32,
+            __oneof_nested_message,
+            __oneof_string,
+            __oneof_bytes,
+            __oneof_bool,
+            __oneof_uint64,
+            __oneof_float,
+            __oneof_double,
+            __oneof_enum,
+            __oneof_null_value,
+            __optional_bool_wrapper,
+            __optional_int32_wrapper,
+            __optional_int64_wrapper,
+            __optional_uint32_wrapper,
+            __optional_uint64_wrapper,
+            __optional_float_wrapper,
+            __optional_double_wrapper,
+            __optional_string_wrapper,
+            __optional_bytes_wrapper,
+            __repeated_bool_wrapper,
+            __repeated_int32_wrapper,
+            __repeated_int64_wrapper,
+            __repeated_uint32_wrapper,
+            __repeated_uint64_wrapper,
+            __repeated_float_wrapper,
+            __repeated_double_wrapper,
+            __repeated_string_wrapper,
+            __repeated_bytes_wrapper,
+            __optional_duration,
+            __optional_timestamp,
+            __optional_field_mask,
+            __optional_struct,
+            __optional_any,
+            __optional_value,
+            __optional_null_value,
+            __repeated_duration,
+            __repeated_timestamp,
+            __repeated_fieldmask,
+            __repeated_struct,
+            __repeated_any,
+            __repeated_value,
+            __repeated_list_value,
+            __fieldname1,
+            __field_name2,
+            ___field_name3,
+            __field__name4_,
+            __field0name5,
+            __field_0_name6,
+            __field_name_7,
+            __field_name_8,
+            __field_name_9,
+            __field_name_10,
+            __field_name_11,
+            __field_name_12,
+            ____field_name13,
+            ____field_name_14,
+            __field__name15,
+            __field__name_16,
+            __field_name17__,
+            __field_name_18__,
+            Unknown(std::string::String),
+        }
+        impl<'de> serde::de::Deserialize<'de> for __FieldTag {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct Visitor;
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = __FieldTag;
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a field name for TestAllTypesProto3")
+                    }
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        use std::result::Result::Ok;
+                        match value {
+                            "optionalInt32" => Ok(__FieldTag::__optional_int32),
+                            "optional_int32" => Ok(__FieldTag::__optional_int32),
+                            "optionalInt64" => Ok(__FieldTag::__optional_int64),
+                            "optional_int64" => Ok(__FieldTag::__optional_int64),
+                            "optionalUint32" => Ok(__FieldTag::__optional_uint32),
+                            "optional_uint32" => Ok(__FieldTag::__optional_uint32),
+                            "optionalUint64" => Ok(__FieldTag::__optional_uint64),
+                            "optional_uint64" => Ok(__FieldTag::__optional_uint64),
+                            "optionalSint32" => Ok(__FieldTag::__optional_sint32),
+                            "optional_sint32" => Ok(__FieldTag::__optional_sint32),
+                            "optionalSint64" => Ok(__FieldTag::__optional_sint64),
+                            "optional_sint64" => Ok(__FieldTag::__optional_sint64),
+                            "optionalFixed32" => Ok(__FieldTag::__optional_fixed32),
+                            "optional_fixed32" => Ok(__FieldTag::__optional_fixed32),
+                            "optionalFixed64" => Ok(__FieldTag::__optional_fixed64),
+                            "optional_fixed64" => Ok(__FieldTag::__optional_fixed64),
+                            "optionalSfixed32" => Ok(__FieldTag::__optional_sfixed32),
+                            "optional_sfixed32" => Ok(__FieldTag::__optional_sfixed32),
+                            "optionalSfixed64" => Ok(__FieldTag::__optional_sfixed64),
+                            "optional_sfixed64" => Ok(__FieldTag::__optional_sfixed64),
+                            "optionalFloat" => Ok(__FieldTag::__optional_float),
+                            "optional_float" => Ok(__FieldTag::__optional_float),
+                            "optionalDouble" => Ok(__FieldTag::__optional_double),
+                            "optional_double" => Ok(__FieldTag::__optional_double),
+                            "optionalBool" => Ok(__FieldTag::__optional_bool),
+                            "optional_bool" => Ok(__FieldTag::__optional_bool),
+                            "optionalString" => Ok(__FieldTag::__optional_string),
+                            "optional_string" => Ok(__FieldTag::__optional_string),
+                            "optionalBytes" => Ok(__FieldTag::__optional_bytes),
+                            "optional_bytes" => Ok(__FieldTag::__optional_bytes),
+                            "optionalNestedMessage" => Ok(__FieldTag::__optional_nested_message),
+                            "optional_nested_message" => Ok(__FieldTag::__optional_nested_message),
+                            "optionalForeignMessage" => Ok(__FieldTag::__optional_foreign_message),
+                            "optional_foreign_message" => {
+                                Ok(__FieldTag::__optional_foreign_message)
+                            }
+                            "optionalNestedEnum" => Ok(__FieldTag::__optional_nested_enum),
+                            "optional_nested_enum" => Ok(__FieldTag::__optional_nested_enum),
+                            "optionalForeignEnum" => Ok(__FieldTag::__optional_foreign_enum),
+                            "optional_foreign_enum" => Ok(__FieldTag::__optional_foreign_enum),
+                            "optionalAliasedEnum" => Ok(__FieldTag::__optional_aliased_enum),
+                            "optional_aliased_enum" => Ok(__FieldTag::__optional_aliased_enum),
+                            "optionalStringPiece" => Ok(__FieldTag::__optional_string_piece),
+                            "optional_string_piece" => Ok(__FieldTag::__optional_string_piece),
+                            "optionalCord" => Ok(__FieldTag::__optional_cord),
+                            "optional_cord" => Ok(__FieldTag::__optional_cord),
+                            "recursiveMessage" => Ok(__FieldTag::__recursive_message),
+                            "recursive_message" => Ok(__FieldTag::__recursive_message),
+                            "repeatedInt32" => Ok(__FieldTag::__repeated_int32),
+                            "repeated_int32" => Ok(__FieldTag::__repeated_int32),
+                            "repeatedInt64" => Ok(__FieldTag::__repeated_int64),
+                            "repeated_int64" => Ok(__FieldTag::__repeated_int64),
+                            "repeatedUint32" => Ok(__FieldTag::__repeated_uint32),
+                            "repeated_uint32" => Ok(__FieldTag::__repeated_uint32),
+                            "repeatedUint64" => Ok(__FieldTag::__repeated_uint64),
+                            "repeated_uint64" => Ok(__FieldTag::__repeated_uint64),
+                            "repeatedSint32" => Ok(__FieldTag::__repeated_sint32),
+                            "repeated_sint32" => Ok(__FieldTag::__repeated_sint32),
+                            "repeatedSint64" => Ok(__FieldTag::__repeated_sint64),
+                            "repeated_sint64" => Ok(__FieldTag::__repeated_sint64),
+                            "repeatedFixed32" => Ok(__FieldTag::__repeated_fixed32),
+                            "repeated_fixed32" => Ok(__FieldTag::__repeated_fixed32),
+                            "repeatedFixed64" => Ok(__FieldTag::__repeated_fixed64),
+                            "repeated_fixed64" => Ok(__FieldTag::__repeated_fixed64),
+                            "repeatedSfixed32" => Ok(__FieldTag::__repeated_sfixed32),
+                            "repeated_sfixed32" => Ok(__FieldTag::__repeated_sfixed32),
+                            "repeatedSfixed64" => Ok(__FieldTag::__repeated_sfixed64),
+                            "repeated_sfixed64" => Ok(__FieldTag::__repeated_sfixed64),
+                            "repeatedFloat" => Ok(__FieldTag::__repeated_float),
+                            "repeated_float" => Ok(__FieldTag::__repeated_float),
+                            "repeatedDouble" => Ok(__FieldTag::__repeated_double),
+                            "repeated_double" => Ok(__FieldTag::__repeated_double),
+                            "repeatedBool" => Ok(__FieldTag::__repeated_bool),
+                            "repeated_bool" => Ok(__FieldTag::__repeated_bool),
+                            "repeatedString" => Ok(__FieldTag::__repeated_string),
+                            "repeated_string" => Ok(__FieldTag::__repeated_string),
+                            "repeatedBytes" => Ok(__FieldTag::__repeated_bytes),
+                            "repeated_bytes" => Ok(__FieldTag::__repeated_bytes),
+                            "repeatedNestedMessage" => Ok(__FieldTag::__repeated_nested_message),
+                            "repeated_nested_message" => Ok(__FieldTag::__repeated_nested_message),
+                            "repeatedForeignMessage" => Ok(__FieldTag::__repeated_foreign_message),
+                            "repeated_foreign_message" => {
+                                Ok(__FieldTag::__repeated_foreign_message)
+                            }
+                            "repeatedNestedEnum" => Ok(__FieldTag::__repeated_nested_enum),
+                            "repeated_nested_enum" => Ok(__FieldTag::__repeated_nested_enum),
+                            "repeatedForeignEnum" => Ok(__FieldTag::__repeated_foreign_enum),
+                            "repeated_foreign_enum" => Ok(__FieldTag::__repeated_foreign_enum),
+                            "repeatedStringPiece" => Ok(__FieldTag::__repeated_string_piece),
+                            "repeated_string_piece" => Ok(__FieldTag::__repeated_string_piece),
+                            "repeatedCord" => Ok(__FieldTag::__repeated_cord),
+                            "repeated_cord" => Ok(__FieldTag::__repeated_cord),
+                            "packedInt32" => Ok(__FieldTag::__packed_int32),
+                            "packed_int32" => Ok(__FieldTag::__packed_int32),
+                            "packedInt64" => Ok(__FieldTag::__packed_int64),
+                            "packed_int64" => Ok(__FieldTag::__packed_int64),
+                            "packedUint32" => Ok(__FieldTag::__packed_uint32),
+                            "packed_uint32" => Ok(__FieldTag::__packed_uint32),
+                            "packedUint64" => Ok(__FieldTag::__packed_uint64),
+                            "packed_uint64" => Ok(__FieldTag::__packed_uint64),
+                            "packedSint32" => Ok(__FieldTag::__packed_sint32),
+                            "packed_sint32" => Ok(__FieldTag::__packed_sint32),
+                            "packedSint64" => Ok(__FieldTag::__packed_sint64),
+                            "packed_sint64" => Ok(__FieldTag::__packed_sint64),
+                            "packedFixed32" => Ok(__FieldTag::__packed_fixed32),
+                            "packed_fixed32" => Ok(__FieldTag::__packed_fixed32),
+                            "packedFixed64" => Ok(__FieldTag::__packed_fixed64),
+                            "packed_fixed64" => Ok(__FieldTag::__packed_fixed64),
+                            "packedSfixed32" => Ok(__FieldTag::__packed_sfixed32),
+                            "packed_sfixed32" => Ok(__FieldTag::__packed_sfixed32),
+                            "packedSfixed64" => Ok(__FieldTag::__packed_sfixed64),
+                            "packed_sfixed64" => Ok(__FieldTag::__packed_sfixed64),
+                            "packedFloat" => Ok(__FieldTag::__packed_float),
+                            "packed_float" => Ok(__FieldTag::__packed_float),
+                            "packedDouble" => Ok(__FieldTag::__packed_double),
+                            "packed_double" => Ok(__FieldTag::__packed_double),
+                            "packedBool" => Ok(__FieldTag::__packed_bool),
+                            "packed_bool" => Ok(__FieldTag::__packed_bool),
+                            "packedNestedEnum" => Ok(__FieldTag::__packed_nested_enum),
+                            "packed_nested_enum" => Ok(__FieldTag::__packed_nested_enum),
+                            "unpackedInt32" => Ok(__FieldTag::__unpacked_int32),
+                            "unpacked_int32" => Ok(__FieldTag::__unpacked_int32),
+                            "unpackedInt64" => Ok(__FieldTag::__unpacked_int64),
+                            "unpacked_int64" => Ok(__FieldTag::__unpacked_int64),
+                            "unpackedUint32" => Ok(__FieldTag::__unpacked_uint32),
+                            "unpacked_uint32" => Ok(__FieldTag::__unpacked_uint32),
+                            "unpackedUint64" => Ok(__FieldTag::__unpacked_uint64),
+                            "unpacked_uint64" => Ok(__FieldTag::__unpacked_uint64),
+                            "unpackedSint32" => Ok(__FieldTag::__unpacked_sint32),
+                            "unpacked_sint32" => Ok(__FieldTag::__unpacked_sint32),
+                            "unpackedSint64" => Ok(__FieldTag::__unpacked_sint64),
+                            "unpacked_sint64" => Ok(__FieldTag::__unpacked_sint64),
+                            "unpackedFixed32" => Ok(__FieldTag::__unpacked_fixed32),
+                            "unpacked_fixed32" => Ok(__FieldTag::__unpacked_fixed32),
+                            "unpackedFixed64" => Ok(__FieldTag::__unpacked_fixed64),
+                            "unpacked_fixed64" => Ok(__FieldTag::__unpacked_fixed64),
+                            "unpackedSfixed32" => Ok(__FieldTag::__unpacked_sfixed32),
+                            "unpacked_sfixed32" => Ok(__FieldTag::__unpacked_sfixed32),
+                            "unpackedSfixed64" => Ok(__FieldTag::__unpacked_sfixed64),
+                            "unpacked_sfixed64" => Ok(__FieldTag::__unpacked_sfixed64),
+                            "unpackedFloat" => Ok(__FieldTag::__unpacked_float),
+                            "unpacked_float" => Ok(__FieldTag::__unpacked_float),
+                            "unpackedDouble" => Ok(__FieldTag::__unpacked_double),
+                            "unpacked_double" => Ok(__FieldTag::__unpacked_double),
+                            "unpackedBool" => Ok(__FieldTag::__unpacked_bool),
+                            "unpacked_bool" => Ok(__FieldTag::__unpacked_bool),
+                            "unpackedNestedEnum" => Ok(__FieldTag::__unpacked_nested_enum),
+                            "unpacked_nested_enum" => Ok(__FieldTag::__unpacked_nested_enum),
+                            "mapInt32Int32" => Ok(__FieldTag::__map_int32_int32),
+                            "map_int32_int32" => Ok(__FieldTag::__map_int32_int32),
+                            "mapInt64Int64" => Ok(__FieldTag::__map_int64_int64),
+                            "map_int64_int64" => Ok(__FieldTag::__map_int64_int64),
+                            "mapUint32Uint32" => Ok(__FieldTag::__map_uint32_uint32),
+                            "map_uint32_uint32" => Ok(__FieldTag::__map_uint32_uint32),
+                            "mapUint64Uint64" => Ok(__FieldTag::__map_uint64_uint64),
+                            "map_uint64_uint64" => Ok(__FieldTag::__map_uint64_uint64),
+                            "mapSint32Sint32" => Ok(__FieldTag::__map_sint32_sint32),
+                            "map_sint32_sint32" => Ok(__FieldTag::__map_sint32_sint32),
+                            "mapSint64Sint64" => Ok(__FieldTag::__map_sint64_sint64),
+                            "map_sint64_sint64" => Ok(__FieldTag::__map_sint64_sint64),
+                            "mapFixed32Fixed32" => Ok(__FieldTag::__map_fixed32_fixed32),
+                            "map_fixed32_fixed32" => Ok(__FieldTag::__map_fixed32_fixed32),
+                            "mapFixed64Fixed64" => Ok(__FieldTag::__map_fixed64_fixed64),
+                            "map_fixed64_fixed64" => Ok(__FieldTag::__map_fixed64_fixed64),
+                            "mapSfixed32Sfixed32" => Ok(__FieldTag::__map_sfixed32_sfixed32),
+                            "map_sfixed32_sfixed32" => Ok(__FieldTag::__map_sfixed32_sfixed32),
+                            "mapSfixed64Sfixed64" => Ok(__FieldTag::__map_sfixed64_sfixed64),
+                            "map_sfixed64_sfixed64" => Ok(__FieldTag::__map_sfixed64_sfixed64),
+                            "mapInt32Float" => Ok(__FieldTag::__map_int32_float),
+                            "map_int32_float" => Ok(__FieldTag::__map_int32_float),
+                            "mapInt32Double" => Ok(__FieldTag::__map_int32_double),
+                            "map_int32_double" => Ok(__FieldTag::__map_int32_double),
+                            "mapBoolBool" => Ok(__FieldTag::__map_bool_bool),
+                            "map_bool_bool" => Ok(__FieldTag::__map_bool_bool),
+                            "mapStringString" => Ok(__FieldTag::__map_string_string),
+                            "map_string_string" => Ok(__FieldTag::__map_string_string),
+                            "mapStringBytes" => Ok(__FieldTag::__map_string_bytes),
+                            "map_string_bytes" => Ok(__FieldTag::__map_string_bytes),
+                            "mapStringNestedMessage" => Ok(__FieldTag::__map_string_nested_message),
+                            "map_string_nested_message" => {
+                                Ok(__FieldTag::__map_string_nested_message)
+                            }
+                            "mapStringForeignMessage" => {
+                                Ok(__FieldTag::__map_string_foreign_message)
+                            }
+                            "map_string_foreign_message" => {
+                                Ok(__FieldTag::__map_string_foreign_message)
+                            }
+                            "mapStringNestedEnum" => Ok(__FieldTag::__map_string_nested_enum),
+                            "map_string_nested_enum" => Ok(__FieldTag::__map_string_nested_enum),
+                            "mapStringForeignEnum" => Ok(__FieldTag::__map_string_foreign_enum),
+                            "map_string_foreign_enum" => Ok(__FieldTag::__map_string_foreign_enum),
+                            "oneofUint32" => Ok(__FieldTag::__oneof_uint32),
+                            "oneof_uint32" => Ok(__FieldTag::__oneof_uint32),
+                            "oneofNestedMessage" => Ok(__FieldTag::__oneof_nested_message),
+                            "oneof_nested_message" => Ok(__FieldTag::__oneof_nested_message),
+                            "oneofString" => Ok(__FieldTag::__oneof_string),
+                            "oneof_string" => Ok(__FieldTag::__oneof_string),
+                            "oneofBytes" => Ok(__FieldTag::__oneof_bytes),
+                            "oneof_bytes" => Ok(__FieldTag::__oneof_bytes),
+                            "oneofBool" => Ok(__FieldTag::__oneof_bool),
+                            "oneof_bool" => Ok(__FieldTag::__oneof_bool),
+                            "oneofUint64" => Ok(__FieldTag::__oneof_uint64),
+                            "oneof_uint64" => Ok(__FieldTag::__oneof_uint64),
+                            "oneofFloat" => Ok(__FieldTag::__oneof_float),
+                            "oneof_float" => Ok(__FieldTag::__oneof_float),
+                            "oneofDouble" => Ok(__FieldTag::__oneof_double),
+                            "oneof_double" => Ok(__FieldTag::__oneof_double),
+                            "oneofEnum" => Ok(__FieldTag::__oneof_enum),
+                            "oneof_enum" => Ok(__FieldTag::__oneof_enum),
+                            "oneofNullValue" => Ok(__FieldTag::__oneof_null_value),
+                            "oneof_null_value" => Ok(__FieldTag::__oneof_null_value),
+                            "optionalBoolWrapper" => Ok(__FieldTag::__optional_bool_wrapper),
+                            "optional_bool_wrapper" => Ok(__FieldTag::__optional_bool_wrapper),
+                            "optionalInt32Wrapper" => Ok(__FieldTag::__optional_int32_wrapper),
+                            "optional_int32_wrapper" => Ok(__FieldTag::__optional_int32_wrapper),
+                            "optionalInt64Wrapper" => Ok(__FieldTag::__optional_int64_wrapper),
+                            "optional_int64_wrapper" => Ok(__FieldTag::__optional_int64_wrapper),
+                            "optionalUint32Wrapper" => Ok(__FieldTag::__optional_uint32_wrapper),
+                            "optional_uint32_wrapper" => Ok(__FieldTag::__optional_uint32_wrapper),
+                            "optionalUint64Wrapper" => Ok(__FieldTag::__optional_uint64_wrapper),
+                            "optional_uint64_wrapper" => Ok(__FieldTag::__optional_uint64_wrapper),
+                            "optionalFloatWrapper" => Ok(__FieldTag::__optional_float_wrapper),
+                            "optional_float_wrapper" => Ok(__FieldTag::__optional_float_wrapper),
+                            "optionalDoubleWrapper" => Ok(__FieldTag::__optional_double_wrapper),
+                            "optional_double_wrapper" => Ok(__FieldTag::__optional_double_wrapper),
+                            "optionalStringWrapper" => Ok(__FieldTag::__optional_string_wrapper),
+                            "optional_string_wrapper" => Ok(__FieldTag::__optional_string_wrapper),
+                            "optionalBytesWrapper" => Ok(__FieldTag::__optional_bytes_wrapper),
+                            "optional_bytes_wrapper" => Ok(__FieldTag::__optional_bytes_wrapper),
+                            "repeatedBoolWrapper" => Ok(__FieldTag::__repeated_bool_wrapper),
+                            "repeated_bool_wrapper" => Ok(__FieldTag::__repeated_bool_wrapper),
+                            "repeatedInt32Wrapper" => Ok(__FieldTag::__repeated_int32_wrapper),
+                            "repeated_int32_wrapper" => Ok(__FieldTag::__repeated_int32_wrapper),
+                            "repeatedInt64Wrapper" => Ok(__FieldTag::__repeated_int64_wrapper),
+                            "repeated_int64_wrapper" => Ok(__FieldTag::__repeated_int64_wrapper),
+                            "repeatedUint32Wrapper" => Ok(__FieldTag::__repeated_uint32_wrapper),
+                            "repeated_uint32_wrapper" => Ok(__FieldTag::__repeated_uint32_wrapper),
+                            "repeatedUint64Wrapper" => Ok(__FieldTag::__repeated_uint64_wrapper),
+                            "repeated_uint64_wrapper" => Ok(__FieldTag::__repeated_uint64_wrapper),
+                            "repeatedFloatWrapper" => Ok(__FieldTag::__repeated_float_wrapper),
+                            "repeated_float_wrapper" => Ok(__FieldTag::__repeated_float_wrapper),
+                            "repeatedDoubleWrapper" => Ok(__FieldTag::__repeated_double_wrapper),
+                            "repeated_double_wrapper" => Ok(__FieldTag::__repeated_double_wrapper),
+                            "repeatedStringWrapper" => Ok(__FieldTag::__repeated_string_wrapper),
+                            "repeated_string_wrapper" => Ok(__FieldTag::__repeated_string_wrapper),
+                            "repeatedBytesWrapper" => Ok(__FieldTag::__repeated_bytes_wrapper),
+                            "repeated_bytes_wrapper" => Ok(__FieldTag::__repeated_bytes_wrapper),
+                            "optionalDuration" => Ok(__FieldTag::__optional_duration),
+                            "optional_duration" => Ok(__FieldTag::__optional_duration),
+                            "optionalTimestamp" => Ok(__FieldTag::__optional_timestamp),
+                            "optional_timestamp" => Ok(__FieldTag::__optional_timestamp),
+                            "optionalFieldMask" => Ok(__FieldTag::__optional_field_mask),
+                            "optional_field_mask" => Ok(__FieldTag::__optional_field_mask),
+                            "optionalStruct" => Ok(__FieldTag::__optional_struct),
+                            "optional_struct" => Ok(__FieldTag::__optional_struct),
+                            "optionalAny" => Ok(__FieldTag::__optional_any),
+                            "optional_any" => Ok(__FieldTag::__optional_any),
+                            "optionalValue" => Ok(__FieldTag::__optional_value),
+                            "optional_value" => Ok(__FieldTag::__optional_value),
+                            "optionalNullValue" => Ok(__FieldTag::__optional_null_value),
+                            "optional_null_value" => Ok(__FieldTag::__optional_null_value),
+                            "repeatedDuration" => Ok(__FieldTag::__repeated_duration),
+                            "repeated_duration" => Ok(__FieldTag::__repeated_duration),
+                            "repeatedTimestamp" => Ok(__FieldTag::__repeated_timestamp),
+                            "repeated_timestamp" => Ok(__FieldTag::__repeated_timestamp),
+                            "repeatedFieldmask" => Ok(__FieldTag::__repeated_fieldmask),
+                            "repeated_fieldmask" => Ok(__FieldTag::__repeated_fieldmask),
+                            "repeatedStruct" => Ok(__FieldTag::__repeated_struct),
+                            "repeated_struct" => Ok(__FieldTag::__repeated_struct),
+                            "repeatedAny" => Ok(__FieldTag::__repeated_any),
+                            "repeated_any" => Ok(__FieldTag::__repeated_any),
+                            "repeatedValue" => Ok(__FieldTag::__repeated_value),
+                            "repeated_value" => Ok(__FieldTag::__repeated_value),
+                            "repeatedListValue" => Ok(__FieldTag::__repeated_list_value),
+                            "repeated_list_value" => Ok(__FieldTag::__repeated_list_value),
+                            "fieldname1" => Ok(__FieldTag::__fieldname1),
+                            "fieldName2" => Ok(__FieldTag::__field_name2),
+                            "field_name2" => Ok(__FieldTag::__field_name2),
+                            "FieldName3" => Ok(__FieldTag::___field_name3),
+                            "_field_name3" => Ok(__FieldTag::___field_name3),
+                            "fieldName4" => Ok(__FieldTag::__field__name4_),
+                            "field__name4_" => Ok(__FieldTag::__field__name4_),
+                            "field0name5" => Ok(__FieldTag::__field0name5),
+                            "field0Name6" => Ok(__FieldTag::__field_0_name6),
+                            "field_0_name6" => Ok(__FieldTag::__field_0_name6),
+                            "fieldName7" => Ok(__FieldTag::__field_name_7),
+                            "FieldName8" => Ok(__FieldTag::__field_name_8),
+                            "fieldName9" => Ok(__FieldTag::__field_name_9),
+                            "field_Name9" => Ok(__FieldTag::__field_name_9),
+                            "FieldName10" => Ok(__FieldTag::__field_name_10),
+                            "Field_Name10" => Ok(__FieldTag::__field_name_10),
+                            "FIELDNAME11" => Ok(__FieldTag::__field_name_11),
+                            "FIELD_NAME11" => Ok(__FieldTag::__field_name_11),
+                            "FIELDName12" => Ok(__FieldTag::__field_name_12),
+                            "FIELD_name12" => Ok(__FieldTag::__field_name_12),
+                            "FieldName13" => Ok(__FieldTag::____field_name13),
+                            "__field_name13" => Ok(__FieldTag::____field_name13),
+                            "FieldName14" => Ok(__FieldTag::____field_name_14),
+                            "__Field_name14" => Ok(__FieldTag::____field_name_14),
+                            "fieldName15" => Ok(__FieldTag::__field__name15),
+                            "field__name15" => Ok(__FieldTag::__field__name15),
+                            "fieldName16" => Ok(__FieldTag::__field__name_16),
+                            "field__Name16" => Ok(__FieldTag::__field__name_16),
+                            "fieldName17" => Ok(__FieldTag::__field_name17__),
+                            "field_name17__" => Ok(__FieldTag::__field_name17__),
+                            "FieldName18" => Ok(__FieldTag::__field_name_18__),
+                            "Field_name18__" => Ok(__FieldTag::__field_name_18__),
+                            _ => Ok(__FieldTag::Unknown(value.to_string())),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(Visitor)
+            }
+        }
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = TestAllTypesProto3;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct TestAllTypesProto3")
+            }
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[allow(unused_imports)]
+                use serde::de::Error;
+                let mut fields = std::collections::HashSet::new();
+                let mut result = Self::Value::new();
+                while let Some(tag) = map.next_key::<__FieldTag>()? {
+                    #[allow(clippy::match_single_binding)]
+                    match tag {
+                        __FieldTag::__optional_int32 => {
+                            if !fields.insert(__FieldTag::__optional_int32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_int32",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_int32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_int64 => {
+                            if !fields.insert(__FieldTag::__optional_int64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_int64",
+                                ));
+                            }
+                            struct __With(std::option::Option<i64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_int64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_uint32 => {
+                            if !fields.insert(__FieldTag::__optional_uint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_uint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<u32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_uint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_uint64 => {
+                            if !fields.insert(__FieldTag::__optional_uint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_uint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<u64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_uint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_sint32 => {
+                            if !fields.insert(__FieldTag::__optional_sint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_sint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_sint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_sint64 => {
+                            if !fields.insert(__FieldTag::__optional_sint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_sint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<i64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_sint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_fixed32 => {
+                            if !fields.insert(__FieldTag::__optional_fixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_fixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<u32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_fixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_fixed64 => {
+                            if !fields.insert(__FieldTag::__optional_fixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_fixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<u64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_fixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_sfixed32 => {
+                            if !fields.insert(__FieldTag::__optional_sfixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_sfixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_sfixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_sfixed64 => {
+                            if !fields.insert(__FieldTag::__optional_sfixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_sfixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<i64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_sfixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_float => {
+                            if !fields.insert(__FieldTag::__optional_float) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_float",
+                                ));
+                            }
+                            struct __With(std::option::Option<f32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::F32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_float =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_double => {
+                            if !fields.insert(__FieldTag::__optional_double) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_double",
+                                ));
+                            }
+                            struct __With(std::option::Option<f64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::F64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_double =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_bool => {
+                            if !fields.insert(__FieldTag::__optional_bool) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_bool",
+                                ));
+                            }
+                            result.optional_bool = map
+                                .next_value::<std::option::Option<bool>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__optional_string => {
+                            if !fields.insert(__FieldTag::__optional_string) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_string",
+                                ));
+                            }
+                            result.optional_string = map
+                                .next_value::<std::option::Option<std::string::String>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__optional_bytes => {
+                            if !fields.insert(__FieldTag::__optional_bytes) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_bytes",
+                                ));
+                            }
+                            struct __With(std::option::Option<::bytes::Bytes>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<serde_with::base64::Base64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_bytes =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_nested_message => {
+                            if !fields.insert(__FieldTag::__optional_nested_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_nested_message",
+                                ));
+                            }
+                            result.optional_nested_message = map.next_value::<std::option::Option<std::boxed::Box<crate::generated::test_protos::test_all_types_proto_3::NestedMessage>>>()?
+                                ;
+                        }
+                        __FieldTag::__optional_foreign_message => {
+                            if !fields.insert(__FieldTag::__optional_foreign_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_foreign_message",
+                                ));
+                            }
+                            result.optional_foreign_message = map
+                                .next_value::<std::option::Option<
+                                    crate::generated::test_protos::ForeignMessage,
+                                >>()?;
+                        }
+                        __FieldTag::__optional_nested_enum => {
+                            if !fields.insert(__FieldTag::__optional_nested_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_nested_enum",
+                                ));
+                            }
+                            result.optional_nested_enum = map.next_value::<std::option::Option<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_foreign_enum => {
+                            if !fields.insert(__FieldTag::__optional_foreign_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_foreign_enum",
+                                ));
+                            }
+                            result.optional_foreign_enum = map.next_value::<std::option::Option<crate::generated::test_protos::ForeignEnum>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_aliased_enum => {
+                            if !fields.insert(__FieldTag::__optional_aliased_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_aliased_enum",
+                                ));
+                            }
+                            result.optional_aliased_enum = map.next_value::<std::option::Option<crate::generated::test_protos::test_all_types_proto_3::AliasedEnum>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_string_piece => {
+                            if !fields.insert(__FieldTag::__optional_string_piece) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_string_piece",
+                                ));
+                            }
+                            result.optional_string_piece = map
+                                .next_value::<std::option::Option<std::string::String>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__optional_cord => {
+                            if !fields.insert(__FieldTag::__optional_cord) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_cord",
+                                ));
+                            }
+                            result.optional_cord = map
+                                .next_value::<std::option::Option<std::string::String>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__recursive_message => {
+                            if !fields.insert(__FieldTag::__recursive_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for recursive_message",
+                                ));
+                            }
+                            result.recursive_message = map.next_value::<std::option::Option<
+                                std::boxed::Box<crate::generated::test_protos::TestAllTypesProto3>,
+                            >>()?;
+                        }
+                        __FieldTag::__repeated_int32 => {
+                            if !fields.insert(__FieldTag::__repeated_int32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_int32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_int32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_int64 => {
+                            if !fields.insert(__FieldTag::__repeated_int64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_int64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_int64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_uint32 => {
+                            if !fields.insert(__FieldTag::__repeated_uint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_uint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_uint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_uint64 => {
+                            if !fields.insert(__FieldTag::__repeated_uint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_uint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_uint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_sint32 => {
+                            if !fields.insert(__FieldTag::__repeated_sint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_sint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_sint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_sint64 => {
+                            if !fields.insert(__FieldTag::__repeated_sint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_sint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_sint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_fixed32 => {
+                            if !fields.insert(__FieldTag::__repeated_fixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_fixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_fixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_fixed64 => {
+                            if !fields.insert(__FieldTag::__repeated_fixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_fixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_fixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_sfixed32 => {
+                            if !fields.insert(__FieldTag::__repeated_sfixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_sfixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_sfixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_sfixed64 => {
+                            if !fields.insert(__FieldTag::__repeated_sfixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_sfixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_sfixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_float => {
+                            if !fields.insert(__FieldTag::__repeated_float) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_float",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<f32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_float =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_double => {
+                            if !fields.insert(__FieldTag::__repeated_double) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_double",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<f64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_double =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_bool => {
+                            if !fields.insert(__FieldTag::__repeated_bool) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_bool",
+                                ));
+                            }
+                            result.repeated_bool = map
+                                .next_value::<std::option::Option<std::vec::Vec<bool>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_string => {
+                            if !fields.insert(__FieldTag::__repeated_string) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_string",
+                                ));
+                            }
+                            result.repeated_string = map.next_value::<std::option::Option<std::vec::Vec<std::string::String>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_bytes => {
+                            if !fields.insert(__FieldTag::__repeated_bytes) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_bytes",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<::bytes::Bytes>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::vec::Vec<serde_with::base64::Base64>,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_bytes =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_nested_message => {
+                            if !fields.insert(__FieldTag::__repeated_nested_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_nested_message",
+                                ));
+                            }
+                            result.repeated_nested_message = map.next_value::<std::option::Option<std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedMessage>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_foreign_message => {
+                            if !fields.insert(__FieldTag::__repeated_foreign_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_foreign_message",
+                                ));
+                            }
+                            result.repeated_foreign_message = map
+                                .next_value::<std::option::Option<
+                                    std::vec::Vec<crate::generated::test_protos::ForeignMessage>,
+                                >>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_nested_enum => {
+                            if !fields.insert(__FieldTag::__repeated_nested_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_nested_enum",
+                                ));
+                            }
+                            result.repeated_nested_enum = map.next_value::<std::option::Option<std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_foreign_enum => {
+                            if !fields.insert(__FieldTag::__repeated_foreign_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_foreign_enum",
+                                ));
+                            }
+                            result.repeated_foreign_enum = map
+                                .next_value::<std::option::Option<
+                                    std::vec::Vec<crate::generated::test_protos::ForeignEnum>,
+                                >>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_string_piece => {
+                            if !fields.insert(__FieldTag::__repeated_string_piece) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_string_piece",
+                                ));
+                            }
+                            result.repeated_string_piece = map.next_value::<std::option::Option<std::vec::Vec<std::string::String>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_cord => {
+                            if !fields.insert(__FieldTag::__repeated_cord) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_cord",
+                                ));
+                            }
+                            result.repeated_cord = map.next_value::<std::option::Option<std::vec::Vec<std::string::String>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_int32 => {
+                            if !fields.insert(__FieldTag::__packed_int32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_int32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_int32 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_int64 => {
+                            if !fields.insert(__FieldTag::__packed_int64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_int64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_int64 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_uint32 => {
+                            if !fields.insert(__FieldTag::__packed_uint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_uint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_uint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_uint64 => {
+                            if !fields.insert(__FieldTag::__packed_uint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_uint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_uint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_sint32 => {
+                            if !fields.insert(__FieldTag::__packed_sint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_sint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_sint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_sint64 => {
+                            if !fields.insert(__FieldTag::__packed_sint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_sint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_sint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_fixed32 => {
+                            if !fields.insert(__FieldTag::__packed_fixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_fixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_fixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_fixed64 => {
+                            if !fields.insert(__FieldTag::__packed_fixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_fixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_fixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_sfixed32 => {
+                            if !fields.insert(__FieldTag::__packed_sfixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_sfixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_sfixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_sfixed64 => {
+                            if !fields.insert(__FieldTag::__packed_sfixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_sfixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_sfixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_float => {
+                            if !fields.insert(__FieldTag::__packed_float) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_float",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<f32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_float = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_double => {
+                            if !fields.insert(__FieldTag::__packed_double) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_double",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<f64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.packed_double =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__packed_bool => {
+                            if !fields.insert(__FieldTag::__packed_bool) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_bool",
+                                ));
+                            }
+                            result.packed_bool = map
+                                .next_value::<std::option::Option<std::vec::Vec<bool>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__packed_nested_enum => {
+                            if !fields.insert(__FieldTag::__packed_nested_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for packed_nested_enum",
+                                ));
+                            }
+                            result.packed_nested_enum = map.next_value::<std::option::Option<std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_int32 => {
+                            if !fields.insert(__FieldTag::__unpacked_int32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_int32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_int32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_int64 => {
+                            if !fields.insert(__FieldTag::__unpacked_int64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_int64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_int64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_uint32 => {
+                            if !fields.insert(__FieldTag::__unpacked_uint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_uint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_uint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_uint64 => {
+                            if !fields.insert(__FieldTag::__unpacked_uint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_uint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_uint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_sint32 => {
+                            if !fields.insert(__FieldTag::__unpacked_sint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_sint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_sint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_sint64 => {
+                            if !fields.insert(__FieldTag::__unpacked_sint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_sint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_sint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_fixed32 => {
+                            if !fields.insert(__FieldTag::__unpacked_fixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_fixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_fixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_fixed64 => {
+                            if !fields.insert(__FieldTag::__unpacked_fixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_fixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_fixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_sfixed32 => {
+                            if !fields.insert(__FieldTag::__unpacked_sfixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_sfixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_sfixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_sfixed64 => {
+                            if !fields.insert(__FieldTag::__unpacked_sfixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_sfixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_sfixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_float => {
+                            if !fields.insert(__FieldTag::__unpacked_float) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_float",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<f32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_float =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_double => {
+                            if !fields.insert(__FieldTag::__unpacked_double) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_double",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<f64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.unpacked_double =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_bool => {
+                            if !fields.insert(__FieldTag::__unpacked_bool) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_bool",
+                                ));
+                            }
+                            result.unpacked_bool = map
+                                .next_value::<std::option::Option<std::vec::Vec<bool>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__unpacked_nested_enum => {
+                            if !fields.insert(__FieldTag::__unpacked_nested_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for unpacked_nested_enum",
+                                ));
+                            }
+                            result.unpacked_nested_enum = map.next_value::<std::option::Option<std::vec::Vec<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__map_int32_int32 => {
+                            if !fields.insert(__FieldTag::__map_int32_int32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_int32_int32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i32, i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I32,
+                                                wkt::internal::I32,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_int32_int32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_int64_int64 => {
+                            if !fields.insert(__FieldTag::__map_int64_int64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_int64_int64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i64, i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I64,
+                                                wkt::internal::I64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_int64_int64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_uint32_uint32 => {
+                            if !fields.insert(__FieldTag::__map_uint32_uint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_uint32_uint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<u32, u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::U32,
+                                                wkt::internal::U32,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_uint32_uint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_uint64_uint64 => {
+                            if !fields.insert(__FieldTag::__map_uint64_uint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_uint64_uint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<u64, u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::U64,
+                                                wkt::internal::U64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_uint64_uint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_sint32_sint32 => {
+                            if !fields.insert(__FieldTag::__map_sint32_sint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_sint32_sint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i32, i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I32,
+                                                wkt::internal::I32,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_sint32_sint32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_sint64_sint64 => {
+                            if !fields.insert(__FieldTag::__map_sint64_sint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_sint64_sint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i64, i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I64,
+                                                wkt::internal::I64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_sint64_sint64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_fixed32_fixed32 => {
+                            if !fields.insert(__FieldTag::__map_fixed32_fixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_fixed32_fixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<u32, u32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::U32,
+                                                wkt::internal::U32,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_fixed32_fixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_fixed64_fixed64 => {
+                            if !fields.insert(__FieldTag::__map_fixed64_fixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_fixed64_fixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<u64, u64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::U64,
+                                                wkt::internal::U64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_fixed64_fixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_sfixed32_sfixed32 => {
+                            if !fields.insert(__FieldTag::__map_sfixed32_sfixed32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_sfixed32_sfixed32",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i32, i32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I32,
+                                                wkt::internal::I32,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_sfixed32_sfixed32 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_sfixed64_sfixed64 => {
+                            if !fields.insert(__FieldTag::__map_sfixed64_sfixed64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_sfixed64_sfixed64",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i64, i64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I64,
+                                                wkt::internal::I64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_sfixed64_sfixed64 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_int32_float => {
+                            if !fields.insert(__FieldTag::__map_int32_float) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_int32_float",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i32, f32>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I32,
+                                                wkt::internal::F32,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_int32_float =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_int32_double => {
+                            if !fields.insert(__FieldTag::__map_int32_double) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_int32_double",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::collections::HashMap<i32, f64>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                wkt::internal::I32,
+                                                wkt::internal::F64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_int32_double =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_bool_bool => {
+                            if !fields.insert(__FieldTag::__map_bool_bool) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_bool_bool",
+                                ));
+                            }
+                            struct __With(
+                                std::option::Option<std::collections::HashMap<bool, bool>>,
+                            );
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                serde_with::DisplayFromStr,
+                                                serde_with::Same,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_bool_bool =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_string_string => {
+                            if !fields.insert(__FieldTag::__map_string_string) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_string_string",
+                                ));
+                            }
+                            result.map_string_string = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        std::string::String,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__map_string_bytes => {
+                            if !fields.insert(__FieldTag::__map_string_bytes) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_string_bytes",
+                                ));
+                            }
+                            struct __With(
+                                std::option::Option<
+                                    std::collections::HashMap<std::string::String, ::bytes::Bytes>,
+                                >,
+                            );
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::collections::HashMap<
+                                                serde_with::Same,
+                                                serde_with::base64::Base64,
+                                            >,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.map_string_bytes =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__map_string_nested_message => {
+                            if !fields.insert(__FieldTag::__map_string_nested_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_string_nested_message",
+                                ));
+                            }
+                            result.map_string_nested_message = map.next_value::<std::option::Option<std::collections::HashMap<std::string::String,crate::generated::test_protos::test_all_types_proto_3::NestedMessage>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__map_string_foreign_message => {
+                            if !fields.insert(__FieldTag::__map_string_foreign_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_string_foreign_message",
+                                ));
+                            }
+                            result.map_string_foreign_message = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        crate::generated::test_protos::ForeignMessage,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__map_string_nested_enum => {
+                            if !fields.insert(__FieldTag::__map_string_nested_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_string_nested_enum",
+                                ));
+                            }
+                            result.map_string_nested_enum = map.next_value::<std::option::Option<std::collections::HashMap<std::string::String,crate::generated::test_protos::test_all_types_proto_3::NestedEnum>>>()?.unwrap_or_default();
+                        }
+                        __FieldTag::__map_string_foreign_enum => {
+                            if !fields.insert(__FieldTag::__map_string_foreign_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for map_string_foreign_enum",
+                                ));
+                            }
+                            result.map_string_foreign_enum = map
+                                .next_value::<std::option::Option<
+                                    std::collections::HashMap<
+                                        std::string::String,
+                                        crate::generated::test_protos::ForeignEnum,
+                                    >,
+                                >>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__oneof_uint32 => {
+                            if !fields.insert(__FieldTag::__oneof_uint32) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_uint32",
+                                ));
+                            }
+                            struct __With(std::option::Option<u32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_uint32, latest field was oneofUint32",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofUint32(
+                                    map.next_value::<__With>()?.0.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_nested_message => {
+                            if !fields.insert(__FieldTag::__oneof_nested_message) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_nested_message",
+                                ));
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_nested_message, latest field was oneofNestedMessage",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofNestedMessage(
+                                    map.next_value::<std::option::Option<std::boxed::Box<crate::generated::test_protos::test_all_types_proto_3::NestedMessage>>>()?.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_string => {
+                            if !fields.insert(__FieldTag::__oneof_string) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_string",
+                                ));
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_string, latest field was oneofString",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofString(
+                                    map.next_value::<std::option::Option<std::string::String>>()?.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_bytes => {
+                            if !fields.insert(__FieldTag::__oneof_bytes) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_bytes",
+                                ));
+                            }
+                            struct __With(std::option::Option<::bytes::Bytes>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<serde_with::base64::Base64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_bytes, latest field was oneofBytes",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofBytes(
+                                    map.next_value::<__With>()?.0.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_bool => {
+                            if !fields.insert(__FieldTag::__oneof_bool) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_bool",
+                                ));
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_bool, latest field was oneofBool",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofBool(
+                                    map.next_value::<std::option::Option<bool>>()?.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_uint64 => {
+                            if !fields.insert(__FieldTag::__oneof_uint64) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_uint64",
+                                ));
+                            }
+                            struct __With(std::option::Option<u64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_uint64, latest field was oneofUint64",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofUint64(
+                                    map.next_value::<__With>()?.0.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_float => {
+                            if !fields.insert(__FieldTag::__oneof_float) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_float",
+                                ));
+                            }
+                            struct __With(std::option::Option<f32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::F32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_float, latest field was oneofFloat",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofFloat(
+                                    map.next_value::<__With>()?.0.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_double => {
+                            if !fields.insert(__FieldTag::__oneof_double) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_double",
+                                ));
+                            }
+                            struct __With(std::option::Option<f64>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::F64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_double, latest field was oneofDouble",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofDouble(
+                                    map.next_value::<__With>()?.0.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_enum => {
+                            if !fields.insert(__FieldTag::__oneof_enum) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_enum",
+                                ));
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_enum, latest field was oneofEnum",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofEnum(
+                                    map.next_value::<std::option::Option<crate::generated::test_protos::test_all_types_proto_3::NestedEnum>>()?.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__oneof_null_value => {
+                            if !fields.insert(__FieldTag::__oneof_null_value) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for oneof_null_value",
+                                ));
+                            }
+                            if result.oneof_field.is_some() {
+                                return Err(A::Error::duplicate_field(
+                                    "multiple values for `oneof_field`, a oneof with full ID .protobuf_test_messages.proto3.TestAllTypesProto3.oneof_null_value, latest field was oneofNullValue",
+                                ));
+                            }
+                            result.oneof_field = std::option::Option::Some(
+                                crate::generated::test_protos::test_all_types_proto_3::OneofField::OneofNullValue(
+                                    map.next_value::<std::option::Option<wkt::NullValue>>()?.unwrap_or_default()
+                                ),
+                            );
+                        }
+                        __FieldTag::__optional_bool_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_bool_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_bool_wrapper",
+                                ));
+                            }
+                            result.optional_bool_wrapper =
+                                map.next_value::<std::option::Option<wkt::BoolValue>>()?;
+                        }
+                        __FieldTag::__optional_int32_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_int32_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_int32_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::Int32Value>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_int32_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__optional_int64_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_int64_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_int64_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::Int64Value>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_int64_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__optional_uint32_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_uint32_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_uint32_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::UInt32Value>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_uint32_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__optional_uint64_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_uint64_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_uint64_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::UInt64Value>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::U64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_uint64_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__optional_float_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_float_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_float_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::FloatValue>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::F32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_float_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__optional_double_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_double_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_double_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::DoubleValue>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::F64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_double_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__optional_string_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_string_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_string_wrapper",
+                                ));
+                            }
+                            result.optional_string_wrapper =
+                                map.next_value::<std::option::Option<wkt::StringValue>>()?;
+                        }
+                        __FieldTag::__optional_bytes_wrapper => {
+                            if !fields.insert(__FieldTag::__optional_bytes_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_bytes_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<wkt::BytesValue>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<serde_with::base64::Base64> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.optional_bytes_wrapper = map.next_value::<__With>()?.0;
+                        }
+                        __FieldTag::__repeated_bool_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_bool_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_bool_wrapper",
+                                ));
+                            }
+                            result.repeated_bool_wrapper = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::BoolValue>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_int32_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_int32_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_int32_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::Int32Value>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_int32_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_int64_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_int64_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_int64_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::Int64Value>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::I64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_int64_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_uint32_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_uint32_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_uint32_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::UInt32Value>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_uint32_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_uint64_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_uint64_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_uint64_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::UInt64Value>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::U64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_uint64_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_float_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_float_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_float_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::FloatValue>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F32>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_float_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_double_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_double_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_double_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::DoubleValue>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<std::vec::Vec<wkt::internal::F64>>,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_double_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_string_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_string_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_string_wrapper",
+                                ));
+                            }
+                            result.repeated_string_wrapper = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::StringValue>>>(
+                                )?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_bytes_wrapper => {
+                            if !fields.insert(__FieldTag::__repeated_bytes_wrapper) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_bytes_wrapper",
+                                ));
+                            }
+                            struct __With(std::option::Option<std::vec::Vec<wkt::BytesValue>>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::<
+                                        std::option::Option<
+                                            std::vec::Vec<serde_with::base64::Base64>,
+                                        >,
+                                    >::deserialize(deserializer)
+                                    .map(__With)
+                                }
+                            }
+                            result.repeated_bytes_wrapper =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__optional_duration => {
+                            if !fields.insert(__FieldTag::__optional_duration) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_duration",
+                                ));
+                            }
+                            result.optional_duration =
+                                map.next_value::<std::option::Option<wkt::Duration>>()?;
+                        }
+                        __FieldTag::__optional_timestamp => {
+                            if !fields.insert(__FieldTag::__optional_timestamp) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_timestamp",
+                                ));
+                            }
+                            result.optional_timestamp =
+                                map.next_value::<std::option::Option<wkt::Timestamp>>()?;
+                        }
+                        __FieldTag::__optional_field_mask => {
+                            if !fields.insert(__FieldTag::__optional_field_mask) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_field_mask",
+                                ));
+                            }
+                            result.optional_field_mask =
+                                map.next_value::<std::option::Option<wkt::FieldMask>>()?;
+                        }
+                        __FieldTag::__optional_struct => {
+                            if !fields.insert(__FieldTag::__optional_struct) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_struct",
+                                ));
+                            }
+                            result.optional_struct =
+                                map.next_value::<std::option::Option<wkt::Struct>>()?;
+                        }
+                        __FieldTag::__optional_any => {
+                            if !fields.insert(__FieldTag::__optional_any) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_any",
+                                ));
+                            }
+                            result.optional_any =
+                                map.next_value::<std::option::Option<wkt::Any>>()?;
+                        }
+                        __FieldTag::__optional_value => {
+                            if !fields.insert(__FieldTag::__optional_value) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_value",
+                                ));
+                            }
+                            result.optional_value = map
+                                .next_value::<std::option::Option<wkt::Value>>()?
+                                .or(Some(wkt::Value::Null));
+                        }
+                        __FieldTag::__optional_null_value => {
+                            if !fields.insert(__FieldTag::__optional_null_value) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for optional_null_value",
+                                ));
+                            }
+                            result.optional_null_value = map
+                                .next_value::<std::option::Option<wkt::NullValue>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_duration => {
+                            if !fields.insert(__FieldTag::__repeated_duration) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_duration",
+                                ));
+                            }
+                            result.repeated_duration = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Duration>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_timestamp => {
+                            if !fields.insert(__FieldTag::__repeated_timestamp) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_timestamp",
+                                ));
+                            }
+                            result.repeated_timestamp = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Timestamp>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_fieldmask => {
+                            if !fields.insert(__FieldTag::__repeated_fieldmask) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_fieldmask",
+                                ));
+                            }
+                            result.repeated_fieldmask = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::FieldMask>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_struct => {
+                            if !fields.insert(__FieldTag::__repeated_struct) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_struct",
+                                ));
+                            }
+                            result.repeated_struct = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Struct>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_any => {
+                            if !fields.insert(__FieldTag::__repeated_any) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_any",
+                                ));
+                            }
+                            result.repeated_any = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Any>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_value => {
+                            if !fields.insert(__FieldTag::__repeated_value) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_value",
+                                ));
+                            }
+                            result.repeated_value = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::Value>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__repeated_list_value => {
+                            if !fields.insert(__FieldTag::__repeated_list_value) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for repeated_list_value",
+                                ));
+                            }
+                            result.repeated_list_value = map
+                                .next_value::<std::option::Option<std::vec::Vec<wkt::ListValue>>>()?
+                                .unwrap_or_default();
+                        }
+                        __FieldTag::__fieldname1 => {
+                            if !fields.insert(__FieldTag::__fieldname1) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for fieldname1",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.fieldname1 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name2 => {
+                            if !fields.insert(__FieldTag::__field_name2) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name2",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name2 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::___field_name3 => {
+                            if !fields.insert(__FieldTag::___field_name3) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for _field_name3",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result._field_name3 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field__name4_ => {
+                            if !fields.insert(__FieldTag::__field__name4_) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field__name4_",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field__name4_ =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field0name5 => {
+                            if !fields.insert(__FieldTag::__field0name5) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field0name5",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field0name5 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_0_name6 => {
+                            if !fields.insert(__FieldTag::__field_0_name6) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_0_name6",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_0_name6 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_7 => {
+                            if !fields.insert(__FieldTag::__field_name_7) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_7",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_7 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_8 => {
+                            if !fields.insert(__FieldTag::__field_name_8) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_8",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_8 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_9 => {
+                            if !fields.insert(__FieldTag::__field_name_9) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_9",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_9 = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_10 => {
+                            if !fields.insert(__FieldTag::__field_name_10) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_10",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_10 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_11 => {
+                            if !fields.insert(__FieldTag::__field_name_11) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_11",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_11 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_12 => {
+                            if !fields.insert(__FieldTag::__field_name_12) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_12",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_12 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::____field_name13 => {
+                            if !fields.insert(__FieldTag::____field_name13) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for __field_name13",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.__field_name13 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::____field_name_14 => {
+                            if !fields.insert(__FieldTag::____field_name_14) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for __field_name_14",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.__field_name_14 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field__name15 => {
+                            if !fields.insert(__FieldTag::__field__name15) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field__name15",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field__name15 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field__name_16 => {
+                            if !fields.insert(__FieldTag::__field__name_16) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field__name_16",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field__name_16 =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name17__ => {
+                            if !fields.insert(__FieldTag::__field_name17__) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name17__",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name17__ =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::__field_name_18__ => {
+                            if !fields.insert(__FieldTag::__field_name_18__) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for field_name_18__",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.field_name_18__ =
+                                map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::Unknown(key) => {
+                            let value = map.next_value::<serde_json::Value>()?;
+                            result._unknown_fields.insert(key, value);
+                        }
+                    }
+                }
+                Ok(result)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+#[doc(hidden)]
+impl serde::ser::Serialize for TestAllTypesProto3 {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut state = serializer.serialize_map(None)?;
+        if !wkt::internal::is_default(&self.optional_int32) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalInt32", &__With(&self.optional_int32))?;
+        }
+        if !wkt::internal::is_default(&self.optional_int64) {
+            struct __With<'a>(&'a i64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalInt64", &__With(&self.optional_int64))?;
+        }
+        if !wkt::internal::is_default(&self.optional_uint32) {
+            struct __With<'a>(&'a u32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::U32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalUint32", &__With(&self.optional_uint32))?;
+        }
+        if !wkt::internal::is_default(&self.optional_uint64) {
+            struct __With<'a>(&'a u64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::U64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalUint64", &__With(&self.optional_uint64))?;
+        }
+        if !wkt::internal::is_default(&self.optional_sint32) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalSint32", &__With(&self.optional_sint32))?;
+        }
+        if !wkt::internal::is_default(&self.optional_sint64) {
+            struct __With<'a>(&'a i64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalSint64", &__With(&self.optional_sint64))?;
+        }
+        if !wkt::internal::is_default(&self.optional_fixed32) {
+            struct __With<'a>(&'a u32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::U32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalFixed32", &__With(&self.optional_fixed32))?;
+        }
+        if !wkt::internal::is_default(&self.optional_fixed64) {
+            struct __With<'a>(&'a u64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::U64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalFixed64", &__With(&self.optional_fixed64))?;
+        }
+        if !wkt::internal::is_default(&self.optional_sfixed32) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalSfixed32", &__With(&self.optional_sfixed32))?;
+        }
+        if !wkt::internal::is_default(&self.optional_sfixed64) {
+            struct __With<'a>(&'a i64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalSfixed64", &__With(&self.optional_sfixed64))?;
+        }
+        if !wkt::internal::is_default(&self.optional_float) {
+            struct __With<'a>(&'a f32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::F32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalFloat", &__With(&self.optional_float))?;
+        }
+        if !wkt::internal::is_default(&self.optional_double) {
+            struct __With<'a>(&'a f64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::F64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalDouble", &__With(&self.optional_double))?;
+        }
+        if !wkt::internal::is_default(&self.optional_bool) {
+            state.serialize_entry("optionalBool", &self.optional_bool)?;
+        }
+        if !self.optional_string.is_empty() {
+            state.serialize_entry("optionalString", &self.optional_string)?;
+        }
+        if !self.optional_bytes.is_empty() {
+            struct __With<'a>(&'a ::bytes::Bytes);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<serde_with::base64::Base64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("optionalBytes", &__With(&self.optional_bytes))?;
+        }
+        if self.optional_nested_message.is_some() {
+            state.serialize_entry("optionalNestedMessage", &self.optional_nested_message)?;
+        }
+        if self.optional_foreign_message.is_some() {
+            state.serialize_entry("optionalForeignMessage", &self.optional_foreign_message)?;
+        }
+        if !wkt::internal::is_default(&self.optional_nested_enum) {
+            state.serialize_entry("optionalNestedEnum", &self.optional_nested_enum)?;
+        }
+        if !wkt::internal::is_default(&self.optional_foreign_enum) {
+            state.serialize_entry("optionalForeignEnum", &self.optional_foreign_enum)?;
+        }
+        if !wkt::internal::is_default(&self.optional_aliased_enum) {
+            state.serialize_entry("optionalAliasedEnum", &self.optional_aliased_enum)?;
+        }
+        if !self.optional_string_piece.is_empty() {
+            state.serialize_entry("optionalStringPiece", &self.optional_string_piece)?;
+        }
+        if !self.optional_cord.is_empty() {
+            state.serialize_entry("optionalCord", &self.optional_cord)?;
+        }
+        if self.recursive_message.is_some() {
+            state.serialize_entry("recursiveMessage", &self.recursive_message)?;
+        }
+        if !self.repeated_int32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedInt32", &__With(&self.repeated_int32))?;
+        }
+        if !self.repeated_int64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedInt64", &__With(&self.repeated_int64))?;
+        }
+        if !self.repeated_uint32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedUint32", &__With(&self.repeated_uint32))?;
+        }
+        if !self.repeated_uint64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedUint64", &__With(&self.repeated_uint64))?;
+        }
+        if !self.repeated_sint32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedSint32", &__With(&self.repeated_sint32))?;
+        }
+        if !self.repeated_sint64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedSint64", &__With(&self.repeated_sint64))?;
+        }
+        if !self.repeated_fixed32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedFixed32", &__With(&self.repeated_fixed32))?;
+        }
+        if !self.repeated_fixed64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedFixed64", &__With(&self.repeated_fixed64))?;
+        }
+        if !self.repeated_sfixed32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedSfixed32", &__With(&self.repeated_sfixed32))?;
+        }
+        if !self.repeated_sfixed64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedSfixed64", &__With(&self.repeated_sfixed64))?;
+        }
+        if !self.repeated_float.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<f32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedFloat", &__With(&self.repeated_float))?;
+        }
+        if !self.repeated_double.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<f64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedDouble", &__With(&self.repeated_double))?;
+        }
+        if !self.repeated_bool.is_empty() {
+            state.serialize_entry("repeatedBool", &self.repeated_bool)?;
+        }
+        if !self.repeated_string.is_empty() {
+            state.serialize_entry("repeatedString", &self.repeated_string)?;
+        }
+        if !self.repeated_bytes.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<::bytes::Bytes>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<serde_with::base64::Base64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("repeatedBytes", &__With(&self.repeated_bytes))?;
+        }
+        if !self.repeated_nested_message.is_empty() {
+            state.serialize_entry("repeatedNestedMessage", &self.repeated_nested_message)?;
+        }
+        if !self.repeated_foreign_message.is_empty() {
+            state.serialize_entry("repeatedForeignMessage", &self.repeated_foreign_message)?;
+        }
+        if !self.repeated_nested_enum.is_empty() {
+            state.serialize_entry("repeatedNestedEnum", &self.repeated_nested_enum)?;
+        }
+        if !self.repeated_foreign_enum.is_empty() {
+            state.serialize_entry("repeatedForeignEnum", &self.repeated_foreign_enum)?;
+        }
+        if !self.repeated_string_piece.is_empty() {
+            state.serialize_entry("repeatedStringPiece", &self.repeated_string_piece)?;
+        }
+        if !self.repeated_cord.is_empty() {
+            state.serialize_entry("repeatedCord", &self.repeated_cord)?;
+        }
+        if !self.packed_int32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedInt32", &__With(&self.packed_int32))?;
+        }
+        if !self.packed_int64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedInt64", &__With(&self.packed_int64))?;
+        }
+        if !self.packed_uint32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedUint32", &__With(&self.packed_uint32))?;
+        }
+        if !self.packed_uint64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedUint64", &__With(&self.packed_uint64))?;
+        }
+        if !self.packed_sint32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedSint32", &__With(&self.packed_sint32))?;
+        }
+        if !self.packed_sint64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedSint64", &__With(&self.packed_sint64))?;
+        }
+        if !self.packed_fixed32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedFixed32", &__With(&self.packed_fixed32))?;
+        }
+        if !self.packed_fixed64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedFixed64", &__With(&self.packed_fixed64))?;
+        }
+        if !self.packed_sfixed32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedSfixed32", &__With(&self.packed_sfixed32))?;
+        }
+        if !self.packed_sfixed64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedSfixed64", &__With(&self.packed_sfixed64))?;
+        }
+        if !self.packed_float.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<f32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedFloat", &__With(&self.packed_float))?;
+        }
+        if !self.packed_double.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<f64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("packedDouble", &__With(&self.packed_double))?;
+        }
+        if !self.packed_bool.is_empty() {
+            state.serialize_entry("packedBool", &self.packed_bool)?;
+        }
+        if !self.packed_nested_enum.is_empty() {
+            state.serialize_entry("packedNestedEnum", &self.packed_nested_enum)?;
+        }
+        if !self.unpacked_int32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedInt32", &__With(&self.unpacked_int32))?;
+        }
+        if !self.unpacked_int64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedInt64", &__With(&self.unpacked_int64))?;
+        }
+        if !self.unpacked_uint32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedUint32", &__With(&self.unpacked_uint32))?;
+        }
+        if !self.unpacked_uint64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedUint64", &__With(&self.unpacked_uint64))?;
+        }
+        if !self.unpacked_sint32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedSint32", &__With(&self.unpacked_sint32))?;
+        }
+        if !self.unpacked_sint64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedSint64", &__With(&self.unpacked_sint64))?;
+        }
+        if !self.unpacked_fixed32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedFixed32", &__With(&self.unpacked_fixed32))?;
+        }
+        if !self.unpacked_fixed64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedFixed64", &__With(&self.unpacked_fixed64))?;
+        }
+        if !self.unpacked_sfixed32.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedSfixed32", &__With(&self.unpacked_sfixed32))?;
+        }
+        if !self.unpacked_sfixed64.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedSfixed64", &__With(&self.unpacked_sfixed64))?;
+        }
+        if !self.unpacked_float.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<f32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedFloat", &__With(&self.unpacked_float))?;
+        }
+        if !self.unpacked_double.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<f64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry("unpackedDouble", &__With(&self.unpacked_double))?;
+        }
+        if !self.unpacked_bool.is_empty() {
+            state.serialize_entry("unpackedBool", &self.unpacked_bool)?;
+        }
+        if !self.unpacked_nested_enum.is_empty() {
+            state.serialize_entry("unpackedNestedEnum", &self.unpacked_nested_enum)?;
+        }
+        if !self.map_int32_int32.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i32, i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I32, wkt::internal::I32>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapInt32Int32", &__With(&self.map_int32_int32))?;
+        }
+        if !self.map_int64_int64.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i64, i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapInt64Int64", &__With(&self.map_int64_int64))?;
+        }
+        if !self.map_uint32_uint32.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<u32, u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::U32, wkt::internal::U32>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapUint32Uint32", &__With(&self.map_uint32_uint32))?;
+        }
+        if !self.map_uint64_uint64.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<u64, u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapUint64Uint64", &__With(&self.map_uint64_uint64))?;
+        }
+        if !self.map_sint32_sint32.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i32, i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I32, wkt::internal::I32>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapSint32Sint32", &__With(&self.map_sint32_sint32))?;
+        }
+        if !self.map_sint64_sint64.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i64, i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapSint64Sint64", &__With(&self.map_sint64_sint64))?;
+        }
+        if !self.map_fixed32_fixed32.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<u32, u32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::U32, wkt::internal::U32>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapFixed32Fixed32", &__With(&self.map_fixed32_fixed32))?;
+        }
+        if !self.map_fixed64_fixed64.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<u64, u64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::U64, wkt::internal::U64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapFixed64Fixed64", &__With(&self.map_fixed64_fixed64))?;
+        }
+        if !self.map_sfixed32_sfixed32.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i32, i32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I32, wkt::internal::I32>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapSfixed32Sfixed32", &__With(&self.map_sfixed32_sfixed32))?;
+        }
+        if !self.map_sfixed64_sfixed64.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i64, i64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I64, wkt::internal::I64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapSfixed64Sfixed64", &__With(&self.map_sfixed64_sfixed64))?;
+        }
+        if !self.map_int32_float.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i32, f32>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I32, wkt::internal::F32>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapInt32Float", &__With(&self.map_int32_float))?;
+        }
+        if !self.map_int32_double.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<i32, f64>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<wkt::internal::I32, wkt::internal::F64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapInt32Double", &__With(&self.map_int32_double))?;
+        }
+        if !self.map_bool_bool.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<bool, bool>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<serde_with::DisplayFromStr, serde_with::Same>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapBoolBool", &__With(&self.map_bool_bool))?;
+        }
+        if !self.map_string_string.is_empty() {
+            state.serialize_entry("mapStringString", &self.map_string_string)?;
+        }
+        if !self.map_string_bytes.is_empty() {
+            struct __With<'a>(&'a std::collections::HashMap<std::string::String, ::bytes::Bytes>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<
+                        std::collections::HashMap<serde_with::Same, serde_with::base64::Base64>,
+                    >::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("mapStringBytes", &__With(&self.map_string_bytes))?;
+        }
+        if !self.map_string_nested_message.is_empty() {
+            state.serialize_entry("mapStringNestedMessage", &self.map_string_nested_message)?;
+        }
+        if !self.map_string_foreign_message.is_empty() {
+            state.serialize_entry("mapStringForeignMessage", &self.map_string_foreign_message)?;
+        }
+        if !self.map_string_nested_enum.is_empty() {
+            state.serialize_entry("mapStringNestedEnum", &self.map_string_nested_enum)?;
+        }
+        if !self.map_string_foreign_enum.is_empty() {
+            state.serialize_entry("mapStringForeignEnum", &self.map_string_foreign_enum)?;
+        }
+        if let Some(value) = self.oneof_uint32() {
+            struct __With<'a>(&'a u32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::U32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("oneofUint32", &__With(value))?;
+        }
+        if let Some(value) = self.oneof_nested_message() {
+            state.serialize_entry("oneofNestedMessage", value)?;
+        }
+        if let Some(value) = self.oneof_string() {
+            state.serialize_entry("oneofString", value)?;
+        }
+        if let Some(value) = self.oneof_bytes() {
+            struct __With<'a>(&'a ::bytes::Bytes);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<serde_with::base64::Base64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("oneofBytes", &__With(value))?;
+        }
+        if let Some(value) = self.oneof_bool() {
+            state.serialize_entry("oneofBool", value)?;
+        }
+        if let Some(value) = self.oneof_uint64() {
+            struct __With<'a>(&'a u64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::U64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("oneofUint64", &__With(value))?;
+        }
+        if let Some(value) = self.oneof_float() {
+            struct __With<'a>(&'a f32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::F32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("oneofFloat", &__With(value))?;
+        }
+        if let Some(value) = self.oneof_double() {
+            struct __With<'a>(&'a f64);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::F64>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("oneofDouble", &__With(value))?;
+        }
+        if let Some(value) = self.oneof_enum() {
+            state.serialize_entry("oneofEnum", value)?;
+        }
+        if let Some(value) = self.oneof_null_value() {
+            state.serialize_entry("oneofNullValue", value)?;
+        }
+        if self.optional_bool_wrapper.is_some() {
+            state.serialize_entry("optionalBoolWrapper", &self.optional_bool_wrapper)?;
+        }
+        if self.optional_int32_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::Int32Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalInt32Wrapper",
+                &__With(&self.optional_int32_wrapper),
+            )?;
+        }
+        if self.optional_int64_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::Int64Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalInt64Wrapper",
+                &__With(&self.optional_int64_wrapper),
+            )?;
+        }
+        if self.optional_uint32_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::UInt32Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalUint32Wrapper",
+                &__With(&self.optional_uint32_wrapper),
+            )?;
+        }
+        if self.optional_uint64_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::UInt64Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalUint64Wrapper",
+                &__With(&self.optional_uint64_wrapper),
+            )?;
+        }
+        if self.optional_float_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::FloatValue>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<wkt::internal::F32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalFloatWrapper",
+                &__With(&self.optional_float_wrapper),
+            )?;
+        }
+        if self.optional_double_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::DoubleValue>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<wkt::internal::F64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalDoubleWrapper",
+                &__With(&self.optional_double_wrapper),
+            )?;
+        }
+        if self.optional_string_wrapper.is_some() {
+            state.serialize_entry("optionalStringWrapper", &self.optional_string_wrapper)?;
+        }
+        if self.optional_bytes_wrapper.is_some() {
+            struct __With<'a>(&'a std::option::Option<wkt::BytesValue>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::option::Option<serde_with::base64::Base64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "optionalBytesWrapper",
+                &__With(&self.optional_bytes_wrapper),
+            )?;
+        }
+        if !self.repeated_bool_wrapper.is_empty() {
+            state.serialize_entry("repeatedBoolWrapper", &self.repeated_bool_wrapper)?;
+        }
+        if !self.repeated_int32_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::Int32Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedInt32Wrapper",
+                &__With(&self.repeated_int32_wrapper),
+            )?;
+        }
+        if !self.repeated_int64_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::Int64Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::I64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedInt64Wrapper",
+                &__With(&self.repeated_int64_wrapper),
+            )?;
+        }
+        if !self.repeated_uint32_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::UInt32Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedUint32Wrapper",
+                &__With(&self.repeated_uint32_wrapper),
+            )?;
+        }
+        if !self.repeated_uint64_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::UInt64Value>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::U64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedUint64Wrapper",
+                &__With(&self.repeated_uint64_wrapper),
+            )?;
+        }
+        if !self.repeated_float_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::FloatValue>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F32>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedFloatWrapper",
+                &__With(&self.repeated_float_wrapper),
+            )?;
+        }
+        if !self.repeated_double_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::DoubleValue>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<wkt::internal::F64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedDoubleWrapper",
+                &__With(&self.repeated_double_wrapper),
+            )?;
+        }
+        if !self.repeated_string_wrapper.is_empty() {
+            state.serialize_entry("repeatedStringWrapper", &self.repeated_string_wrapper)?;
+        }
+        if !self.repeated_bytes_wrapper.is_empty() {
+            struct __With<'a>(&'a std::vec::Vec<wkt::BytesValue>);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<std::vec::Vec<serde_with::base64::Base64>>::serialize(
+                        self.0, serializer,
+                    )
+                }
+            }
+            state.serialize_entry(
+                "repeatedBytesWrapper",
+                &__With(&self.repeated_bytes_wrapper),
+            )?;
+        }
+        if self.optional_duration.is_some() {
+            state.serialize_entry("optionalDuration", &self.optional_duration)?;
+        }
+        if self.optional_timestamp.is_some() {
+            state.serialize_entry("optionalTimestamp", &self.optional_timestamp)?;
+        }
+        if self.optional_field_mask.is_some() {
+            state.serialize_entry("optionalFieldMask", &self.optional_field_mask)?;
+        }
+        if self.optional_struct.is_some() {
+            state.serialize_entry("optionalStruct", &self.optional_struct)?;
+        }
+        if self.optional_any.is_some() {
+            state.serialize_entry("optionalAny", &self.optional_any)?;
+        }
+        if self.optional_value.is_some() {
+            state.serialize_entry("optionalValue", &self.optional_value)?;
+        }
+        if !wkt::internal::is_default(&self.optional_null_value) {
+            state.serialize_entry("optionalNullValue", &self.optional_null_value)?;
+        }
+        if !self.repeated_duration.is_empty() {
+            state.serialize_entry("repeatedDuration", &self.repeated_duration)?;
+        }
+        if !self.repeated_timestamp.is_empty() {
+            state.serialize_entry("repeatedTimestamp", &self.repeated_timestamp)?;
+        }
+        if !self.repeated_fieldmask.is_empty() {
+            state.serialize_entry("repeatedFieldmask", &self.repeated_fieldmask)?;
+        }
+        if !self.repeated_struct.is_empty() {
+            state.serialize_entry("repeatedStruct", &self.repeated_struct)?;
+        }
+        if !self.repeated_any.is_empty() {
+            state.serialize_entry("repeatedAny", &self.repeated_any)?;
+        }
+        if !self.repeated_value.is_empty() {
+            state.serialize_entry("repeatedValue", &self.repeated_value)?;
+        }
+        if !self.repeated_list_value.is_empty() {
+            state.serialize_entry("repeatedListValue", &self.repeated_list_value)?;
+        }
+        if !wkt::internal::is_default(&self.fieldname1) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldname1", &__With(&self.fieldname1))?;
+        }
+        if !wkt::internal::is_default(&self.field_name2) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName2", &__With(&self.field_name2))?;
+        }
+        if !wkt::internal::is_default(&self._field_name3) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FieldName3", &__With(&self._field_name3))?;
+        }
+        if !wkt::internal::is_default(&self.field__name4_) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName4", &__With(&self.field__name4_))?;
+        }
+        if !wkt::internal::is_default(&self.field0name5) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("field0name5", &__With(&self.field0name5))?;
+        }
+        if !wkt::internal::is_default(&self.field_0_name6) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("field0Name6", &__With(&self.field_0_name6))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_7) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName7", &__With(&self.field_name_7))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_8) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FieldName8", &__With(&self.field_name_8))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_9) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName9", &__With(&self.field_name_9))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_10) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FieldName10", &__With(&self.field_name_10))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_11) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FIELDNAME11", &__With(&self.field_name_11))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_12) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FIELDName12", &__With(&self.field_name_12))?;
+        }
+        if !wkt::internal::is_default(&self.__field_name13) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FieldName13", &__With(&self.__field_name13))?;
+        }
+        if !wkt::internal::is_default(&self.__field_name_14) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FieldName14", &__With(&self.__field_name_14))?;
+        }
+        if !wkt::internal::is_default(&self.field__name15) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName15", &__With(&self.field__name15))?;
+        }
+        if !wkt::internal::is_default(&self.field__name_16) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName16", &__With(&self.field__name_16))?;
+        }
+        if !wkt::internal::is_default(&self.field_name17__) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("fieldName17", &__With(&self.field_name17__))?;
+        }
+        if !wkt::internal::is_default(&self.field_name_18__) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("FieldName18", &__With(&self.field_name_18__))?;
+        }
+        if !self._unknown_fields.is_empty() {
+            for (key, value) in self._unknown_fields.iter() {
+                state.serialize_entry(key, &value)?;
+            }
+        }
+        state.end()
+    }
+}
+
 /// Defines additional types related to [TestAllTypesProto3].
 pub mod test_all_types_proto_3 {
     #[allow(unused_imports)]
     use super::*;
 
-    #[serde_with::serde_as]
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(default, rename_all = "camelCase")]
+    #[derive(Clone, Debug, Default, PartialEq)]
     #[non_exhaustive]
     pub struct NestedMessage {
-        #[serde(skip_serializing_if = "wkt::internal::is_default")]
-        #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
         pub a: i32,
 
-        #[serde(skip_serializing_if = "std::option::Option::is_none")]
         pub corecursive:
             std::option::Option<std::boxed::Box<crate::generated::test_protos::TestAllTypesProto3>>,
 
-        #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
         _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
     }
 
@@ -2540,6 +7118,142 @@ pub mod test_all_types_proto_3 {
     impl wkt::message::Message for NestedMessage {
         fn typename() -> &'static str {
             "type.googleapis.com/protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage"
+        }
+    }
+
+    #[doc(hidden)]
+    impl<'de> serde::de::Deserialize<'de> for NestedMessage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            #[doc(hidden)]
+            #[derive(PartialEq, Eq, Hash)]
+            enum __FieldTag {
+                __a,
+                __corecursive,
+                Unknown(std::string::String),
+            }
+            impl<'de> serde::de::Deserialize<'de> for __FieldTag {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    struct Visitor;
+                    impl<'de> serde::de::Visitor<'de> for Visitor {
+                        type Value = __FieldTag;
+                        fn expecting(
+                            &self,
+                            formatter: &mut std::fmt::Formatter,
+                        ) -> std::fmt::Result {
+                            formatter.write_str("a field name for NestedMessage")
+                        }
+                        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+                        where
+                            E: serde::de::Error,
+                        {
+                            use std::result::Result::Ok;
+                            match value {
+                                "a" => Ok(__FieldTag::__a),
+                                "corecursive" => Ok(__FieldTag::__corecursive),
+                                _ => Ok(__FieldTag::Unknown(value.to_string())),
+                            }
+                        }
+                    }
+                    deserializer.deserialize_identifier(Visitor)
+                }
+            }
+            struct Visitor;
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = NestedMessage;
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    formatter.write_str("struct NestedMessage")
+                }
+                fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+                where
+                    A: serde::de::MapAccess<'de>,
+                {
+                    #[allow(unused_imports)]
+                    use serde::de::Error;
+                    let mut fields = std::collections::HashSet::new();
+                    let mut result = Self::Value::new();
+                    while let Some(tag) = map.next_key::<__FieldTag>()? {
+                        #[allow(clippy::match_single_binding)]
+                        match tag {
+                            __FieldTag::__a => {
+                                if !fields.insert(__FieldTag::__a) {
+                                    return std::result::Result::Err(A::Error::duplicate_field(
+                                        "multiple values for a",
+                                    ));
+                                }
+                                struct __With(std::option::Option<i32>);
+                                impl<'de> serde::de::Deserialize<'de> for __With {
+                                    fn deserialize<D>(
+                                        deserializer: D,
+                                    ) -> std::result::Result<Self, D::Error>
+                                    where
+                                        D: serde::de::Deserializer<'de>,
+                                    {
+                                        serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                    }
+                                }
+                                result.a = map.next_value::<__With>()?.0.unwrap_or_default();
+                            }
+                            __FieldTag::__corecursive => {
+                                if !fields.insert(__FieldTag::__corecursive) {
+                                    return std::result::Result::Err(A::Error::duplicate_field(
+                                        "multiple values for corecursive",
+                                    ));
+                                }
+                                result.corecursive = map.next_value::<std::option::Option<
+                                    std::boxed::Box<
+                                        crate::generated::test_protos::TestAllTypesProto3,
+                                    >,
+                                >>()?;
+                            }
+                            __FieldTag::Unknown(key) => {
+                                let value = map.next_value::<serde_json::Value>()?;
+                                result._unknown_fields.insert(key, value);
+                            }
+                        }
+                    }
+                    Ok(result)
+                }
+            }
+            deserializer.deserialize_any(Visitor)
+        }
+    }
+
+    #[doc(hidden)]
+    impl serde::ser::Serialize for NestedMessage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::ser::Serializer,
+        {
+            use serde::ser::SerializeMap;
+            let mut state = serializer.serialize_map(None)?;
+            if !wkt::internal::is_default(&self.a) {
+                struct __With<'a>(&'a i32);
+                impl<'a> serde::ser::Serialize for __With<'a> {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::ser::Serializer,
+                    {
+                        serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                    }
+                }
+                state.serialize_entry("a", &__With(&self.a))?;
+            }
+            if self.corecursive.is_some() {
+                state.serialize_entry("corecursive", &self.corecursive)?;
+            }
+            if !self._unknown_fields.is_empty() {
+                for (key, value) in self._unknown_fields.iter() {
+                    state.serialize_entry(key, &value)?;
+                }
+            }
+            state.end()
         }
     }
 
@@ -2816,42 +7530,29 @@ pub mod test_all_types_proto_3 {
         }
     }
 
-    #[serde_with::serde_as]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, Debug, PartialEq)]
     #[non_exhaustive]
     pub enum OneofField {
-        OneofUint32(#[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::U32>")] u32),
+        OneofUint32(u32),
         OneofNestedMessage(
             std::boxed::Box<crate::generated::test_protos::test_all_types_proto_3::NestedMessage>,
         ),
-        OneofString(#[serde_as(as = "serde_with::DefaultOnNull<_>")] std::string::String),
-        OneofBytes(
-            #[serde_as(as = "serde_with::DefaultOnNull<serde_with::base64::Base64>")]
-            ::bytes::Bytes,
-        ),
-        OneofBool(#[serde_as(as = "serde_with::DefaultOnNull<_>")] bool),
-        OneofUint64(#[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::U64>")] u64),
-        OneofFloat(#[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::F32>")] f32),
-        OneofDouble(#[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::F64>")] f64),
-        OneofEnum(
-            #[serde_as(as = "serde_with::DefaultOnNull<_>")]
-            crate::generated::test_protos::test_all_types_proto_3::NestedEnum,
-        ),
-        OneofNullValue(#[serde_as(as = "serde_with::DefaultOnNull<_>")] wkt::NullValue),
+        OneofString(std::string::String),
+        OneofBytes(::bytes::Bytes),
+        OneofBool(bool),
+        OneofUint64(u64),
+        OneofFloat(f32),
+        OneofDouble(f64),
+        OneofEnum(crate::generated::test_protos::test_all_types_proto_3::NestedEnum),
+        OneofNullValue(wkt::NullValue),
     }
 }
 
-#[serde_with::serde_as]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct ForeignMessage {
-    #[serde(skip_serializing_if = "wkt::internal::is_default")]
-    #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub c: i32,
 
-    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
     _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
@@ -2873,12 +7574,125 @@ impl wkt::message::Message for ForeignMessage {
     }
 }
 
-#[serde_with::serde_as]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[doc(hidden)]
+impl<'de> serde::de::Deserialize<'de> for ForeignMessage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        #[derive(PartialEq, Eq, Hash)]
+        enum __FieldTag {
+            __c,
+            Unknown(std::string::String),
+        }
+        impl<'de> serde::de::Deserialize<'de> for __FieldTag {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct Visitor;
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = __FieldTag;
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a field name for ForeignMessage")
+                    }
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        use std::result::Result::Ok;
+                        match value {
+                            "c" => Ok(__FieldTag::__c),
+                            _ => Ok(__FieldTag::Unknown(value.to_string())),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(Visitor)
+            }
+        }
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = ForeignMessage;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct ForeignMessage")
+            }
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[allow(unused_imports)]
+                use serde::de::Error;
+                let mut fields = std::collections::HashSet::new();
+                let mut result = Self::Value::new();
+                while let Some(tag) = map.next_key::<__FieldTag>()? {
+                    #[allow(clippy::match_single_binding)]
+                    match tag {
+                        __FieldTag::__c => {
+                            if !fields.insert(__FieldTag::__c) {
+                                return std::result::Result::Err(A::Error::duplicate_field(
+                                    "multiple values for c",
+                                ));
+                            }
+                            struct __With(std::option::Option<i32>);
+                            impl<'de> serde::de::Deserialize<'de> for __With {
+                                fn deserialize<D>(
+                                    deserializer: D,
+                                ) -> std::result::Result<Self, D::Error>
+                                where
+                                    D: serde::de::Deserializer<'de>,
+                                {
+                                    serde_with::As::< std::option::Option<wkt::internal::I32> >::deserialize(deserializer).map(__With)
+                                }
+                            }
+                            result.c = map.next_value::<__With>()?.0.unwrap_or_default();
+                        }
+                        __FieldTag::Unknown(key) => {
+                            let value = map.next_value::<serde_json::Value>()?;
+                            result._unknown_fields.insert(key, value);
+                        }
+                    }
+                }
+                Ok(result)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+#[doc(hidden)]
+impl serde::ser::Serialize for ForeignMessage {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut state = serializer.serialize_map(None)?;
+        if !wkt::internal::is_default(&self.c) {
+            struct __With<'a>(&'a i32);
+            impl<'a> serde::ser::Serialize for __With<'a> {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::ser::Serializer,
+                {
+                    serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
+                }
+            }
+            state.serialize_entry("c", &__With(&self.c))?;
+        }
+        if !self._unknown_fields.is_empty() {
+            for (key, value) in self._unknown_fields.iter() {
+                state.serialize_entry(key, &value)?;
+            }
+        }
+        state.end()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct NullHypothesisProto3 {
-    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
     _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
@@ -2894,12 +7708,89 @@ impl wkt::message::Message for NullHypothesisProto3 {
     }
 }
 
-#[serde_with::serde_as]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[doc(hidden)]
+impl<'de> serde::de::Deserialize<'de> for NullHypothesisProto3 {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        #[derive(PartialEq, Eq, Hash)]
+        enum __FieldTag {
+            Unknown(std::string::String),
+        }
+        impl<'de> serde::de::Deserialize<'de> for __FieldTag {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct Visitor;
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = __FieldTag;
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a field name for NullHypothesisProto3")
+                    }
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        use std::result::Result::Ok;
+                        Ok(__FieldTag::Unknown(value.to_string()))
+                    }
+                }
+                deserializer.deserialize_identifier(Visitor)
+            }
+        }
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = NullHypothesisProto3;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct NullHypothesisProto3")
+            }
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[allow(unused_imports)]
+                use serde::de::Error;
+                let mut result = Self::Value::new();
+                while let Some(tag) = map.next_key::<__FieldTag>()? {
+                    #[allow(clippy::match_single_binding)]
+                    match tag {
+                        __FieldTag::Unknown(key) => {
+                            let value = map.next_value::<serde_json::Value>()?;
+                            result._unknown_fields.insert(key, value);
+                        }
+                    }
+                }
+                Ok(result)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+#[doc(hidden)]
+impl serde::ser::Serialize for NullHypothesisProto3 {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut state = serializer.serialize_map(None)?;
+        if !self._unknown_fields.is_empty() {
+            for (key, value) in self._unknown_fields.iter() {
+                state.serialize_entry(key, &value)?;
+            }
+        }
+        state.end()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct EnumOnlyProto3 {
-    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
     _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
@@ -2912,6 +7803,86 @@ impl EnumOnlyProto3 {
 impl wkt::message::Message for EnumOnlyProto3 {
     fn typename() -> &'static str {
         "type.googleapis.com/protobuf_test_messages.proto3.EnumOnlyProto3"
+    }
+}
+
+#[doc(hidden)]
+impl<'de> serde::de::Deserialize<'de> for EnumOnlyProto3 {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        #[derive(PartialEq, Eq, Hash)]
+        enum __FieldTag {
+            Unknown(std::string::String),
+        }
+        impl<'de> serde::de::Deserialize<'de> for __FieldTag {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct Visitor;
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = __FieldTag;
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a field name for EnumOnlyProto3")
+                    }
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        use std::result::Result::Ok;
+                        Ok(__FieldTag::Unknown(value.to_string()))
+                    }
+                }
+                deserializer.deserialize_identifier(Visitor)
+            }
+        }
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = EnumOnlyProto3;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct EnumOnlyProto3")
+            }
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[allow(unused_imports)]
+                use serde::de::Error;
+                let mut result = Self::Value::new();
+                while let Some(tag) = map.next_key::<__FieldTag>()? {
+                    #[allow(clippy::match_single_binding)]
+                    match tag {
+                        __FieldTag::Unknown(key) => {
+                            let value = map.next_value::<serde_json::Value>()?;
+                            result._unknown_fields.insert(key, value);
+                        }
+                    }
+                }
+                Ok(result)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+#[doc(hidden)]
+impl serde::ser::Serialize for EnumOnlyProto3 {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut state = serializer.serialize_map(None)?;
+        if !self._unknown_fields.is_empty() {
+            for (key, value) in self._unknown_fields.iter() {
+                state.serialize_entry(key, &value)?;
+            }
+        }
+        state.end()
     }
 }
 


### PR DESCRIPTION
Part of the work for #2376, fixes #2328

We generate more code, but since there are fewer `#[derive(...)]` attributes the total code is smaller:

```
cargo expand -p protojson-conformance --lib generated::test_protos > expand-pos-pr21.rs
wc -l expand-p*
   11334 expand-pos-pr21.rs
   21773 expand-pre-pr21.rs
   33107 total
```