### PR TITLE
docs: explain binding errors

### DIFF
--- a/guide/samples/src/binding_errors.rs
+++ b/guide/samples/src/binding_errors.rs
@@ -1,0 +1,70 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use google_cloud_gax as gax;
+use google_cloud_secretmanager_v1 as sm;
+use std::error::Error as _;
+
+pub async fn binding_fail() -> crate::Result<()> {
+    let client = sm::client::SecretManagerService::builder().build().await?;
+
+    // ANCHOR: inspect
+    // ANCHOR: request
+    let secret = client
+        .get_secret()
+        //.set_name("projects/my-project/secrets/my-secret")
+        .send()
+        .await;
+    // ANCHOR_END: request
+
+    use gax::error::binding::BindingError;
+    let e = secret.unwrap_err();
+    assert!(e.is_binding(), "{e:?}");
+    assert!(e.source().is_some(), "{e:?}");
+    let _ = e
+        .source()
+        .and_then(|e| e.downcast_ref::<BindingError>())
+        .expect("should be a BindingError");
+    // ANCHOR_END: inspect
+
+    Ok(())
+}
+
+pub async fn binding_success() -> crate::Result<()> {
+    let client = sm::client::SecretManagerService::builder().build().await?;
+
+    // ANCHOR: request-success-1
+    let secret = client
+        .get_secret()
+        .set_name("projects/my-project/secrets/my-secret")
+        .send()
+        .await;
+    // ANCHOR_END: request-success-1
+
+    let e = secret.unwrap_err();
+    assert!(!e.is_binding(), "{e:?}");
+
+    // ANCHOR: request-success-2
+    let secret = client
+        .get_secret()
+        .set_name("projects/my-project/locations/us-central1/secrets/my-secret")
+        .send()
+        .await;
+    // ANCHOR_END: request-success-2
+
+    let e = secret.unwrap_err();
+    assert!(!e.is_binding(), "{e:?}");
+
+    Ok(())
+}

--- a/guide/samples/src/lib.rs
+++ b/guide/samples/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+pub mod binding_errors;
 pub mod error_handling;
 pub mod examine_error_details;
 pub mod gemini;

--- a/guide/samples/src/pagination.rs
+++ b/guide/samples/src/pagination.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Examples showing itearting Google API List methods with paginator.
+//! Examples showing iterating Google API List methods with paginator.
 
 use google_cloud_gax as gax;
 

--- a/guide/samples/tests/driver.rs
+++ b/guide/samples/tests/driver.rs
@@ -227,4 +227,16 @@ mod driver {
         user_guide_samples::examine_error_details::examine_error_details().await?;
         Ok(())
     }
+
+    #[tokio::test]
+    async fn binding_fail() -> user_guide_samples::Result<()> {
+        user_guide_samples::binding_errors::binding_fail().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn binding_success() -> user_guide_samples::Result<()> {
+        user_guide_samples::binding_errors::binding_success().await?;
+        Ok(())
+    }
 }

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -24,6 +24,7 @@ limitations under the License.
 - [Configuring retry policies](configuring_retry_policies.md)
 - [Error handling](error_handling.md)
 - [Examine error details](examine_error_details.md)
+- [Handling binding errors](binding_errors.md)
 - [Working with List operations](pagination.md)
 - [Working with long-running operations](working_with_long_running_operations.md)
 - [Configuring polling policies](configuring_polling_policies.md)

--- a/guide/src/binding_errors.md
+++ b/guide/src/binding_errors.md
@@ -102,7 +102,6 @@ Also, when a template ends in `/**`, that initial slash is optionally included.
 If you need to inspect the error programmatically, you can do so by checking
 that it is a binding error, then downcasting it to a `BindingError`.
 
-
 ```rust,ignore
 {{#include ../samples/src/binding_errors.rs:inspect}}
 ```

--- a/guide/src/binding_errors.md
+++ b/guide/src/binding_errors.md
@@ -20,19 +20,28 @@ You might have tried to make a request and run into an error that looks like:
 
 ```norust
 Error: cannot find a matching binding to send the request: at least one of the
-conditions must be met: (1) field `name` needs to be set and match:
-'projects/*/secrets/*' OR (2) field `name` needs to be set and match:
-'projects/*/locations/*/secrets/*'
+conditions must be met: (1) field `name` needs to be set and match the template:
+'projects/*/secrets/*' OR (2) field `name` needs to be set and match the
+template: 'projects/*/locations/*/secrets/*'
 ```
 
-This is a binding error. Let's break this down.
+This guide will explain how to troubleshoot this type of error.
 
 ## When this happens
 
-When a client cannot match the request to a [URI] for the service, it will fail
-the request locally with a binding error.
+The Google Cloud Client Libraries for Rust primarily use HTTP to send requests
+to Google Cloud services.
 
-Typically this happens when a field is either missing, or in an invalid format.
+Some RPCs correspond to multiple [URI]s. The contents of the request determine
+which URI is used.
+
+The client library considers all possible URIs, and only returns a binding error
+if no URIs work. Typically this happens when a field is either missing, or in an
+invalid format.
+
+The example error above was produced by trying to get a resource, without naming
+the resource. Specifically, the `name` field on a [`GetSecretRequest`] was
+required, but not set.
 
 ```rust,ignore
 {{#include ../samples/src/binding_errors.rs:request}}
@@ -40,9 +49,9 @@ Typically this happens when a field is either missing, or in an invalid format.
 
 ## How to fix it
 
-In this example, the `name` field on the top level request was not set. To fix
-the code, we will set it to something matching one of the above templates.
-Either will allow us to make a request to the server.
+To fix the code, we need to set the `name` field to something matching one of
+the above templates. Either will allow the client library to make a request to
+the server.
 
 ```rust,ignore
 {{#include ../samples/src/binding_errors.rs:request-success-1}}
@@ -56,7 +65,9 @@ OR
 
 ## Interpreting the templates
 
-In the template strings, there are two special matchers.
+The error message includes a number of "template strings" showing possible
+values for the request fields. Most template strings, use `*` and `**` as
+wildcards to match the field values.
 
 ### Single wildcard
 
@@ -107,3 +118,4 @@ that it is a binding error, then downcasting it to a `BindingError`.
 ```
 
 [uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html
+[`getsecretrequest`]: https://docs.rs/google-cloud-secretmanager-v1/latest/google_cloud_secretmanager_v1/model/struct.GetSecretRequest.html

--- a/guide/src/binding_errors.md
+++ b/guide/src/binding_errors.md
@@ -1,0 +1,110 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Handling binding errors
+
+You might have tried to make a request and run into an error that looks like:
+
+```
+Error: cannot find a matching binding to send the request: at least one of the
+conditions must be met: (1) field `name` needs to be set and match:
+'projects/*/secrets/*' OR (2) field `name` needs to be set and match:
+'projects/*/locations/*/secrets/*'
+```
+
+This is a binding error. Let's break this down.
+
+## When this happens
+
+When a client cannot match the request to a [URI] for the service, it will fail
+the request locally with a binding error.
+
+Typically this happens when a field is either missing, or in an invalid format.
+
+```rust,ignore
+{{#include ../samples/src/binding_errors.rs:request}}
+```
+
+## How to fix it
+
+In this example, the `name` field on the top level request was not set. To fix
+the code, we will set it to something matching one of the above templates.
+Either will allow us to make a request to the server.
+
+```rust,ignore
+{{#include ../samples/src/binding_errors.rs:request-success-1}}
+```
+
+OR
+
+```rust,ignore
+{{#include ../samples/src/binding_errors.rs:request-success-2}}
+```
+
+## Interpreting the templates
+
+In the template strings, there are two special matchers.
+
+### Single wildcard
+
+The `*` alone means: a non-empty string without a `/`. It can be thought of as
+the regex `[^/]+`.
+
+Here are some examples:
+
+| Template | Input | Match? |
+|-|-|-|
+| `"*"` | `"simple-string-123"` | `true` |
+| `"projects/*"` | `"projects/p"` | `true` |
+| `"projects/*/locations"` | `"projects/p/locations"` | `true` |
+| `"projects/*/locations/*"` | `"projects/p/locations/l"` | `true` |
+| `"*"` | `""` (empty) | `false` |
+| `"*"` | `"string/with/slashes"` | `false` |
+| `"projects/*"` | `"projects/"` (empty) | `false` |
+| `"projects/*"` | `"projects/p/"` (extra slash) | `false` |
+| `"projects/*"` | `"projects/p/locations/l"` | `false` |
+| `"projects/*/locations"` | `"projects/p"` | `false` |
+| `"projects/*/locations"` | `"projects/p/locations/l"` | `false` |
+
+### Double wildcard
+
+Less common is the `**`, which means: any string. The string can be empty or
+contain any number of `/`'s. It can be thought of as the regex `.*`.
+
+Also, when a template ends in `/**`, that initial slash is optionally included.
+
+| Template | Input | Match? |
+|-|-|-|
+| `"**"` | `""` | `true` |
+| `"**"` | `"simple-string-123"` | `true` |
+| `"**"` | `"string/with/slashes"` | `true` |
+| `"projects/*/**"` | `"projects/p"` | `true` |
+| `"projects/*/**"` | `"projects/p/locations"` | `true` |
+| `"projects/*/**"` | `"projects/p/locations/l"` | `true` |
+| `"projects/*/**"` | `"locations/l"` | `false` |
+| `"projects/*/**"` | `"projects//locations/l"` | `false` |
+
+## Inspecting the error
+
+If you need to inspect the error programmatically, you can do so by checking
+that it is a binding error, then downcasting it to a `BindingError`.
+
+
+```rust,ignore
+{{#include ../samples/src/binding_errors.rs:inspect}}
+```
+
+[uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html

--- a/guide/src/binding_errors.md
+++ b/guide/src/binding_errors.md
@@ -66,13 +66,13 @@ OR
 ## Interpreting the templates
 
 The error message includes a number of "template strings" showing possible
-values for the request fields. Most template strings, use `*` and `**` as
+values for the request fields. Most template strings include `*` and `**` as
 wildcards to match the field values.
 
 ### Single wildcard
 
-The `*` alone means: a non-empty string without a `/`. It can be thought of as
-the regex `[^/]+`.
+The `*` wildcard alone means: a non-empty string without a `/`. It can be
+thought of as the regex `[^/]+`.
 
 Here are some examples:
 
@@ -92,8 +92,8 @@ Here are some examples:
 
 ### Double wildcard
 
-Less common is the `**`, which means: any string. The string can be empty or
-contain any number of `/`'s. It can be thought of as the regex `.*`.
+Less common is the `**` wildcard, which means: any string. The string can be
+empty or contain any number of `/`'s. It can be thought of as the regex `.*`.
 
 Also, when a template ends in `/**`, that initial slash is optionally included.
 

--- a/guide/src/binding_errors.md
+++ b/guide/src/binding_errors.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 You might have tried to make a request and run into an error that looks like:
 
-```
+```norust
 Error: cannot find a matching binding to send the request: at least one of the
 conditions must be met: (1) field `name` needs to be set and match:
 'projects/*/secrets/*' OR (2) field `name` needs to be set and match:
@@ -65,19 +65,19 @@ the regex `[^/]+`.
 
 Here are some examples:
 
-| Template | Input | Match? |
-|-|-|-|
-| `"*"` | `"simple-string-123"` | `true` |
-| `"projects/*"` | `"projects/p"` | `true` |
-| `"projects/*/locations"` | `"projects/p/locations"` | `true` |
-| `"projects/*/locations/*"` | `"projects/p/locations/l"` | `true` |
-| `"*"` | `""` (empty) | `false` |
-| `"*"` | `"string/with/slashes"` | `false` |
-| `"projects/*"` | `"projects/"` (empty) | `false` |
-| `"projects/*"` | `"projects/p/"` (extra slash) | `false` |
-| `"projects/*"` | `"projects/p/locations/l"` | `false` |
-| `"projects/*/locations"` | `"projects/p"` | `false` |
-| `"projects/*/locations"` | `"projects/p/locations/l"` | `false` |
+| Template                   | Input                         | Match?  |
+| -------------------------- | ----------------------------- | ------- |
+| `"*"`                      | `"simple-string-123"`         | `true`  |
+| `"projects/*"`             | `"projects/p"`                | `true`  |
+| `"projects/*/locations"`   | `"projects/p/locations"`      | `true`  |
+| `"projects/*/locations/*"` | `"projects/p/locations/l"`    | `true`  |
+| `"*"`                      | `""` (empty)                  | `false` |
+| `"*"`                      | `"string/with/slashes"`       | `false` |
+| `"projects/*"`             | `"projects/"` (empty)         | `false` |
+| `"projects/*"`             | `"projects/p/"` (extra slash) | `false` |
+| `"projects/*"`             | `"projects/p/locations/l"`    | `false` |
+| `"projects/*/locations"`   | `"projects/p"`                | `false` |
+| `"projects/*/locations"`   | `"projects/p/locations/l"`    | `false` |
 
 ### Double wildcard
 
@@ -86,16 +86,16 @@ contain any number of `/`'s. It can be thought of as the regex `.*`.
 
 Also, when a template ends in `/**`, that initial slash is optionally included.
 
-| Template | Input | Match? |
-|-|-|-|
-| `"**"` | `""` | `true` |
-| `"**"` | `"simple-string-123"` | `true` |
-| `"**"` | `"string/with/slashes"` | `true` |
-| `"projects/*/**"` | `"projects/p"` | `true` |
-| `"projects/*/**"` | `"projects/p/locations"` | `true` |
-| `"projects/*/**"` | `"projects/p/locations/l"` | `true` |
-| `"projects/*/**"` | `"locations/l"` | `false` |
-| `"projects/*/**"` | `"projects//locations/l"` | `false` |
+| Template          | Input                      | Match?  |
+| ----------------- | -------------------------- | ------- |
+| `"**"`            | `""`                       | `true`  |
+| `"**"`            | `"simple-string-123"`      | `true`  |
+| `"**"`            | `"string/with/slashes"`    | `true`  |
+| `"projects/*/**"` | `"projects/p"`             | `true`  |
+| `"projects/*/**"` | `"projects/p/locations"`   | `true`  |
+| `"projects/*/**"` | `"projects/p/locations/l"` | `true`  |
+| `"projects/*/**"` | `"locations/l"`            | `false` |
+| `"projects/*/**"` | `"projects//locations/l"`  | `false` |
 
 ## Inspecting the error
 

--- a/src/gax/src/error/binding.rs
+++ b/src/gax/src/error/binding.rs
@@ -23,6 +23,10 @@
 ///
 /// For more details on the specification, see: [AIP-127].
 ///
+/// Also see the [Handling binding errors] section in the user guide to learn
+/// how to resolve these errors.
+///
+/// [Handling binding errors]: https://google-cloud-rust.github.io/binding_errors.html
 /// [aip-127]: https://google.aip.dev/127
 /// [uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html
 #[derive(thiserror::Error, Debug, PartialEq)]

--- a/src/gax/src/error/binding.rs
+++ b/src/gax/src/error/binding.rs
@@ -88,14 +88,14 @@ impl std::fmt::Display for SubstitutionMismatch {
             SubstitutionFail::UnsetExpecting(expected) => {
                 write!(
                     f,
-                    "field `{}` needs to be set and match: '{}'",
+                    "field `{}` needs to be set and match the template: '{}'",
                     self.field_name, expected
                 )
             }
             SubstitutionFail::MismatchExpecting(actual, expected) => {
                 write!(
                     f,
-                    "field `{}` should match: '{}'; found: '{}'",
+                    "field `{}` should match the template: '{}'; found: '{}'",
                     self.field_name, expected, actual
                 )
             }


### PR DESCRIPTION
Fixes #2317  (there are some cleanups we should do, but this closes out everything that is public-facing).

Add a user guide section on handling binding errors. My main goal is to explain what is a `*`.

It renders like this: [ug_binding_errors.pdf](https://github.com/user-attachments/files/20953752/ug_binding_errors.pdf)
