### PR TITLE
impl(generator): `PathTemplate` from protobuf

### DIFF
--- a/generator/internal/parser/protobuf_mixin_test.go
+++ b/generator/internal/parser/protobuf_mixin_test.go
@@ -78,6 +78,13 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("name"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithVariable(api.NewPathVariable("name").
+							WithLiteral("projects").
+							WithMatch().
+							WithLiteral("locations").
+							WithMatch()),
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -142,6 +149,12 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 						api.NewFieldPathPathSegment("resource"),
 						api.NewVerbPathSegment("getIamPolicy"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithVariable(api.NewPathVariable("resource").
+							WithLiteral("services").
+							WithMatch()).
+						WithVerb("getIamPolicy"),
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -212,6 +225,11 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 						api.NewLiteralPathSegment("v2"),
 						api.NewFieldPathPathSegment("name"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v2").
+						WithVariable(api.NewPathVariable("name").
+							WithLiteral("operations").
+							WithMatch()),
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -294,6 +312,11 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 						api.NewLiteralPathSegment("v2"),
 						api.NewFieldPathPathSegment("name"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v2").
+						WithVariable(api.NewPathVariable("name").
+							WithLiteral("operations").
+							WithMatch()),
 					QueryParameters: map[string]bool{},
 				},
 			},
@@ -373,6 +396,11 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 						api.NewLiteralPathSegment("v1"),
 						api.NewFieldPathPathSegment("name"),
 					},
+					PathTemplate: api.NewPathTemplate().
+						WithLiteral("v1").
+						WithVariable(api.NewPathVariable("name").
+							WithLiteral("operations").
+							WithMatch()),
 					QueryParameters: map[string]bool{},
 				},
 			},

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -451,6 +451,12 @@ func TestProtobuf_Comments(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{}},
 					},
 					BodyFieldPath: "*",
@@ -834,6 +840,13 @@ func TestProtobuf_Service(t *testing.T) {
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("name"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("name").
+									WithLiteral("projects").
+									WithMatch().
+									WithLiteral("foos").
+									WithMatch()),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -855,6 +868,12 @@ func TestProtobuf_Service(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"foo_id": true},
 						},
 					},
@@ -875,6 +894,13 @@ func TestProtobuf_Service(t *testing.T) {
 								api.NewLiteralPathSegment("v1"),
 								api.NewFieldPathPathSegment("name"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("name").
+									WithLiteral("projects").
+									WithMatch().
+									WithLiteral("foos").
+									WithMatch()),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -914,6 +940,14 @@ func TestProtobuf_Service(t *testing.T) {
 								api.NewFieldPathPathSegment("name"),
 								api.NewVerbPathSegment("Download"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("name").
+									WithLiteral("projects").
+									WithMatch().
+									WithLiteral("foos").
+									WithMatch()).
+								WithVerb("Download"),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -972,6 +1006,12 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"foo_id": true},
 						},
 					},
@@ -993,6 +1033,14 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewVerbPathSegment("addFoo"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch().
+									WithLiteral("foos").
+									WithMatch()).
+								WithVerb("addFoo"),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -1078,6 +1126,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 						},
 					},
@@ -1104,6 +1158,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1130,6 +1190,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"max_results": true, "page_token": true},
 						},
 					},
@@ -1156,6 +1222,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 						},
 					},
@@ -1175,6 +1247,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"page_token": true},
 						},
 					},
@@ -1194,6 +1272,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"page_size": true},
 						},
 					},
@@ -1213,6 +1297,12 @@ func TestProtobuf_Pagination(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 						},
 					},
@@ -1332,6 +1422,12 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -1357,6 +1453,12 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 								api.NewFieldPathPathSegment("parent"),
 								api.NewLiteralPathSegment("foos"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v1").
+								WithVariable(api.NewPathVariable("parent").
+									WithLiteral("projects").
+									WithMatch()).
+								WithLiteral("foos"),
 							QueryParameters: map[string]bool{},
 						},
 					},
@@ -1381,6 +1483,11 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 								api.NewLiteralPathSegment("v2"),
 								api.NewFieldPathPathSegment("name"),
 							},
+							PathTemplate: api.NewPathTemplate().
+								WithLiteral("v2").
+								WithVariable(api.NewPathVariable("name").
+									WithLiteral("operations").
+									WithMatch()),
 							QueryParameters: map[string]bool{},
 						},
 					},


### PR DESCRIPTION
Part of the work for #2317

Store the full `api.PathTemplate` when parsing protobuf.

Note that with protobuf, `PathTemplate` holds extra information (the variable templates) which `LegacyPathTemplate` does not.