### PR TITLE
cleanup: simpler routing info template

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -214,7 +214,6 @@ func (info *operationInfo) NoneAreEmpty() bool {
 }
 
 type routingVariantAnnotations struct {
-	FirstVariant     bool
 	FieldAccessors   []string
 	PrefixSegments   []string
 	MatchingSegments []string
@@ -658,9 +657,8 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 	}
 
 	for _, routing := range m.Routing {
-		for index, variant := range routing.Variants {
+		for _, variant := range routing.Variants {
 			routingVariantAnnotations := &routingVariantAnnotations{
-				FirstVariant:     index == 0,
 				FieldAccessors:   c.annotateRoutingAccessors(variant, m, state),
 				PrefixSegments:   annotateSegments(variant.Prefix.Segments),
 				MatchingSegments: annotateSegments(variant.Matching.Segments),

--- a/generator/internal/rust/templates/grpc-client/routinginfo.mustache
+++ b/generator/internal/rust/templates/grpc-client/routinginfo.mustache
@@ -17,19 +17,14 @@ let x_goog_request_params = {
     use gaxi::routing_parameter::Segment;
     gaxi::routing_parameter::format(&[
         {{#Routing}}
+        None
         {{#Variants}}
-        {{^Codec.FirstVariant}}
-        .or_else(||
-        {{/Codec.FirstVariant}}
-        gaxi::routing_parameter::value(
+        .or_else(|| gaxi::routing_parameter::value(
             Some(&req){{#Codec.FieldAccessors}}{{{.}}}{{/Codec.FieldAccessors}},
             &[ {{#Codec.PrefixSegments}}{{{.}}}, {{/Codec.PrefixSegments}} ],
             &[ {{#Codec.MatchingSegments}}{{{.}}}, {{/Codec.MatchingSegments}} ],
             &[ {{#Codec.SuffixSegments}}{{{.}}}, {{/Codec.SuffixSegments}} ],
-        )
-        {{^Codec.FirstVariant}}
-        )
-        {{/Codec.FirstVariant}}
+        ))
         {{/Variants}}
         .map(|v| ("{{Name}}", v)),
         {{/Routing}}

--- a/src/storage-control/src/generated/gapic/transport.rs
+++ b/src/storage-control/src/generated/gapic/transport.rs
@@ -75,13 +75,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteBucket");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = ();
@@ -116,13 +119,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetBucket");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Bucket;
@@ -157,24 +163,27 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateBucket");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req)
-                    .and_then(|m| m.bucket.as_ref())
-                    .map(|m| &m.project)
-                    .map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .or_else(|| {
-                gaxi::routing_parameter::value(
-                    Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                    &[],
-                    &[Segment::MultiWildcard],
-                    &[],
-                )
-            })
-            .map(|v| ("project", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .and_then(|m| m.bucket.as_ref())
+                            .map(|m| &m.project)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("project", v))])
         };
 
         type TR = crate::google::storage::v2::Bucket;
@@ -209,13 +218,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListBuckets");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("project", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("project", v))])
         };
 
         type TR = crate::google::storage::v2::ListBucketsResponse;
@@ -252,13 +264,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Bucket;
@@ -293,26 +308,29 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetIamPolicy");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .or_else(|| {
-                gaxi::routing_parameter::value(
-                    Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                    &[],
-                    &[Segment::MultiWildcard],
-                    &[],
-                )
-            })
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::iam::v1::Policy;
@@ -347,26 +365,29 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/SetIamPolicy");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .or_else(|| {
-                gaxi::routing_parameter::value(
-                    Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                    &[],
-                    &[Segment::MultiWildcard],
-                    &[],
-                )
-            })
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::iam::v1::Policy;
@@ -402,42 +423,45 @@ impl super::stub::StorageControl for StorageControl {
             http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/TestIamPermissions");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[
-                    Segment::Literal("managedFolders"),
-                    Segment::TrailingMultiWildcard,
-                ],
-            )
-            .or_else(|| {
-                gaxi::routing_parameter::value(
-                    Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                    &[],
-                    &[
-                        Segment::Literal("projects/"),
-                        Segment::SingleWildcard,
-                        Segment::Literal("/buckets/"),
-                        Segment::SingleWildcard,
-                    ],
-                    &[Segment::Literal("objects"), Segment::TrailingMultiWildcard],
-                )
-            })
-            .or_else(|| {
-                gaxi::routing_parameter::value(
-                    Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
-                    &[],
-                    &[Segment::MultiWildcard],
-                    &[],
-                )
-            })
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[
+                            Segment::Literal("managedFolders"),
+                            Segment::TrailingMultiWildcard,
+                        ],
+                    )
+                })
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::Literal("objects"), Segment::TrailingMultiWildcard],
+                    )
+                })
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::iam::v1::TestIamPermissionsResponse;
@@ -472,16 +496,19 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateBucket");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req)
-                    .and_then(|m| m.bucket.as_ref())
-                    .map(|m| &m.name)
-                    .map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .and_then(|m| m.bucket.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Bucket;
@@ -516,16 +543,19 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ComposeObject");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req)
-                    .and_then(|m| m.destination.as_ref())
-                    .map(|m| &m.bucket)
-                    .map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .and_then(|m| m.destination.as_ref())
+                            .map(|m| &m.bucket)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Object;
@@ -560,13 +590,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteObject");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = ();
@@ -601,13 +634,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/RestoreObject");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Object;
@@ -642,13 +678,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetObject");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Object;
@@ -683,16 +722,19 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateObject");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req)
-                    .and_then(|m| m.object.as_ref())
-                    .map(|m| &m.bucket)
-                    .map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .and_then(|m| m.object.as_ref())
+                            .map(|m| &m.bucket)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Object;
@@ -727,13 +769,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListObjects");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::ListObjectsResponse;
@@ -769,21 +814,25 @@ impl super::stub::StorageControl for StorageControl {
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
             gaxi::routing_parameter::format(&[
-                gaxi::routing_parameter::value(
-                    Some(&req)
-                        .map(|m| &m.destination_bucket)
-                        .map(|s| s.as_str()),
-                    &[],
-                    &[Segment::MultiWildcard],
-                    &[],
-                )
+                None.or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .map(|m| &m.destination_bucket)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
                 .map(|v| ("bucket", v)),
-                gaxi::routing_parameter::value(
-                    Some(&req).map(|m| &m.source_bucket).map(|s| s.as_str()),
-                    &[],
-                    &[Segment::MultiWildcard],
-                    &[],
-                )
+                None.or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.source_bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
                 .map(|v| ("source_bucket", v)),
             ])
         };
@@ -820,13 +869,16 @@ impl super::stub::StorageControl for StorageControl {
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/MoveObject");
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::v2::Object;

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -77,13 +77,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::Folder;
@@ -120,18 +123,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = ();
@@ -168,18 +174,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::Folder;
@@ -216,13 +225,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::ListFoldersResponse;
@@ -259,18 +271,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::longrunning::Operation;
@@ -307,18 +322,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::StorageLayout;
@@ -355,13 +373,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::ManagedFolder;
@@ -398,18 +419,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = ();
@@ -446,18 +470,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::ManagedFolder;
@@ -494,13 +521,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::ListManagedFoldersResponse;
@@ -537,13 +567,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::longrunning::Operation;
@@ -580,21 +613,24 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req)
-                    .and_then(|m| m.anywhere_cache.as_ref())
-                    .map(|m| &m.name)
-                    .map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .and_then(|m| m.anywhere_cache.as_ref())
+                            .map(|m| &m.name)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::longrunning::Operation;
@@ -631,18 +667,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
@@ -679,18 +718,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
@@ -727,18 +769,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
@@ -775,18 +820,21 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.name).map(|s| s.as_str()),
-                &[],
-                &[
-                    Segment::Literal("projects/"),
-                    Segment::SingleWildcard,
-                    Segment::Literal("/buckets/"),
-                    Segment::SingleWildcard,
-                ],
-                &[Segment::MultiWildcard],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.name).map(|s| s.as_str()),
+                        &[],
+                        &[
+                            Segment::Literal("projects/"),
+                            Segment::SingleWildcard,
+                            Segment::Literal("/buckets/"),
+                            Segment::SingleWildcard,
+                        ],
+                        &[Segment::MultiWildcard],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
@@ -823,13 +871,16 @@ impl super::stub::StorageControl for StorageControl {
         );
         let x_goog_request_params = {
             use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
-                Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
-                &[],
-                &[Segment::MultiWildcard],
-                &[],
-            )
-            .map(|v| ("bucket", v))])
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
         };
 
         type TR = crate::google::storage::control::v2::ListAnywhereCachesResponse;


### PR DESCRIPTION
I prefer to have a simpler template, but that is just me. If @coryan disagrees, I am happy to just close this PR. The difference is miniscule.

FWIW, the HTTP path computation also uses the `None.or_else(...).or_else(...)...` set up.

https://github.com/googleapis/google-cloud-rust/blob/7b40638a34e5c2ce0f3b359c563a1aa9e5bd76fe/generator/internal/rust/templates/crate/src/transport.rs.mustache#L77-L79