### PR TITLE
docs: more prerequisites to set up development environment

### DIFF
--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -76,8 +76,9 @@ Manager API, do the following:
    cargo add google-cloud-secretmanager-v1
    ```
 
-   You'll need to enable the Secret Manager API in [APIs and services](https://console.cloud.google.com/apis),
-   if you haven't already done so. 
+   You'll need to enable the Secret Manager API in
+   [APIs and services](https://console.cloud.google.com/apis), if you haven't
+   already done so.
 
 1. Add the [google-cloud-gax] crate to the new project
 

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -80,6 +80,10 @@ Manager API, do the following:
    [APIs and services](https://console.cloud.google.com/apis), if you haven't
    already done so.
 
+   ```shell
+   gcloud services enable secretmanager.googleapis.com
+   ```
+
 1. Add the [google-cloud-gax] crate to the new project
 
    ```shell

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -76,6 +76,9 @@ Manager API, do the following:
    cargo add google-cloud-secretmanager-v1
    ```
 
+   You'll need to enable the Secret Manager API in [APIs and services](https://console.cloud.google.com/apis),
+   if you haven't already done so. 
+
 1. Add the [google-cloud-gax] crate to the new project
 
    ```shell


### PR DESCRIPTION
Add a call out in the dev setup guide noting that you have to enable the Secret Manager API.