### PR TITLE
cleanup(generator): correct sample API

### DIFF
--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -660,7 +660,7 @@ func TestHttpPathFmt(t *testing.T) {
 		method *api.Method
 		want   string
 	}{
-		{method: sample.MethodCreate(), want: "/v1/${request.parent}/secrets/${request.secretId}"},
+		{method: sample.MethodCreate(), want: "/v1/projects/${request.project}/secrets"},
 		{method: sample.MethodUpdate(), want: "/v1/${request.secret.name}"},
 		{method: sample.MethodAddSecretVersion(), want: "/v1/projects/${request.project}/secrets/${request.secret}:addVersion"},
 		{method: sample.MethodListSecretVersions(), want: "/v1/projects/${request.parent}/secrets/${request.secret}:listSecretVersions"},

--- a/generator/internal/language/codec_test.go
+++ b/generator/internal/language/codec_test.go
@@ -77,7 +77,7 @@ func TestPathParams(t *testing.T) {
 	less := func(a, b *api.Field) bool { return a.Name < b.Name }
 
 	got := PathParams(sample.MethodCreate(), test.State)
-	want := sample.CreateRequest().Fields
+	want := []*api.Field{sample.CreateRequest().Fields[0]}
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
 		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
 	}

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -750,12 +750,6 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 	})
 
 	cs := sample.MethodCreate()
-	cs.PathInfo.Bindings[0].LegacyPathTemplate = []api.LegacyPathSegment{
-		api.NewLiteralPathSegment("v1"),
-		api.NewLiteralPathSegment("projects"),
-		api.NewFieldPathPathSegment("project"),
-		api.NewLiteralPathSegment("secrets"),
-	}
 	checkMethod(t, service, cs.Name, cs)
 
 	asv := sample.MethodAddSecretVersion()

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -75,9 +75,9 @@ func MethodCreate() *api.Method {
 					Verb: http.MethodPost,
 					LegacyPathTemplate: []api.LegacyPathSegment{
 						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
+						api.NewLiteralPathSegment("projects"),
+						api.NewFieldPathPathSegment("project"),
 						api.NewLiteralPathSegment("secrets"),
-						api.NewFieldPathPathSegment("secret_id"),
 					},
 					QueryParameters: map[string]bool{"secretId": true},
 				},
@@ -175,13 +175,13 @@ func CreateRequest() *api.Message {
 		Package:       Package,
 		Fields: []*api.Field{
 			{
-				Name:     "parent",
-				JSONName: "parent",
+				Name:     "project",
+				JSONName: "project",
 				Typez:    api.STRING_TYPE,
 			},
 			{
 				Name:     "secret_id",
-				JSONName: "secret_id",
+				JSONName: "secretId",
 				Typez:    api.STRING_TYPE,
 			},
 		},


### PR DESCRIPTION
Noticed while working on #2317 

We had the wrong hardcoded expectations, leading to weirdness. This is the spec for `CreateSecret`:

https://github.com/googleapis/google-cloud-rust/blob/97ff8eb0b68ff39c89c024b43d6e9b7001dae048/generator/testdata/openapi/secretmanager_openapi_v1.json#L223

https://github.com/googleapis/google-cloud-rust/blob/97ff8eb0b68ff39c89c024b43d6e9b7001dae048/generator/testdata/openapi/secretmanager_openapi_v1.json#L316-L334