### PR TITLE
feat(storage)!: change return type for next()

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -68,8 +68,8 @@ pub async fn objects(builder: storage::client::ClientBuilder) -> Result<()> {
         .read_object(&bucket.name, &insert.name)
         .send()
         .await?;
-    while let Some(chunk) = resp.next().await? {
-        contents.extend_from_slice(&chunk);
+    while let Some(chunk) = resp.next().await {
+        contents.extend_from_slice(&chunk?);
     }
     assert_eq!(contents, CONTENTS.as_bytes());
     tracing::info!("success with contents={contents:?}");

--- a/src/storage/src/client.rs
+++ b/src/storage/src/client.rs
@@ -737,13 +737,13 @@ impl ReadObjectResponse {
     ///     .send()
     ///     .await?;
     ///
-    /// while let Some(next) = resp.next().await? {
-    ///     println!("next={next:?}");
+    /// while let Some(next) = resp.next().await {
+    ///     println!("next={:?}", next?);
     /// }
     /// # Ok::<(), anyhow::Error>(()) });
     /// ```
-    pub async fn next(&mut self) -> Result<Option<bytes::Bytes>> {
-        self.inner.chunk().await.map_err(Error::io)
+    pub async fn next(&mut self) -> Option<Result<bytes::Bytes>> {
+        self.inner.chunk().await.map_err(Error::io).transpose()
     }
 }
 


### PR DESCRIPTION
Make the method signature more similar to futures::StreamExt. It is simple to convert between the two with `transpose()` so this will not greatly affect the usability of the API. We can also consider adding a try_next helper to return a Result<Option<Bytes>> as well.