### PR TITLE
refactor!: rename `gax::loop_state::LoopState`

### DIFF
--- a/src/gax-internal/tests/http_client_polling.rs
+++ b/src/gax-internal/tests/http_client_polling.rs
@@ -28,8 +28,8 @@ mod test {
             _loop_start: std::time::Instant,
             _attempt_count: u32,
             error: gax::error::Error,
-        ) -> gax::loop_state::LoopState {
-            gax::loop_state::LoopState::Continue(error)
+        ) -> gax::retry_result::RetryResult {
+            gax::retry_result::RetryResult::Continue(error)
         }
     }
 

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -47,11 +47,11 @@ pub mod response;
 pub mod backoff_policy;
 pub mod client_builder;
 pub mod exponential_backoff;
-pub mod loop_state;
 pub mod options;
 pub mod polling_backoff_policy;
 pub mod polling_error_policy;
 pub mod retry_policy;
+pub mod retry_result;
 pub mod retry_throttler;
 pub mod throttle_result;
 

--- a/src/gax/src/throttle_result.rs
+++ b/src/gax/src/throttle_result.rs
@@ -31,7 +31,7 @@ use crate::error::Error;
 ///
 /// ```
 /// # use google_cloud_gax::{error::Error, retry_policy::RetryPolicy};
-/// # use google_cloud_gax::{loop_state::LoopState, throttle_result::ThrottleResult};
+/// # use google_cloud_gax::{retry_result::RetryResult, throttle_result::ThrottleResult};
 /// #[derive(Debug)]
 /// struct MyRetryPolicy;
 /// impl google_cloud_gax::retry_policy::RetryPolicy for MyRetryPolicy {
@@ -49,7 +49,7 @@ use crate::error::Error;
 ///         loop_start: std::time::Instant,
 ///         attempt_count: u32,
 ///         idempotent: bool,
-///         error: Error) -> LoopState {
+///         error: Error) -> RetryResult {
 ///        # panic!();
 ///     }
 /// }

--- a/src/gax/tests/retry_policy.rs
+++ b/src/gax/tests/retry_policy.rs
@@ -17,8 +17,8 @@
 #[cfg(test)]
 mod tests {
     use google_cloud_gax::error::Error;
-    use google_cloud_gax::loop_state::LoopState;
     use google_cloud_gax::retry_policy::*;
+    use google_cloud_gax::retry_result::RetryResult;
     use std::time::Duration;
 
     #[derive(Debug)]
@@ -30,11 +30,11 @@ mod tests {
             _attempt_count: u32,
             idempotent: bool,
             error: Error,
-        ) -> LoopState {
+        ) -> RetryResult {
             if idempotent {
-                LoopState::Continue(error)
+                RetryResult::Continue(error)
             } else {
-                LoopState::Permanent(error)
+                RetryResult::Permanent(error)
             }
         }
 

--- a/src/integration-tests/tests/idempotency.rs
+++ b/src/integration-tests/tests/idempotency.rs
@@ -23,16 +23,16 @@ mod default_idempotency {
 
     type Result = anyhow::Result<()>;
     use gax::error::Error;
-    use gax::loop_state::LoopState;
     use gax::options::RequestOptionsBuilder;
     use gax::retry_policy::RetryPolicy;
+    use gax::retry_result::RetryResult;
     use gax::throttle_result::ThrottleResult;
 
     mockall::mock! {
         #[derive(Debug)]
         RetryPolicy {}
         impl RetryPolicy for RetryPolicy {
-            fn on_error(&self, loop_start: std::time::Instant, attempt_count: u32, idempotent: bool, error: Error) -> LoopState;
+            fn on_error(&self, loop_start: std::time::Instant, attempt_count: u32, idempotent: bool, error: Error) -> RetryResult;
             fn on_throttle(&self, loop_start: std::time::Instant, attempt_count: u32, error: Error) -> ThrottleResult;
             fn remaining_time(&self, loop_start: std::time::Instant, attempt_count: u32) -> Option<std::time::Duration>;
         }
@@ -53,7 +53,7 @@ mod default_idempotency {
             .withf(move |_, _, idempotent, _| *idempotent == expected_idempotency)
             .once()
             .in_sequence(&mut seq)
-            .returning(move |_, _, _, e| LoopState::Permanent(e));
+            .returning(move |_, _, _, e| RetryResult::Permanent(e));
 
         retry_policy
     }

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -15,8 +15,8 @@
 //! Simplifies the implementation of `PollerImpl`
 
 use super::*;
-use gax::loop_state::LoopState;
 use gax::polling_error_policy::PollingErrorPolicy;
+use gax::retry_result::RetryResult;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
@@ -115,7 +115,7 @@ where
 }
 
 fn handle_polling_error<R, M>(
-    state: gax::loop_state::LoopState,
+    state: gax::retry_result::RetryResult,
     operation_name: String,
 ) -> (Option<String>, PollingResult<R, M>)
 where
@@ -123,8 +123,8 @@ where
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
     match state {
-        LoopState::Continue(e) => (Some(operation_name), PollingResult::PollingError(e)),
-        LoopState::Exhausted(e) | LoopState::Permanent(e) => {
+        RetryResult::Continue(e) => (Some(operation_name), PollingResult::PollingError(e)),
+        RetryResult::Exhausted(e) | RetryResult::Permanent(e) => {
             (None, PollingResult::Completed(Err(e)))
         }
     }


### PR DESCRIPTION
The name did not reflect its function, and it is more jarring now that
we have `ThrottleResult`.