### PR TITLE
docs(wkt): hide `serde` trait implementations

### DIFF
--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -222,6 +222,7 @@ impl crate::message::Message for Any {
 }
 
 /// Implement [`serde`](::serde) serialization for [Any].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl serde::ser::Serialize for Any {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -237,6 +238,7 @@ type ValueMap = serde_json::Map<String, serde_json::Value>;
 const EXPECTED: &str = "a valid type URL string in the @type field";
 
 /// Implement [`serde`](::serde) deserialization for [Any].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl<'de> serde::de::Deserialize<'de> for Any {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -469,6 +469,7 @@ impl From<Duration> for chrono::Duration {
 }
 
 /// Implement [`serde`](::serde) serialization for [Duration].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl serde::ser::Serialize for Duration {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -498,6 +499,7 @@ impl serde::de::Visitor<'_> for DurationVisitor {
 }
 
 /// Implement [`serde`](::serde) deserialization for [`Duration`].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl<'de> serde::de::Deserialize<'de> for Duration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -288,6 +288,7 @@ impl crate::message::Message for FieldMask {
 }
 
 /// Implement [serde] serialization for [FieldMask]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl serde::ser::Serialize for FieldMask {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -298,6 +299,7 @@ impl serde::ser::Serialize for FieldMask {
 }
 
 /// Implement [serde] deserialization for [FieldMask].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl<'de> serde::de::Deserialize<'de> for FieldMask {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -135,6 +135,7 @@ impl From<&NullValue> for serde_json::Value {
 }
 
 /// Implement [`serde`](::serde) serialization for [NullValue].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl serde::ser::Serialize for NullValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -145,6 +146,7 @@ impl serde::ser::Serialize for NullValue {
 }
 
 /// Implement [`serde`](::serde) deserialization for [NullValue].
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl<'de> serde::de::Deserialize<'de> for NullValue {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -243,6 +243,7 @@ impl crate::message::Message for Timestamp {
 const NS: i128 = 1_000_000_000;
 
 /// Implement [`serde`](::serde) serialization for timestamps.
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl serde::ser::Serialize for Timestamp {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -270,6 +271,7 @@ impl serde::de::Visitor<'_> for TimestampVisitor {
 }
 
 /// Implement [`serde`](::serde) deserialization for timestamps.
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 impl<'de> serde::de::Deserialize<'de> for Timestamp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
We do not want to advertise these too much. We need them to serialize
the messages over HTTP+JSON. We do not want to commit to supporting
these nor do we want to guarantee they work over any serde serialization
format.
