### PR TITLE
refactor(generator): towards `QueryParams` per binding

### DIFF
--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -515,7 +515,7 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 		annotate.annotateOperationInfo(method.OperationInfo)
 	}
 
-	queryParams := language.QueryParams(method, state)
+	queryParams := language.QueryParams(method, method.PathInfo.Bindings[0])
 	queryLines := []string{}
 	for _, field := range queryParams {
 		queryLines = buildQueryLines(queryLines, "request.", "", field, state)

--- a/generator/internal/golang/gotemplate.go
+++ b/generator/internal/golang/gotemplate.go
@@ -218,7 +218,7 @@ func annotateMethod(m *api.Method, s *api.Service, state *api.APIState) {
 		Name:              strcase.ToCamel(m.Name),
 		NameToPascal:      toPascal(m.Name),
 		PathParams:        language.PathParams(m, state),
-		QueryParams:       language.QueryParams(m, state),
+		QueryParams:       language.QueryParams(m, m.PathInfo.Bindings[0]),
 		ServiceStructName: s.Name,
 	}
 	if m.OperationInfo != nil {

--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -64,16 +64,10 @@ func PathParams(m *api.Method, state *api.APIState) []*api.Field {
 	return params
 }
 
-func QueryParams(m *api.Method, state *api.APIState) []*api.Field {
-	msg, ok := state.MessageByID[m.InputTypeID]
-	if !ok {
-		slog.Error("unable to lookup request type", "id", m.InputTypeID)
-		return nil
-	}
-
+func QueryParams(m *api.Method, b *api.PathBinding) []*api.Field {
 	var queryParams []*api.Field
-	for _, field := range msg.Fields {
-		if !m.PathInfo.Bindings[0].QueryParameters[field.Name] {
+	for _, field := range m.InputType.Fields {
+		if !b.QueryParameters[field.Name] {
 			continue
 		}
 		queryParams = append(queryParams, field)

--- a/generator/internal/language/codec_test.go
+++ b/generator/internal/language/codec_test.go
@@ -24,63 +24,43 @@ import (
 )
 
 func TestQueryParams(t *testing.T) {
-	options := &api.Message{
-		Name:   "Options",
-		ID:     "..Options",
-		Fields: []*api.Field{},
+	field1 := &api.Field{
+		Name: "field1",
 	}
-	optionsField := &api.Field{
-		Name:     "options_field",
-		JSONName: "optionsField",
-		Typez:    api.MESSAGE_TYPE,
-		TypezID:  options.ID,
-	}
-	anotherField := &api.Field{
-		Name:     "another_field",
-		JSONName: "anotherField",
-		Typez:    api.STRING_TYPE,
-		TypezID:  options.ID,
+	field2 := &api.Field{
+		Name: "field2",
 	}
 	request := &api.Message{
 		Name: "TestRequest",
 		ID:   "..TestRequest",
 		Fields: []*api.Field{
-			optionsField, anotherField,
+			field1, field2,
 			{
-				Name: "unused",
+				Name: "used_in_path",
 			},
+			{
+				Name: "used_in_body",
+			},
+		},
+	}
+	binding := &api.PathBinding{
+		Verb: "GET",
+		QueryParameters: map[string]bool{
+			"field1": true,
+			"field2": true,
 		},
 	}
 	method := &api.Method{
-		Name:         "Test",
-		ID:           "..TestService.Test",
-		InputTypeID:  request.ID,
-		OutputTypeID: ".google.protobuf.Empty",
+		Name:      "Test",
+		ID:        "..TestService.Test",
+		InputType: request,
 		PathInfo: &api.PathInfo{
-			Bindings: []*api.PathBinding{
-				{
-					Verb: "GET",
-					QueryParameters: map[string]bool{
-						"options_field": true,
-						"another_field": true,
-					},
-				},
-			},
+			Bindings: []*api.PathBinding{binding},
 		},
 	}
-	test := api.NewTestAPI(
-		[]*api.Message{options, request},
-		[]*api.Enum{},
-		[]*api.Service{
-			{
-				Name:    "TestService",
-				ID:      "..TestService",
-				Methods: []*api.Method{method},
-			},
-		})
 
-	got := QueryParams(method, test.State)
-	want := []*api.Field{optionsField, anotherField}
+	got := QueryParams(method, binding)
+	want := []*api.Field{field1, field2}
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
 		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -591,7 +591,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		BodyAccessor:        bodyAccessor(m),
 		DocLines:            c.formatDocComments(m.Documentation, m.ID, state, s.Scopes()),
 		PathInfo:            m.PathInfo,
-		QueryParams:         language.QueryParams(m, state),
+		QueryParams:         language.QueryParams(m, m.PathInfo.Bindings[0]),
 		ServiceNameToPascal: toPascal(serviceName),
 		ServiceNameToCamel:  toCamel(serviceName),
 		ServiceNameToSnake:  toSnake(serviceName),

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -67,6 +67,7 @@ func serviceAnnotationsModel() *api.API {
 	method := &api.Method{
 		Name:         "GetResource",
 		ID:           ".test.v1.ResourceService.GetResource",
+		InputType:    request,
 		InputTypeID:  ".test.v1.Request",
 		OutputTypeID: ".test.v1.Response",
 		PathInfo: &api.PathInfo{
@@ -83,6 +84,7 @@ func serviceAnnotationsModel() *api.API {
 	emptyMethod := &api.Method{
 		Name:         "DeleteResource",
 		ID:           ".test.v1.ResourceService.DeleteResource",
+		InputType:    request,
 		InputTypeID:  ".test.v1.Request",
 		OutputTypeID: ".google.protobuf.Empty",
 		PathInfo: &api.PathInfo{
@@ -226,35 +228,6 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 		Bindings:      []*api.PathBinding{binding},
 	}
 
-	service := &api.Service{
-		Name:    "LroService",
-		ID:      ".test.LroService",
-		Package: "test",
-		Methods: []*api.Method{
-			{
-				Name:         "CreateResource",
-				ID:           ".test.LroService.CreateResource",
-				PathInfo:     pathInfo,
-				InputTypeID:  ".test.CreateResourceRequest",
-				OutputTypeID: ".google.longrunning.Operation",
-				OperationInfo: &api.OperationInfo{
-					MetadataTypeID: ".test.OperationMetadata",
-					ResponseTypeID: ".test.Resource",
-				},
-			},
-			{
-				Name:         "DeleteResource",
-				ID:           ".test.LroService.DeleteResource",
-				PathInfo:     pathInfo,
-				InputTypeID:  ".test.DeleteResourceRequest",
-				OutputTypeID: ".google.longrunning.Operation",
-				OperationInfo: &api.OperationInfo{
-					MetadataTypeID: ".test.OperationMetadata",
-					ResponseTypeID: ".google.protobuf.Empty",
-				},
-			},
-		},
-	}
 	create := &api.Message{
 		Name:    "CreateResourceRequest",
 		ID:      ".test.CreateResourceRequest",
@@ -279,6 +252,37 @@ func TestServiceAnnotationsLROTypes(t *testing.T) {
 		Name:    "Empty",
 		ID:      ".google.protobuf.Empty",
 		Package: "google.protobuf",
+	}
+	service := &api.Service{
+		Name:    "LroService",
+		ID:      ".test.LroService",
+		Package: "test",
+		Methods: []*api.Method{
+			{
+				Name:         "CreateResource",
+				ID:           ".test.LroService.CreateResource",
+				PathInfo:     pathInfo,
+				InputType:    create,
+				InputTypeID:  ".test.CreateResourceRequest",
+				OutputTypeID: ".google.longrunning.Operation",
+				OperationInfo: &api.OperationInfo{
+					MetadataTypeID: ".test.OperationMetadata",
+					ResponseTypeID: ".test.Resource",
+				},
+			},
+			{
+				Name:         "DeleteResource",
+				ID:           ".test.LroService.DeleteResource",
+				PathInfo:     pathInfo,
+				InputType:    delete,
+				InputTypeID:  ".test.DeleteResourceRequest",
+				OutputTypeID: ".google.longrunning.Operation",
+				OperationInfo: &api.OperationInfo{
+					MetadataTypeID: ".test.OperationMetadata",
+					ResponseTypeID: ".google.protobuf.Empty",
+				},
+			},
+		},
 	}
 	model := api.NewTestAPI([]*api.Message{create, delete, resource, metadata}, []*api.Enum{}, []*api.Service{service})
 	api.CrossReference(model)


### PR DESCRIPTION
Part of the work for #2317 

We need to compute query parameters per path binding, not per method. So prepare for that.