### PR TITLE
fix(generator): preserve numbered lists

### DIFF
--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -1539,6 +1539,59 @@ func TestFormatDocCommentsBullets(t *testing.T) {
 	}
 }
 
+func TestFormatDocCommentsNumbers(t *testing.T) {
+	input := `Numbered lists are different:
+
+1.   A simple list item
+2.   A number list item
+     continued in the next line
+3.   A second list item
+
+     with a second paragraph
+4.   A third list item
+
+     also with a second paragraph
+
+	 * And some nested list items
+	 * and some more
+	   even split ones
+	 * and more
+5.   A fourth list item
+    with some bad indentation
+`
+	want := []string{
+		"/// Numbered lists are different:",
+		"///",
+		"/// 1. A simple list item",
+		"///",
+		"/// 1. A number list item",
+		"///    continued in the next line",
+		"///",
+		"/// 1. A second list item",
+		"///",
+		"///    with a second paragraph",
+		"///",
+		"/// 1. A third list item",
+		"///",
+		"///    also with a second paragraph",
+		"///",
+		"///    * And some nested list items",
+		"///    * and some more",
+		"///      even split ones",
+		"///    * and more",
+		"/// 1. A fourth list item",
+		"///    with some bad indentation",
+		"///",
+	}
+
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	c := createRustCodec()
+	got := c.formatDocComments(input, "test-only-ID", model.State, []string{})
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
+	}
+}
+
 func TestFormatDocCommentsImplicitBlockQuote(t *testing.T) {
 	input := `
 Blockquotes come in many forms. They can start with a leading '> ', as in:

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -5687,13 +5687,13 @@ impl wkt::message::Message for BatchWriteResponse {
 ///
 /// The query stages are executed in the following order:
 ///
-/// . from
-/// . where
-/// . select
-/// . order_by + start_at + end_at
-/// . offset
-/// . limit
-/// . find_nearest
+/// 1. from
+/// 1. where
+/// 1. select
+/// 1. order_by + start_at + end_at
+/// 1. offset
+/// 1. limit
+/// 1. find_nearest
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -2624,13 +2624,13 @@ pub struct AllocateQuotaResponse {
     /// Quota metrics to indicate the result of allocation. Depending on the
     /// request, one or more of the following metrics will be included:
     ///
-    /// . Per quota group or per quota metric incremental usage will be specified
-    ///   using the following delta metric :
-    ///   "serviceruntime.googleapis.com/api/consumer/quota_used_count"
+    /// 1. Per quota group or per quota metric incremental usage will be specified
+    ///    using the following delta metric :
+    ///    "serviceruntime.googleapis.com/api/consumer/quota_used_count"
     ///
-    /// . The quota limit reached condition will be specified using the following
-    ///   boolean metric :
-    ///   "serviceruntime.googleapis.com/quota/exceeded"
+    /// 1. The quota limit reached condition will be specified using the following
+    ///    boolean metric :
+    ///    "serviceruntime.googleapis.com/quota/exceeded"
     ///
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
@@ -3529,17 +3529,17 @@ pub struct ReportResponse {
     /// Partial failures, one for each `Operation` in the request that failed
     /// processing. There are three possible combinations of the RPC status:
     ///
-    /// . The combination of a successful RPC status and an empty `report_errors`
-    ///   list indicates a complete success where all `Operations` in the
-    ///   request are processed successfully.
-    /// . The combination of a successful RPC status and a non-empty
-    ///   `report_errors` list indicates a partial success where some
-    ///   `Operations` in the request succeeded. Each
-    ///   `Operation` that failed processing has a corresponding item
-    ///   in this list.
-    /// . A failed RPC status indicates a general non-deterministic failure.
-    ///   When this happens, it's impossible to know which of the
-    ///   'Operations' in the request succeeded or failed.
+    /// 1. The combination of a successful RPC status and an empty `report_errors`
+    ///    list indicates a complete success where all `Operations` in the
+    ///    request are processed successfully.
+    /// 1. The combination of a successful RPC status and a non-empty
+    ///    `report_errors` list indicates a partial success where some
+    ///    `Operations` in the request succeeded. Each
+    ///    `Operation` that failed processing has a corresponding item
+    ///    in this list.
+    /// 1. A failed RPC status indicates a general non-deterministic failure.
+    ///    When this happens, it's impossible to know which of the
+    ///    'Operations' in the request succeeded or failed.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub report_errors: std::vec::Vec<crate::model::report_response::ReportError>,

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -415,9 +415,9 @@ pub struct AuthProvider {
     ///
     /// If not specified,  default to use following 3 locations:
     ///
-    /// ) Authorization: Bearer
-    /// ) x-goog-iap-jwt-assertion
-    /// ) access_token query parameter
+    /// 1. Authorization: Bearer
+    /// 1. x-goog-iap-jwt-assertion
+    /// 1. access_token query parameter
     ///
     /// Default locations can be specified as followings:
     /// jwt_locations:
@@ -4890,22 +4890,22 @@ impl wkt::message::Message for Http {
 ///
 /// Rules for HTTP mapping
 ///
-/// . Leaf request fields (recursive expansion nested messages in the request
-///   message) are classified into three categories:
-///   - Fields referred by the path template. They are passed via the URL path.
-///   - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
-///     are passed via the HTTP
-///     request body.
-///   - All other fields are passed via the URL query parameters, and the
-///     parameter name is the field path in the request message. A repeated
-///     field can be represented as multiple query parameters under the same
-///     name.
-/// . If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
-///   query parameter, all fields
-///   are passed via URL path and HTTP request body.
-/// . If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
-///   request body, all
-///   fields are passed via URL path and URL query parameters.
+/// 1. Leaf request fields (recursive expansion nested messages in the request
+///    message) are classified into three categories:
+///    - Fields referred by the path template. They are passed via the URL path.
+///    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+///      are passed via the HTTP
+///      request body.
+///    - All other fields are passed via the URL query parameters, and the
+///      parameter name is the field path in the request message. A repeated
+///      field can be represented as multiple query parameters under the same
+///      name.
+/// 1. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+///    query parameter, all fields
+///    are passed via URL path and HTTP request body.
+/// 1. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+///    request body, all
+///    fields are passed via URL path and URL query parameters.
 ///
 /// Path template syntax
 ///

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -7581,13 +7581,13 @@ pub mod cluster {
         /// Describes the Cloud KMS encryption key that will be used to protect the
         /// destination Bigtable cluster. The requirements for this key are:
         ///
-        /// ) The Cloud Bigtable service account associated with the project that
-        ///   contains this cluster must be granted the
-        ///   `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key.
-        /// ) Only regional keys can be used and the region of the CMEK key must
-        ///   match the region of the cluster.
-        ///   Values are of the form
-        ///   `projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}`
+        /// 1. The Cloud Bigtable service account associated with the project that
+        ///    contains this cluster must be granted the
+        ///    `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key.
+        /// 1. Only regional keys can be used and the region of the CMEK key must
+        ///    match the region of the cluster.
+        ///    Values are of the form
+        ///    `projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}`
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
         #[serde_as(as = "serde_with::DefaultOnNull<_>")]
         pub kms_key_name: std::string::String,

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -10495,10 +10495,10 @@ impl wkt::message::Message for BatchCreateInstancesMetadata {
 /// because of failure of the previous one. Then, resulting states would look
 /// something like:
 ///
-/// . Instance1 = ROLLED_BACK
-/// . Instance2 = ROLLED_BACK
-/// . Instance3 = FAILED
-/// . Instance4 = FAILED
+/// 1. Instance1 = ROLLED_BACK
+/// 1. Instance2 = ROLLED_BACK
+/// 1. Instance3 = FAILED
+/// 1. Instance4 = FAILED
 ///
 /// However, while the operation is running, the instance might be in other
 /// states including PENDING_CREATE, ACTIVE, DELETING and CREATING. The states
@@ -10512,11 +10512,11 @@ pub struct BatchCreateInstanceStatus {
     /// Once the operation is complete, the final state of the instances in the
     /// LRO can be one of:
     ///
-    /// . ACTIVE, indicating that instances were created successfully
-    /// . FAILED, indicating that a particular instance failed creation
-    /// . ROLLED_BACK indicating that although the instance was created
-    ///   successfully, it had to be rolled back and deleted due to failure in
-    ///   other steps of the workflow.
+    /// 1. ACTIVE, indicating that instances were created successfully
+    /// 1. FAILED, indicating that a particular instance failed creation
+    /// 1. ROLLED_BACK indicating that although the instance was created
+    ///    successfully, it had to be rolled back and deleted due to failure in
+    ///    other steps of the workflow.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub state: crate::model::batch_create_instance_status::State,

--- a/src/generated/cloud/apihub/v1/src/client.rs
+++ b/src/generated/cloud/apihub/v1/src/client.rs
@@ -288,9 +288,9 @@ impl ApiHub {
     ///
     /// In case of an OAS spec, updating spec contents can lead to:
     ///
-    /// . Creation, deletion and update of operations.
-    /// . Creation, deletion and update of definitions.
-    /// . Update of other info parsed out from the new spec.
+    /// 1. Creation, deletion and update of operations.
+    /// 1. Creation, deletion and update of definitions.
+    /// 1. Update of other info parsed out from the new spec.
     ///
     /// In case of contents or source_uri being present in update mask, spec_type
     /// must also be present. Also, spec_type can not be present in update mask if

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -382,8 +382,8 @@ pub struct ManagementServer {
     /// Optional. Resource labels to represent user provided metadata.
     /// Labels currently defined:
     ///
-    /// . migrate_from_go=<false|true>
-    ///   If set to true, the MS is created in migration ready mode.
+    /// 1. migrate_from_go=<false|true>
+    ///    If set to true, the MS is created in migration ready mode.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub labels: std::collections::HashMap<std::string::String, std::string::String>,

--- a/src/generated/cloud/bigquery/reservation/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/client.rs
@@ -327,10 +327,10 @@ impl ReservationService {
     /// Deprecated: Looks up assignments for a specified resource for a particular
     /// region. If the request is about a project:
     ///
-    /// . Assignments created on the project will be returned if they exist.
-    /// . Otherwise assignments created on the closest ancestor will be
-    ///   returned.
-    /// . Assignments for different JobTypes will all be returned.
+    /// 1. Assignments created on the project will be returned if they exist.
+    /// 1. Otherwise assignments created on the closest ancestor will be
+    ///    returned.
+    /// 1. Assignments for different JobTypes will all be returned.
     ///
     /// The same logic applies if the request is about a folder.
     ///
@@ -340,10 +340,10 @@ impl ReservationService {
     /// Comparing to ListAssignments, there are some behavior
     /// differences:
     ///
-    /// . permission on the assignee will be verified in this API.
-    /// . Hierarchy lookup (project->folder->organization) happens in this API.
-    /// . Parent here is `projects/*/locations/*`, instead of
-    ///   `projects/*/locations/*reservations/*`.
+    /// 1. permission on the assignee will be verified in this API.
+    /// 1. Hierarchy lookup (project->folder->organization) happens in this API.
+    /// 1. Parent here is `projects/*/locations/*`, instead of
+    ///    `projects/*/locations/*reservations/*`.
     ///
     /// **Note** "-" cannot be used for projects
     /// nor locations.
@@ -355,10 +355,10 @@ impl ReservationService {
     /// Looks up assignments for a specified resource for a particular region.
     /// If the request is about a project:
     ///
-    /// . Assignments created on the project will be returned if they exist.
-    /// . Otherwise assignments created on the closest ancestor will be
-    ///   returned.
-    /// . Assignments for different JobTypes will all be returned.
+    /// 1. Assignments created on the project will be returned if they exist.
+    /// 1. Otherwise assignments created on the closest ancestor will be
+    ///    returned.
+    /// 1. Assignments for different JobTypes will all be returned.
     ///
     /// The same logic applies if the request is about a folder.
     ///
@@ -368,10 +368,10 @@ impl ReservationService {
     /// Comparing to ListAssignments, there are some behavior
     /// differences:
     ///
-    /// . permission on the assignee will be verified in this API.
-    /// . Hierarchy lookup (project->folder->organization) happens in this API.
-    /// . Parent here is `projects/*/locations/*`, instead of
-    ///   `projects/*/locations/*reservations/*`.
+    /// 1. permission on the assignee will be verified in this API.
+    /// 1. Hierarchy lookup (project->folder->organization) happens in this API.
+    /// 1. Parent here is `projects/*/locations/*`, instead of
+    ///    `projects/*/locations/*reservations/*`.
     pub fn search_all_assignments(
         &self,
     ) -> super::builder::reservation_service::SearchAllAssignments {

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -22117,14 +22117,14 @@ pub mod model {
             /// The column to split data with. This column won't be used as a
             /// feature.
             ///
-            /// . When data_split_method is CUSTOM, the corresponding column should
-            ///   be boolean. The rows with true value tag are eval data, and the false
-            ///   are training data.
-            /// . When data_split_method is SEQ, the first DATA_SPLIT_EVAL_FRACTION
-            ///   rows (from smallest to largest) in the corresponding column are used
-            ///   as training data, and the rest are eval data. It respects the order
-            ///   in Orderable data types:
-            ///   <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#data_type_properties>
+            /// 1. When data_split_method is CUSTOM, the corresponding column should
+            ///    be boolean. The rows with true value tag are eval data, and the false
+            ///    are training data.
+            /// 1. When data_split_method is SEQ, the first DATA_SPLIT_EVAL_FRACTION
+            ///    rows (from smallest to largest) in the corresponding column are used
+            ///    as training data, and the rest are eval data. It respects the order
+            ///    in Orderable data types:
+            ///    <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#data_type_properties>
             pub data_split_column: std::string::String,
 
             /// The strategy to determine learn rate for the current iteration.
@@ -45963,14 +45963,14 @@ impl serde::ser::Serialize for RowAccessPolicyReference {
 ///
 /// * ARRAY\<STRING\>:
 ///
-/// * {
+///   {
 ///   "typeKind": "ARRAY",
 ///   "arrayElementType": {"typeKind": "STRING"}
 ///   }
 ///
 /// * STRUCT<x STRING, y ARRAY\<DATE\>>:
 ///
-/// * {
+///   {
 ///   "typeKind": "STRUCT",
 ///   "structType":
 ///   {
@@ -45994,7 +45994,7 @@ impl serde::ser::Serialize for RowAccessPolicyReference {
 ///
 /// * RANGE\<DATE\>:
 ///
-/// * {
+///   {
 ///   "typeKind": "RANGE",
 ///   "rangeElementType": {"typeKind": "DATE"}
 ///   }

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -1197,11 +1197,11 @@ pub struct ContainerImageSignature {
     /// Optional. A signature over the payload.
     /// The container image digest is incorporated into the signature as follows:
     ///
-    /// . Generate a SimpleSigning format payload that includes the container
-    ///   image digest.
-    /// . Generate a signature over SHA256 digest of the payload.
-    ///   The signature generation process can be represented as follows:
-    ///   `Sign(sha256(SimpleSigningPayload(sha256(Image Manifest))))`
+    /// 1. Generate a SimpleSigning format payload that includes the container
+    ///    image digest.
+    /// 1. Generate a signature over SHA256 digest of the payload.
+    ///    The signature generation process can be represented as follows:
+    ///    `Sign(sha256(SimpleSigningPayload(sha256(Image Manifest))))`
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<serde_with::base64::Base64>")]
     pub signature: ::bytes::Bytes,

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -2103,11 +2103,11 @@ pub mod lookup_entry_request {
         ///
         /// * For non-regionalized resources:
         ///
-        /// * `{SYSTEM}:{PROJECT}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
+        ///   `{SYSTEM}:{PROJECT}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
         ///
         /// * For regionalized resources:
         ///
-        /// * `{SYSTEM}:{PROJECT}.{LOCATION_ID}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
+        ///   `{SYSTEM}:{PROJECT}.{LOCATION_ID}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
         ///
         ///
         /// Example for a DPMS table:
@@ -11722,11 +11722,11 @@ pub struct SearchCatalogResult {
     ///
     /// * For non-regionalized resources:
     ///
-    /// * `{SYSTEM}:{PROJECT}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
+    ///   `{SYSTEM}:{PROJECT}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
     ///
     /// * For regionalized resources:
     ///
-    /// * `{SYSTEM}:{PROJECT}.{LOCATION_ID}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
+    ///   `{SYSTEM}:{PROJECT}.{LOCATION_ID}.{PATH_TO_RESOURCE_SEPARATED_WITH_DOTS}`
     ///
     ///
     /// Example for a DPMS table:

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -8912,22 +8912,22 @@ pub mod data_discovery_spec {
         /// Optional. The location of the BigQuery dataset to publish BigLake
         /// external or non-BigLake external tables to.
         ///
-        /// . If the Cloud Storage bucket is located in a multi-region bucket, then
-        ///   BigQuery dataset can be in the same multi-region bucket or any single
-        ///   region that is included in the same multi-region bucket. The datascan can
-        ///   be created in any single region that is included in the same multi-region
-        ///   bucket
-        /// . If the Cloud Storage bucket is located in a dual-region bucket, then
-        ///   BigQuery dataset can be located in regions that are included in the
-        ///   dual-region bucket, or in a multi-region that includes the dual-region.
-        ///   The datascan can be created in any single region that is included in the
-        ///   same dual-region bucket.
-        /// . If the Cloud Storage bucket is located in a single region, then
-        ///   BigQuery dataset can be in the same single region or any multi-region
-        ///   bucket that includes the same single region. The datascan will be created
-        ///   in the same single region as the bucket.
-        /// . If the BigQuery dataset is in single region, it must be in the same
-        ///   single region as the datascan.
+        /// 1. If the Cloud Storage bucket is located in a multi-region bucket, then
+        ///    BigQuery dataset can be in the same multi-region bucket or any single
+        ///    region that is included in the same multi-region bucket. The datascan can
+        ///    be created in any single region that is included in the same multi-region
+        ///    bucket
+        /// 1. If the Cloud Storage bucket is located in a dual-region bucket, then
+        ///    BigQuery dataset can be located in regions that are included in the
+        ///    dual-region bucket, or in a multi-region that includes the dual-region.
+        ///    The datascan can be created in any single region that is included in the
+        ///    same dual-region bucket.
+        /// 1. If the Cloud Storage bucket is located in a single region, then
+        ///    BigQuery dataset can be in the same single region or any multi-region
+        ///    bucket that includes the same single region. The datascan will be created
+        ///    in the same single region as the bucket.
+        /// 1. If the BigQuery dataset is in single region, it must be in the same
+        ///    single region as the datascan.
         ///
         /// For supported values, refer to
         /// <https://cloud.google.com/bigquery/docs/locations#supported_locations>.

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -8764,24 +8764,24 @@ pub struct ListChangelogsRequest {
     /// The filter string. Supports filter by user_email, resource, type and
     /// create_time. Some examples:
     ///
-    /// . By user email:
-    ///   user_email = "someone@google.com"
-    /// . By resource name:
-    ///   resource = "projects/123/locations/global/agents/456/flows/789"
-    /// . By resource display name:
-    ///   display_name = "my agent"
-    /// . By action:
-    ///   action = "Create"
-    /// . By type:
-    ///   type = "flows"
-    /// . By create time. Currently predicates on `create_time` and
-    ///   `create_time_epoch_seconds` are supported:
-    ///   create_time_epoch_seconds > 1551790877 AND create_time <=
-    ///   2017-01-15T01:30:15.01Z
-    /// . Combination of above filters:
-    ///   resource = "projects/123/locations/global/agents/456/flows/789"
-    ///   AND user_email = "someone@google.com"
-    ///   AND create_time <= 2017-01-15T01:30:15.01Z
+    /// 1. By user email:
+    ///    user_email = "someone@google.com"
+    /// 1. By resource name:
+    ///    resource = "projects/123/locations/global/agents/456/flows/789"
+    /// 1. By resource display name:
+    ///    display_name = "my agent"
+    /// 1. By action:
+    ///    action = "Create"
+    /// 1. By type:
+    ///    type = "flows"
+    /// 1. By create time. Currently predicates on `create_time` and
+    ///    `create_time_epoch_seconds` are supported:
+    ///    create_time_epoch_seconds > 1551790877 AND create_time <=
+    ///    2017-01-15T01:30:15.01Z
+    /// 1. Combination of above filters:
+    ///    resource = "projects/123/locations/global/agents/456/flows/789"
+    ///    AND user_email = "someone@google.com"
+    ///    AND create_time <= 2017-01-15T01:30:15.01Z
     pub filter: std::string::String,
 
     /// The maximum number of items to return in a single page. By default 100 and
@@ -31278,11 +31278,11 @@ pub struct Fulfillment {
     /// Dialogflow invokes webhook.
     /// Warning:
     ///
-    /// ) This flag only affects streaming API. Responses are still queued
-    ///   and returned once in non-streaming API.
-    /// ) The flag can be enabled in any fulfillment but only the first 3 partial
-    ///   responses will be returned. You may only want to apply it to fulfillments
-    ///   that have slow webhooks.
+    /// 1. This flag only affects streaming API. Responses are still queued
+    ///    and returned once in non-streaming API.
+    /// 1. The flag can be enabled in any fulfillment but only the first 3 partial
+    ///    responses will be returned. You may only want to apply it to fulfillments
+    ///    that have slow webhooks.
     pub return_partial_responses: bool,
 
     /// The value of this field will be populated in the
@@ -51935,31 +51935,31 @@ pub mod detect_intent_response {
 ///
 /// Multiple request messages should be sent in order:
 ///
-/// . The first message must contain
-///   [session][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.session],
-///   [query_input][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.query_input]
-///   plus optionally
-///   [query_params][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.query_params].
-///   If the client wants to receive an audio response, it should also contain
-///   [output_audio_config][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.output_audio_config].
+/// 1. The first message must contain
+///    [session][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.session],
+///    [query_input][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.query_input]
+///    plus optionally
+///    [query_params][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.query_params].
+///    If the client wants to receive an audio response, it should also contain
+///    [output_audio_config][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.output_audio_config].
 ///
-/// . If
-///   [query_input][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.query_input]
-///   was set to
-///   [query_input.audio.config][google.cloud.dialogflow.cx.v3.AudioInput.config],
-///   all subsequent messages must contain
-///   [query_input.audio.audio][google.cloud.dialogflow.cx.v3.AudioInput.audio]
-///   to continue with Speech recognition. If you decide to rather detect an
-///   intent from text input after you already started Speech recognition,
-///   please send a message with
-///   [query_input.text][google.cloud.dialogflow.cx.v3.QueryInput.text].
+/// 1. If
+///    [query_input][google.cloud.dialogflow.cx.v3.StreamingDetectIntentRequest.query_input]
+///    was set to
+///    [query_input.audio.config][google.cloud.dialogflow.cx.v3.AudioInput.config],
+///    all subsequent messages must contain
+///    [query_input.audio.audio][google.cloud.dialogflow.cx.v3.AudioInput.audio]
+///    to continue with Speech recognition. If you decide to rather detect an
+///    intent from text input after you already started Speech recognition,
+///    please send a message with
+///    [query_input.text][google.cloud.dialogflow.cx.v3.QueryInput.text].
 ///
-/// . However, note that:
+///    However, note that:
 ///
-///   * Dialogflow will bill you for the audio duration so far.
-///   * Dialogflow discards all Speech recognition results in favor of the
-///     input text.
-///   * Dialogflow will use the language code from the first message.
+///    * Dialogflow will bill you for the audio duration so far.
+///    * Dialogflow discards all Speech recognition results in favor of the
+///      input text.
+///    * Dialogflow will use the language code from the first message.
 ///
 /// After you sent all input, you must half-close or abort the request stream.
 ///
@@ -55510,11 +55510,11 @@ pub mod boost_spec {
             pub struct ControlPoint {
                 /// Optional. Can be one of:
                 ///
-                /// . The numerical field value.
-                /// . The duration spec for freshness:
-                ///   The value must be formatted as an XSD `dayTimeDuration` value (a
-                ///   restricted subset of an ISO 8601 duration value). The pattern for
-                ///   this is: `[nD][T[nH][nM][nS]]`.
+                /// 1. The numerical field value.
+                /// 1. The duration spec for freshness:
+                ///    The value must be formatted as an XSD `dayTimeDuration` value (a
+                ///    restricted subset of an ISO 8601 duration value). The pattern for
+                ///    this is: `[nD][T[nH][nM][nS]]`.
                 pub attribute_value: std::string::String,
 
                 /// Optional. The value between -1 to 1 by which to boost the score if
@@ -56354,17 +56354,17 @@ impl serde::ser::Serialize for FilterSpecs {
 
 /// Represents the query input. It can contain one of:
 ///
-/// . A conversational query in the form of text.
+/// 1. A conversational query in the form of text.
 ///
-/// . An intent query that specifies which intent to trigger.
+/// 1. An intent query that specifies which intent to trigger.
 ///
-/// . Natural language speech audio to be processed.
+/// 1. Natural language speech audio to be processed.
 ///
-/// . An event to be triggered.
+/// 1. An event to be triggered.
 ///
-/// . DTMF digits to invoke an intent and fill in parameter value.
+/// 1. DTMF digits to invoke an intent and fill in parameter value.
 ///
-/// . The results of a tool executed by the client.
+/// 1. The results of a tool executed by the client.
 ///
 #[cfg(any(feature = "sessions", feature = "test-cases",))]
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -83639,7 +83639,7 @@ pub enum SpeechModelVariant {
     ///   [model][google.cloud.dialogflow.cx.v3.InputAudioConfig.model] and request
     ///   language, Dialogflow falls back to the standard variant.
     ///
-    /// * The [Cloud Speech
+    ///   The [Cloud Speech
     ///   documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
     ///   describes which models have enhanced variants.
     ///

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -1538,15 +1538,15 @@ impl wkt::message::Message for GetValidationResultRequest {
 ///
 /// A typical workflow for customers provide feedback to an answer is:
 ///
-/// . For human agent assistant, customers get suggestion via ListSuggestions
-///   API. Together with the answers,
-///   [AnswerRecord.name][google.cloud.dialogflow.v2.AnswerRecord.name] are
-///   returned to the customers.
-/// . The customer uses the
-///   [AnswerRecord.name][google.cloud.dialogflow.v2.AnswerRecord.name] to call the
-///   [AnswerRecords.UpdateAnswerRecord][google.cloud.dialogflow.v2.AnswerRecords.UpdateAnswerRecord]
-///   method to send feedback about a specific answer that they believe is
-///   wrong.
+/// 1. For human agent assistant, customers get suggestion via ListSuggestions
+///    API. Together with the answers,
+///    [AnswerRecord.name][google.cloud.dialogflow.v2.AnswerRecord.name] are
+///    returned to the customers.
+/// 1. The customer uses the
+///    [AnswerRecord.name][google.cloud.dialogflow.v2.AnswerRecord.name] to call the
+///    [AnswerRecords.UpdateAnswerRecord][google.cloud.dialogflow.v2.AnswerRecords.UpdateAnswerRecord]
+///    method to send feedback about a specific answer that they believe is
+///    wrong.
 ///
 /// [google.cloud.dialogflow.v2.AnswerRecord.name]: crate::model::AnswerRecord::name
 /// [google.cloud.dialogflow.v2.AnswerRecords.UpdateAnswerRecord]: crate::client::AnswerRecords::update_answer_record
@@ -5912,9 +5912,9 @@ pub struct CreateConversationRequest {
     /// `[a-zA-Z][a-zA-Z0-9_-]*` with the characters length in range of [3,64].
     /// If the field is provided, the caller is responsible for
     ///
-    /// . the uniqueness of the ID, otherwise the request will be rejected.
-    /// . the consistency for whether to use custom ID or not under a project to
-    ///   better ensure uniqueness.
+    /// 1. the uniqueness of the ID, otherwise the request will be rejected.
+    /// 1. the consistency for whether to use custom ID or not under a project to
+    ///    better ensure uniqueness.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub conversation_id: std::string::String,
@@ -7995,11 +7995,11 @@ pub mod search_knowledge_request {
                         pub struct ControlPoint {
                             /// Optional. Can be one of:
                             ///
-                            /// . The numerical field value.
-                            /// . The duration spec for freshness:
-                            ///   The value must be formatted as an XSD `dayTimeDuration` value
-                            ///   (a restricted subset of an ISO 8601 duration value). The
-                            ///   pattern for this is: `[nD][T[nH][nM][nS]]`.
+                            /// 1. The numerical field value.
+                            /// 1. The duration spec for freshness:
+                            ///    The value must be formatted as an XSD `dayTimeDuration` value
+                            ///    (a restricted subset of an ISO 8601 duration value). The
+                            ///    pattern for this is: `[nD][T[nH][nM][nS]]`.
                             #[serde(skip_serializing_if = "std::string::String::is_empty")]
                             #[serde_as(as = "serde_with::DefaultOnNull<_>")]
                             pub attribute_value: std::string::String,
@@ -21920,9 +21920,9 @@ pub struct CreateGeneratorRequest {
     /// If the field is not provided, an Id will be auto-generated.
     /// If the field is provided, the caller is responsible for
     ///
-    /// . the uniqueness of the ID, otherwise the request will be rejected.
-    /// . the consistency for whether to use custom ID or not under a project to
-    ///   better ensure uniqueness.
+    /// 1. the uniqueness of the ID, otherwise the request will be rejected.
+    /// 1. the consistency for whether to use custom ID or not under a project to
+    ///    better ensure uniqueness.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub generator_id: std::string::String,
@@ -30483,18 +30483,18 @@ pub struct Participant {
     ///
     /// You can specify a user id as follows:
     ///
-    /// . If you set this field in
-    ///   [CreateParticipantRequest][google.cloud.dialogflow.v2.CreateParticipantRequest.participant]
-    ///   or
-    ///   [UpdateParticipantRequest][google.cloud.dialogflow.v2.UpdateParticipantRequest.participant],
-    ///   Dialogflow adds the obfuscated user id with the participant.
+    /// 1. If you set this field in
+    ///    [CreateParticipantRequest][google.cloud.dialogflow.v2.CreateParticipantRequest.participant]
+    ///    or
+    ///    [UpdateParticipantRequest][google.cloud.dialogflow.v2.UpdateParticipantRequest.participant],
+    ///    Dialogflow adds the obfuscated user id with the participant.
     ///
-    /// . If you set this field in
-    ///   [AnalyzeContent][google.cloud.dialogflow.v2.AnalyzeContentRequest.participant]
-    ///   or
-    ///   [StreamingAnalyzeContent][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.participant],
-    ///   Dialogflow will update
-    ///   [Participant.obfuscated_external_user_id][google.cloud.dialogflow.v2.Participant.obfuscated_external_user_id].
+    /// 1. If you set this field in
+    ///    [AnalyzeContent][google.cloud.dialogflow.v2.AnalyzeContentRequest.participant]
+    ///    or
+    ///    [StreamingAnalyzeContent][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.participant],
+    ///    Dialogflow will update
+    ///    [Participant.obfuscated_external_user_id][google.cloud.dialogflow.v2.Participant.obfuscated_external_user_id].
     ///
     ///
     /// Dialogflow returns an error if you try to add a user id for a
@@ -31856,36 +31856,36 @@ impl wkt::message::Message for AnalyzeContentResponse {
 ///
 /// Multiple request messages should be sent in order:
 ///
-/// . The first message must contain
-///   [participant][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.participant],
-///   [config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.config]
-///   and optionally
-///   [query_params][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.query_params].
-///   If you want to receive an audio response, it should also contain
-///   [reply_audio_config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.reply_audio_config].
-///   The message must not contain
-///   [input][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.input].
+/// 1. The first message must contain
+///    [participant][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.participant],
+///    [config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.config]
+///    and optionally
+///    [query_params][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.query_params].
+///    If you want to receive an audio response, it should also contain
+///    [reply_audio_config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.reply_audio_config].
+///    The message must not contain
+///    [input][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.input].
 ///
-/// . If
-///   [config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.config] in
-///   the first message
-///   was set to
-///   [audio_config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.audio_config],
-///   all subsequent messages must contain
-///   [input_audio][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.input_audio]
-///   to continue with Speech recognition. However, note that:
+/// 1. If
+///    [config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.config] in
+///    the first message
+///    was set to
+///    [audio_config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.audio_config],
+///    all subsequent messages must contain
+///    [input_audio][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.input_audio]
+///    to continue with Speech recognition. However, note that:
 ///
-///   * Dialogflow will bill you for the audio so far.
-///   * Dialogflow discards all Speech recognition results in favor of the
-///     text input.
-/// . If
-///   [StreamingAnalyzeContentRequest.config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.config]
-///   in the first message was set
-///   to
-///   [StreamingAnalyzeContentRequest.text_config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.text_config],
-///   then the second message must contain only
-///   [input_text][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.input_text].
-///   Moreover, you must not send more than two messages.
+///    * Dialogflow will bill you for the audio so far.
+///    * Dialogflow discards all Speech recognition results in favor of the
+///      text input.
+/// 1. If
+///    [StreamingAnalyzeContentRequest.config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.config]
+///    in the first message was set
+///    to
+///    [StreamingAnalyzeContentRequest.text_config][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.text_config],
+///    then the second message must contain only
+///    [input_text][google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.input_text].
+///    Moreover, you must not send more than two messages.
 ///
 ///
 /// After you sent all input, you must half-close or abort the request stream.
@@ -32332,24 +32332,24 @@ pub mod streaming_analyze_content_request {
 ///
 /// Multiple response messages can be returned in order:
 ///
-/// . If the input was set to streaming audio, the first one or more messages
-///   contain `recognition_result`. Each `recognition_result` represents a more
-///   complete transcript of what the user said. The last `recognition_result`
-///   has `is_final` set to `true`.
+/// 1. If the input was set to streaming audio, the first one or more messages
+///    contain `recognition_result`. Each `recognition_result` represents a more
+///    complete transcript of what the user said. The last `recognition_result`
+///    has `is_final` set to `true`.
 ///
-/// . In virtual agent stage: if `enable_partial_automated_agent_reply` is
-///   true, the following N (currently 1 <= N <= 4) messages
-///   contain `automated_agent_reply` and optionally `reply_audio`
-///   returned by the virtual agent. The first (N-1)
-///   `automated_agent_reply`s will have `automated_agent_reply_type` set to
-///   `PARTIAL`. The last `automated_agent_reply` has
-///   `automated_agent_reply_type` set to `FINAL`.
-///   If `enable_partial_automated_agent_reply` is not enabled, response stream
-///   only contains the final reply.
+/// 1. In virtual agent stage: if `enable_partial_automated_agent_reply` is
+///    true, the following N (currently 1 <= N <= 4) messages
+///    contain `automated_agent_reply` and optionally `reply_audio`
+///    returned by the virtual agent. The first (N-1)
+///    `automated_agent_reply`s will have `automated_agent_reply_type` set to
+///    `PARTIAL`. The last `automated_agent_reply` has
+///    `automated_agent_reply_type` set to `FINAL`.
+///    If `enable_partial_automated_agent_reply` is not enabled, response stream
+///    only contains the final reply.
 ///
-/// . In human assist stage: the following N (N >= 1) messages contain
-///   `human_agent_suggestion_results`, `end_user_suggestion_results` or
-///   `message`.
+///    In human assist stage: the following N (N >= 1) messages contain
+///    `human_agent_suggestion_results`, `end_user_suggestion_results` or
+///    `message`.
 ///
 #[cfg(feature = "participants")]
 #[serde_with::serde_as]
@@ -35371,12 +35371,12 @@ pub struct DetectIntentRequest {
 
     /// Required. The input specification. It can be set to:
     ///
-    /// . an audio config which instructs the speech recognizer how to process
-    ///   the speech audio,
+    /// 1. an audio config which instructs the speech recognizer how to process
+    ///    the speech audio,
     ///
-    /// . a conversational query in the form of text, or
+    /// 1. a conversational query in the form of text, or
     ///
-    /// . an event that specifies which intent to trigger.
+    /// 1. an event that specifies which intent to trigger.
     ///
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub query_input: std::option::Option<crate::model::QueryInput>,
@@ -35838,12 +35838,12 @@ impl wkt::message::Message for QueryParameters {
 
 /// Represents the query input. It can contain either:
 ///
-/// . An audio config which instructs the speech recognizer how to process the
-///   speech audio.
+/// 1. An audio config which instructs the speech recognizer how to process the
+///    speech audio.
 ///
-/// . A conversational query in the form of text.
+/// 1. A conversational query in the form of text.
 ///
-/// . An event that specifies which intent to trigger.
+/// 1. An event that specifies which intent to trigger.
 ///
 #[cfg(feature = "sessions")]
 #[serde_with::serde_as]
@@ -36334,33 +36334,33 @@ impl wkt::message::Message for QueryResult {
 ///
 /// Multiple request messages should be sent in order:
 ///
-/// . The first message must contain
-///   [session][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.session],
-///   [query_input][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.query_input]
-///   plus optionally
-///   [query_params][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.query_params].
-///   If the client wants to receive an audio response, it should also contain
-///   [output_audio_config][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.output_audio_config].
-///   The message must not contain
-///   [input_audio][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio].
+/// 1. The first message must contain
+///    [session][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.session],
+///    [query_input][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.query_input]
+///    plus optionally
+///    [query_params][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.query_params].
+///    If the client wants to receive an audio response, it should also contain
+///    [output_audio_config][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.output_audio_config].
+///    The message must not contain
+///    [input_audio][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio].
 ///
-/// . If
-///   [query_input][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.query_input]
-///   was set to
-///   [query_input.audio_config][google.cloud.dialogflow.v2.InputAudioConfig],
-///   all subsequent messages must contain
-///   [input_audio][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio]
-///   to continue with Speech recognition. If you decide to rather detect an
-///   intent from text input after you already started Speech recognition,
-///   please send a message with
-///   [query_input.text][google.cloud.dialogflow.v2.QueryInput.text].
+/// 1. If
+///    [query_input][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.query_input]
+///    was set to
+///    [query_input.audio_config][google.cloud.dialogflow.v2.InputAudioConfig],
+///    all subsequent messages must contain
+///    [input_audio][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio]
+///    to continue with Speech recognition. If you decide to rather detect an
+///    intent from text input after you already started Speech recognition,
+///    please send a message with
+///    [query_input.text][google.cloud.dialogflow.v2.QueryInput.text].
 ///
-/// . However, note that:
+///    However, note that:
 ///
-///   * Dialogflow will bill you for the audio duration so far.
-///   * Dialogflow discards all Speech recognition results in favor of the
-///     input text.
-///   * Dialogflow will use the language code from the first message.
+///    * Dialogflow will bill you for the audio duration so far.
+///    * Dialogflow discards all Speech recognition results in favor of the
+///      input text.
+///    * Dialogflow will use the language code from the first message.
 ///
 /// After you sent all input, you must half-close or abort the request stream.
 ///
@@ -36404,12 +36404,12 @@ pub struct StreamingDetectIntentRequest {
 
     /// Required. The input specification. It can be set to:
     ///
-    /// . an audio config which instructs the speech recognizer how to process
-    ///   the speech audio,
+    /// 1. an audio config which instructs the speech recognizer how to process
+    ///    the speech audio,
     ///
-    /// . a conversational query in the form of text, or
+    /// 1. a conversational query in the form of text, or
     ///
-    /// . an event that specifies which intent to trigger.
+    /// 1. an event that specifies which intent to trigger.
     ///
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub query_input: std::option::Option<crate::model::QueryInput>,
@@ -36924,17 +36924,17 @@ impl wkt::message::Message for CloudConversationDebuggingInfo {
 ///
 /// Multiple response messages can be returned in order:
 ///
-/// . If the
-///   [StreamingDetectIntentRequest.input_audio][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio]
-///   field was
-///   set, the `recognition_result` field is populated for one
-///   or more messages.
-///   See the
-///   [StreamingRecognitionResult][google.cloud.dialogflow.v2.StreamingRecognitionResult]
-///   message for details about the result message sequence.
+/// 1. If the
+///    [StreamingDetectIntentRequest.input_audio][google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio]
+///    field was
+///    set, the `recognition_result` field is populated for one
+///    or more messages.
+///    See the
+///    [StreamingRecognitionResult][google.cloud.dialogflow.v2.StreamingRecognitionResult]
+///    message for details about the result message sequence.
 ///
-/// . The next message contains `response_id`, `query_result`
-///   and optionally `webhook_status` if a WebHook was called.
+/// 1. The next message contains `response_id`, `query_result`
+///    and optionally `webhook_status` if a WebHook was called.
 ///
 ///
 /// [google.cloud.dialogflow.v2.StreamingDetectIntentRequest.input_audio]: crate::model::StreamingDetectIntentRequest::input_audio
@@ -40484,7 +40484,7 @@ pub enum SpeechModelVariant {
     ///   [model][google.cloud.dialogflow.v2.InputAudioConfig.model] and request
     ///   language, Dialogflow falls back to the standard variant.
     ///
-    /// * The [Cloud Speech
+    ///   The [Cloud Speech
     ///   documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
     ///   describes which models have enhanced variants.
     ///

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -273,9 +273,9 @@ pub mod channel {
         /// The INACTIVE state indicates that the Channel cannot receive events
         /// permanently. There are two possible cases this state can happen:
         ///
-        /// . The SaaS provider disconnected from this Channel.
-        /// . The Channel activation token has expired but the SaaS provider
-        ///   wasn't connected.
+        /// 1. The SaaS provider disconnected from this Channel.
+        /// 1. The Channel activation token has expired but the SaaS provider
+        ///    wasn't connected.
         ///
         /// To re-establish a Connection with a provider, the subscriber
         /// should create a new Channel and give it to the provider.
@@ -5947,11 +5947,11 @@ pub mod pipeline {
             /// To construct the HTTP request payload and the value of the content-type
             /// HTTP header, the payload format is defined as follows:
             ///
-            /// ) Use the output_payload_format_type on the Pipeline.Destination if it
-            ///   is set, else:
-            /// ) Use the input_payload_format_type on the Pipeline if it is set,
-            ///   else:
-            /// ) Treat the payload as opaque binary data.
+            /// 1. Use the output_payload_format_type on the Pipeline.Destination if it
+            ///    is set, else:
+            /// 1. Use the input_payload_format_type on the Pipeline if it is set,
+            ///    else:
+            /// 1. Treat the payload as opaque binary data.
             ///
             /// The `data` field of the message is converted to the payload format or
             /// left as-is for case 3) and then attached as the payload of the HTTP

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -8390,12 +8390,12 @@ pub mod restore_config {
             /// The "add" operation performs one of the following functions,
             /// depending upon what the target location references:
             ///
-            /// . If the target location specifies an array index, a new value is
-            ///   inserted into the array at the specified index.
-            /// . If the target location specifies an object member that does not
-            ///   already exist, a new member is added to the object.
-            /// . If the target location specifies an object member that does exist,
-            ///   that member's value is replaced.
+            /// 1. If the target location specifies an array index, a new value is
+            ///    inserted into the array at the specified index.
+            /// 1. If the target location specifies an object member that does not
+            ///    already exist, a new member is added to the object.
+            /// 1. If the target location specifies an object member that does exist,
+            ///    that member's value is replaced.
             Add,
             /// The "test" operation tests that a value at the target location is
             /// equal to a specified value.

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -1048,9 +1048,9 @@ pub struct Membership {
     ///
     /// `membership_id` must be a valid RFC 1123 compliant DNS label:
     ///
-    /// . At most 63 characters in length
-    /// . It must consist of lower case alphanumeric characters or `-`
-    /// . It must start and end with an alphanumeric character
+    /// 1. At most 63 characters in length
+    /// 1. It must consist of lower case alphanumeric characters or `-`
+    /// 1. It must start and end with an alphanumeric character
     ///
     /// Which can be expressed as the regex: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`,
     /// with a maximum length of 63 characters.
@@ -2270,19 +2270,19 @@ pub struct ListMembershipsRequest {
     ///
     /// - Name is `bar` in project `foo-proj` and location `global`:
     ///
-    /// - name = "projects/foo-proj/locations/global/membership/bar"
+    ///   name = "projects/foo-proj/locations/global/membership/bar"
     ///
     /// - Memberships that have a label called `foo`:
     ///
-    /// - labels.foo:*
+    ///   labels.foo:*
     ///
     /// - Memberships that have a label called `foo` whose value is `bar`:
     ///
-    /// - labels.foo = bar
+    ///   labels.foo = bar
     ///
     /// - Memberships in the CREATING state:
     ///
-    /// - state = CREATING
+    ///   state = CREATING
     ///
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
@@ -2470,9 +2470,9 @@ pub struct CreateMembershipRequest {
     /// Required. Client chosen ID for the membership. `membership_id` must be a
     /// valid RFC 1123 compliant DNS label:
     ///
-    /// . At most 63 characters in length
-    /// . It must consist of lower case alphanumeric characters or `-`
-    /// . It must start and end with an alphanumeric character
+    /// 1. At most 63 characters in length
+    /// 1. It must consist of lower case alphanumeric characters or `-`
+    /// 1. It must start and end with an alphanumeric character
     ///
     /// Which can be expressed as the regex: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`,
     /// with a maximum length of 63 characters.
@@ -3023,15 +3023,15 @@ pub struct ListFeaturesRequest {
     ///
     /// - Feature with the name "servicemesh" in project "foo-proj":
     ///
-    /// - name = "projects/foo-proj/locations/global/features/servicemesh"
+    ///   name = "projects/foo-proj/locations/global/features/servicemesh"
     ///
     /// - Features that have a label called `foo`:
     ///
-    /// - labels.foo:*
+    ///   labels.foo:*
     ///
     /// - Features that have a label called `foo` whose value is `bar`:
     ///
-    /// - labels.foo = bar
+    ///   labels.foo = bar
     ///
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -4026,13 +4026,13 @@ pub mod aws_node_pool {
 /// Set the surge_settings parameter to use the Surge Update mechanism for
 /// the rolling update of node pool nodes.
 ///
-/// . max_surge controls the number of additional nodes that can be created
-///   beyond the current size of the node pool temporarily for the time of the
-///   update to increase the number of available nodes.
-/// . max_unavailable controls the number of nodes that can be simultaneously
-///   unavailable during the update.
-/// . (max_surge + max_unavailable) determines the level of parallelism (i.e.,
-///   the number of nodes being updated at the same time).
+/// 1. max_surge controls the number of additional nodes that can be created
+///    beyond the current size of the node pool temporarily for the time of the
+///    update to increase the number of available nodes.
+/// 1. max_unavailable controls the number of nodes that can be simultaneously
+///    unavailable during the update.
+/// 1. (max_surge + max_unavailable) determines the level of parallelism (i.e.,
+///    the number of nodes being updated at the same time).
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -2210,8 +2210,8 @@ pub struct CryptoKey {
     /// At [next_rotation_time][google.cloud.kms.v1.CryptoKey.next_rotation_time],
     /// the Key Management Service will automatically:
     ///
-    /// . Create a new version of this [CryptoKey][google.cloud.kms.v1.CryptoKey].
-    /// . Mark the new version as primary.
+    /// 1. Create a new version of this [CryptoKey][google.cloud.kms.v1.CryptoKey].
+    /// 1. Mark the new version as primary.
     ///
     /// Key rotations performed manually via
     /// [CreateCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]

--- a/src/generated/cloud/metastore/v1/src/client.rs
+++ b/src/generated/cloud/metastore/v1/src/client.rs
@@ -48,7 +48,7 @@
 ///
 /// * Dataproc Metastore services are resources with names of the form:
 ///
-/// * `/projects/{project_number}/locations/{location_id}/services/{service_id}`.
+///   `/projects/{project_number}/locations/{location_id}/services/{service_id}`.
 ///
 ///
 /// # Configuration

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -2154,11 +2154,11 @@ pub struct SanitizationResult {
     /// Output only. Overall filter match state for Sanitization.
     /// The state can have below two values.
     ///
-    /// ) NO_MATCH_FOUND: No filters in configuration satisfy matching criteria.
-    ///   In other words, input passed all filters.
+    /// 1. NO_MATCH_FOUND: No filters in configuration satisfy matching criteria.
+    ///    In other words, input passed all filters.
     ///
-    /// ) MATCH_FOUND: At least one filter in configuration satisfies matching.
-    ///   In other words, input did not pass one or more filters.
+    /// 1. MATCH_FOUND: At least one filter in configuration satisfies matching.
+    ///    In other words, input did not pass one or more filters.
     ///
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]

--- a/src/generated/cloud/networkmanagement/v1/src/client.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/client.rs
@@ -437,16 +437,16 @@ impl VpcFlowLogsService {
     /// ID is different), the creation fails.
     /// Notes:
     ///
-    /// . Creating a configuration with state=DISABLED will fail
-    /// . The following fields are not considered as `settings` for the purpose
-    ///   of the check mentioned above, therefore - creating another configuration
-    ///   with the same fields but different values for the following fields will
-    ///   fail as well:
-    ///   * name
-    ///   * create_time
-    ///   * update_time
-    ///   * labels
-    ///   * description
+    /// 1. Creating a configuration with state=DISABLED will fail
+    /// 1. The following fields are not considered as `settings` for the purpose
+    ///    of the check mentioned above, therefore - creating another configuration
+    ///    with the same fields but different values for the following fields will
+    ///    fail as well:
+    ///    * name
+    ///    * create_time
+    ///    * update_time
+    ///    * labels
+    ///    * description
     ///
     /// # Long running operations
     ///
@@ -468,16 +468,16 @@ impl VpcFlowLogsService {
     /// ID is different), the creation fails.
     /// Notes:
     ///
-    /// . Updating a configuration with state=DISABLED will fail.
-    /// . The following fields are not considered as `settings` for the purpose
-    ///   of the check mentioned above, therefore - updating another configuration
-    ///   with the same fields but different values for the following fields will
-    ///   fail as well:
-    ///   * name
-    ///   * create_time
-    ///   * update_time
-    ///   * labels
-    ///   * description
+    /// 1. Updating a configuration with state=DISABLED will fail.
+    /// 1. The following fields are not considered as `settings` for the purpose
+    ///    of the check mentioned above, therefore - updating another configuration
+    ///    with the same fields but different values for the following fields will
+    ///    fail as well:
+    ///    * name
+    ///    * create_time
+    ///    * update_time
+    ///    * labels
+    ///    * description
     ///
     /// # Long running operations
     ///

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -447,11 +447,11 @@ pub struct Endpoint {
     /// network URI.
     /// The following are two cases where you may need to provide the project ID:
     ///
-    /// . Only the IP address is specified, and the IP address is within a Google
-    ///   Cloud project.
-    /// . When you are using Shared VPC and the IP address that you provide is
-    ///   from the service project. In this case, the network that the IP address
-    ///   resides in is defined in the host project.
+    /// 1. Only the IP address is specified, and the IP address is within a Google
+    ///    Cloud project.
+    /// 1. When you are using Shared VPC and the IP address that you provide is
+    ///    from the service project. In this case, the network that the IP address
+    ///    resides in is defined in the host project.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub project_id: std::string::String,

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -6159,12 +6159,12 @@ pub struct OSPolicyAssignment {
     /// Required. Rollout to deploy the OS policy assignment.
     /// A rollout is triggered in the following situations:
     ///
-    /// ) OSPolicyAssignment is created.
-    /// ) OSPolicyAssignment is updated and the update contains changes to one of
-    ///   the following fields:
-    ///   - instance_filter
-    ///   - os_policies
-    /// ) OSPolicyAssignment is deleted.
+    /// 1. OSPolicyAssignment is created.
+    /// 1. OSPolicyAssignment is updated and the update contains changes to one of
+    ///    the following fields:
+    ///    - instance_filter
+    ///    - os_policies
+    /// 1. OSPolicyAssignment is deleted.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub rollout: std::option::Option<crate::model::os_policy_assignment::Rollout>,
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
@@ -45,7 +45,7 @@
 /// * A collection of `Grant` resources. A grant is a request by a requester to
 ///   get the privileged access specified in an entitlement for some duration.
 ///
-/// * After the approval workflow as specified in the entitlement is satisfied,
+///   After the approval workflow as specified in the entitlement is satisfied,
 ///   the specified access is given to the requester. The access is automatically
 ///   taken back after the requested duration is over.
 ///

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -11418,7 +11418,7 @@ pub struct PredictRequest {
     ///   `NOT "tagA"`. Tag values must be double quoted UTF-8 encoded strings
     ///   with a size limit of 1,000 characters.
     ///
-    /// * Note: "Recently viewed" models don't support tag filtering at the
+    ///   Note: "Recently viewed" models don't support tag filtering at the
     ///   moment.
     ///
     /// * filterOutOfStockItems. Restricts predictions to products that do not
@@ -20410,9 +20410,9 @@ pub struct UserEvent {
     ///
     /// A general guideline to populate the sesion_id:
     ///
-    /// . If user has no activity for 30 min, a new session_id should be assigned.
-    /// . The session_id should be unique across users, suggest use uuid or add
-    ///   visitor_id as prefix.
+    /// 1. If user has no activity for 30 min, a new session_id should be assigned.
+    /// 1. The session_id should be unique across users, suggest use uuid or add
+    ///    visitor_id as prefix.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub session_id: std::string::String,

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -12193,9 +12193,9 @@ impl wkt::message::Message for BatchCreateResourceValueConfigsResponse {
 ///
 /// Note:
 ///
-/// . If multiple bulk update requests match the same resource, the order in
-///   which they get executed is not defined.
-/// . Once a bulk operation is started, there is no way to stop it.
+/// 1. If multiple bulk update requests match the same resource, the order in
+///    which they get executed is not defined.
+/// 1. Once a bulk operation is started, there is no way to stop it.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -13274,7 +13274,7 @@ pub struct GroupFindingsRequest {
     ///
     /// * event_time: `=`, `>`, `<`, `>=`, `<=`
     ///
-    /// * Usage: This should be milliseconds since epoch or an RFC3339 string.
+    ///   Usage: This should be milliseconds since epoch or an RFC3339 string.
     ///   Examples:
     ///   `event_time = "2019-06-10T16:07:18-07:00"`
     ///   `event_time = 1560208038000`
@@ -13906,7 +13906,7 @@ pub struct ListFindingsRequest {
     ///
     /// * event_time: `=`, `>`, `<`, `>=`, `<=`
     ///
-    /// * Usage: This should be milliseconds since epoch or an RFC3339 string.
+    ///   Usage: This should be milliseconds since epoch or an RFC3339 string.
     ///   Examples:
     ///   `event_time = "2019-06-10T16:07:18-07:00"`
     ///   `event_time = 1560208038000`

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -5606,27 +5606,27 @@ impl wkt::message::Message for StreamingRecognitionResult {
 /// Here are some examples of `StreamingRecognizeResponse`s that might
 /// be returned while processing audio:
 ///
-/// . results { alternatives { transcript: "tube" } stability: 0.01 }
+/// 1. results { alternatives { transcript: "tube" } stability: 0.01 }
 ///
-/// . results { alternatives { transcript: "to be a" } stability: 0.01 }
+/// 1. results { alternatives { transcript: "to be a" } stability: 0.01 }
 ///
-/// . results { alternatives { transcript: "to be" } stability: 0.9 }
-///   results { alternatives { transcript: " or not to be" } stability: 0.01 }
+/// 1. results { alternatives { transcript: "to be" } stability: 0.9 }
+///    results { alternatives { transcript: " or not to be" } stability: 0.01 }
 ///
-/// . results { alternatives { transcript: "to be or not to be"
-///   confidence: 0.92 }
-///   alternatives { transcript: "to bee or not to bee" }
-///   is_final: true }
+/// 1. results { alternatives { transcript: "to be or not to be"
+///    confidence: 0.92 }
+///    alternatives { transcript: "to bee or not to bee" }
+///    is_final: true }
 ///
-/// . results { alternatives { transcript: " that's" } stability: 0.01 }
+/// 1. results { alternatives { transcript: " that's" } stability: 0.01 }
 ///
-/// . results { alternatives { transcript: " that is" } stability: 0.9 }
-///   results { alternatives { transcript: " the question" } stability: 0.01 }
+/// 1. results { alternatives { transcript: " that is" } stability: 0.9 }
+///    results { alternatives { transcript: " the question" } stability: 0.01 }
 ///
-/// . results { alternatives { transcript: " that is the question"
-///   confidence: 0.98 }
-///   alternatives { transcript: " that was the question" }
-///   is_final: true }
+/// 1. results { alternatives { transcript: " that is the question"
+///    confidence: 0.98 }
+///    alternatives { transcript: " that was the question" }
+///    is_final: true }
 ///
 ///
 /// Notes:

--- a/src/generated/cloud/storagebatchoperations/v1/src/model.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/model.rs
@@ -1284,12 +1284,12 @@ pub struct Manifest {
     /// upon.
     /// `manifest_location` should either be
     ///
-    /// ) An absolute path to the object in the format of
-    ///   `gs://bucket_name/path/file_name.csv`.
-    /// ) An absolute path with a single wildcard character in the file name, for
-    ///   example `gs://bucket_name/path/file_name*.csv`.
-    ///   If manifest location is specified with a wildcard, objects in all manifest
-    ///   files matching the pattern will be acted upon.
+    /// 1. An absolute path to the object in the format of
+    ///    `gs://bucket_name/path/file_name.csv`.
+    /// 1. An absolute path with a single wildcard character in the file name, for
+    ///    example `gs://bucket_name/path/file_name*.csv`.
+    ///    If manifest location is specified with a wildcard, objects in all manifest
+    ///    files matching the pattern will be acted upon.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub manifest_location: std::string::String,

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -4350,15 +4350,15 @@ pub struct LocationFilter {
 
     /// CLDR region code of the country/region. This field may be used in two ways:
     ///
-    /// ) If telecommute preference is not set, this field is used address
-    ///   ambiguity of the user-input address. For example, "Liverpool" may refer to
-    ///   "Liverpool, NY, US" or "Liverpool, UK". This region code biases the
-    ///   address resolution toward a specific country or territory. If this field is
-    ///   not set, address resolution is biased toward the United States by default.
+    /// 1. If telecommute preference is not set, this field is used address
+    ///    ambiguity of the user-input address. For example, "Liverpool" may refer to
+    ///    "Liverpool, NY, US" or "Liverpool, UK". This region code biases the
+    ///    address resolution toward a specific country or territory. If this field is
+    ///    not set, address resolution is biased toward the United States by default.
     ///
-    /// ) If telecommute preference is set to TELECOMMUTE_ALLOWED, the
-    ///   telecommute location filter will be limited to the region specified in this
-    ///   field. If this field is not set, the telecommute job locations will not be
+    /// 1. If telecommute preference is set to TELECOMMUTE_ALLOWED, the
+    ///    telecommute location filter will be limited to the region specified in this
+    ///    field. If this field is not set, the telecommute job locations will not be
     ///
     ///
     /// See

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -3163,12 +3163,12 @@ pub struct SearchBlueprintRevisionsRequest {
 
     /// Required. Supported queries:
     ///
-    /// . ""                       : Lists all revisions across all blueprints.
-    /// . "latest=true"            : Lists latest revisions across all blueprints.
-    /// . "name={name}"            : Lists all revisions of blueprint with name
-    ///   {name}.
-    /// . "name={name} latest=true": Lists latest revision of blueprint with name
-    ///   {name}
+    /// 1. ""                       : Lists all revisions across all blueprints.
+    /// 1. "latest=true"            : Lists latest revisions across all blueprints.
+    /// 1. "name={name}"            : Lists all revisions of blueprint with name
+    ///    {name}.
+    /// 1. "name={name} latest=true": Lists latest revision of blueprint with name
+    ///    {name}
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub query: std::string::String,
@@ -3987,13 +3987,13 @@ pub struct SearchDeploymentRevisionsRequest {
 
     /// Required. Supported queries:
     ///
-    /// . ""                       : Lists all revisions across all deployments.
-    /// . "latest=true"            : Lists latest revisions across all
-    ///   deployments.
-    /// . "name={name}"            : Lists all revisions of deployment with name
-    ///   {name}.
-    /// . "name={name} latest=true": Lists latest revision of deployment with name
-    ///   {name}
+    /// 1. ""                       : Lists all revisions across all deployments.
+    /// 1. "latest=true"            : Lists latest revisions across all
+    ///    deployments.
+    /// 1. "name={name}"            : Lists all revisions of deployment with name
+    ///    {name}.
+    /// 1. "name={name} latest=true": Lists latest revision of deployment with name
+    ///    {name}
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub query: std::string::String,

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -114,9 +114,9 @@ impl wkt::message::Message for BigqueryMapping {
 pub struct DataSource {
     /// Data source URI.
     ///
-    /// ) Google Cloud Storage files (JSON) are defined in the following form.
-    ///   `gs://bucket_name/object_name`. For more information on Cloud Storage URIs,
-    ///   please see <https://cloud.google.com/storage/docs/reference-uris>.
+    /// 1. Google Cloud Storage files (JSON) are defined in the following form.
+    ///    `gs://bucket_name/object_name`. For more information on Cloud Storage URIs,
+    ///    please see <https://cloud.google.com/storage/docs/reference-uris>.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub uri: std::string::String,
@@ -750,18 +750,18 @@ pub struct AppendEventsRequest {
     ///
     /// Note:
     ///
-    /// . The [DataSet][google.cloud.timeseriesinsights.v1.DataSet] must be shown in a `LOADED` state
-    ///   in the results of `list` method; otherwise, all events from
-    ///   the append request will be dropped, and a `NOT_FOUND` status will be
-    ///   returned.
-    /// . All events in a single request must have the same
-    ///   [groupId][google.cloud.timeseriesinsights.v1.Event.group_id] if set; otherwise, an
-    ///   `INVALID_ARGUMENT` status will be returned.
-    /// . If [groupId][google.cloud.timeseriesinsights.v1.Event.group_id] is not set (or 0), there
-    ///   should be only 1 event; otherwise, an `INVALID_ARGUMENT` status will be
-    ///   returned.
-    /// . The events must be newer than the current time minus
-    ///   [DataSet TTL][google.cloud.timeseriesinsights.v1.DataSet.ttl] or they will be dropped.
+    /// 1. The [DataSet][google.cloud.timeseriesinsights.v1.DataSet] must be shown in a `LOADED` state
+    ///    in the results of `list` method; otherwise, all events from
+    ///    the append request will be dropped, and a `NOT_FOUND` status will be
+    ///    returned.
+    /// 1. All events in a single request must have the same
+    ///    [groupId][google.cloud.timeseriesinsights.v1.Event.group_id] if set; otherwise, an
+    ///    `INVALID_ARGUMENT` status will be returned.
+    /// 1. If [groupId][google.cloud.timeseriesinsights.v1.Event.group_id] is not set (or 0), there
+    ///    should be only 1 event; otherwise, an `INVALID_ARGUMENT` status will be
+    ///    returned.
+    /// 1. The events must be newer than the current time minus
+    ///    [DataSet TTL][google.cloud.timeseriesinsights.v1.DataSet.ttl] or they will be dropped.
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
     /// [google.cloud.timeseriesinsights.v1.DataSet.ttl]: crate::model::DataSet::ttl

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -4977,8 +4977,8 @@ pub struct Clip {
     /// `{clipId}` is a user-specified resource id that conforms to the following
     /// criteria:
     ///
-    /// . 1 character minimum, 63 characters maximum
-    /// . Only contains letters, digits, underscores, and hyphens
+    /// 1. 1 character minimum, 63 characters maximum
+    /// 1. Only contains letters, digits, underscores, and hyphens
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub name: std::string::String,
@@ -5759,8 +5759,8 @@ pub struct DvrSession {
     /// `{dvrSessionId}` is a user-specified resource id that conforms to the
     /// following criteria:
     ///
-    /// . 1 character minimum, 63 characters maximum
-    /// . Only contains letters, digits, underscores, and hyphens
+    /// 1. 1 character minimum, 63 characters maximum
+    /// 1. Only contains letters, digits, underscores, and hyphens
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub name: std::string::String,
@@ -9396,8 +9396,8 @@ pub struct CreateClipRequest {
 
     /// Required. Id of the requesting object in the following form:
     ///
-    /// . 1 character minimum, 63 characters maximum
-    /// . Only contains letters, digits, underscores, and hyphens
+    /// 1. 1 character minimum, 63 characters maximum
+    /// 1. Only contains letters, digits, underscores, and hyphens
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub clip_id: std::string::String,
@@ -9737,8 +9737,8 @@ pub struct CreateDvrSessionRequest {
 
     /// Required. Id of the requesting object in the following form:
     ///
-    /// . 1 character minimum, 63 characters maximum
-    /// . Only contains letters, digits, underscores, and hyphens
+    /// 1. 1 character minimum, 63 characters maximum
+    /// 1. Only contains letters, digits, underscores, and hyphens
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<_>")]
     pub dvr_session_id: std::string::String,

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -529,18 +529,18 @@ pub struct ImageSource {
 
     /// The URI of the source image. Can be either:
     ///
-    /// . A Google Cloud Storage URI of the form
-    ///   `gs://bucket_name/object_name`. Object versioning is not supported. See
-    ///   [Google Cloud Storage Request
-    ///   URIs](https://cloud.google.com/storage/docs/reference-uris) for more
-    ///   info.
+    /// 1. A Google Cloud Storage URI of the form
+    ///    `gs://bucket_name/object_name`. Object versioning is not supported. See
+    ///    [Google Cloud Storage Request
+    ///    URIs](https://cloud.google.com/storage/docs/reference-uris) for more
+    ///    info.
     ///
-    /// . A publicly-accessible image HTTP/HTTPS URL. When fetching images from
-    ///   HTTP/HTTPS URLs, Google cannot guarantee that the request will be
-    ///   completed. Your request may fail if the specified host denies the
-    ///   request (e.g. due to request throttling or DOS prevention), or if Google
-    ///   throttles requests to the site for abuse prevention. You should not
-    ///   depend on externally-hosted images for production applications.
+    /// 1. A publicly-accessible image HTTP/HTTPS URL. When fetching images from
+    ///    HTTP/HTTPS URLs, Google cannot guarantee that the request will be
+    ///    completed. Your request may fail if the specified host denies the
+    ///    request (e.g. due to request throttling or DOS prevention), or if Google
+    ///    throttles requests to the site for abuse prevention. You should not
+    ///    depend on externally-hosted images for production applications.
     ///
     ///
     /// When both `gcs_image_uri` and `image_uri` are specified, `image_uri` takes
@@ -6100,14 +6100,14 @@ pub struct ImportProductSetsGcsSource {
     /// The format of the input csv file should be one image per line.
     /// In each line, there are 8 columns.
     ///
-    /// . image-uri
-    /// . image-id
-    /// . product-set-id
-    /// . product-id
-    /// . product-category
-    /// . product-display-name
-    /// . labels
-    /// . bounding-poly
+    /// 1. image-uri
+    /// 1. image-id
+    /// 1. product-set-id
+    /// 1. product-id
+    /// 1. product-category
+    /// 1. product-display-name
+    /// 1. labels
+    /// 1. bounding-poly
     ///
     /// The `image-uri`, `product-set-id`, `product-id`, and `product-category`
     /// columns are required. All other columns are optional.
@@ -7323,7 +7323,7 @@ pub struct Block {
     ///
     /// * when it's rotated 180 degrees around the top-left corner it becomes:
     ///
-    /// * and the vertex order will still be (0, 1, 2, 3).
+    ///   and the vertex order will still be (0, 1, 2, 3).
     ///
     ///
     /// ```norust

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -16160,24 +16160,24 @@ pub mod node_pool {
     /// If the strategy is ROLLING, use max_surge and max_unavailable to control
     /// the level of parallelism and the level of disruption caused by upgrade.
     ///
-    /// . maxSurge controls the number of additional nodes that can be added to
-    ///   the node pool temporarily for the time of the upgrade to increase the
-    ///   number of available nodes.
-    /// . maxUnavailable controls the number of nodes that can be simultaneously
-    ///   unavailable.
-    /// . (maxUnavailable + maxSurge) determines the level of parallelism (how
-    ///   many nodes are being upgraded at the same time).
+    /// 1. maxSurge controls the number of additional nodes that can be added to
+    ///    the node pool temporarily for the time of the upgrade to increase the
+    ///    number of available nodes.
+    /// 1. maxUnavailable controls the number of nodes that can be simultaneously
+    ///    unavailable.
+    /// 1. (maxUnavailable + maxSurge) determines the level of parallelism (how
+    ///    many nodes are being upgraded at the same time).
     ///
     /// If the strategy is BLUE_GREEN, use blue_green_settings to configure the
     /// blue-green upgrade related settings.
     ///
-    /// . standard_rollout_policy is the default policy. The policy is used to
-    ///   control the way blue pool gets drained. The draining is executed in the
-    ///   batch mode. The batch size could be specified as either percentage of the
-    ///   node pool size or the number of nodes. batch_soak_duration is the soak
-    ///   time after each batch gets drained.
-    /// . node_pool_soak_duration is the soak time after all blue nodes are
-    ///   drained. After this period, the blue pool nodes will be deleted.
+    /// 1. standard_rollout_policy is the default policy. The policy is used to
+    ///    control the way blue pool gets drained. The draining is executed in the
+    ///    batch mode. The batch size could be specified as either percentage of the
+    ///    node pool size or the number of nodes. batch_soak_duration is the soak
+    ///    time after each batch gets drained.
+    /// 1. node_pool_soak_duration is the soak time after all blue nodes are
+    ///    drained. After this period, the blue pool nodes will be deleted.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
@@ -27494,15 +27494,15 @@ pub struct LocalNvmeSsdBlockConfig {
     /// A zero (or unset) value has different meanings depending on machine type
     /// being used:
     ///
-    /// . For pre-Gen3 machines, which support flexible numbers of local ssds,
-    ///   zero (or unset) means to disable using local SSDs as ephemeral storage.
-    /// . For Gen3 machines which dictate a specific number of local ssds, zero
-    ///   (or unset) means to use the default number of local ssds that goes with
-    ///   that machine type. For example, for a c3-standard-8-lssd machine, 2 local
-    ///   ssds would be provisioned. For c3-standard-8 (which doesn't support local
-    ///   ssds), 0 will be provisioned. See
-    ///   <https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds>
-    ///   for more info.
+    /// 1. For pre-Gen3 machines, which support flexible numbers of local ssds,
+    ///    zero (or unset) means to disable using local SSDs as ephemeral storage.
+    /// 1. For Gen3 machines which dictate a specific number of local ssds, zero
+    ///    (or unset) means to use the default number of local ssds that goes with
+    ///    that machine type. For example, for a c3-standard-8-lssd machine, 2 local
+    ///    ssds would be provisioned. For c3-standard-8 (which doesn't support local
+    ///    ssds), 0 will be provisioned. See
+    ///    <https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds>
+    ///    for more info.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub local_ssd_count: i32,
@@ -27542,19 +27542,19 @@ pub struct EphemeralStorageLocalSsdConfig {
     /// A zero (or unset) value has different meanings depending on machine type
     /// being used:
     ///
-    /// . For pre-Gen3 machines, which support flexible numbers of local ssds,
-    ///   zero (or unset) means to disable using local SSDs as ephemeral storage. The
-    ///   limit for this value is dependent upon the maximum number of disk
-    ///   available on a machine per zone. See:
-    ///   <https://cloud.google.com/compute/docs/disks/local-ssd>
-    ///   for more information.
-    /// . For Gen3 machines which dictate a specific number of local ssds, zero
-    ///   (or unset) means to use the default number of local ssds that goes with
-    ///   that machine type. For example, for a c3-standard-8-lssd machine, 2 local
-    ///   ssds would be provisioned. For c3-standard-8 (which doesn't support local
-    ///   ssds), 0 will be provisioned. See
-    ///   <https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds>
-    ///   for more info.
+    /// 1. For pre-Gen3 machines, which support flexible numbers of local ssds,
+    ///    zero (or unset) means to disable using local SSDs as ephemeral storage. The
+    ///    limit for this value is dependent upon the maximum number of disk
+    ///    available on a machine per zone. See:
+    ///    <https://cloud.google.com/compute/docs/disks/local-ssd>
+    ///    for more information.
+    /// 1. For Gen3 machines which dictate a specific number of local ssds, zero
+    ///    (or unset) means to use the default number of local ssds that goes with
+    ///    that machine type. For example, for a c3-standard-8-lssd machine, 2 local
+    ///    ssds would be provisioned. For c3-standard-8 (which doesn't support local
+    ///    ssds), 0 will be provisioned. See
+    ///    <https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds>
+    ///    for more info.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "serde_with::DefaultOnNull<wkt::internal::I32>")]
     pub local_ssd_count: i32,
@@ -27605,9 +27605,9 @@ impl wkt::message::Message for EphemeralStorageLocalSsdConfig {
 pub struct ResourceManagerTags {
     /// TagKeyValue must be in one of the following formats ([KEY]=[VALUE])
     ///
-    /// . `tagKeys/{tag_key_id}=tagValues/{tag_value_id}`
-    /// . `{org_id}/{tag_key_name}={tag_value_name}`
-    /// . `{project_id}/{tag_key_name}={tag_value_name}`
+    /// 1. `tagKeys/{tag_key_id}=tagValues/{tag_value_id}`
+    /// 1. `{org_id}/{tag_key_name}={tag_value_name}`
+    /// 1. `{project_id}/{tag_key_name}={tag_value_name}`
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<std::collections::HashMap<_, _>>")]
     pub tags: std::collections::HashMap<std::string::String, std::string::String>,

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -6722,10 +6722,10 @@ pub mod build_trigger {
         /// Autodetect build configuration.  The following precedence is used (case
         /// insensitive):
         ///
-        /// . cloudbuild.yaml
-        /// . cloudbuild.yml
-        /// . cloudbuild.json
-        /// . Dockerfile
+        /// 1. cloudbuild.yaml
+        /// 1. cloudbuild.yml
+        /// 1. cloudbuild.json
+        /// 1. Dockerfile
         ///
         /// Currently only available for GitHub App Triggers.
         Autodetect(#[serde_as(as = "serde_with::DefaultOnNull<_>")] bool),
@@ -7772,16 +7772,16 @@ pub mod pull_request_filter {
         CommentsDisabled,
         /// Builds will only fire in response to pull requests if:
         ///
-        /// . The pull request author has repository write permission or above and
-        ///   `/gcbrun` is in the PR description.
-        /// . A user with repository writer permissions or above comments `/gcbrun`
-        ///   on a pull request authored by any user.
+        /// 1. The pull request author has repository write permission or above and
+        ///    `/gcbrun` is in the PR description.
+        /// 1. A user with repository writer permissions or above comments `/gcbrun`
+        ///    on a pull request authored by any user.
         CommentsEnabled,
         /// Builds will only fire in response to pull requests if:
         ///
-        /// . The pull request author is a repository writer or above.
-        /// . If the author does not have write permissions, a user with write
-        ///   permissions or above must comment `/gcbrun` in order to fire a build.
+        /// 1. The pull request author is a repository writer or above.
+        /// 1. If the author does not have write permissions, a user with write
+        ///    permissions or above must comment `/gcbrun` in order to fire a build.
         CommentsEnabledForExternalContributorsOnly,
         /// If set, the enum was initialized with an unknown value.
         ///

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -375,10 +375,10 @@ impl Iam {
     /// This method does not enable the service account to access other resources.
     /// To grant roles to a service account on a resource, follow these steps:
     ///
-    /// . Call the resource's `getIamPolicy` method to get its current IAM policy.
-    /// . Edit the policy so that it binds the service account to an IAM role for
-    ///   the resource.
-    /// . Call the resource's `setIamPolicy` method to update its IAM policy.
+    /// 1. Call the resource's `getIamPolicy` method to get its current IAM policy.
+    /// 1. Edit the policy so that it binds the service account to an IAM role for
+    ///    the resource.
+    /// 1. Call the resource's `setIamPolicy` method to update its IAM policy.
     ///
     /// For detailed instructions, see
     /// [Manage access to project, folders, and

--- a/src/generated/iam/v2/src/client.rs
+++ b/src/generated/iam/v2/src/client.rs
@@ -153,9 +153,9 @@ impl Policies {
     ///
     /// To update a policy, you should use a read-modify-write loop:
     ///
-    /// . Use [GetPolicy][google.iam.v2.Policies.GetPolicy] to read the current version of the policy.
-    /// . Modify the policy as needed.
-    /// . Use `UpdatePolicy` to write the updated policy.
+    /// 1. Use [GetPolicy][google.iam.v2.Policies.GetPolicy] to read the current version of the policy.
+    /// 1. Modify the policy as needed.
+    /// 1. Use `UpdatePolicy` to write the updated policy.
     ///
     /// This pattern helps prevent conflicts between concurrent updates.
     ///

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -6257,14 +6257,14 @@ pub struct LogMetric {
     /// Two functions are supported for value extraction: `EXTRACT(field)` or
     /// `REGEXP_EXTRACT(field, regex)`. The arguments are:
     ///
-    /// . field: The name of the log entry field from which the value is to be
-    ///   extracted.
-    /// . regex: A regular expression using the Google RE2 syntax
-    ///   (<https://github.com/google/re2/wiki/Syntax>) with a single capture
-    ///   group to extract data from the specified log entry field. The value
-    ///   of the field is converted to a string before applying the regex.
-    ///   It is an error to specify a regex that does not include exactly one
-    ///   capture group.
+    /// 1. field: The name of the log entry field from which the value is to be
+    ///    extracted.
+    /// 1. regex: A regular expression using the Google RE2 syntax
+    ///    (<https://github.com/google/re2/wiki/Syntax>) with a single capture
+    ///    group to extract data from the specified log entry field. The value
+    ///    of the field is converted to a string before applying the regex.
+    ///    It is an error to specify a regex that does not include exactly one
+    ///    capture group.
     ///
     /// The result of the extraction must be convertible to a double type, as the
     /// distribution always records double values. If either the extraction or

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -14282,12 +14282,12 @@ pub mod uptime_check_config {
         /// The content type header to use for the check. The following
         /// configurations result in errors:
         ///
-        /// . Content type is specified in both the `headers` field and the
-        ///   `content_type` field.
-        /// . Request method is `GET` and `content_type` is not `TYPE_UNSPECIFIED`
-        /// . Request method is `POST` and `content_type` is `TYPE_UNSPECIFIED`.
-        /// . Request method is `POST` and a "Content-Type" header is provided via
-        ///   `headers` field. The `content_type` field should be used instead.
+        /// 1. Content type is specified in both the `headers` field and the
+        ///    `content_type` field.
+        /// 1. Request method is `GET` and `content_type` is not `TYPE_UNSPECIFIED`
+        /// 1. Request method is `POST` and `content_type` is `TYPE_UNSPECIFIED`.
+        /// 1. Request method is `POST` and a "Content-Type" header is provided via
+        ///    `headers` field. The `content_type` field should be used instead.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
         #[serde_as(as = "serde_with::DefaultOnNull<_>")]
         pub content_type: crate::model::uptime_check_config::http_check::ContentType,
@@ -14296,9 +14296,9 @@ pub mod uptime_check_config {
         /// configurations outlined in the `content_type` field apply to
         /// `custom_content_type`, as well as the following:
         ///
-        /// . `content_type` is `URL_ENCODED` and `custom_content_type` is set.
-        /// . `content_type` is `USER_PROVIDED` and `custom_content_type` is not
-        ///   set.
+        /// 1. `content_type` is `URL_ENCODED` and `custom_content_type` is set.
+        /// 1. `content_type` is `USER_PROVIDED` and `custom_content_type` is not
+        ///    set.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
         #[serde_as(as = "serde_with::DefaultOnNull<_>")]
         pub custom_content_type: std::string::String,

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -11044,8 +11044,8 @@ pub struct CryptoDeterministicConfig {
     /// If the context is not set, plaintext would be used as is for encryption.
     /// If the context is set but:
     ///
-    /// . there is no record present when transforming a given value or
-    /// . the field is not present when transforming a given value,
+    /// 1. there is no record present when transforming a given value or
+    /// 1. the field is not present when transforming a given value,
     ///
     /// plaintext would be used as is for encryption.
     ///
@@ -11962,8 +11962,8 @@ pub struct CryptoReplaceFfxFpeConfig {
     ///
     /// If the context is set but:
     ///
-    /// . there is no record present when transforming a given value or
-    /// . the field is not present when transforming a given value,
+    /// 1. there is no record present when transforming a given value or
+    /// 1. the field is not present when transforming a given value,
     ///
     /// a default tweak will be used.
     ///

--- a/src/generated/showcase/src/client.rs
+++ b/src/generated/showcase/src/client.rs
@@ -1139,9 +1139,9 @@ impl SequenceService {
 /// against Showcase.
 /// Adding this comment with special characters for comment formatting tests:
 ///
-/// . (abra->kadabra->alakazam)
+/// 1. (abra->kadabra->alakazam)
 ///
-/// ) [Nonsense][]: `pokemon/*/psychic/*`
+/// 1. [Nonsense][]: `pokemon/*/psychic/*`
 ///
 /// # Configuration
 ///
@@ -1233,9 +1233,9 @@ impl Testing {
     /// Creates a new testing session.
     /// Adding this comment with special characters for comment formatting tests:
     ///
-    /// . (abra->kadabra->alakazam)
+    /// 1. (abra->kadabra->alakazam)
     ///
-    /// ) [Nonsense][]: `pokemon/*/psychic/*`
+    /// 1. [Nonsense][]: `pokemon/*/psychic/*`
     pub fn create_session(&self) -> super::builder::testing::CreateSession {
         super::builder::testing::CreateSession::new(self.inner.clone())
     }

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -4614,9 +4614,9 @@ pub struct DdlStatementActionInfo {
     /// The entity name(s) being operated on the DDL statement.
     /// E.g.
     ///
-    /// . For statement "CREATE TABLE t1(...)", `entity_names` = ["t1"].
-    /// . For statement "GRANT ROLE r1, r2 ...", `entity_names` = ["r1", "r2"].
-    /// . For statement "ANALYZE", `entity_names` = [].
+    /// 1. For statement "CREATE TABLE t1(...)", `entity_names` = ["t1"].
+    /// 1. For statement "GRANT ROLE r1, r2 ...", `entity_names` = ["r1", "r2"].
+    /// 1. For statement "ANALYZE", `entity_names` = [].
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     #[serde_as(as = "serde_with::DefaultOnNull<std::vec::Vec<_>>")]
     pub entity_names: std::vec::Vec<std::string::String>,

--- a/src/protojson-conformance/src/generated/gapic/model.rs
+++ b/src/protojson-conformance/src/generated/gapic/model.rs
@@ -114,9 +114,9 @@ impl wkt::message::Message for FailureSet {
 
 /// Represents a single test case's input.  The testee should:
 ///
-/// . parse this proto (which should always succeed)
-/// . parse the protobuf or JSON payload in "payload" (which may fail)
-/// . if the parse succeeded, serialize the message in the requested format.
+/// 1. parse this proto (which should always succeed)
+/// 1. parse the protobuf or JSON payload in "payload" (which may fail)
+/// 1. if the parse succeeded, serialize the message in the requested format.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]


### PR DESCRIPTION
Fixes most of  the clippy warnings from:

https://github.com/googleapis/google-cloud-rust/actions/runs/15762699268/job/44432800432?pr=2464

I do not know why these clippy warnings only appear after #2464 The warnings are completely valid, the documentation output is terrible:

https://docs.rs/google-cloud-dialogflow-v2/0.3.0/google_cloud_dialogflow_v2/model/struct.StreamingDetectIntentRequest.html

Note that the source protos really are a numbered list:

https://github.com/googleapis/googleapis/blob/f01a17a560b4fbc888fd552c978f4e1f8614100b/google/cloud/dialogflow/v2/session.proto#L393-L418

With these changes the documentation output looks much better:

![image](https://github.com/user-attachments/assets/44ed6ef6-048f-4a84-a4c9-2df1c6ce7d1e)


