### PR TITLE
refactor(generator/rust): PathFmt from `PathTemplate`

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -565,7 +565,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		pathInfoAnnotation := &pathInfoAnnotation{
 			Method:        m.PathInfo.Bindings[0].Verb,
 			MethodToLower: strings.ToLower(m.PathInfo.Bindings[0].Verb),
-			PathFmt:       httpPathFmt(m.PathInfo),
+			PathFmt:       httpPathFmt(m.PathInfo.Bindings[0].PathTemplate),
 			PathArgs:      httpPathArgs(m.PathInfo, m, state),
 			HasBody:       m.PathInfo.BodyFieldPath != "",
 		}

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -676,17 +676,17 @@ func bodyAccessor(m *api.Method) string {
 	return "." + toSnake(m.PathInfo.BodyFieldPath)
 }
 
-func httpPathFmt(m *api.PathInfo) string {
-	binding := m.Bindings[0]
+func httpPathFmt(t *api.PathTemplate) string {
 	fmt := ""
-	for _, segment := range binding.LegacyPathTemplate {
+	for _, segment := range t.Segments {
 		if segment.Literal != nil {
 			fmt = fmt + "/" + *segment.Literal
-		} else if segment.FieldPath != nil {
+		} else if segment.Variable != nil {
 			fmt = fmt + "/{}"
-		} else if segment.Verb != nil {
-			fmt = fmt + ":" + *segment.Verb
 		}
+	}
+	if t.Verb != nil {
+		fmt = fmt + ":" + *t.Verb
 	}
 	return fmt
 }

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -1793,55 +1793,53 @@ func TestEnumValueVariantName(t *testing.T) {
 func TestPathFmt(t *testing.T) {
 	for _, test := range []struct {
 		want     string
-		pathInfo *api.PathInfo
+		template *api.PathTemplate
 	}{
 		{
 			"/v1/fixed",
-			&api.PathInfo{
-				Bindings: []*api.PathBinding{
-					{LegacyPathTemplate: []api.LegacyPathSegment{api.NewLiteralPathSegment("v1"), api.NewLiteralPathSegment("fixed")}},
-				},
-			},
+			api.NewPathTemplate().
+				WithLiteral("v1").
+				WithLiteral("fixed"),
 		},
 		{
 			"/v1/{}",
-			&api.PathInfo{
-				Bindings: []*api.PathBinding{
-					{LegacyPathTemplate: []api.LegacyPathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent")}},
-				},
-			},
+			api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("parent"),
+		},
+		{
+			"/v1/{}",
+			api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariable(api.NewPathVariable("parent").
+					WithLiteral("projects").
+					WithMatch().
+					WithLiteral("locations").
+					WithMatch()),
 		},
 		{
 			"/v1/{}:action",
-			&api.PathInfo{
-				Bindings: []*api.PathBinding{
-					{LegacyPathTemplate: []api.LegacyPathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent"), api.NewVerbPathSegment("action")}},
-				},
-			},
+			api.NewPathTemplate().
+				WithLiteral("v1").
+				WithVariableNamed("parent").
+				WithVerb("action"),
 		},
 		{
 			"/v1/projects/{}/locations/{}/secrets/{}:action",
-			&api.PathInfo{
-				Bindings: []*api.PathBinding{
-					{
-						LegacyPathTemplate: []api.LegacyPathSegment{
-							api.NewLiteralPathSegment("v1"),
-							api.NewLiteralPathSegment("projects"),
-							api.NewFieldPathPathSegment("project"),
-							api.NewLiteralPathSegment("locations"),
-							api.NewFieldPathPathSegment("location"),
-							api.NewLiteralPathSegment("secrets"),
-							api.NewFieldPathPathSegment("secret"),
-							api.NewVerbPathSegment("action"),
-						},
-					},
-				},
-			},
+			api.NewPathTemplate().
+				WithLiteral("v1").
+				WithLiteral("projects").
+				WithVariableNamed("project").
+				WithLiteral("locations").
+				WithVariableNamed("location").
+				WithLiteral("secrets").
+				WithVariableNamed("secret").
+				WithVerb("action"),
 		},
 	} {
-		got := httpPathFmt(test.pathInfo)
+		got := httpPathFmt(test.template)
 		if test.want != got {
-			t.Errorf("mismatched path info fmt for %v\nwant=%s\n got=%s", test.pathInfo, test.want, got)
+			t.Errorf("mismatched path fmt for %v\nwant=%s\n got=%s", test.template, test.want, got)
 		}
 	}
 


### PR DESCRIPTION
Part of the work for #2499

use `api.PathTemplate` to produce the path fmt string.

Part of the work for #2317 

Looking ahead, this `PathFmt` will be used as an annotation on a `PathBinding` (so we have one path per binding, instead of one path per method).