### PR TITLE
impl(gaxi): path mismatch error builder

### DIFF
--- a/src/gax/src/error/binding.rs
+++ b/src/gax/src/error/binding.rs
@@ -47,7 +47,7 @@ pub struct PathMismatch {
 /// Ways substituting a variable from a request into a [URI] can fail.
 ///
 /// [uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SubstitutionFail {
     /// A required field was not set
     Unset,
@@ -65,7 +65,7 @@ pub enum SubstitutionFail {
 /// A failure to substitute a variable from a request into a [URI].
 ///
 /// [uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct SubstitutionMismatch {
     /// The name of the field that was not substituted.
     ///


### PR DESCRIPTION
Part of the work for #2317 

Introduce a type to help us build errors. It is nicer if we factor this logic out into a common place to keep the generated code down.

If you are wondering "why not `let mut builder = ...` in the examples, that is because some paths do not have any substitutions. We could avoid this code altogether in the mustache template (as these paths can never error), but I find it easier to generate code that works for them anyways.