### PR TITLE
cleanup: avoid binding errors in tests

### DIFF
--- a/src/integration-tests/tests/idempotency.rs
+++ b/src/integration-tests/tests/idempotency.rs
@@ -77,7 +77,7 @@ mod default_idempotency {
             // be idempotent.
             let _ = client
                 .get_secret()
-                .set_name("invalid")
+                .set_name("projects/fake-project/secrets/fake-secret")
                 .with_retry_policy(expect_idempotent())
                 .send()
                 .await;
@@ -93,7 +93,7 @@ mod default_idempotency {
             // request should not be idempotent.
             let _ = client
                 .add_secret_version()
-                .set_parent("invalid")
+                .set_parent("projects/fake-project/secrets/fake-secret")
                 .with_retry_policy(expect_non_idempotent())
                 .send()
                 .await;

--- a/src/integration-tests/tests/requests.rs
+++ b/src/integration-tests/tests/requests.rs
@@ -34,7 +34,7 @@ mod requests {
 
         client
             .cancel_operation()
-            .set_name("operations/test-001")
+            .set_name("projects/test-project/locations/test-locations/operations/test-001")
             .send()
             .await?;
         Ok(())


### PR DESCRIPTION
Part of the work for #2317 

These are invalid resource names. When we start validating bindings, the tests will fail. So avoid that.