### PR TITLE
impl(generator/rust): additional bindings in showcase

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -92,6 +92,17 @@ type serviceAnnotations struct {
 	Incomplete bool
 }
 
+func (m *methodAnnotation) HasBindingSubstitutions() bool {
+	for _, b := range m.PathInfo.Bindings {
+		for _, s := range b.PathTemplate.Segments {
+			if s.Variable != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // If true, this service includes methods that return long-running operations.
 func (s *serviceAnnotations) HasLROs() bool {
 	return len(s.LROTypes) > 0
@@ -270,6 +281,22 @@ type pathBindingAnnotation struct {
 
 	// The variables to be substituted into the path
 	Substitutions []*bindingSubstitution
+}
+
+// We serialize certain query parameters, which can fail. The code we generate
+// uses the try operator '?'. We need to run this code in a closure which
+// returns a `Result<>`.
+func (b *pathBindingAnnotation) QueryParamsCanFail() bool {
+	for _, f := range b.QueryParams {
+		if f.Typez == api.MESSAGE_TYPE {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *pathBindingAnnotation) HasVariablePath() bool {
+	return len(b.Substitutions) != 0
 }
 
 type oneOfAnnotation struct {

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -166,6 +166,8 @@ type methodAnnotation struct {
 	ReturnType          string
 	HasVeneer           bool
 	Attributes          []string
+	// TODO(#2317) - remove when this is on by default
+	AdditionalBindings bool
 }
 
 type pathInfoAnnotation struct {
@@ -661,6 +663,8 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 	if len(m.PathInfo.Bindings) != 0 {
 		query_params = language.QueryParams(m, m.PathInfo.Bindings[0])
 	}
+	// TODO(#2317) - remove when this is on by default
+	additionalBindings := sourceSpecificationPackageName == "google.showcase.v1beta1"
 	annotation := &methodAnnotation{
 		Name:                strcase.ToSnake(m.Name),
 		BuilderName:         toPascal(m.Name),
@@ -674,6 +678,8 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		SystemParameters:    c.systemParameters,
 		ReturnType:          returnType,
 		HasVeneer:           c.hasVeneer,
+		// TODO(#2317) - remove when this is on by default
+		AdditionalBindings: additionalBindings,
 	}
 	if annotation.Name == "clone" {
 		// Some methods look too similar to standard Rust traits. Clippy makes

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -25,12 +25,6 @@ limitations under the License.
 use crate::Result;
 #[allow(unused_imports)]
 use gax::error::Error;
-#[allow(unused_imports)]
-use gax::error::binding::BindingError;
-#[allow(unused_imports)]
-use gaxi::routing_parameter::Segment;
-#[allow(unused_imports)]
-use gaxi::path_parameter::{PathMismatchBuilder, try_match};
 
 {{/Codec.HasServices}}
 {{#Codec.Services}}
@@ -79,26 +73,45 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{PathInfo.Codec.IsIdempotent}},
         );
         {{#Codec.AdditionalBindings}}
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        {{#Codec.HasBindingSubstitutions}}
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
+        {{/Codec.HasBindingSubstitutions}}
         let builder = None
         {{#PathInfo.Bindings}}
         .or_else(|| {
+            {{#Codec.HasVariablePath}}
             let path = format!(
                 "{{Codec.PathFmt}}",
                 {{#Codec.Substitutions}}
                 try_match({{{FieldAccessor}}}, {{{TemplateAsArray}}})?,
                 {{/Codec.Substitutions}}
             );
+            {{/Codec.HasVariablePath}}
+            {{^Codec.HasVariablePath}}
+            let path = "{{Codec.PathFmt}}".to_string();
+            {{/Codec.HasVariablePath}}
 
+            let builder = self
+                .inner
+                .builder(reqwest::Method::{{Verb}}, path);
+            {{^Codec.QueryParamsCanFail}}
+            {{#Codec.QueryParams}}
+            {{{Codec.AddQueryParameter}}}
+            {{/Codec.QueryParams}}
+            Some(Ok(builder))
+            {{/Codec.QueryParamsCanFail}}
+            {{#Codec.QueryParamsCanFail}}
             let builder = (|| {
-                let builder = self
-                    .inner
-                    .builder(reqwest::Method::{{Verb}}, path);
                 {{#Codec.QueryParams}}
                 {{{Codec.AddQueryParameter}}}
                 {{/Codec.QueryParams}}
                 Ok(builder)
             })();
             Some(builder)
+            {{/Codec.QueryParamsCanFail}}
         })
         {{/PathInfo.Bindings}}
         .ok_or_else(|| {

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -25,6 +25,12 @@ limitations under the License.
 use crate::Result;
 #[allow(unused_imports)]
 use gax::error::Error;
+#[allow(unused_imports)]
+use gax::error::binding::BindingError;
+#[allow(unused_imports)]
+use gaxi::routing_parameter::Segment;
+#[allow(unused_imports)]
+use gaxi::path_parameter::{PathMismatchBuilder, try_match};
 
 {{/Codec.HasServices}}
 {{#Codec.Services}}
@@ -72,6 +78,53 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             options,
             {{PathInfo.Codec.IsIdempotent}},
         );
+        {{#Codec.AdditionalBindings}}
+        let builder = None
+        {{#PathInfo.Bindings}}
+        .or_else(|| {
+            let path = format!(
+                "{{Codec.PathFmt}}",
+                {{#Codec.Substitutions}}
+                try_match({{{FieldAccessor}}}, {{{TemplateAsArray}}})?,
+                {{/Codec.Substitutions}}
+            );
+
+            let builder = (|| {
+                let builder = self
+                    .inner
+                    .builder(reqwest::Method::{{Verb}}, path);
+                {{#Codec.QueryParams}}
+                {{{Codec.AddQueryParameter}}}
+                {{/Codec.QueryParams}}
+                Ok(builder)
+            })();
+            Some(builder)
+        })
+        {{/PathInfo.Bindings}}
+        .ok_or_else(|| {
+            let mut paths = Vec::new();
+            {{#PathInfo.Bindings}}
+            {
+                let builder = PathMismatchBuilder::default();
+                {{#Codec.Substitutions}}
+                let builder = builder.maybe_add(
+                    {{{FieldAccessor}}},
+                    {{{TemplateAsArray}}},
+                    "{{FieldName}}",
+                    "{{{TemplateAsString}}}");
+                {{/Codec.Substitutions}}
+                paths.push(builder.build());
+            }
+            {{/PathInfo.Bindings}}
+            gax::error::Error::binding(BindingError { paths })
+        })??;
+        let builder = builder
+                {{#Codec.SystemParameters}}
+                .query(&[("{{Name}}", "{{Value}}")])
+                {{/Codec.SystemParameters}}
+                .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
+        {{/Codec.AdditionalBindings}}
+        {{^Codec.AdditionalBindings}}
         let path =
             {{^PathInfo.Codec.HasPathArgs}}
             {{! Sometimes there are no path args and `format!()` produces warnings }}
@@ -105,6 +158,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{#Codec.QueryParams}}
         {{{Codec.AddQueryParameter}}}
         {{/Codec.QueryParams}}
+        {{/Codec.AdditionalBindings}}
         self.inner.execute(
             builder,
             {{#PathInfo.Codec.HasBody}}

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -97,12 +97,6 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             let builder = self
                 .inner
                 .builder(reqwest::Method::{{Verb}}, path);
-            {{^Codec.QueryParamsCanFail}}
-            {{#Codec.QueryParams}}
-            {{{Codec.AddQueryParameter}}}
-            {{/Codec.QueryParams}}
-            Some(Ok(builder))
-            {{/Codec.QueryParamsCanFail}}
             {{#Codec.QueryParamsCanFail}}
             let builder = (|| {
                 {{#Codec.QueryParams}}
@@ -111,6 +105,12 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                 Ok(builder)
             })();
             Some(builder)
+            {{/Codec.QueryParamsCanFail}}
+            {{^Codec.QueryParamsCanFail}}
+            {{#Codec.QueryParams}}
+            {{{Codec.AddQueryParameter}}}
+            {{/Codec.QueryParams}}
+            Some(Ok(builder))
             {{/Codec.QueryParamsCanFail}}
         })
         {{/PathInfo.Bindings}}

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -17,12 +17,6 @@
 use crate::Result;
 #[allow(unused_imports)]
 use gax::error::Error;
-#[allow(unused_imports)]
-use gax::error::binding::BindingError;
-#[allow(unused_imports)]
-use gaxi::path_parameter::{PathMismatchBuilder, try_match};
-#[allow(unused_imports)]
-use gaxi::routing_parameter::Segment;
 
 /// Implements [Compliance](super::stub::Compliance) using a [gaxi::http::ReqwestClient].
 #[derive(Clone)]
@@ -52,15 +46,14 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/repeat:body",);
+                let path = "/v1beta1/repeat:body".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -83,35 +76,34 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/repeat:bodyinfo",);
+                let path = "/v1beta1/repeat:bodyinfo".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
-                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
-                        builder.query(&[("intendedBindingUri", p)])
-                    });
-                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
-                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
-                    let builder = builder.query(&[("fDouble", &req.f_double)]);
-                    let builder = req
-                        .p_int32
-                        .iter()
-                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
-                    let builder = req
-                        .p_int64
-                        .iter()
-                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
-                    let builder = req
-                        .p_double
-                        .iter()
-                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                    builder.query(&[("intendedBindingUri", p)])
+                });
+                let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                let builder = builder.query(&[("fDouble", &req.f_double)]);
+                let builder = req
+                    .p_int32
+                    .iter()
+                    .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                let builder = req
+                    .p_int64
+                    .iter()
+                    .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                let builder = req
+                    .p_double
+                    .iter()
+                    .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -134,12 +126,14 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/repeat:query",);
+                let path = "/v1beta1/repeat:query".to_string();
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = builder.query(&[("name", &req.name)]);
                     let builder = req
                         .info
@@ -197,6 +191,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -230,8 +228,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = builder.query(&[("name", &req.name)]);
                     let builder = req
                         .info
@@ -326,6 +324,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -351,8 +353,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = builder.query(&[("name", &req.name)]);
                     let builder = req
                         .info
@@ -411,8 +413,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = builder.query(&[("name", &req.name)]);
                     let builder = req
                         .info
@@ -524,6 +526,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -545,8 +551,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = builder.query(&[("name", &req.name)]);
                     let builder = req
                         .info
@@ -623,15 +629,14 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/repeat:bodyput",);
+                let path = "/v1beta1/repeat:bodyput".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::PUT, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::PUT, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -654,15 +659,14 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/repeat:bodypatch",);
+                let path = "/v1beta1/repeat:bodypatch".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::PATCH, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -685,16 +689,15 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/compliance/enum",);
+                let path = "/v1beta1/compliance/enum".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("unknownEnum", &req.unknown_enum)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("unknownEnum", &req.unknown_enum)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -719,12 +722,14 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/compliance/enum",);
+                let path = "/v1beta1/compliance/enum".to_string();
 
+                let builder = self.inner.builder(reqwest::Method::POST, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
                     let builder = req
                         .request
                         .as_ref()
@@ -763,6 +768,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -773,14 +782,11 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -811,6 +817,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -826,11 +836,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -866,6 +873,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -876,11 +887,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -891,11 +899,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -911,11 +916,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -926,11 +928,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -994,6 +993,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1004,8 +1007,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -1029,8 +1032,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -1059,8 +1062,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -1084,8 +1087,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -1164,6 +1167,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1174,11 +1181,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -1189,11 +1193,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -1209,11 +1210,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -1224,11 +1222,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1292,19 +1287,18 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/operations",);
+                let path = "/v1beta1/operations".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1329,6 +1323,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1342,11 +1340,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1380,6 +1375,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1393,11 +1392,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1435,6 +1431,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1448,11 +1448,8 @@ impl super::stub::Compliance for Compliance {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1511,15 +1508,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EchoResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:echo",);
+                let path = "/v1beta1/echo:echo".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1542,15 +1538,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EchoErrorDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:error-details",);
+                let path = "/v1beta1/echo:error-details".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1573,15 +1568,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FailEchoWithDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:failWithDetails",);
+                let path = "/v1beta1/echo:failWithDetails".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1604,15 +1598,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:pagedExpand",);
+                let path = "/v1beta1/echo:pagedExpand".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1635,15 +1628,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:pagedExpandLegacy",);
+                let path = "/v1beta1/echo:pagedExpandLegacy".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1666,15 +1658,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandLegacyMappedResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:pagedExpandLegacyMapped",);
+                let path = "/v1beta1/echo:pagedExpandLegacyMapped".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1697,15 +1688,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:wait",);
+                let path = "/v1beta1/echo:wait".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1728,15 +1718,14 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BlockResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/echo:block",);
+                let path = "/v1beta1/echo:block".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1759,6 +1748,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1769,14 +1762,11 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1807,6 +1797,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1822,11 +1816,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1862,6 +1853,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -1872,11 +1867,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -1887,11 +1879,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -1907,11 +1896,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -1922,11 +1908,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -1990,6 +1973,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2000,8 +1987,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -2025,8 +2012,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -2055,8 +2042,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -2080,8 +2067,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -2160,6 +2147,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2170,11 +2161,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -2185,11 +2173,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -2205,11 +2190,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -2220,11 +2202,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2288,19 +2267,18 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/operations",);
+                let path = "/v1beta1/operations".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2325,6 +2303,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2338,11 +2320,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2376,6 +2355,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2389,11 +2372,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2431,6 +2411,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2444,11 +2428,8 @@ impl super::stub::Echo for Echo {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2523,15 +2504,14 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/users",);
+                let path = "/v1beta1/users".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2554,6 +2534,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2564,11 +2548,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2599,6 +2580,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2612,8 +2597,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::PATCH, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
                     let builder = req
                         .update_mask
                         .as_ref()
@@ -2658,6 +2643,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2668,11 +2657,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2707,17 +2693,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/users",);
+                let path = "/v1beta1/users".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2742,6 +2727,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2752,14 +2741,11 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2790,6 +2776,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2805,11 +2795,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2845,6 +2832,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2855,11 +2846,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -2870,11 +2858,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -2890,11 +2875,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -2905,11 +2887,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -2973,6 +2952,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -2983,8 +2966,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -3008,8 +2991,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -3038,8 +3021,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -3063,8 +3046,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -3143,6 +3126,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3153,11 +3140,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -3168,11 +3152,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -3188,11 +3169,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -3203,11 +3181,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3271,19 +3246,18 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/operations",);
+                let path = "/v1beta1/operations".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3308,6 +3282,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3321,11 +3299,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3359,6 +3334,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3372,11 +3351,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3414,6 +3390,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3427,11 +3407,8 @@ impl super::stub::Identity for Identity {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3492,15 +3469,14 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/rooms",);
+                let path = "/v1beta1/rooms".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3523,6 +3499,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3533,11 +3513,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3568,6 +3545,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3581,8 +3562,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::PATCH, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
                     let builder = req
                         .update_mask
                         .as_ref()
@@ -3627,6 +3608,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3637,11 +3622,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3676,17 +3658,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoomsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/rooms",);
+                let path = "/v1beta1/rooms".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3711,6 +3692,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3721,11 +3706,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -3740,11 +3722,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3787,6 +3766,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3802,11 +3785,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -3822,11 +3802,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -3877,6 +3854,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -3895,8 +3876,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::PATCH, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
                     let builder = req
                         .update_mask
                         .as_ref()
@@ -3928,8 +3909,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::PATCH, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
                     let builder = req
                         .update_mask
                         .as_ref()
@@ -3997,6 +3978,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4012,11 +3997,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4032,11 +4014,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4091,6 +4070,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBlurbsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4101,13 +4084,10 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4122,13 +4102,10 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4173,6 +4150,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4183,11 +4164,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4202,14 +4180,11 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    let builder = builder.query(&[("query", &req.query)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                let builder = builder.query(&[("query", &req.query)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4252,6 +4227,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4262,14 +4241,11 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4300,6 +4276,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4315,11 +4295,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4355,6 +4332,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4365,11 +4346,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4380,11 +4358,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4400,11 +4375,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4415,11 +4387,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4483,6 +4452,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4493,8 +4466,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -4518,8 +4491,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -4548,8 +4521,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -4573,8 +4546,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -4653,6 +4626,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4663,11 +4640,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4678,11 +4652,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4698,11 +4669,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -4713,11 +4681,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4781,19 +4746,18 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/operations",);
+                let path = "/v1beta1/operations".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4818,6 +4782,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4831,11 +4799,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4869,6 +4834,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4882,11 +4851,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -4924,6 +4890,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -4937,11 +4907,8 @@ impl super::stub::Messaging for Messaging {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5016,15 +4983,14 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Sequence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/sequences",);
+                let path = "/v1beta1/sequences".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5049,15 +5015,14 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamingSequence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/streamingSequences",);
+                let path = "/v1beta1/streamingSequences".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5082,6 +5047,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SequenceReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5096,11 +5065,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5135,6 +5101,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamingSequenceReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5149,11 +5119,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5188,6 +5155,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5198,11 +5169,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5236,6 +5204,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5246,14 +5218,11 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5284,6 +5253,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5299,11 +5272,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5339,6 +5309,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5349,11 +5323,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -5364,11 +5335,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -5384,11 +5352,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -5399,11 +5364,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5467,6 +5429,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5477,8 +5443,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -5502,8 +5468,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -5532,8 +5498,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -5557,8 +5523,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -5637,6 +5603,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5647,11 +5617,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -5662,11 +5629,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -5682,11 +5646,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -5697,11 +5658,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5765,19 +5723,18 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/operations",);
+                let path = "/v1beta1/operations".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5802,6 +5759,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5815,11 +5776,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5853,6 +5811,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5866,11 +5828,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5908,6 +5867,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -5921,11 +5884,8 @@ impl super::stub::SequenceService for SequenceService {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -5986,15 +5946,14 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/sessions",);
+                let path = "/v1beta1/sessions".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6019,6 +5978,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6029,11 +5992,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6064,17 +6024,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/sessions",);
+                let path = "/v1beta1/sessions".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6099,6 +6058,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6109,11 +6072,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6148,6 +6108,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportSessionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6158,11 +6122,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6193,6 +6154,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTestsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6203,13 +6168,10 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6240,6 +6202,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6255,11 +6221,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6299,6 +6262,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VerifyTestResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6314,16 +6281,13 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    let builder = builder.query(&[("answer", &req.answer)]);
-                    let builder = req
-                        .answers
-                        .iter()
-                        .fold(builder, |builder, p| builder.query(&[("answers", p)]));
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                let builder = builder.query(&[("answer", &req.answer)]);
+                let builder = req
+                    .answers
+                    .iter()
+                    .fold(builder, |builder, p| builder.query(&[("answers", p)]));
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6359,6 +6323,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6369,14 +6337,11 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6407,6 +6372,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6422,11 +6391,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6462,6 +6428,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6472,11 +6442,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -6487,11 +6454,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -6507,11 +6471,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -6522,11 +6483,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6590,6 +6548,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6600,8 +6562,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -6625,8 +6587,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -6655,8 +6617,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -6680,8 +6642,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
+                let builder = self.inner.builder(reqwest::Method::GET, path);
                 let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
                     let builder = req
                         .options
                         .as_ref()
@@ -6760,6 +6722,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6770,11 +6736,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -6785,11 +6748,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -6805,11 +6765,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .or_else(|| {
                 let path = format!(
@@ -6820,11 +6777,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6888,19 +6842,18 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
         let builder = None
             .or_else(|| {
-                let path = format!("/v1beta1/operations",);
+                let path = "/v1beta1/operations".to_string();
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    let builder = builder.query(&[("name", &req.name)]);
-                    let builder = builder.query(&[("filter", &req.filter)]);
-                    let builder = builder.query(&[("pageSize", &req.page_size)]);
-                    let builder = builder.query(&[("pageToken", &req.page_token)]);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                let builder = builder.query(&[("name", &req.name)]);
+                let builder = builder.query(&[("filter", &req.filter)]);
+                let builder = builder.query(&[("pageSize", &req.page_size)]);
+                let builder = builder.query(&[("pageToken", &req.page_token)]);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6925,6 +6878,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6938,11 +6895,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::GET, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::GET, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -6976,6 +6930,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -6989,11 +6947,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();
@@ -7031,6 +6986,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        use gax::error::binding::BindingError;
+        use gaxi::path_parameter::PathMismatchBuilder;
+        use gaxi::path_parameter::try_match;
+        use gaxi::routing_parameter::Segment;
         let builder = None
             .or_else(|| {
                 let path = format!(
@@ -7044,11 +7003,8 @@ impl super::stub::Testing for Testing {
                     )?,
                 );
 
-                let builder = (|| {
-                    let builder = self.inner.builder(reqwest::Method::POST, path);
-                    Ok(builder)
-                })();
-                Some(builder)
+                let builder = self.inner.builder(reqwest::Method::POST, path);
+                Some(Ok(builder))
             })
             .ok_or_else(|| {
                 let mut paths = Vec::new();

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -17,6 +17,12 @@
 use crate::Result;
 #[allow(unused_imports)]
 use gax::error::Error;
+#[allow(unused_imports)]
+use gax::error::binding::BindingError;
+#[allow(unused_imports)]
+use gaxi::path_parameter::{PathMismatchBuilder, try_match};
+#[allow(unused_imports)]
+use gaxi::routing_parameter::Segment;
 
 /// Implements [Compliance](super::stub::Compliance) using a [gaxi::http::ReqwestClient].
 #[derive(Clone)]
@@ -46,15 +52,28 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/repeat:body".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/repeat:body",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -64,35 +83,48 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/repeat:bodyinfo".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("serverVerify", &req.server_verify)]);
-        let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
-            builder.query(&[("intendedBindingUri", p)])
-        });
-        let builder = builder.query(&[("fInt32", &req.f_int32)]);
-        let builder = builder.query(&[("fInt64", &req.f_int64)]);
-        let builder = builder.query(&[("fDouble", &req.f_double)]);
-        let builder = req
-            .p_int32
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
-        let builder = req
-            .p_int64
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
-        let builder = req
-            .p_double
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/repeat:bodyinfo",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                        builder.query(&[("intendedBindingUri", p)])
+                    });
+                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                    let builder = builder.query(&[("fDouble", &req.f_double)]);
+                    let builder = req
+                        .p_int32
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                    let builder = req
+                        .p_int64
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                    let builder = req
+                        .p_double
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req.info), options).await
     }
 
@@ -102,45 +134,58 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/repeat:query".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = req
-            .info
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "info")
-            });
-        let builder = builder.query(&[("serverVerify", &req.server_verify)]);
-        let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
-            builder.query(&[("intendedBindingUri", p)])
-        });
-        let builder = builder.query(&[("fInt32", &req.f_int32)]);
-        let builder = builder.query(&[("fInt64", &req.f_int64)]);
-        let builder = builder.query(&[("fDouble", &req.f_double)]);
-        let builder = req
-            .p_int32
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
-        let builder = req
-            .p_int64
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
-        let builder = req
-            .p_double
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/repeat:query",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = req
+                        .info
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "info")
+                        });
+                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                        builder.query(&[("intendedBindingUri", p)])
+                    });
+                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                    let builder = builder.query(&[("fDouble", &req.f_double)]);
+                    let builder = req
+                        .p_int32
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                    let builder = req
+                        .p_int64
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                    let builder = req
+                        .p_double
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -152,82 +197,124 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!(
-            "/v1beta1/repeat/{}/{}/{}/{}/{}:simplepath",
-            {
-                let arg = &req
-                    .info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_string;
-                if arg.is_empty() {
-                    return Err(gaxi::path_parameter::missing("info.f_string"));
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/repeat/{}/{}/{}/{}/{}:simplepath",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_int32),
+                        &[Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_double),
+                        &[Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_bool),
+                        &[Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_kingdom),
+                        &[Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = req
+                        .info
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "info")
+                        });
+                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                        builder.query(&[("intendedBindingUri", p)])
+                    });
+                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                    let builder = builder.query(&[("fDouble", &req.f_double)]);
+                    let builder = req
+                        .p_int32
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                    let builder = req
+                        .p_int64
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                    let builder = req
+                        .p_double
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::SingleWildcard],
+                        "info.f_string",
+                        "*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_int32),
+                        &[Segment::SingleWildcard],
+                        "info.f_int32",
+                        "*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_double),
+                        &[Segment::SingleWildcard],
+                        "info.f_double",
+                        "*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_bool),
+                        &[Segment::SingleWildcard],
+                        "info.f_bool",
+                        "*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_kingdom),
+                        &[Segment::SingleWildcard],
+                        "info.f_kingdom",
+                        "*",
+                    );
+                    paths.push(builder.build());
                 }
-                arg
-            },
-            {
-                &req.info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_int32
-            },
-            {
-                &req.info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_double
-            },
-            {
-                &req.info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_bool
-            },
-            {
-                &req.info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_kingdom
-            },
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
         );
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = req
-            .info
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "info")
-            });
-        let builder = builder.query(&[("serverVerify", &req.server_verify)]);
-        let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
-            builder.query(&[("intendedBindingUri", p)])
-        });
-        let builder = builder.query(&[("fInt32", &req.f_int32)]);
-        let builder = builder.query(&[("fInt64", &req.f_int64)]);
-        let builder = builder.query(&[("fDouble", &req.f_double)]);
-        let builder = req
-            .p_int32
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
-        let builder = req
-            .p_int64
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
-        let builder = req
-            .p_double
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -239,78 +326,193 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!(
-            "/v1beta1/repeat/{}/{}/bool/{}:pathresource",
-            {
-                let arg = &req
-                    .info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_string;
-                if arg.is_empty() {
-                    return Err(gaxi::path_parameter::missing("info.f_string"));
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/repeat/{}/{}/bool/{}:pathresource",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("first/"), Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .and_then(|m| m.f_child.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("second/"), Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_bool),
+                        &[Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = req
+                        .info
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "info")
+                        });
+                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                        builder.query(&[("intendedBindingUri", p)])
+                    });
+                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                    let builder = builder.query(&[("fDouble", &req.f_double)]);
+                    let builder = req
+                        .p_int32
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                    let builder = req
+                        .p_int64
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                    let builder = req
+                        .p_double
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/repeat/{}/{}/bool/{}:childfirstpathresource",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .and_then(|m| m.f_child.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("first/"), Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("second/"), Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_bool),
+                        &[Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = req
+                        .info
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "info")
+                        });
+                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                        builder.query(&[("intendedBindingUri", p)])
+                    });
+                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                    let builder = builder.query(&[("fDouble", &req.f_double)]);
+                    let builder = req
+                        .p_int32
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                    let builder = req
+                        .p_int64
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                    let builder = req
+                        .p_double
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("first/"), Segment::SingleWildcard],
+                        "info.f_string",
+                        "first/*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .and_then(|m| m.f_child.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("second/"), Segment::SingleWildcard],
+                        "info.f_child.f_string",
+                        "second/*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_bool),
+                        &[Segment::SingleWildcard],
+                        "info.f_bool",
+                        "*",
+                    );
+                    paths.push(builder.build());
                 }
-                arg
-            },
-            {
-                let arg = &req
-                    .info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_child
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
-                    .f_string;
-                if arg.is_empty() {
-                    return Err(gaxi::path_parameter::missing("info.f_child.f_string"));
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .and_then(|m| m.f_child.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("first/"), Segment::SingleWildcard],
+                        "info.f_child.f_string",
+                        "first/*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("second/"), Segment::SingleWildcard],
+                        "info.f_string",
+                        "second/*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req).and_then(|m| m.info.as_ref()).map(|m| &m.f_bool),
+                        &[Segment::SingleWildcard],
+                        "info.f_bool",
+                        "*",
+                    );
+                    paths.push(builder.build());
                 }
-                arg
-            },
-            {
-                &req.info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_bool
-            },
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
         );
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = req
-            .info
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "info")
-            });
-        let builder = builder.query(&[("serverVerify", &req.server_verify)]);
-        let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
-            builder.query(&[("intendedBindingUri", p)])
-        });
-        let builder = builder.query(&[("fInt32", &req.f_int32)]);
-        let builder = builder.query(&[("fInt64", &req.f_int64)]);
-        let builder = builder.query(&[("fDouble", &req.f_double)]);
-        let builder = req
-            .p_int32
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
-        let builder = req
-            .p_int64
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
-        let builder = req
-            .p_double
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -322,72 +524,94 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!(
-            "/v1beta1/repeat/{}/{}:pathtrailingresource",
-            {
-                let arg = &req
-                    .info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_string;
-                if arg.is_empty() {
-                    return Err(gaxi::path_parameter::missing("info.f_string"));
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/repeat/{}/{}:pathtrailingresource",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("first/"), Segment::SingleWildcard]
+                    )?,
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .and_then(|m| m.f_child.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("second"), Segment::TrailingMultiWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = req
+                        .info
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "info")
+                        });
+                    let builder = builder.query(&[("serverVerify", &req.server_verify)]);
+                    let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
+                        builder.query(&[("intendedBindingUri", p)])
+                    });
+                    let builder = builder.query(&[("fInt32", &req.f_int32)]);
+                    let builder = builder.query(&[("fInt64", &req.f_int64)]);
+                    let builder = builder.query(&[("fDouble", &req.f_double)]);
+                    let builder = req
+                        .p_int32
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
+                    let builder = req
+                        .p_int64
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
+                    let builder = req
+                        .p_double
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("first/"), Segment::SingleWildcard],
+                        "info.f_string",
+                        "first/*",
+                    );
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.info.as_ref())
+                            .and_then(|m| m.f_child.as_ref())
+                            .map(|m| &m.f_string)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("second"), Segment::TrailingMultiWildcard],
+                        "info.f_child.f_string",
+                        "second/**",
+                    );
+                    paths.push(builder.build());
                 }
-                arg
-            },
-            {
-                let arg = &req
-                    .info
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_child
-                    .as_ref()
-                    .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
-                    .f_string;
-                if arg.is_empty() {
-                    return Err(gaxi::path_parameter::missing("info.f_child.f_string"));
-                }
-                arg
-            },
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
         );
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = req
-            .info
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "info")
-            });
-        let builder = builder.query(&[("serverVerify", &req.server_verify)]);
-        let builder = req.intended_binding_uri.iter().fold(builder, |builder, p| {
-            builder.query(&[("intendedBindingUri", p)])
-        });
-        let builder = builder.query(&[("fInt32", &req.f_int32)]);
-        let builder = builder.query(&[("fInt64", &req.f_int64)]);
-        let builder = builder.query(&[("fDouble", &req.f_double)]);
-        let builder = req
-            .p_int32
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt32", p)]));
-        let builder = req
-            .p_int64
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pInt64", p)]));
-        let builder = req
-            .p_double
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("pDouble", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -399,15 +623,28 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/repeat:bodyput".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::PUT, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/repeat:bodyput",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::PUT, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -417,15 +654,28 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/repeat:bodypatch".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::PATCH, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/repeat:bodypatch",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -435,16 +685,29 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/compliance/enum".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("unknownEnum", &req.unknown_enum)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/compliance/enum",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("unknownEnum", &req.unknown_enum)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -456,26 +719,39 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/compliance/enum".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .request
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "request")
-            });
-        let builder = builder.query(&[("continent", &req.continent)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/compliance/enum",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    let builder = req
+                        .request
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "request")
+                        });
+                    let builder = builder.query(&[("continent", &req.continent)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -487,24 +763,43 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/locations", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/locations",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard],
+                        "name",
+                        "projects/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -516,21 +811,50 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "projects/*/locations/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -542,21 +866,125 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:setIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -566,31 +994,165 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}:getIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .options
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "options")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -602,21 +1164,125 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:testIamPermissions", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -626,19 +1292,32 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/operations".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/operations",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -650,21 +1329,46 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -676,21 +1380,46 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -706,21 +1435,46 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:cancel", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:cancel",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -757,15 +1511,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EchoResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:echo".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:echo",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -775,15 +1542,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EchoErrorDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:error-details".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:error-details",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -793,15 +1573,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FailEchoWithDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:failWithDetails".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:failWithDetails",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -811,15 +1604,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:pagedExpand".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:pagedExpand",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -829,15 +1635,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:pagedExpandLegacy".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:pagedExpandLegacy",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -847,15 +1666,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandLegacyMappedResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:pagedExpandLegacyMapped".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:pagedExpandLegacyMapped",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -865,15 +1697,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:wait".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:wait",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -883,15 +1728,28 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BlockResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/echo:block".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/echo:block",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -901,24 +1759,43 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/locations", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/locations",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard],
+                        "name",
+                        "projects/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -930,21 +1807,50 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "projects/*/locations/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -956,21 +1862,125 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:setIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -980,31 +1990,165 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}:getIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .options
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "options")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1016,21 +2160,125 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:testIamPermissions", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1040,19 +2288,32 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/operations".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/operations",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1064,21 +2325,46 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1090,21 +2376,46 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1120,21 +2431,46 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:cancel", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:cancel",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -1187,15 +2523,28 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/users".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/users",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1205,21 +2554,40 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "name",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1231,35 +2599,56 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req
-                .user
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("user"))?
-                .name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("user.name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::PATCH, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .update_mask
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "updateMask")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.user.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
+                    let builder = req
+                        .update_mask
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "updateMask")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.user.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "user.name",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req.user), options).await
     }
 
@@ -1269,21 +2658,40 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "name",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1299,17 +2707,30 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/users".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/users",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1321,24 +2742,43 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/locations", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/locations",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard],
+                        "name",
+                        "projects/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1350,21 +2790,50 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "projects/*/locations/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1376,21 +2845,125 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:setIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1400,31 +2973,165 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}:getIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .options
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "options")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1436,21 +3143,125 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:testIamPermissions", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1460,19 +3271,32 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/operations".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/operations",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1484,21 +3308,46 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1510,21 +3359,46 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1540,21 +3414,46 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:cancel", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:cancel",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -1593,15 +3492,28 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/rooms".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/rooms",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1611,21 +3523,40 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "name",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1637,35 +3568,56 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req
-                .room
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("room"))?
-                .name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("room.name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::PATCH, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .update_mask
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "updateMask")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.room.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
+                    let builder = req
+                        .update_mask
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "updateMask")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.room.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "room.name",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req.room), options).await
     }
 
@@ -1675,21 +3627,40 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "name",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1705,17 +3676,30 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoomsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/rooms".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/rooms",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1727,21 +3711,73 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}/blurbs", {
-            let arg = &req.parent;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("parent"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/blurbs",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/blurbs",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile")
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "parent",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile"),
+                        ],
+                        "parent",
+                        "users/*/profile",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1751,21 +3787,85 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "users/*/profile/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1777,35 +3877,117 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req
-                .blurb
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("blurb"))?
-                .name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("blurb.name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::PATCH, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .update_mask
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "updateMask")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.blurb.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
+                    let builder = req
+                        .update_mask
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "updateMask")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req)
+                            .and_then(|m| m.blurb.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::PATCH, path);
+                    let builder = req
+                        .update_mask
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "updateMask")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.blurb.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "blurb.name",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req)
+                            .and_then(|m| m.blurb.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "blurb.name",
+                        "users/*/profile/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req.blurb), options).await
     }
 
@@ -1815,21 +3997,85 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "users/*/profile/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1845,23 +4091,77 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBlurbsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/blurbs", {
-            let arg = &req.parent;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("parent"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/blurbs",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/blurbs",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile")
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "parent",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile"),
+                        ],
+                        "parent",
+                        "users/*/profile",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1873,21 +4173,76 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}/blurbs:search", {
-            let arg = &req.parent;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("parent"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/blurbs:search",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/blurbs:search",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile")
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    let builder = builder.query(&[("query", &req.query)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "parent",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("users/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/profile"),
+                        ],
+                        "parent",
+                        "users/*/profile",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1897,24 +4252,43 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/locations", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/locations",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard],
+                        "name",
+                        "projects/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1926,21 +4300,50 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "projects/*/locations/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1952,21 +4355,125 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:setIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -1976,31 +4483,165 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}:getIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .options
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "options")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2012,21 +4653,125 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:testIamPermissions", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -2036,19 +4781,32 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/operations".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/operations",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2060,21 +4818,46 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2086,21 +4869,46 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2116,21 +4924,46 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:cancel", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:cancel",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -2183,15 +5016,28 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Sequence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/sequences".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/sequences",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(req.sequence), options)
             .await
@@ -2203,15 +5049,28 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamingSequence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/streamingSequences".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/streamingSequences",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(req.streaming_sequence), options)
             .await
@@ -2223,21 +5082,48 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SequenceReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("sequences/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/sequenceReport")
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("sequences/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/sequenceReport"),
+                        ],
+                        "name",
+                        "sequences/*/sequenceReport",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2249,21 +5135,48 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamingSequenceReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("streamingSequences/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/streamingSequenceReport")
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("streamingSequences/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/streamingSequenceReport"),
+                        ],
+                        "name",
+                        "streamingSequences/*/streamingSequenceReport",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2275,21 +5188,40 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "name",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await.map(
             |r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2304,24 +5236,43 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/locations", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/locations",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard],
+                        "name",
+                        "projects/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2333,21 +5284,50 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "projects/*/locations/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2359,21 +5339,125 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:setIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -2383,31 +5467,165 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}:getIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .options
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "options")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2419,21 +5637,125 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:testIamPermissions", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -2443,19 +5765,32 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/operations".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/operations",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2467,21 +5802,46 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2493,21 +5853,46 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2523,21 +5908,46 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:cancel", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:cancel",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -2576,15 +5986,28 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = "/v1beta1/sessions".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/sessions",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(req.session), options)
             .await
@@ -2596,21 +6019,40 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard],
+                        "name",
+                        "sessions/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2622,17 +6064,30 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/sessions".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/sessions",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2644,21 +6099,40 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard],
+                        "name",
+                        "sessions/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2674,21 +6148,40 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportSessionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:report", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:report",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard],
+                        "name",
+                        "sessions/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -2700,23 +6193,42 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTestsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/tests", {
-            let arg = &req.parent;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("parent"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/tests",
+                    try_match(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[Segment::Literal("sessions/"), Segment::SingleWildcard],
+                        "parent",
+                        "sessions/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2728,21 +6240,50 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("sessions/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/tests/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("sessions/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/tests/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "sessions/*/tests/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2758,26 +6299,55 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VerifyTestResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:check", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("answer", &req.answer)]);
-        let builder = req
-            .answers
-            .iter()
-            .fold(builder, |builder, p| builder.query(&[("answers", p)]));
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:check",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("sessions/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/tests/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    let builder = builder.query(&[("answer", &req.answer)]);
+                    let builder = req
+                        .answers
+                        .iter()
+                        .fold(builder, |builder, p| builder.query(&[("answers", p)]));
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("sessions/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/tests/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "sessions/*/tests/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await
@@ -2789,24 +6359,43 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}/locations", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}/locations",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[Segment::Literal("projects/"), Segment::SingleWildcard],
+                        "name",
+                        "projects/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2818,21 +6407,50 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/locations/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "name",
+                        "projects/*/locations/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2844,21 +6462,125 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:setIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:setIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -2868,31 +6590,165 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}:getIamPolicy", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = req
-            .options
-            .as_ref()
-            .map(|p| serde_json::to_value(p).map_err(Error::ser))
-            .transpose()?
-            .into_iter()
-            .fold(builder, |builder, v| {
-                use gaxi::query_parameter::QueryParameter;
-                v.add(builder, "options")
-            });
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:getIamPolicy",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = req
+                        .options
+                        .as_ref()
+                        .map(|p| serde_json::to_value(p).map_err(Error::ser))
+                        .transpose()?
+                        .into_iter()
+                        .fold(builder, |builder, v| {
+                            use gaxi::query_parameter::QueryParameter;
+                            v.add(builder, "options")
+                        });
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2904,21 +6760,125 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:testIamPermissions", {
-            let arg = &req.resource;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("resource"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:testIamPermissions",
+                    try_match(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("users/"), Segment::SingleWildcard],
+                        "resource",
+                        "users/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("rooms/"), Segment::SingleWildcard],
+                        "resource",
+                        "rooms/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("rooms/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/blurbs/"),
+                            Segment::SingleWildcard,
+                        ],
+                        "resource",
+                        "rooms/*/blurbs/*",
+                    );
+                    paths.push(builder.build());
+                }
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[Segment::Literal("sequences/"), Segment::SingleWildcard],
+                        "resource",
+                        "sequences/*",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner.execute(builder, Some(req), options).await
     }
 
@@ -2928,19 +6888,32 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = "/v1beta1/operations".to_string();
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
-        let builder = builder.query(&[("name", &req.name)]);
-        let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = None
+            .or_else(|| {
+                let path = format!("/v1beta1/operations",);
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    let builder = builder.query(&[("name", &req.name)]);
+                    let builder = builder.query(&[("filter", &req.filter)]);
+                    let builder = builder.query(&[("pageSize", &req.page_size)]);
+                    let builder = builder.query(&[("pageToken", &req.page_token)]);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2952,21 +6925,46 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::GET, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::GET, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2978,21 +6976,46 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
-        let path = format!("/v1beta1/{}", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::DELETE, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::DELETE, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -3008,21 +7031,46 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
-        let path = format!("/v1beta1/{}:cancel", {
-            let arg = &req.name;
-            if arg.is_empty() {
-                return Err(gaxi::path_parameter::missing("name"));
-            }
-            arg
-        },);
-        let builder = self
-            .inner
-            .builder(reqwest::Method::POST, path)
-            .query(&[("$alt", "json;enum-encoding=int")])
-            .header(
-                "x-goog-api-client",
-                reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
-            );
+        let builder = None
+            .or_else(|| {
+                let path = format!(
+                    "/v1beta1/{}:cancel",
+                    try_match(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard
+                        ]
+                    )?,
+                );
+
+                let builder = (|| {
+                    let builder = self.inner.builder(reqwest::Method::POST, path);
+                    Ok(builder)
+                })();
+                Some(builder)
+            })
+            .ok_or_else(|| {
+                let mut paths = Vec::new();
+                {
+                    let builder = PathMismatchBuilder::default();
+                    let builder = builder.maybe_add(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[
+                            Segment::Literal("operations"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                        "name",
+                        "operations/**",
+                    );
+                    paths.push(builder.build());
+                }
+                gax::error::Error::binding(BindingError { paths })
+            })??;
+        let builder = builder.query(&[("$alt", "json;enum-encoding=int")]).header(
+            "x-goog-api-client",
+            reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
+        );
         self.inner
             .execute(builder, Some(gaxi::http::NoBody), options)
             .await

--- a/src/integration-tests/src/showcase/compliance.rs
+++ b/src/integration-tests/src/showcase/compliance.rs
@@ -321,7 +321,8 @@ async fn additional_binding_used(client: &showcase::client::Compliance) -> Resul
         .send()
         .await?;
     tracing::info!("response: {response:?}");
-    // Note the different repsonse between this and `repeat_data_path_resource`.
+    // Note the different verb in the response, when compared with the
+    // `repeat_data_path_resource()` test.
     assert_eq!(
         response.binding_uri,
         "/v1beta1/repeat/{info.f_child.f_string=first/*}/{info.f_string=second/*}/bool/{info.f_bool}:childfirstpathresource"


### PR DESCRIPTION
Part of the work for #2317 

Add the mustache template needed to support additional bindings for Rust.

Enable this for gapic-showcase, with tests that it works.

I prefer to hardcode the `AdditionalBindings` flag, instead of plumbing a sidekick feature. The flag should have a lifetime of <1 day.