### PR TITLE
cleanup(gaxi): trait for working with path fields

### DIFF
--- a/src/gax-internal/src/path_parameter.rs
+++ b/src/gax-internal/src/path_parameter.rs
@@ -130,8 +130,8 @@ pub fn try_match<T: PathField>(value: T, template: &[Segment]) -> T {
 ///     "projects/*");
 /// let builder = builder.maybe_add(
 ///     id,
-///     "id",
 ///     &[Segment::SingleWildcard],
+///     "id",
 ///     "*");
 /// // etc.
 ///


### PR DESCRIPTION
Fixes #2497, part of the work for #2317

Basically a refactor.

As @coryan suggested, introduce a trait to unify the strings vs. non-string path fields.

Now we treat them differently from within gaxi, instead of keeping track of which fields are strings in the model, and in the gaxi interface. This is cleaner.