### PR TITLE
feat(internal/gcloud): add structs for gcloud config YAML

### DIFF
--- a/generator/go.mod
+++ b/generator/go.mod
@@ -17,6 +17,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250414145226-207652e42e2e
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -33,6 +34,5 @@ require (
 	golang.org/x/text v0.24.0 // indirect
 	google.golang.org/grpc v1.71.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/generator/internal/gcloud/gcloud.go
+++ b/generator/internal/gcloud/gcloud.go
@@ -1,0 +1,222 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+// Config represents the top-level schema of a gcloud config YAML file.
+type Config struct {
+	// ServiceName is the name of a service. Each gcloud.yaml file should
+	// correlate to a single service config with one or more APIs defined.
+	ServiceName string `yaml:"service_name"`
+
+	// APIs describes the APIs for which to generate a gcloud surface.
+	APIs []API `yaml:"apis,omitempty"`
+
+	// ResourcePatterns describes resource patterns not included in
+	// descriptors, providing additional patterns that might be used for
+	// resource identification or command generation.
+	ResourcePatterns []ResourcePattern `yaml:"resource_patterns,omitempty"`
+}
+
+// API describes an API to generate a surface for. This structure holds
+// configurations specific to a single API within the gcloud surface.
+type API struct {
+	// Name is the name of the API. This should be the API name as it appears
+	// in the normalized service config (e.g., "compute.googleapis.com").
+	Name string `yaml:"name"`
+
+	// APIVersion is the API version of the API (e.g., "v1", "v2beta1").
+	APIVersion string `yaml:"api_version,omitempty"`
+
+	// SupportsStarUpdateMasks indicates that this API supports '*' updateMasks
+	// in accordance with https://google.aip.dev/134#request-message. The
+	// default is assumed to be true for AIP compliant APIs.
+	SupportsStarUpdateMasks bool `yaml:"supports_star_update_masks,omitempty"`
+
+	// RootIsHidden applies the gcloud 'hidden' flag to the root command group
+	// of the generated surface.  When true, the top-level command group for
+	// this API will not appear in `--help` output by default.  See
+	// go/gcloud-advanced-topics#hiding-commands-and-command-groups for more
+	// details.
+	RootIsHidden bool `yaml:"root_is_hidden"`
+
+	// ReleaseTracks are the gcloud release tracks this surface should appear
+	// in. This determines the visibility and stability level of the generated
+	// commands and resources.
+	ReleaseTracks []ReleaseTrack `yaml:"release_tracks,omitempty"`
+
+	// HelpText contains all help text configurations for the surfaces
+	// including groups, commands, resources, and flags/arguments related to
+	// this API.
+	HelpText *HelpText `yaml:"help_text,omitempty"`
+
+	// OutputFormatting contains all output formatting rules for commands
+	// within this API. These rules dictate how the results of commands are
+	// displayed to the user.
+	OutputFormatting []*OutputFormatting `yaml:"output_formatting,omitempty"`
+
+	// CommandOperationsConfig contains long running operations config for
+	// methods within this API. This allows customization of how asynchronous
+	// operations are handled and displayed.
+	CommandOperationsConfig []*CommandOperationsConfig `yaml:"command_operations_config,omitempty"`
+}
+
+// HelpText contains rules for various types of help text within an API
+// surface. It groups help text definitions by the type of CLI element they
+// apply to.
+type HelpText struct {
+	// ServiceRules defines help text rules specifically for services.
+	ServiceRules []*HelpTextRule `yaml:"service_rules,omitempty"`
+
+	// MessageRules defines help text rules specifically for messages (resource
+	// command groups).
+	MessageRules []*HelpTextRule `yaml:"message_rules,omitempty"`
+
+	// MethodRules defines help text rules specifically for API methods
+	// (commands).
+	MethodRules []*HelpTextRule `yaml:"method_rules,omitempty"`
+
+	// FieldRules defines help text rules specifically for individual fields
+	// (flags/arguments).
+	FieldRules []*HelpTextRule `yaml:"field_rules,omitempty"`
+}
+
+// HelpTextRule maps an API selector to its corresponding HelpTextElement.
+// This allows for targeted help text customization based on specific API
+// elements.
+type HelpTextRule struct {
+	// Selector is a comma-separated list of patterns for any element such as a
+	// method, a field, an enum value. Each pattern is a qualified name of the
+	// element which may end in "*", indicating a wildcard. Wildcards are only
+	// allowed at the end and for a whole component of the qualified name, i.e.
+	// "foo.*" is ok, but not "foo.b*" or "foo.*.bar".
+	//
+	// Wildcard may not be applicable for some elements, in those cases an
+	// 'InvalidSelectorWildcardError' error will be thrown.  Additionally, some
+	// gcloud data elements expect a singular selector, if a comma separated
+	// selector string is passed, a 'InvalidSelectorList' error will be thrown.
+	//
+	// See http://google3/google/api/documentation.proto;l=253;rcl=525006895
+	// for API selector details.
+	Selector string `yaml:"selector,omitempty"`
+
+	// HelpText contains the detailed help text content for the selected
+	// element.
+	HelpText *HelpTextElement `yaml:"help_text,omitempty"`
+}
+
+// HelpTextElement describes the actual content of the help text for a CLI
+// Element. This structure holds the brief, description, and examples for a
+// given element. This can be linked to an individual API RPC/Command, a
+// Resource Message, Enum, Service, Enum.value or Message.field.
+type HelpTextElement struct {
+	// Brief is a concise, single-line summary of the help text for the CLI
+	// element.
+	Brief string `yaml:"brief,omitempty"`
+
+	// Description provides a detailed, multi-line description for the CLI
+	// element.
+	Description string `yaml:"description,omitempty"`
+
+	// Examples provides a list of string examples illustrating how to use the
+	// CLI element.
+	Examples []string `yaml:"examples,omitempty"`
+}
+
+// OutputFormatting contains a collection of command output formatting rules.
+// These rules are used to specify how the output of gcloud commands should be
+// presented.
+type OutputFormatting struct {
+	// Selector is a comma-separated list of patterns for any element such as a
+	// method, a field, an enum value. Each pattern is a qualified name of the
+	// element which may end in "*", indicating a wildcard. Wildcards are only
+	// allowed at the end and for a whole component of the qualified name, i.e.
+	// "foo.*" is ok, but not "foo.b*" or "foo.*.bar".
+	//
+	// Wildcard may not be applicable for some elements, in those cases an
+	// 'InvalidSelectorWildcardError' error will be thrown.  Additionally, some
+	// gcloud data elements expect a singular selector, if a comma separated
+	// selector string is passed, a 'InvalidSelectorList' error will be thrown.
+	//
+	// See http://google3/google/api/documentation.proto;l=253;rcl=525006895
+	// for API selector details.  Must point to a single RPC/command. Wildcards
+	// ('*') not allowed for output formatting.
+	Selector string `yaml:"selector"`
+
+	// Format is the output formatting string to apply. This string typically
+	// follows the `gcloud topic formats` specification (e.g., "table(name,
+	// createTime)", "json").
+	Format string `yaml:"format"`
+}
+
+// CommandOperationsConfig contains a collection of command operations
+// configuration rules.  These rules govern the behavior of long-running
+// operations triggered by gcloud commands.
+type CommandOperationsConfig struct {
+	// Selector is a comma-separated list of patterns for any element such as a
+	// method, a field, an enum value. Each pattern is a qualified name of the
+	// element which may end in "*", indicating a wildcard. Wildcards are only
+	// allowed at the end and for a whole component of the qualified name, i.e.
+	// "foo.*" is ok, but not "foo.b*" or "foo.*.bar".
+	//
+	// Wildcard may not be applicable for some elements, in those cases an
+	// 'InvalidSelectorWildcardError' error will be thrown.  Additionally, some
+	// gcloud data elements expect a singular selector, if a comma separated
+	// selector string is passed, a 'InvalidSelectorList' error will be thrown.
+	//
+	// See http://google3/google/api/documentation.proto;l=253;rcl=525006895
+	// for API selector details.
+	Selector string `yaml:"selector"`
+
+	// DisplayOperationResult determines whether to display the resource result
+	// in the output of the command by default.  Set to `true` to display the
+	// operation result instead of the final resource.  See
+	// http://go/gcloud-creating-commands#async for more details.
+	DisplayOperationResult bool `yaml:"display_operation_result"`
+}
+
+// ReleaseTrack is an enumeration of the gcloud release tracks. These indicate
+// the stability level and visibility of commands and features.
+type ReleaseTrack string
+
+const (
+	// ReleaseTrackAlpha represents the ALPHA release track. Features in this
+	// track are experimental and subject to change.
+	ReleaseTrackAlpha ReleaseTrack = "ALPHA"
+
+	// ReleaseTrackBeta represents the BETA release track. Features in this
+	// track are more stable than ALPHA but may still undergo minor changes.
+	ReleaseTrackBeta ReleaseTrack = "BETA"
+
+	// ReleaseTrackGA represents the GA (Generally Available) release track.
+	// Features in this track are stable and suitable for production use.
+	ReleaseTrackGA ReleaseTrack = "GA"
+)
+
+// ResourcePattern describes resource patterns not explicitly included in API
+// descriptors.  These patterns can be used to define additional resource
+// identifiers or custom resource structures.
+type ResourcePattern struct {
+	// Type is the resource type (e.g., "example.googleapis.com/Service").
+	Type string `yaml:"type"`
+
+	// Patterns is a list of resource patterns (e.g.,
+	// "projects/{project}/locations/{location}/services/{service}").  These
+	// define the structure of resource names.
+	Patterns []string `yaml:"patterns,omitempty"`
+
+	// APIVersion is the API version associated with this resource pattern
+	// (e.g., "v1").
+	APIVersion string `yaml:"api_version,omitempty"`
+}

--- a/generator/internal/gcloud/gcloud_test.go
+++ b/generator/internal/gcloud/gcloud_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
+)
+
+func TestGcloudConfig(t *testing.T) {
+	data, err := os.ReadFile("testdata/parallelstore/gcloud.yaml")
+	if err != nil {
+		t.Fatalf("failed to read temporary YAML file: %v", err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	got, err := yaml.Marshal(&config)
+	if err != nil {
+		t.Fatalf("failed to marshal struct to YAML: %v", err)
+	}
+
+	var index int
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			// Skip the header, and the new lines after the header
+			index = i + 2
+			continue
+		}
+	}
+	want := strings.Join(lines[index:], "\n")
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("mismatch(-want, +got)\n%s", diff)
+	}
+}

--- a/generator/internal/gcloud/testdata/parallelstore/gcloud.yaml
+++ b/generator/internal/gcloud/testdata/parallelstore/gcloud.yaml
@@ -1,0 +1,129 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+service_name: parallelstore.googleapis.com
+apis:
+- name: Parallelstore
+  api_version: v1
+  root_is_hidden: true
+  release_tracks:
+  - GA
+  help_text:
+    service_rules:
+    - selector: google.cloud.parallelstore.v1.Parallelstore
+      help_text:
+        brief: Manage Parallelstore resources
+        description: Manage Parallelstore resources
+    message_rules:
+    - selector: google.cloud.parallelstore.v1.Instance
+      help_text:
+        brief: Manage Parallelstore instance resources
+        description: Manage Parallelstore instance resources.
+    method_rules:
+    - selector: google.cloud.parallelstore.v1.Parallelstore.ListInstances
+      help_text:
+        brief: List Parallelstore instances
+        description: |
+          List Parallelstore instances.
+        examples:
+        - |-
+          To list all instances in particular location `us-central1-a` run:
+
+          $ {command} --location=us-central1-a
+    - selector: google.cloud.parallelstore.v1.Parallelstore.GetInstance
+      help_text:
+        brief: Gets details of a single Parallelstore instance
+        description: |
+          Gets details of a single Parallelstore instance.
+        examples:
+        - |-
+          To get the details of a single instance `my-instance` in location `us-central1-a` run:
+
+          $ {command} my-instance --location=us-central1-a
+    - selector: google.cloud.parallelstore.v1.Parallelstore.CreateInstance
+      help_text:
+        brief: Creates a Parallelstore instance
+        description: |
+          Creates a Parallelstore instance.
+        examples:
+        - |-
+          To create an instance `my-instance` in location `us-central1-a` with 12000 Gib capacity run:
+
+          $ {command} my-instance --capacity-gib=12000 --location=us-central1-a
+    - selector: google.cloud.parallelstore.v1.Parallelstore.UpdateInstance
+      help_text:
+        brief: Updates the parameters of a single Parallelstore instance
+        description: |
+          Updates the parameters of a single Parallelstore instance.
+        examples:
+        - |-
+          To update the description of an instance `my-instance` in location `us-central1-a` run:
+
+          $ {command} my-instance --location=us-central1-a --description="<updated description>"
+    - selector: google.cloud.parallelstore.v1.Parallelstore.DeleteInstance
+      help_text:
+        brief: Deletes a single Parallelstore instance
+        description: |
+          Deletes a single Parallelstore instance.
+        examples:
+        - |-
+          To delete an instance `my-instance` run:
+
+          $ {command} my-instance
+    - selector: google.cloud.parallelstore.v1.Parallelstore.ImportData
+      help_text:
+        brief: Imports data from Cloud Storage to Parallelstore instance.
+        description: |
+          Imports data from Cloud Storage to Parallelstore instance.
+        examples:
+        - |-
+          To import data from `gs://my-bucket` storage to `my-instance` run:
+
+          $ {command} my-instance --location=us-central-a --source-gcs-bucket-uri=gs://my_bucket --destination-parallelstore-path='/'
+    - selector: google.cloud.parallelstore.v1.Parallelstore.ExportData
+      help_text:
+        brief: Exports data from Parallelstore instance to Cloud Storage.
+        description: |
+          Exports data from Parallelstore instance to Cloud Storage.
+        examples:
+        - |-
+          To export data from `my-instance` to `gs://my-bucket` storage  run:
+
+          $ {command} my-instance --location=us-central-a --destination-gcs-bucket-uri=gs://my-bucket --source-parallelstore-path='/'
+  output_formatting:
+  - selector: google.cloud.parallelstore.v1.Parallelstore.ListInstances
+    format: |-
+      table(name,
+            capacityGib:label=Capacity,
+            description,
+            createTime,
+            updateTime,
+            state,
+            network,
+            reserved_ip_range,
+            accessPoints.join(","))
+  command_operations_config:
+  - selector: google.cloud.parallelstore.v1.Parallelstore.ImportData
+    display_operation_result: true
+  - selector: google.cloud.parallelstore.v1.Parallelstore.ExportData
+    display_operation_result: true
+- name: Operations
+  api_version: v1
+  root_is_hidden: true
+  release_tracks:
+  - GA
+resource_patterns:
+- type: iam.googleapis.com/ServiceAccount
+  patterns:
+  - projects/{project}/serviceAccounts/{service_account}


### PR DESCRIPTION
Introduce Go structs for parsing a sample gcloud config YAML file. This is a first step to evaluate if we can use sidekick for automating gcloud command generation.