### PR TITLE
cleanup: fix `grpc-server` deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4829,6 +4835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5339,6 +5351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "mutants"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,6 +5479,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.9.0",
+]
 
 [[package]]
 name = "pin-project"
@@ -5592,6 +5620,26 @@ checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
 ]
 
 [[package]]
@@ -6334,6 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -6578,6 +6627,8 @@ checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
+ "prost-build",
+ "prost-types",
  "quote",
  "syn",
 ]

--- a/src/gax-internal/grpc-server/Cargo.toml
+++ b/src/gax-internal/grpc-server/Cargo.toml
@@ -38,4 +38,4 @@ gax.workspace  = true
 gaxi           = { workspace = true, features = ["_internal-grpc-client"] }
 
 [build-dependencies]
-tonic-build = { workspace = true, optional = true }
+tonic-build = { workspace = true, optional = true, features = ["prost"] }


### PR DESCRIPTION
```sh
$ cargo build -p grpc-server --all-features

error[E0425]: cannot find function `configure` in crate `tonic_build`
  --> src/gax-internal/grpc-server/build.rs:18:22
   |
18 |         tonic_build::configure()
   |                      ^^^^^^^^^ not found in `tonic_build`
   |
note: found an item that was configured out
  --> /usr/local/google/home/dbolduc/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tonic-build-0.13.1/src/lib.rs:83:46
   |
83 | pub use prost::{compile_fds, compile_protos, configure, Builder};
   |                                              ^^^^^^^^^
note: the item is gated behind the `prost` feature
  --> /usr/local/google/home/dbolduc/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tonic-build-0.13.1/src/lib.rs:82:7
   |
82 | #[cfg(feature = "prost")]
   |       ^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0425`.
error: could not compile `grpc-server` (build script) due to 1 previous error
```