### PR TITLE
impl(generator/rust): annotations for `PathBindings`

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -271,6 +271,8 @@ type PathBinding struct {
 	PathTemplate *PathTemplate
 	// Query parameter fields.
 	QueryParameters map[string]bool
+	// Language specific annotations
+	Codec any
 }
 
 // Normalized long running operation info


### PR DESCRIPTION
Part of the work for #2317

Introduce an annotation for `api.PathBinding` in Rust.

`annotatePathBinding` will grow to include the variable substitutions we need for path matching. But it is better to start small.

I am definitely open to suggestions on how to test this stuff. I settled for just defining a new service with N bindings, which should cover the cases we need to complete #2317. And if I missed something, we will just add the (N+1)th binding. The `want_*`s should grow as `annotatePathBinding` grows.