### PR TITLE
impl(generator/rust): all request params over gRPC

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -179,16 +179,23 @@ type methodAnnotation struct {
 }
 
 type pathInfoAnnotation struct {
-	Method      string
-	PathArgs    []pathArg
-	HasPathArgs bool
-	HasBody     bool
-}
+	// Whether the request has a body or not
+	HasBody bool
 
-// Returns true if the HTTP request requires a payload. This is relevant for
-// POST and PUT requests that do not have a body parameter.
-func (a *pathInfoAnnotation) RequiresContentLength() bool {
-	return a.Method == "POST" || a.Method == "PUT"
+	// A list of possible request parameters
+	//
+	// This is only used for gRPC-based clients, where we must consider all
+	// possible request parameters.
+	//
+	// https://google.aip.dev/client-libraries/4222
+	//
+	// Templates are ignored. We only care about the FieldName and FieldAccessor.
+	UniqueParameters []*bindingSubstitution
+
+	// Whether this is idempotent by default
+	//
+	// This is only used for gRPC-based clients.
+	IsIdempotent string
 }
 
 type operationInfo struct {
@@ -641,22 +648,7 @@ func (c *codec) annotateMessage(m *api.Message, state *api.APIState, sourceSpeci
 }
 
 func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIState, sourceSpecificationPackageName string, packageNamespace string) {
-	// TODO(#2317) - move to pathBindingAnnotation
-	if len(m.PathInfo.Bindings) != 0 {
-		pathInfoAnnotation := &pathInfoAnnotation{
-			Method:   m.PathInfo.Bindings[0].Verb,
-			PathArgs: httpPathArgs(m.PathInfo, m, state),
-			HasBody:  m.PathInfo.BodyFieldPath != "",
-		}
-		pathInfoAnnotation.HasPathArgs = len(pathInfoAnnotation.PathArgs) > 0
-		m.PathInfo.Codec = pathInfoAnnotation
-	} else {
-		// Even when there are no bindings, we still want a concrete
-		// annotation, which we use to determine the default idempotency
-		// of the method. An empty annotation yields `false`.
-		m.PathInfo.Codec = &pathInfoAnnotation{}
-	}
-
+	annotatePathInfo(m.PathInfo, m, state)
 	for _, routing := range m.Routing {
 		for index, variant := range routing.Variants {
 			routingVariantAnnotations := &routingVariantAnnotations{
@@ -668,10 +660,6 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 			}
 			variant.Codec = routingVariantAnnotations
 		}
-	}
-
-	for _, b := range m.PathInfo.Bindings {
-		annotatePathBinding(b, m, state)
 	}
 	returnType := c.methodInOutTypeName(m.OutputTypeID, state, sourceSpecificationPackageName)
 	if m.ReturnsEmpty {
@@ -808,7 +796,7 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method, state *api.APIS
 	}
 }
 
-func annotatePathBinding(b *api.PathBinding, m *api.Method, state *api.APIState) {
+func annotatePathBinding(b *api.PathBinding, m *api.Method, state *api.APIState) *pathBindingAnnotation {
 	var subs []*bindingSubstitution
 	for _, s := range b.PathTemplate.Segments {
 		if s.Variable != nil {
@@ -816,10 +804,39 @@ func annotatePathBinding(b *api.PathBinding, m *api.Method, state *api.APIState)
 			subs = append(subs, &sub)
 		}
 	}
-	b.Codec = &pathBindingAnnotation{
+	return &pathBindingAnnotation{
 		PathFmt:       httpPathFmt(b.PathTemplate),
 		QueryParams:   language.QueryParams(m, b),
 		Substitutions: subs,
+	}
+}
+
+// Annotates the `PathInfo` and all of its `PathBinding`s.
+func annotatePathInfo(p *api.PathInfo, m *api.Method, state *api.APIState) {
+	seen := make(map[string]bool)
+	var uniqueParameters []*bindingSubstitution
+
+	for _, b := range p.Bindings {
+		ann := annotatePathBinding(b, m, state)
+
+		// We need to keep track of unique path parameters to support
+		// implicit routing over gRPC. This is go/aip/4222.
+		for _, s := range ann.Substitutions {
+			if _, ok := seen[s.FieldName]; !ok {
+				uniqueParameters = append(uniqueParameters, s)
+				seen[s.FieldName] = true
+			}
+		}
+
+		// Annotate the `PathBinding`
+		b.Codec = ann
+	}
+
+	// Annotate the `PathInfo`
+	p.Codec = &pathInfoAnnotation{
+		HasBody:          m.PathInfo.BodyFieldPath != "",
+		UniqueParameters: uniqueParameters,
+		IsIdempotent:     isIdempotent(p),
 	}
 }
 
@@ -993,9 +1010,14 @@ func (c *codec) annotateEnumValue(ev *api.EnumValue, e *api.Enum, state *api.API
 }
 
 // Returns "true" if the method is idempotent by default, and "false", if not.
-func (p *pathInfoAnnotation) IsIdempotent() string {
-	if p.Method == "GET" || p.Method == "PUT" || p.Method == "DELETE" {
-		return "true"
+func isIdempotent(p *api.PathInfo) string {
+	if len(p.Bindings) == 0 {
+		return "false"
 	}
-	return "false"
+	for _, b := range p.Bindings {
+		if b.Verb == "POST" || b.Verb == "PATCH" {
+			return "false"
+		}
+	}
+	return "true"
 }

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -1201,16 +1201,29 @@ func TestEnumFieldAnnotations(t *testing.T) {
 }
 
 func TestPathInfoAnnotations(t *testing.T) {
+	binding := func(verb string) *api.PathBinding {
+		return &api.PathBinding{
+			Verb: verb,
+			PathTemplate: api.NewPathTemplate().
+				WithLiteral("v1").
+				WithLiteral("resource"),
+		}
+	}
+
 	type TestCase struct {
-		Verb               string
+		Bindings           []*api.PathBinding
 		DefaultIdempotency string
 	}
 	testCases := []TestCase{
-		{"GET", "true"},
-		{"PUT", "true"},
-		{"DELETE", "true"},
-		{"POST", "false"},
-		{"PATCH", "false"},
+		{[]*api.PathBinding{}, "false"},
+		{[]*api.PathBinding{binding("GET")}, "true"},
+		{[]*api.PathBinding{binding("PUT")}, "true"},
+		{[]*api.PathBinding{binding("DELETE")}, "true"},
+		{[]*api.PathBinding{binding("POST")}, "false"},
+		{[]*api.PathBinding{binding("PATCH")}, "false"},
+		{[]*api.PathBinding{binding("GET"), binding("GET")}, "true"},
+		{[]*api.PathBinding{binding("GET"), binding("POST")}, "false"},
+		{[]*api.PathBinding{binding("POST"), binding("POST")}, "false"},
 	}
 	for _, testCase := range testCases {
 		request := &api.Message{
@@ -1229,14 +1242,7 @@ func TestPathInfoAnnotations(t *testing.T) {
 			InputTypeID:  ".test.v1.Request",
 			OutputTypeID: ".test.v1.Response",
 			PathInfo: &api.PathInfo{
-				Bindings: []*api.PathBinding{
-					{
-						Verb: testCase.Verb,
-						PathTemplate: api.NewPathTemplate().
-							WithLiteral("v1").
-							WithLiteral("resource"),
-					},
-				},
+				Bindings: testCase.Bindings,
 			},
 		}
 		service := &api.Service{
@@ -1251,14 +1257,16 @@ func TestPathInfoAnnotations(t *testing.T) {
 			[]*api.Enum{},
 			[]*api.Service{service})
 		api.CrossReference(model)
-		codec, err := newCodec(true, map[string]string{})
+		codec, err := newCodec(true, map[string]string{
+			"include-grpc-only-methods": "true",
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
 		annotateModel(model, codec)
 
 		pathInfoAnn := method.PathInfo.Codec.(*pathInfoAnnotation)
-		if pathInfoAnn.IsIdempotent() != testCase.DefaultIdempotency {
+		if pathInfoAnn.IsIdempotent != testCase.DefaultIdempotency {
 			t.Errorf("fail")
 		}
 	}

--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -122,13 +122,17 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/HasRouting}}
         {{^HasRouting}}
         let x_goog_request_params = [
-            {{#PathInfo.Codec.PathArgs}}
-            format!("{{Name}}={}", req{{{Accessor}}}),
-            {{/PathInfo.Codec.PathArgs}}
-            {{^PathInfo.Codec.PathArgs}}
+            {{#PathInfo.Codec.UniqueParameters}}
+                {{{FieldAccessor}}}.map(|v| format!("{{FieldName}}={}", v)),
+            {{/PathInfo.Codec.UniqueParameters}}
+            {{^PathInfo.Codec.UniqueParameters}}
             ""; 0
-            {{/PathInfo.Codec.PathArgs}}
-        ].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+            {{/PathInfo.Codec.UniqueParameters}}
+        ]
+        .into_iter()
+        .filter_map(|o| o)
+        {{! TODO(#2548) - skip empty strings, and don't lead with a '&' }}
+        .fold(String::new(), |b, p| b + "&" + &p);
         {{/HasRouting}}
 
         {{#ReturnsEmpty}}

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -74,9 +74,13 @@ impl super::stub::Firestore for Firestore {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/GetDocument");
-        let x_goog_request_params = [format!("name={}", req.name)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::Document;
         self.inner
@@ -110,10 +114,17 @@ impl super::stub::Firestore for Firestore {
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/ListDocuments");
         let x_goog_request_params = [
-            format!("parent={}", req.parent),
-            format!("collection_id={}", req.collection_id),
+            Some(&req)
+                .map(|m| &m.parent)
+                .map(|s| s.as_str())
+                .map(|v| format!("parent={}", v)),
+            Some(&req)
+                .map(|m| &m.collection_id)
+                .map(|s| s.as_str())
+                .map(|v| format!("collection_id={}", v)),
         ]
         .into_iter()
+        .filter_map(|o| o)
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::ListDocumentsResponse;
@@ -147,14 +158,13 @@ impl super::stub::Firestore for Firestore {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/UpdateDocument");
-        let x_goog_request_params = [format!(
-            "document.name={}",
-            req.document
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("document"))?
-                .name
-        )]
+        let x_goog_request_params = [Some(&req)
+            .and_then(|m| m.document.as_ref())
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("document.name={}", v))]
         .into_iter()
+        .filter_map(|o| o)
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::Document;
@@ -188,9 +198,13 @@ impl super::stub::Firestore for Firestore {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/DeleteDocument");
-        let x_goog_request_params = [format!("name={}", req.name)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = ();
         self.inner
@@ -223,9 +237,13 @@ impl super::stub::Firestore for Firestore {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/BeginTransaction");
-        let x_goog_request_params = [format!("database={}", req.database)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.database)
+            .map(|s| s.as_str())
+            .map(|v| format!("database={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::BeginTransactionResponse;
         self.inner
@@ -257,9 +275,13 @@ impl super::stub::Firestore for Firestore {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/Commit");
-        let x_goog_request_params = [format!("database={}", req.database)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.database)
+            .map(|s| s.as_str())
+            .map(|v| format!("database={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::CommitResponse;
         self.inner
@@ -291,9 +313,13 @@ impl super::stub::Firestore for Firestore {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/Rollback");
-        let x_goog_request_params = [format!("database={}", req.database)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.database)
+            .map(|s| s.as_str())
+            .map(|v| format!("database={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = ();
         self.inner
@@ -326,9 +352,13 @@ impl super::stub::Firestore for Firestore {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/PartitionQuery");
-        let x_goog_request_params = [format!("parent={}", req.parent)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.parent)
+            .map(|s| s.as_str())
+            .map(|v| format!("parent={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::PartitionQueryResponse;
         self.inner
@@ -362,9 +392,13 @@ impl super::stub::Firestore for Firestore {
         let path = http::uri::PathAndQuery::from_static(
             "/google.firestore.v1.Firestore/ListCollectionIds",
         );
-        let x_goog_request_params = [format!("parent={}", req.parent)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.parent)
+            .map(|s| s.as_str())
+            .map(|v| format!("parent={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::ListCollectionIdsResponse;
         self.inner
@@ -397,9 +431,13 @@ impl super::stub::Firestore for Firestore {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/BatchWrite");
-        let x_goog_request_params = [format!("database={}", req.database)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.database)
+            .map(|s| s.as_str())
+            .map(|v| format!("database={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::BatchWriteResponse;
         self.inner
@@ -433,10 +471,17 @@ impl super::stub::Firestore for Firestore {
         let path =
             http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/CreateDocument");
         let x_goog_request_params = [
-            format!("parent={}", req.parent),
-            format!("collection_id={}", req.collection_id),
+            Some(&req)
+                .map(|m| &m.parent)
+                .map(|s| s.as_str())
+                .map(|v| format!("parent={}", v)),
+            Some(&req)
+                .map(|m| &m.collection_id)
+                .map(|s| s.as_str())
+                .map(|v| format!("collection_id={}", v)),
         ]
         .into_iter()
+        .filter_map(|o| o)
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::firestore::v1::Document;

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -864,9 +864,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/GetProjectIntelligenceConfig",
         );
-        let x_goog_request_params = [format!("name={}", req.name)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
         self.inner
@@ -900,14 +904,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/UpdateProjectIntelligenceConfig",
         );
-        let x_goog_request_params = [format!(
-            "intelligence_config.name={}",
-            req.intelligence_config
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("intelligence_config"))?
-                .name
-        )]
+        let x_goog_request_params = [Some(&req)
+            .and_then(|m| m.intelligence_config.as_ref())
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("intelligence_config.name={}", v))]
         .into_iter()
+        .filter_map(|o| o)
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
@@ -942,9 +945,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/GetFolderIntelligenceConfig",
         );
-        let x_goog_request_params = [format!("name={}", req.name)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
         self.inner
@@ -978,14 +985,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/UpdateFolderIntelligenceConfig",
         );
-        let x_goog_request_params = [format!(
-            "intelligence_config.name={}",
-            req.intelligence_config
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("intelligence_config"))?
-                .name
-        )]
+        let x_goog_request_params = [Some(&req)
+            .and_then(|m| m.intelligence_config.as_ref())
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("intelligence_config.name={}", v))]
         .into_iter()
+        .filter_map(|o| o)
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
@@ -1020,9 +1026,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/GetOrganizationIntelligenceConfig",
         );
-        let x_goog_request_params = [format!("name={}", req.name)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
         self.inner
@@ -1056,14 +1066,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/UpdateOrganizationIntelligenceConfig",
         );
-        let x_goog_request_params = [format!(
-            "intelligence_config.name={}",
-            req.intelligence_config
-                .as_ref()
-                .ok_or_else(|| gaxi::path_parameter::missing("intelligence_config"))?
-                .name
-        )]
+        let x_goog_request_params = [Some(&req)
+            .and_then(|m| m.intelligence_config.as_ref())
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("intelligence_config.name={}", v))]
         .into_iter()
+        .filter_map(|o| o)
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
@@ -1098,9 +1107,13 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.control.v2.StorageControl/GetOperation",
         );
-        let x_goog_request_params = [format!("name={}", req.name)]
-            .into_iter()
-            .fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={}", v))]
+        .into_iter()
+        .filter_map(|o| o)
+        .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::longrunning::Operation;
         self.inner


### PR DESCRIPTION
Fixes #2534 and cleans up some leftovers from #2317 

Reuse the `bindingSubstitution` which has the `FieldName`, `FieldAccessor` over gRPC. And also loop over all possible path params (which at the moment is the same set).

This lets us remove most of the fields of the `pathInfoAnnotation`.

A missing parameter is not an error. We just skip it in the header.

Other logic is wrong. I am just going to open a new issue to fix it. #2548. This stuff needs testing.