### PR TITLE
impl(generator): support documentation overrides

### DIFF
--- a/generator/internal/api/documentation.go
+++ b/generator/internal/api/documentation.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
+)
+
+func PatchDocumentation(model *API, config *config.Config) error {
+	for _, override := range config.CommentOverrides {
+		id := override.ID
+		if msg, ok := model.State.MessageByID[id]; ok {
+			if err := patchElementDocs(&msg.Documentation, &override); err != nil {
+				return err
+			}
+			continue
+		}
+		if enu, ok := model.State.EnumByID[id]; ok {
+			if err := patchElementDocs(&enu.Documentation, &override); err != nil {
+				return err
+			}
+			continue
+		}
+		if svc, ok := model.State.ServiceByID[id]; ok {
+			if err := patchElementDocs(&svc.Documentation, &override); err != nil {
+				return err
+			}
+			continue
+		}
+		idx := strings.LastIndex(id, ".")
+		if idx == -1 {
+			return fmt.Errorf("cannot find element %s to apply comment overrides", id)
+		}
+		parentId := id[0:idx]
+		childId := id[idx+1:]
+		if msg, ok := model.State.MessageByID[parentId]; ok {
+			if err := patchFieldDocs(msg, childId, &override); err != nil {
+				return err
+			}
+			continue
+		}
+		if enu, ok := model.State.EnumByID[parentId]; ok {
+			if err := patchEnumValueDocs(enu, childId, &override); err != nil {
+				return err
+			}
+			continue
+		}
+		if svc, ok := model.State.ServiceByID[parentId]; ok {
+			if err := patchMethodDocs(svc, childId, &override); err != nil {
+				return err
+			}
+			continue
+		}
+		return fmt.Errorf("cannot find element %s to apply comment overrides, only searched for messages, enums and services", id)
+	}
+	return nil
+}
+
+func patchFieldDocs(msg *Message, fieldName string, override *config.DocumentationOverride) error {
+	for _, field := range msg.Fields {
+		if field.Name != fieldName {
+			continue
+		}
+		if err := patchElementDocs(&field.Documentation, override); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("cannot find field %s in message %s to apply comment override", fieldName, msg.ID)
+}
+
+func patchEnumValueDocs(enu *Enum, name string, override *config.DocumentationOverride) error {
+	for _, v := range enu.Values {
+		if v.Name != name {
+			continue
+		}
+		if err := patchElementDocs(&v.Documentation, override); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("cannot find field %s in message %s to apply comment override", name, enu.ID)
+}
+
+func patchMethodDocs(svc *Service, name string, override *config.DocumentationOverride) error {
+	for _, m := range svc.Methods {
+		if m.Name != name {
+			continue
+		}
+		if err := patchElementDocs(&m.Documentation, override); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("cannot find field %s in message %s to apply comment override", name, svc.ID)
+}
+
+func patchElementDocs(documentation *string, override *config.DocumentationOverride) error {
+	new := strings.Replace(*documentation, override.Match, override.Replace, -1)
+	if *documentation == new {
+		return fmt.Errorf("comment override for %s did not match", override.ID)
+	}
+	*documentation = new
+	return nil
+}

--- a/generator/internal/api/documentation_test.go
+++ b/generator/internal/api/documentation_test.go
@@ -1,0 +1,236 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
+)
+
+const (
+	Input = `Title
+
+Thing to preserve
+
+Valid versions are:
+  Article Suggestion baseline model:
+    - 0.9
+    - 1.0 (default)
+  Summarization baseline model:
+    - 1.0
+
+More things that are preserved.
+`
+
+	Want = `Title
+
+Thing to preserve
+
+Valid versions are:
+* Article Suggestion baseline model:
+    - 0.9
+    - 1.0 (default)
+* Summarization baseline model:
+    - 1.0
+
+More things that are preserved.
+`
+	Match = `Valid versions are:
+  Article Suggestion baseline model:
+    - 0.9
+    - 1.0 (default)
+  Summarization baseline model:
+    - 1.0`
+	Replace = `Valid versions are:
+* Article Suggestion baseline model:
+    - 0.9
+    - 1.0 (default)
+* Summarization baseline model:
+    - 1.0`
+)
+
+func TestPatchCommentsMessage(t *testing.T) {
+	m0 := &Message{
+		Name:          "Message0",
+		Package:       "test",
+		ID:            ".test.Message0",
+		Documentation: Input,
+	}
+	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
+	cfg := config.Config{
+		CommentOverrides: []config.DocumentationOverride{
+			{
+				ID:      ".test.Message0",
+				Match:   Match,
+				Replace: Replace,
+			},
+		},
+	}
+	if err := PatchDocumentation(model, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(m0.Documentation, Want); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestPatchCommentsField(t *testing.T) {
+	f0 := &Field{
+		Name:          "field_name",
+		ID:            ".test.Message0.field_name",
+		Documentation: Input,
+	}
+	m0 := &Message{
+		Name:    "Message0",
+		Package: "test",
+		ID:      ".test.Message0",
+		Fields:  []*Field{f0},
+	}
+	model := NewTestAPI([]*Message{m0}, []*Enum{}, []*Service{})
+	cfg := config.Config{
+		CommentOverrides: []config.DocumentationOverride{
+			{
+				ID:      ".test.Message0.field_name",
+				Match:   Match,
+				Replace: Replace,
+			},
+		},
+	}
+	if err := PatchDocumentation(model, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(f0.Documentation, Want); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestPatchCommentsEnum(t *testing.T) {
+	e0 := &Enum{
+		Name:          "Enum0",
+		Package:       "test",
+		ID:            ".test.Enum0",
+		Documentation: Input,
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{e0}, []*Service{})
+	cfg := config.Config{
+		CommentOverrides: []config.DocumentationOverride{
+			{
+				ID:      ".test.Enum0",
+				Match:   Match,
+				Replace: Replace,
+			},
+		},
+	}
+	if err := PatchDocumentation(model, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(e0.Documentation, Want); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestPatchCommentsEnumValue(t *testing.T) {
+	v0 := &EnumValue{
+		Name:          "ENUM_VALUE",
+		ID:            ".test.Enum0.ENUM_VALUE",
+		Documentation: Input,
+	}
+	e0 := &Enum{
+		Name:          "Enum0",
+		Package:       "test",
+		ID:            ".test.Enum0",
+		Values:        []*EnumValue{v0},
+		Documentation: Input,
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{e0}, []*Service{})
+	cfg := config.Config{
+		CommentOverrides: []config.DocumentationOverride{
+			{
+				ID:      ".test.Enum0.ENUM_VALUE",
+				Match:   Match,
+				Replace: Replace,
+			},
+		},
+	}
+	if err := PatchDocumentation(model, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(v0.Documentation, Want); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestPatchCommentsService(t *testing.T) {
+	s0 := &Service{
+		Name:          "Service0",
+		Package:       "test",
+		ID:            ".test.Service0",
+		Documentation: Input,
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{s0})
+	cfg := config.Config{
+		CommentOverrides: []config.DocumentationOverride{
+			{
+				ID:      ".test.Service0",
+				Match:   Match,
+				Replace: Replace,
+			},
+		},
+	}
+	if err := PatchDocumentation(model, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(s0.Documentation, Want); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}
+
+func TestPatchCommentsMethod(t *testing.T) {
+	m0 := &Method{
+		Name:          "Method",
+		ID:            ".test.Service0.Method",
+		Documentation: Input,
+	}
+	s0 := &Service{
+		Name:    "Service0",
+		Package: "test",
+		ID:      ".test.Service0",
+		Methods: []*Method{m0},
+	}
+	model := NewTestAPI([]*Message{}, []*Enum{}, []*Service{s0})
+	cfg := config.Config{
+		CommentOverrides: []config.DocumentationOverride{
+			{
+				ID:      ".test.Service0.Method",
+				Match:   Match,
+				Replace: Replace,
+			},
+		},
+	}
+	if err := PatchDocumentation(model, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(m0.Documentation, Want); diff != "" {
+		t.Errorf("mismatch in enums (-want, +got)\n:%s", diff)
+	}
+}

--- a/generator/internal/config/config.go
+++ b/generator/internal/config/config.go
@@ -37,11 +37,24 @@ const (
 	branch           = "master"
 )
 
+// Describe overrides for the documentation of a single element.
+//
+// This should be used sparingly. Generally we should prefer updating the
+// comments upstream, and then getting a new version of the services
+// specification. The exception may be when the fixes take a long time, or are
+// specific to one language.
+type DocumentationOverride struct {
+	ID      string `toml:"id"`
+	Match   string `toml:"match"`
+	Replace string `toml:"replace"`
+}
+
 type Config struct {
 	General GeneralConfig `toml:"general"`
 
-	Source map[string]string `toml:"source,omitempty"`
-	Codec  map[string]string `toml:"codec,omitempty"`
+	Source           map[string]string       `toml:"source,omitempty"`
+	Codec            map[string]string       `toml:"codec,omitempty"`
+	CommentOverrides []DocumentationOverride `toml:"documentation-overrides,omitempty"`
 }
 
 // Configuration parameters that affect Parsers and Codecs, including the
@@ -110,8 +123,9 @@ func mergeConfigs(rootConfig, local *Config) (*Config, error) {
 			Language:            rootConfig.General.Language,
 			SpecificationFormat: rootConfig.General.SpecificationFormat,
 		},
-		Source: map[string]string{},
-		Codec:  map[string]string{},
+		Source:           map[string]string{},
+		Codec:            map[string]string{},
+		CommentOverrides: local.CommentOverrides,
 	}
 	for k, v := range rootConfig.Codec {
 		merged.Codec[k] = v

--- a/generator/internal/config/config_test.go
+++ b/generator/internal/config/config_test.go
@@ -133,6 +133,58 @@ func TestMergeLocalForGeneral(t *testing.T) {
 	}
 }
 
+func TestMergeLocalForDocumentationOverrides(t *testing.T) {
+	root := Config{
+		General: GeneralConfig{
+			Language:            "root-language",
+			SpecificationFormat: "root-specification-format",
+		},
+		CommentOverrides: []DocumentationOverride{
+			{
+				ID: "root.Override",
+			},
+		},
+	}
+
+	local := Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		CommentOverrides: []DocumentationOverride{
+			{
+				ID: "local.Override",
+			},
+		},
+	}
+
+	got, err := mergeTestConfigs(t, &root, &local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		Codec:  map[string]string{},
+		Source: map[string]string{},
+		CommentOverrides: []DocumentationOverride{
+			{
+				ID: "local.Override",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}
+
 func TestMergeIgnoreRootSourceAndServiceConfig(t *testing.T) {
 	root := Config{
 		General: GeneralConfig{

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -79,6 +79,9 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 		return err
 	}
 	api.SkipModelElements(model, config.Source)
+	if err := api.PatchDocumentation(model, config); err != nil {
+		return err
+	}
 	// Verify all the services, messages and enums are in the same package.
 	if err := api.Validate(model); err != nil {
 		return err

--- a/src/generated/cloud/dialogflow/v2/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/v2/.sidekick.toml
@@ -19,3 +19,18 @@ service-config = 'google/cloud/dialogflow/v2/dialogflow_v2.yaml'
 [codec]
 copyright-year = '2025'
 per-service-features = 'true'
+
+[[documentation-overrides]]
+id      = '.google.cloud.dialogflow.v2.HumanAgentAssistantConfig.ConversationModelConfig.baseline_model_version'
+match   = """Valid versions are:
+  Article Suggestion baseline model:
+    - 0.9
+    - 1.0 (default)
+  Summarization baseline model:
+    - 1.0"""
+replace   = """Valid versions are:
+- Article Suggestion baseline model:
+  - 0.9
+  - 1.0 (default)
+- Summarization baseline model:
+  - 1.0"""

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -15222,11 +15222,12 @@ pub mod human_agent_assistant_config {
         /// Version of current baseline model. It will be ignored if
         /// [model][google.cloud.dialogflow.v2.HumanAgentAssistantConfig.ConversationModelConfig.model]
         /// is set. Valid versions are:
-        /// Article Suggestion baseline model:
-        /// - 0.9
-        /// - 1.0 (default)
-        /// Summarization baseline model:
-        /// - 1.0
+        ///
+        /// - Article Suggestion baseline model:
+        ///   - 0.9
+        ///   - 1.0 (default)
+        /// - Summarization baseline model:
+        ///   - 1.0
         ///
         /// [google.cloud.dialogflow.v2.HumanAgentAssistantConfig.ConversationModelConfig.model]: crate::model::human_agent_assistant_config::ConversationModelConfig::model
         #[serde(skip_serializing_if = "std::string::String::is_empty")]


### PR DESCRIPTION
From time to time we may need to patch the documentation for a service,
method, message, field, enum, or enum value. This new configuration
option provides the necessary functionality.

Part of the work for #2376
