### PR TITLE
fix(generator): stabilize `cargo fmt` output

### DIFF
--- a/generator/internal/rust/templates/common/deser_plain_message_field.mustache
+++ b/generator/internal/rust/templates/common/deser_plain_message_field.mustache
@@ -35,7 +35,7 @@ result.{{Codec.FieldName}} = map.next_value::<std::option::Option<{{{Codec.Field
 if result.{{Group.Codec.FieldName}}.is_some() {
     return std::result::Result::Err(A::Error::duplicate_field(
         "multiple values for `{{Group.Codec.FieldName}}`, a oneof with full ID {{ID}}, latest field was {{JSONName}}",
-    ))
+    ));
 }
 result.{{Group.Codec.FieldName}} = std::option::Option::Some(
     {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(

--- a/generator/internal/rust/templates/common/deser_with_message_field.mustache
+++ b/generator/internal/rust/templates/common/deser_with_message_field.mustache
@@ -60,7 +60,7 @@ impl<'de> serde::de::Deserialize<'de> for __With {
 if result.{{Group.Codec.FieldName}}.is_some() {
     return std::result::Result::Err(A::Error::duplicate_field(
         "multiple values for `{{Group.Codec.FieldName}}`, a oneof with full ID {{ID}}, latest field was {{JSONName}}",
-    ))
+    ));
 }
 result.{{Group.Codec.FieldName}} = std::option::Option::Some(
     {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(


### PR DESCRIPTION
With the missing `;` we need two passes of `cargo fmt` to stabilize the
code in large services. That seems undersirable.

Part of the work for #2376