### PR TITLE
refactor(generator): use `PathTemplate` over `LegacyPathTemplate`

### DIFF
--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -42,7 +42,7 @@ func PathParams(m *api.Method, state *api.APIState) []*api.Field {
 		return nil
 	}
 	pathNames := []string{}
-        t := m.PathInfo.Bindings[0].PathTemplate
+	t := m.PathInfo.Bindings[0].PathTemplate
 	for _, s := range t.Segments {
 		if s.Variable != nil {
 			pathNames = append(pathNames, s.Variable.FieldPath[0])


### PR DESCRIPTION
Part of the work for #2499 

This code looks underpowered (it cannot handle nested fields), but I am leaving it no worse than before.