### PR TITLE
cleanup(generator): weaker typed variable subsegments

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -343,9 +343,9 @@ type RoutingPathSpec struct {
 
 const (
 	// A special routing path segment which indicates "match anything that does not include a `/`"
-	RoutingSingleSegmentWildcard = "*"
+	SingleSegmentWildcard = "*"
 	// A special routing path segment which indicates "match anything including `/`"
-	RoutingMultiSegmentWildcard = "**"
+	MultiSegmentWildcard = "**"
 )
 
 type PathTemplate struct {
@@ -360,13 +360,7 @@ type PathSegment struct {
 
 type PathVariable struct {
 	FieldPath []string
-	Segments  []PathVariableSegment
-}
-
-type PathVariableSegment struct {
-	Literal        *string
-	Match          *PathMatch
-	MatchRecursive *PathMatchRecursive
+	Segments  []string
 }
 
 // PathMatch represents a single '*' match.
@@ -405,17 +399,17 @@ func (p *PathTemplate) WithVerb(v string) *PathTemplate {
 }
 
 func (v *PathVariable) WithLiteral(l string) *PathVariable {
-	v.Segments = append(v.Segments, PathVariableSegment{Literal: &l})
+	v.Segments = append(v.Segments, l)
 	return v
 }
 
 func (v *PathVariable) WithMatchRecursive() *PathVariable {
-	v.Segments = append(v.Segments, PathVariableSegment{MatchRecursive: &PathMatchRecursive{}})
+	v.Segments = append(v.Segments, MultiSegmentWildcard)
 	return v
 }
 
 func (v *PathVariable) WithMatch() *PathVariable {
-	v.Segments = append(v.Segments, PathVariableSegment{Match: &PathMatch{}})
+	v.Segments = append(v.Segments, SingleSegmentWildcard)
 	return v
 }
 

--- a/generator/internal/parser/routing_info.go
+++ b/generator/internal/parser/routing_info.go
@@ -90,13 +90,13 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 			Variants: []*api.RoutingInfoVariant{{
 				FieldPath: fieldPath,
 				Matching: api.RoutingPathSpec{
-					Segments: []string{api.RoutingMultiSegmentWildcard},
+					Segments: []string{api.MultiSegmentWildcard},
 				},
 			}},
 		}
 		return info, nil
 	}
-	if strings.Count(pathTemplate, api.RoutingMultiSegmentWildcard) > 1 {
+	if strings.Count(pathTemplate, api.MultiSegmentWildcard) > 1 {
 		return nil, fmt.Errorf("too many `**` matchers in pathTemplate=%q", pathTemplate)
 	}
 
@@ -122,12 +122,12 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 		suffix, width = parseRoutingSuffix(pathTemplate[pos:])
 		pos += width
 	}
-	index := slices.Index(prefix.Segments, api.RoutingMultiSegmentWildcard)
+	index := slices.Index(prefix.Segments, api.MultiSegmentWildcard)
 	if index != -1 {
 		return nil, fmt.Errorf("multi segment wildcards may not appear in the prefix portion of a path template, template=%s", pathTemplate)
 	}
 	for _, spec := range []*api.RoutingPathSpec{&match, &suffix} {
-		index := slices.Index(spec.Segments, api.RoutingMultiSegmentWildcard)
+		index := slices.Index(spec.Segments, api.MultiSegmentWildcard)
 		if index == -1 || index == len(spec.Segments)-1 {
 			continue
 		}
@@ -153,7 +153,7 @@ func parseRoutingPrefix(pathTemplate string) (api.RoutingPathSpec, int) {
 }
 
 func isRoutingWildcard(segment string) bool {
-	return segment == api.RoutingSingleSegmentWildcard || segment == api.RoutingMultiSegmentWildcard
+	return segment == api.SingleSegmentWildcard || segment == api.MultiSegmentWildcard
 }
 
 func parseRoutingVariable(defaultName, pathTemplate string) (string, api.RoutingPathSpec, int, error) {
@@ -195,11 +195,11 @@ func parseRoutingPathSpec(pathTemplate string) (api.RoutingPathSpec, int) {
 }
 
 func parseRoutingSegment(pathTemplate string) (string, int) {
-	if strings.HasPrefix(pathTemplate, api.RoutingMultiSegmentWildcard) {
-		return api.RoutingMultiSegmentWildcard, len(api.RoutingMultiSegmentWildcard)
+	if strings.HasPrefix(pathTemplate, api.MultiSegmentWildcard) {
+		return api.MultiSegmentWildcard, len(api.MultiSegmentWildcard)
 	}
-	if strings.HasPrefix(pathTemplate, api.RoutingSingleSegmentWildcard) {
-		return api.RoutingSingleSegmentWildcard, len(api.RoutingSingleSegmentWildcard)
+	if strings.HasPrefix(pathTemplate, api.SingleSegmentWildcard) {
+		return api.SingleSegmentWildcard, len(api.SingleSegmentWildcard)
 	}
 	index := strings.IndexAny(pathTemplate, "=/{}")
 	if index == -1 {

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -759,7 +759,7 @@ func annotateSegments(segments []string) []string {
 	}
 	for index, segment := range segments {
 		switch {
-		case segment == api.RoutingMultiSegmentWildcard:
+		case segment == api.MultiSegmentWildcard:
 			flushBuffer()
 			if len(segments) == 1 {
 				ann = append(ann, "Segment::MultiWildcard")
@@ -768,7 +768,7 @@ func annotateSegments(segments []string) []string {
 			} else {
 				ann = append(ann, "Segment::TrailingMultiWildcard")
 			}
-		case segment == api.RoutingSingleSegmentWildcard:
+		case segment == api.SingleSegmentWildcard:
 			if index != 0 {
 				literalBuffer += "/"
 			}
@@ -790,21 +790,10 @@ func makeBindingSubstitution(v *api.PathVariable, m *api.Method, state *api.APIS
 	for _, a := range makeAccessors(v.FieldPath, m, state) {
 		fieldAccessor += a
 	}
-	var segments []string
-	for _, s := range v.Segments {
-		if s.Literal != nil {
-			segments = append(segments, *s.Literal)
-		} else if s.Match != nil {
-			segments = append(segments, "*")
-		} else if s.MatchRecursive != nil {
-			segments = append(segments, "**")
-		}
-	}
-
 	return bindingSubstitution{
 		FieldAccessor: fieldAccessor,
 		FieldName:     strings.Join(v.FieldPath, "."),
-		Template:      segments,
+		Template:      v.Segments,
 	}
 }
 


### PR DESCRIPTION
Related to #557 

Just represent a variable subsegment as a string, instead of a strongly typed variant. e.g. `{"projects", "*"}`

This is what we do with explicit routing, might as well be consistent. The code is a littler simpler too. There is just less structure in the model.