### PR TITLE
test(storage): use a larger file for chunking read

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -62,18 +62,6 @@ pub async fn objects(builder: storage::client::ClientBuilder) -> Result<()> {
     assert_eq!(contents, CONTENTS.as_bytes());
     tracing::info!("success with contents={contents:?}");
 
-    tracing::info!("testing read_object() streaming");
-    let mut contents = bytes::BytesMut::new();
-    let mut resp = client
-        .read_object(&bucket.name, &insert.name)
-        .send()
-        .await?;
-    while let Some(chunk) = resp.next().await? {
-        contents.extend_from_slice(&chunk);
-    }
-    assert_eq!(contents, CONTENTS.as_bytes());
-    tracing::info!("success with contents={contents:?}");
-
     control
         .delete_object()
         .set_bucket(&insert.bucket)
@@ -132,6 +120,71 @@ pub async fn objects_customer_supplied_encryption(
         .await?;
     assert_eq!(contents, CONTENTS.as_bytes());
     tracing::info!("success with contents={contents:?}");
+
+    control
+        .delete_object()
+        .set_bucket(&insert.bucket)
+        .set_object(&insert.name)
+        .set_generation(insert.generation)
+        .send()
+        .await?;
+    control
+        .delete_bucket()
+        .set_name(&bucket.name)
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+pub async fn objects_large_file(builder: storage::client::ClientBuilder) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    // Create a temporary bucket for the test.
+    let (control, bucket) = create_test_bucket().await?;
+
+    let client = builder.build().await?;
+
+    // Create a large enough file that will require multiple chunks to download.
+    const TOTAL_BYTES: usize = 4000;
+    const BLOCK_SIZE: usize = 500;
+    let mut contents: Vec<u8> = vec![0; TOTAL_BYTES];
+    for i in 0..TOTAL_BYTES {
+        contents[i] = (i / BLOCK_SIZE) as u8;
+    }
+
+    tracing::info!("testing insert_object()");
+    let insert = client
+        .insert_object(&bucket.name, "quick.text", contents.clone())
+        .send()
+        .await?;
+    tracing::info!("success with insert={insert:?}");
+
+    tracing::info!("testing read_object() streaming");
+    let mut resp = client
+        .read_object(&bucket.name, &insert.name)
+        .send()
+        .await?;
+
+    // This should take multiple chunks to download.
+    let mut got = bytes::BytesMut::new();
+    while let Some(chunk) = resp.next().await? {
+        got.extend_from_slice(&chunk);
+    }
+    assert_eq!(got, contents);
+    tracing::info!("success with large contents");
 
     control
         .delete_object()

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -127,6 +127,16 @@ mod driver {
 
     #[test_case(Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_storage_objects_large_file(
+        builder: storage::client::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::storage::objects_large_file(builder)
+            .await
+            .map_err(integration_tests::report_error)
+    }
+
+    #[test_case(Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects_with_key(
         builder: storage::client::ClientBuilder,
     ) -> integration_tests::Result<()> {


### PR DESCRIPTION
Make the test more realistic and use a larger object. Chose a size that returned 4 chunks when running the integration tests locally.

While it would be easier to create a `const CONTENTS: &[u8] = &[5_u8; TOTAL_BYTES]`, it would be harder to verify that the data actually matched, since downloading the first chunk repeatedly would yield the same result.