### PR TITLE
impl(generator): use `PathTemplate` in model, OpenAPI

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -265,7 +265,10 @@ type PathBinding struct {
 	// - PATCH
 	Verb string
 	// The path broken by components.
+	// TODO(#2499) - Remove this.
 	LegacyPathTemplate []LegacyPathSegment
+	// The path broken by components.
+	PathTemplate *PathTemplate
 	// Query parameter fields.
 	QueryParameters map[string]bool
 }
@@ -439,20 +442,24 @@ func (v *PathVariable) WithMatch() *PathVariable {
 // ```
 //
 // The Codec interpret these elements as needed.
+// TODO(#2499) - Remove this.
 type LegacyPathSegment struct {
 	Literal   *string
 	FieldPath *string
 	Verb      *string
 }
 
+// TODO(#2499) - Remove this.
 func NewLiteralPathSegment(s string) LegacyPathSegment {
 	return LegacyPathSegment{Literal: &s}
 }
 
+// TODO(#2499) - Remove this.
 func NewFieldPathPathSegment(s string) LegacyPathSegment {
 	return LegacyPathSegment{FieldPath: &s}
 }
 
+// TODO(#2499) - Remove this.
 func NewVerbPathSegment(s string) LegacyPathSegment {
 	return LegacyPathSegment{Verb: &s}
 }

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -181,7 +181,11 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 		return methods, nil
 	}
 	for pattern, item := range model.Model.Paths.PathItems.FromOldest() {
-		pathTemplate, err := httprule.LegacyParseSegments(pattern)
+		pathTemplate, err := httprule.ParseSegments(pattern)
+		if err != nil {
+			return nil, err
+		}
+		legacyPathTemplate, err := httprule.LegacyParseSegments(pattern)
 		if err != nil {
 			return nil, err
 		}
@@ -217,7 +221,8 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 				Bindings: []*api.PathBinding{
 					{
 						Verb:               op.Verb,
-						LegacyPathTemplate: pathTemplate,
+						LegacyPathTemplate: legacyPathTemplate,
+						PathTemplate:       pathTemplate,
 						QueryParameters:    queryParameters,
 					},
 				},

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -730,6 +730,11 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 						api.NewFieldPathPathSegment("project"),
 						api.NewLiteralPathSegment("locations"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("project").
+						WithLiteral("locations"),
 					QueryParameters: map[string]bool{
 						"filter":    true,
 						"pageSize":  true,
@@ -910,6 +915,11 @@ func TestOpenAPI_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("project"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithLiteral("projects").
+								WithVariableNamed("project").
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"pageSize": true, "pageToken": true},
 						},
 					},
@@ -1124,6 +1134,12 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 						api.NewLiteralPathSegment("rpc"),
 						api.NewLiteralPathSegment("a"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("project").
+						WithLiteral("rpc").
+						WithLiteral("a"),
 					QueryParameters: map[string]bool{"filter": true},
 				},
 			},
@@ -1147,6 +1163,12 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 						api.NewLiteralPathSegment("rpc"),
 						api.NewLiteralPathSegment("b"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("project").
+						WithLiteral("rpc").
+						WithLiteral("b"),
 					QueryParameters: map[string]bool{},
 				},
 			},

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -79,6 +79,11 @@ func MethodCreate() *api.Method {
 						api.NewFieldPathPathSegment("project"),
 						api.NewLiteralPathSegment("secrets"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("project").
+						WithLiteral("secrets"),
 					QueryParameters: map[string]bool{"secretId": true},
 				},
 			},
@@ -102,6 +107,9 @@ func MethodUpdate() *api.Method {
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("secret.name"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithVariableNamed("secret", "name"),
 					QueryParameters: map[string]bool{
 						"field_mask": true,
 					},
@@ -130,6 +138,13 @@ func MethodAddSecretVersion() *api.Method {
 						api.NewFieldPathPathSegment("secret"),
 						api.NewVerbPathSegment("addVersion"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("project").
+						WithLiteral("secrets").
+						WithVariableNamed("secret").
+						WithVerb("addVersion"),
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -159,6 +174,13 @@ func MethodListSecretVersions() *api.Method {
 						api.NewFieldPathPathSegment("secret"),
 						api.NewVerbPathSegment("listSecretVersions"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithLiteral("projects").
+						WithVariableNamed("parent").
+						WithLiteral("secrets").
+						WithVariableNamed("secret").
+						WithVerb("listSecretVersions"),
 					QueryParameters: map[string]bool{},
 				},
 			},


### PR DESCRIPTION
Part of the work for #2317 

Add `PathTemplate` to the model. We only use it in OpenAPI to start (just to keep the PRs manageable).

TIL: `go fmt` will preserve linebreaks if the line ends with a `.`, but not if the line starts with a `.`