### PR TITLE
cleanup(gax): idiomatic return type for `PollingErrorPolicy::on_in_progress()`

### DIFF
--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -102,8 +102,8 @@ where
                 PollingResult::Completed(_) => (name, result),
                 PollingResult::InProgress(_) => {
                     match error_policy.on_in_progress(loop_start, attempt_count, &operation_name) {
-                        None => (name, result),
-                        Some(e) => (None, PollingResult::Completed(Err(e))),
+                        Ok(()) => (name, result),
+                        Err(e) => (None, PollingResult::Completed(Err(e))),
                     }
                 }
                 PollingResult::PollingError(_) => {


### PR DESCRIPTION
Resolves the remaining half of #2335.

The other half was fixed in #2456 (`RetryPolicy::on_throttle()`)

cc: @dbolduc 

