### PR TITLE
refactor(generator): make way for a new `PathSegment` representation

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -265,7 +265,7 @@ type PathBinding struct {
 	// - PATCH
 	Verb string
 	// The path broken by components.
-	PathTemplate []PathSegment
+	LegacyPathTemplate []LegacyPathSegment
 	// Query parameter fields.
 	QueryParameters map[string]bool
 }
@@ -356,7 +356,7 @@ const (
 // should produce:
 // ```
 //
-//	[]PathSegment{
+//	[]LegacyPathSegment{
 //	  {Literal:   &"v1"},
 //	  {Literal:   &"projects"},
 //	  {FieldPath: &"project"},
@@ -368,22 +368,22 @@ const (
 // ```
 //
 // The Codec interpret these elements as needed.
-type PathSegment struct {
+type LegacyPathSegment struct {
 	Literal   *string
 	FieldPath *string
 	Verb      *string
 }
 
-func NewLiteralPathSegment(s string) PathSegment {
-	return PathSegment{Literal: &s}
+func NewLiteralPathSegment(s string) LegacyPathSegment {
+	return LegacyPathSegment{Literal: &s}
 }
 
-func NewFieldPathPathSegment(s string) PathSegment {
-	return PathSegment{FieldPath: &s}
+func NewFieldPathPathSegment(s string) LegacyPathSegment {
+	return LegacyPathSegment{FieldPath: &s}
 }
 
-func NewVerbPathSegment(s string) PathSegment {
-	return PathSegment{Verb: &s}
+func NewVerbPathSegment(s string) LegacyPathSegment {
+	return LegacyPathSegment{Verb: &s}
 }
 
 // Message defines a message used in request/response handling.

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -157,7 +157,7 @@ func enumValueName(e *api.EnumValue) string {
 
 func httpPathFmt(pathInfo *api.PathInfo) string {
 	var builder strings.Builder
-	for _, segment := range pathInfo.Bindings[0].PathTemplate {
+	for _, segment := range pathInfo.Bindings[0].LegacyPathTemplate {
 		switch {
 		case segment.Literal != nil:
 			builder.WriteString("/")
@@ -242,7 +242,7 @@ func shouldGenerateMethod(m *api.Method) bool {
 	if len(m.PathInfo.Bindings) == 0 {
 		return false
 	}
-	return len(m.PathInfo.Bindings[0].PathTemplate) != 0
+	return len(m.PathInfo.Bindings[0].LegacyPathTemplate) != 0
 }
 
 func formatDirectory(dir string) error {

--- a/generator/internal/golang/golang.go
+++ b/generator/internal/golang/golang.go
@@ -168,7 +168,7 @@ func bodyAccessor(m *api.Method) string {
 
 func httpPathFmt(m *api.PathInfo) string {
 	fmt := ""
-	for _, segment := range m.Bindings[0].PathTemplate {
+	for _, segment := range m.Bindings[0].LegacyPathTemplate {
 		if segment.Literal != nil {
 			fmt = fmt + "/" + *segment.Literal
 		} else if segment.FieldPath != nil {
@@ -183,7 +183,7 @@ func httpPathFmt(m *api.PathInfo) string {
 func httpPathArgs(h *api.PathInfo) []string {
 	var args []string
 	// TODO(codyoss): https://github.com/googleapis/google-cloud-rust/issues/34
-	for _, segment := range h.Bindings[0].PathTemplate {
+	for _, segment := range h.Bindings[0].LegacyPathTemplate {
 		if segment.FieldPath != nil {
 			// TODO(#34) - handle nested path params
 			args = append(args, fmt.Sprintf(", req.%s", strcase.ToCamel(*segment.FieldPath)))
@@ -230,7 +230,7 @@ func generateMethod(m *api.Method) bool {
 	if len(m.PathInfo.Bindings) == 0 {
 		return false
 	}
-	return len(m.PathInfo.Bindings[0].PathTemplate) != 0
+	return len(m.PathInfo.Bindings[0].LegacyPathTemplate) != 0
 }
 
 // The list of Golang keywords and reserved words can be found at:

--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -43,7 +43,7 @@ func PathParams(m *api.Method, state *api.APIState) []*api.Field {
 		return nil
 	}
 	pathNames := []string{}
-	for _, arg := range m.PathInfo.Bindings[0].PathTemplate {
+	for _, arg := range m.PathInfo.Bindings[0].LegacyPathTemplate {
 		if arg.FieldPath != nil {
 			components := strings.Split(*arg.FieldPath, ".")
 			pathNames = append(pathNames, components[0])

--- a/generator/internal/parser/httprule/http_rule_parser.go
+++ b/generator/internal/parser/httprule/http_rule_parser.go
@@ -76,27 +76,25 @@ import (
 //
 // LITERAL     = unreserved | pct-encoded { unreserved | pct-encoded }
 //
-//
 // [RFC 3986]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
 // [Backus-Naur Form]: https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form
 // [C++ HTTP Annotation parser]: https://github.com/googleapis/google-cloud-cpp/blob/4174d656136f4b849c8a3d327237f3a96be3e003/generator/internal/http_annotation_parser.h#L49-L58
 // [google.api.http annotation]: https://github.com/googleapis/google-cloud-rust/blob/61b9d3bbac5530e4321ac19fe7d2760db82e31db/generator/testdata/googleapis/google/api/http.proto
-
 func Parse(pathTemplate string) (*PathTemplate, error) {
 	return parsePathTemplate(pathTemplate)
 }
 
-// ParseSegments flattens the result of Parse into a slice of api.PathSegment,
+// ParseSegments flattens the result of Parse into a slice of api.LegacyPathSegment,
 // ignoring variable values and match (* and **) segments.
 // TODO(#557): This function is a temporary shim to allow the existing tests to pass.
-func ParseSegments(pathTemplate string) ([]api.PathSegment, error) {
+func ParseSegments(pathTemplate string) ([]api.LegacyPathSegment, error) {
 	path, err := parsePathTemplate(pathTemplate)
 	if err != nil {
 		return nil, err
 	}
-	var segments []api.PathSegment
+	var segments []api.LegacyPathSegment
 	for _, s := range path.Segments {
-		segment := api.PathSegment{}
+		segment := api.LegacyPathSegment{}
 		if s.Literal != nil {
 			literal := string(*s.Literal)
 			segment.Literal = &literal
@@ -113,7 +111,7 @@ func ParseSegments(pathTemplate string) ([]api.PathSegment, error) {
 
 	if path.Verb != nil {
 		verb := string(*path.Verb)
-		segments = append(segments, api.PathSegment{
+		segments = append(segments, api.LegacyPathSegment{
 			Verb: &verb,
 		})
 	}

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -212,9 +212,9 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 			pathInfo := &api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						Verb:            op.Verb,
-						PathTemplate:    pathTemplate,
-						QueryParameters: queryParameters,
+						Verb:               op.Verb,
+						LegacyPathTemplate: pathTemplate,
+						QueryParameters:    queryParameters,
 					},
 				},
 				BodyFieldPath: bodyFieldPath,
@@ -236,11 +236,11 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 	return methods, nil
 }
 
-func makePathTemplate(template string) []api.PathSegment {
-	segments := []api.PathSegment{}
+func makePathTemplate(template string) []api.LegacyPathSegment {
+	segments := []api.LegacyPathSegment{}
 	for idx, component := range strings.Split(template, ":") {
 		if idx != 0 {
-			segments = append(segments, api.PathSegment{Verb: &component})
+			segments = append(segments, api.NewVerbPathSegment(component))
 			continue
 		}
 		for _, element := range strings.Split(component, "/") {
@@ -249,10 +249,10 @@ func makePathTemplate(template string) []api.PathSegment {
 			}
 			if strings.HasPrefix(element, "{") && strings.HasSuffix(element, "}") {
 				element = element[1 : len(element)-1]
-				segments = append(segments, api.PathSegment{FieldPath: &element})
+				segments = append(segments, api.NewFieldPathPathSegment(element))
 				continue
 			}
-			segments = append(segments, api.PathSegment{Literal: &element})
+			segments = append(segments, api.NewLiteralPathSegment(element))
 		}
 	}
 	return segments

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -724,7 +724,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewLiteralPathSegment("projects"),
 						api.NewFieldPathPathSegment("project"),
@@ -750,7 +750,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 	})
 
 	cs := sample.MethodCreate()
-	cs.PathInfo.Bindings[0].PathTemplate = []api.PathSegment{
+	cs.PathInfo.Bindings[0].LegacyPathTemplate = []api.LegacyPathSegment{
 		api.NewLiteralPathSegment("v1"),
 		api.NewLiteralPathSegment("projects"),
 		api.NewFieldPathPathSegment("project"),
@@ -910,7 +910,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewLiteralPathSegment("projects"),
 								api.NewFieldPathPathSegment("project"),
@@ -1123,7 +1123,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewLiteralPathSegment("projects"),
 						api.NewFieldPathPathSegment("project"),
@@ -1146,7 +1146,7 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewLiteralPathSegment("projects"),
 						api.NewFieldPathPathSegment("project"),

--- a/generator/internal/parser/protobuf_annotations.go
+++ b/generator/internal/parser/protobuf_annotations.go
@@ -107,9 +107,9 @@ func processRuleShallow(httpRule *annotations.HttpRule, state *api.APIState, mID
 		// Most often this happens with streaming RPCs. We will handle any
 		/// errors later in the code generation, maybe by ignoring the RPC.
 		return &api.PathBinding{
-			Verb:            "POST",
-			PathTemplate:    []api.PathSegment{},
-			QueryParameters: map[string]bool{},
+			Verb:               "POST",
+			LegacyPathTemplate: []api.LegacyPathSegment{},
+			QueryParameters:    map[string]bool{},
 		}, "*", nil
 	}
 	pathTemplate, err := httprule.ParseSegments(rawPath)
@@ -122,13 +122,13 @@ func processRuleShallow(httpRule *annotations.HttpRule, state *api.APIState, mID
 	}
 
 	return &api.PathBinding{
-		Verb:            verb,
-		PathTemplate:    pathTemplate,
-		QueryParameters: queryParameters,
+		Verb:               verb,
+		LegacyPathTemplate: pathTemplate,
+		QueryParameters:    queryParameters,
 	}, httpRule.GetBody(), nil
 }
 
-func queryParameters(msgID string, pathTemplate []api.PathSegment, body string, state *api.APIState) (map[string]bool, error) {
+func queryParameters(msgID string, pathTemplate []api.LegacyPathSegment, body string, state *api.APIState) (map[string]bool, error) {
 	msg, ok := state.MessageByID[msgID]
 	if !ok {
 		return nil, fmt.Errorf("unable to lookup type %s", msgID)

--- a/generator/internal/parser/protobuf_mixin_test.go
+++ b/generator/internal/parser/protobuf_mixin_test.go
@@ -74,7 +74,7 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("name"),
 					},
@@ -137,7 +137,7 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("resource"),
 						api.NewVerbPathSegment("getIamPolicy"),
@@ -208,7 +208,7 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v2"),
 						api.NewFieldPathPathSegment("name"),
 					},
@@ -290,7 +290,7 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v2"),
 						api.NewFieldPathPathSegment("name"),
 					},
@@ -369,7 +369,7 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("name"),
 					},

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -446,7 +446,7 @@ func TestProtobuf_Comments(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -830,7 +830,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("name"),
 							},
@@ -850,7 +850,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -871,7 +871,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "DELETE",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("name"),
 							},
@@ -890,9 +890,9 @@ func TestProtobuf_Service(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:            "POST",
-							PathTemplate:    []api.PathSegment{},
-							QueryParameters: map[string]bool{},
+							Verb:               "POST",
+							LegacyPathTemplate: []api.LegacyPathSegment{},
+							QueryParameters:    map[string]bool{},
 						},
 					},
 					BodyFieldPath: "*",
@@ -909,7 +909,7 @@ func TestProtobuf_Service(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("name"),
 								api.NewVerbPathSegment("Download"),
@@ -930,9 +930,9 @@ func TestProtobuf_Service(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:            "POST",
-							PathTemplate:    []api.PathSegment{},
-							QueryParameters: map[string]bool{},
+							Verb:               "POST",
+							LegacyPathTemplate: []api.LegacyPathSegment{},
+							QueryParameters:    map[string]bool{},
 						},
 					},
 					BodyFieldPath: "*",
@@ -967,7 +967,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -988,7 +988,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewVerbPathSegment("addFoo"),
@@ -1073,7 +1073,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1099,7 +1099,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1125,7 +1125,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1151,7 +1151,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1170,7 +1170,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1189,7 +1189,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1208,7 +1208,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1327,7 +1327,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1352,7 +1352,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
@@ -1377,7 +1377,7 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("v2"),
 								api.NewFieldPathPathSegment("name"),
 							},
@@ -1574,9 +1574,9 @@ func TestProtobuf_Deprecated(t *testing.T) {
 				PathInfo: &api.PathInfo{
 					Bindings: []*api.PathBinding{
 						{
-							Verb:            "POST",
-							PathTemplate:    []api.PathSegment{},
-							QueryParameters: map[string]bool{},
+							Verb:               "POST",
+							LegacyPathTemplate: []api.LegacyPathSegment{},
+							QueryParameters:    map[string]bool{},
 						},
 					},
 					BodyFieldPath: "*",

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -73,7 +73,7 @@ func serviceAnnotationsModel() *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("/v1/resource"),
 					},
 				},
@@ -89,7 +89,7 @@ func serviceAnnotationsModel() *api.API {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("/v1/resource"),
 					},
 				},
@@ -217,9 +217,9 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 	// The default binding we use when services do not have HTTP path
 	// annotations.
 	binding := &api.PathBinding{
-		Verb:            "POST",
-		PathTemplate:    []api.PathSegment{},
-		QueryParameters: map[string]bool{},
+		Verb:                     "POST",
+		LegacyLegacyPathTemplate: []api.LegacyPathSegment{},
+		QueryParameters:          map[string]bool{},
 	}
 	pathInfo := &api.PathInfo{
 		BodyFieldPath: "*",
@@ -1315,7 +1315,7 @@ func TestPathInfoAnnotations(t *testing.T) {
 				Bindings: []*api.PathBinding{
 					{
 						Verb: testCase.Verb,
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("/v1/resource"),
 						},
 					},

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -217,9 +217,9 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 	// The default binding we use when services do not have HTTP path
 	// annotations.
 	binding := &api.PathBinding{
-		Verb:                     "POST",
+		Verb:               "POST",
 		LegacyPathTemplate: []api.LegacyPathSegment{},
-		QueryParameters:          map[string]bool{},
+		QueryParameters:    map[string]bool{},
 	}
 	pathInfo := &api.PathInfo{
 		BodyFieldPath: "*",

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -218,7 +218,7 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 	// annotations.
 	binding := &api.PathBinding{
 		Verb:                     "POST",
-		LegacyLegacyPathTemplate: []api.LegacyPathSegment{},
+		LegacyPathTemplate: []api.LegacyPathSegment{},
 		QueryParameters:          map[string]bool{},
 	}
 	pathInfo := &api.PathInfo{

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -914,7 +914,7 @@ func bodyAccessor(m *api.Method) string {
 func httpPathFmt(m *api.PathInfo) string {
 	binding := m.Bindings[0]
 	fmt := ""
-	for _, segment := range binding.PathTemplate {
+	for _, segment := range binding.LegacyPathTemplate {
 		if segment.Literal != nil {
 			fmt = fmt + "/" + *segment.Literal
 		} else if segment.FieldPath != nil {
@@ -1003,7 +1003,7 @@ func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []pa
 		return []pathArg{}
 	}
 	var params []pathArg
-	for _, arg := range h.Bindings[0].PathTemplate {
+	for _, arg := range h.Bindings[0].LegacyPathTemplate {
 		if arg.FieldPath != nil {
 			leafTypez := leafFieldTypez(*arg.FieldPath, message, state)
 			params = append(params, pathArg{
@@ -1742,7 +1742,7 @@ func (c *codec) generateMethod(m *api.Method) bool {
 	if m.PathInfo == nil || len(m.PathInfo.Bindings) == 0 {
 		return false
 	}
-	return len(m.PathInfo.Bindings[0].PathTemplate) != 0
+	return len(m.PathInfo.Bindings[0].LegacyPathTemplate) != 0
 }
 
 // The list of Rust keywords and reserved words can be found at:

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -2013,7 +2013,7 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("/v1/foo"),
 							},
 						},
@@ -2035,7 +2035,7 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
-							PathTemplate: []api.PathSegment{
+							LegacyPathTemplate: []api.LegacyPathSegment{
 								api.NewLiteralPathSegment("/v1/thing"),
 							},
 						},
@@ -2271,7 +2271,7 @@ func TestPathFmt(t *testing.T) {
 			"/v1/fixed",
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
-					{PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewLiteralPathSegment("fixed")}},
+					{LegacyPathTemplate: []api.LegacyPathSegment{api.NewLiteralPathSegment("v1"), api.NewLiteralPathSegment("fixed")}},
 				},
 			},
 		},
@@ -2279,7 +2279,7 @@ func TestPathFmt(t *testing.T) {
 			"/v1/{}",
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
-					{PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent")}},
+					{LegacyPathTemplate: []api.LegacyPathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent")}},
 				},
 			},
 		},
@@ -2287,7 +2287,7 @@ func TestPathFmt(t *testing.T) {
 			"/v1/{}:action",
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
-					{PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent"), api.NewVerbPathSegment("action")}},
+					{LegacyPathTemplate: []api.LegacyPathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent"), api.NewVerbPathSegment("action")}},
 				},
 			},
 		},
@@ -2296,7 +2296,7 @@ func TestPathFmt(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewLiteralPathSegment("projects"),
 							api.NewFieldPathPathSegment("project"),
@@ -2369,7 +2369,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("v"),
 						},
@@ -2388,7 +2388,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("w"),
 						},
@@ -2401,7 +2401,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("x"),
 						},
@@ -2419,7 +2419,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("y"),
 						},
@@ -2438,7 +2438,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("z.a"),
 						},
@@ -2458,7 +2458,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("z.b"),
 						},
@@ -2476,7 +2476,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("z.c"),
 						},
@@ -2495,7 +2495,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("z.d"),
 						},
@@ -2519,7 +2519,7 @@ func TestPathArgs(t *testing.T) {
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
-						PathTemplate: []api.PathSegment{
+						LegacyPathTemplate: []api.LegacyPathSegment{
 							api.NewLiteralPathSegment("v1"),
 							api.NewFieldPathPathSegment("v"),
 							api.NewFieldPathPathSegment("w"),

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -73,7 +73,7 @@ func MethodCreate() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("parent"),
 						api.NewLiteralPathSegment("secrets"),
@@ -98,7 +98,7 @@ func MethodUpdate() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPatch,
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("secret.name"),
 					},
@@ -122,7 +122,7 @@ func MethodAddSecretVersion() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewLiteralPathSegment("projects"),
 						api.NewFieldPathPathSegment("project"),
@@ -151,7 +151,7 @@ func MethodListSecretVersions() *api.Method {
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
-					PathTemplate: []api.PathSegment{
+					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
 						api.NewLiteralPathSegment("projects"),
 						api.NewFieldPathPathSegment("parent"),


### PR DESCRIPTION
Part of the work for #2317, #557

I want the name `api.PathSegment` for myself. So make room for it, by giving the current representation a disparaging `Legacy*` prefix.

There are too many changes to swap out the representation for path segments in place. Both will have to exist while we build out the new implementation.