### PR TITLE
cleanup(wkt)!: `Message`s are `Ser`/`De`

### DIFF
--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -169,7 +169,7 @@ impl Any {
     /// ```
     pub fn from_msg<T>(message: &T) -> Result<Self, Error>
     where
-        T: crate::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
+        T: crate::message::Message,
     {
         let serializer = T::serializer();
         let value = serializer.serialize_to_map(message)?;
@@ -188,7 +188,7 @@ impl Any {
     /// ```
     pub fn to_msg<T>(&self) -> Result<T, Error>
     where
-        T: crate::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
+        T: crate::message::Message,
     {
         let map = &self.0;
         let r#type = map


### PR DESCRIPTION
You must be `serde::Serialize` and `serde::DeserializeOwned` in order to be a `wkt::message::Message`.

It makes more sense to enforce this on the `Message` trait, than on the `wkt::Any` pack/unpack functions.

Technically a breaking change if someone had defined their own `Message`, without ever using it with an `Any`. That would be... odd.