### PR TITLE
impl(storage): `insert_object()` streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,12 +4205,14 @@ dependencies = [
  "anyhow",
  "base64",
  "bytes",
+ "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-storage-control",
  "google-cloud-wkt",
  "http",
+ "http-body-util",
  "lazy_static",
  "percent-encoding",
  "reqwest",
@@ -5899,6 +5901,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -5918,12 +5921,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -6911,6 +6916,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -245,7 +245,7 @@ pub async fn to_http_error<O>(response: reqwest::Response) -> Result<O> {
     let response = http::Response::from(response);
     let (parts, body) = response.into_parts();
 
-    let body = (http_body_util::BodyExt::collect(body))
+    let body = http_body_util::BodyExt::collect(body)
         .await
         .map_err(Error::io)?
         .to_bytes();

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -245,7 +245,7 @@ pub async fn to_http_error<O>(response: reqwest::Response) -> Result<O> {
     let response = http::Response::from(response);
     let (parts, body) = response.into_parts();
 
-    let body = http_body_util::BodyExt::collect(body)
+    let body = (http_body_util::BodyExt::collect(body))
         .await
         .map_err(Error::io)?
         .to_bytes();

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -166,7 +166,11 @@ pub async fn objects_large_file(builder: storage::client::ClientBuilder) -> Resu
 
     tracing::info!("testing insert_object()");
     let insert = client
-        .insert_object(&bucket.name, "quick.text", contents.clone())
+        .insert_object(
+            &bucket.name,
+            "quick.text",
+            bytes::Bytes::from_owner(contents.clone()),
+        )
         .send()
         .await?;
     tracing::info!("success with insert={insert:?}");

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -30,9 +30,10 @@ rust-version.workspace = true
 base64.workspace           = true
 bytes.workspace            = true
 http.workspace             = true
+futures.workspace          = true
 lazy_static.workspace      = true
 percent-encoding.workspace = true
-reqwest.workspace          = true
+reqwest                    = { workspace = true, features = ["stream"] }
 serde.workspace            = true
 serde_json.workspace       = true
 serde_with.workspace       = true
@@ -48,8 +49,9 @@ gaxi           = { workspace = true, features = ["_internal-common", "_internal-
 wkt.workspace  = true
 
 [dev-dependencies]
-anyhow.workspace     = true
-test-case.workspace  = true
-tempfile.workspace   = true
-tokio-test.workspace = true
-tokio.workspace      = true
+anyhow.workspace         = true
+http-body-util.workspace = true
+test-case.workspace      = true
+tempfile.workspace       = true
+tokio-test.workspace     = true
+tokio.workspace          = true

--- a/src/storage/src/client.rs
+++ b/src/storage/src/client.rs
@@ -14,10 +14,12 @@
 
 pub use crate::Error;
 pub use crate::Result;
+use crate::upload_source::{InsertPayload, StreamingSource};
 use auth::credentials::CacheableResource;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 pub use control::model::Object;
+use futures::stream::unfold;
 use http::Extensions;
 use sha2::{Digest, Sha256};
 
@@ -129,11 +131,12 @@ impl Storage {
     /// println!("response details={response:?}");
     /// # Ok::<(), anyhow::Error>(()) });
     /// ```
-    pub fn insert_object<B, O, P>(&self, bucket: B, object: O, payload: P) -> InsertObject
+    pub fn insert_object<B, O, T, P>(&self, bucket: B, object: O, payload: T) -> InsertObject<P>
     where
         B: Into<String>,
         O: Into<String>,
-        P: Into<bytes::Bytes>,
+        T: Into<InsertPayload<P>>,
+        InsertPayload<P>: StreamingSource,
     {
         InsertObject::new(self.inner.clone(), bucket, object, payload)
     }
@@ -269,32 +272,38 @@ pub(crate) mod info {
     }
 }
 
-pub struct InsertObject {
+pub struct InsertObject<T> {
     inner: std::sync::Arc<StorageInner>,
     request: control::model::WriteObjectRequest,
+    payload: InsertPayload<T>,
 }
 
-impl InsertObject {
+impl<T> InsertObject<T> {
     fn new<B, O, P>(inner: std::sync::Arc<StorageInner>, bucket: B, object: O, payload: P) -> Self
     where
         B: Into<String>,
         O: Into<String>,
-        P: Into<bytes::Bytes>,
+        P: Into<InsertPayload<T>>,
     {
         InsertObject {
             inner,
-            request: control::model::WriteObjectRequest::new()
-                .set_write_object_spec(
-                    control::model::WriteObjectSpec::new().set_resource(
-                        control::model::Object::new()
-                            .set_bucket(bucket)
-                            .set_name(object),
-                    ),
-                )
-                .set_checksummed_data(control::model::ChecksummedData::new().set_content(payload)),
+            request: control::model::WriteObjectRequest::new().set_write_object_spec(
+                control::model::WriteObjectSpec::new().set_resource(
+                    control::model::Object::new()
+                        .set_bucket(bucket)
+                        .set_name(object),
+                ),
+            ),
+            payload: payload.into(),
         }
     }
+}
 
+impl<T> InsertObject<T>
+where
+    T: StreamingSource + Send + Sync + 'static,
+    T::Error: std::error::Error + Send + Sync + 'static,
+{
     /// A simple upload from a buffer.
     ///
     /// # Example
@@ -358,11 +367,16 @@ impl InsertObject {
         );
 
         let builder = self.inner.apply_auth_headers(builder).await?;
-        let content = match self.request.data {
-            Some(Data::ChecksummedData(data)) => data.content,
-            _ => unreachable!("content for the checksummed data is set in the constructor"),
-        };
-        let builder = builder.body(content);
+
+        let stream = Box::pin(unfold(Some(self.payload), move |state| async move {
+            if let Some(mut payload) = state {
+                if let Some(n) = payload.next().await {
+                    return Some((n, Some(payload)));
+                }
+            }
+            None
+        }));
+        let builder = builder.body(reqwest::Body::wrap_stream(stream));
         Ok(builder)
     }
 
@@ -897,6 +911,7 @@ fn apply_customer_supplied_encryption_headers(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::upload_source::test::VecStream;
     use std::{collections::HashMap, error::Error};
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
     use test_case::test_case;
@@ -909,20 +924,56 @@ mod tests {
             .build()
             .await?;
 
-        let insert_object_builder = client
+        let request = client
             .insert_object("projects/_/buckets/bucket", "object", "hello")
             .http_request_builder()
             .await?
             .build()?;
 
-        assert_eq!(insert_object_builder.method(), reqwest::Method::POST);
+        assert_eq!(request.method(), reqwest::Method::POST);
         assert_eq!(
-            insert_object_builder.url().as_str(),
+            request.url().as_str(),
             "http://private.googleapis.com/upload/storage/v1/b/bucket/o?uploadType=media&name=object"
         );
+        let mut request = request;
+        let body = request.body_mut().take().unwrap();
+        let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
+        assert_eq!(bytes::Bytes::from_static(b"hello"), contents);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_object_stream() -> Result {
+        let client = Storage::builder()
+            .with_endpoint("http://private.googleapis.com")
+            .with_credentials(auth::credentials::testing::test_credentials())
+            .build()
+            .await?;
+
+        let stream = VecStream::new(
+            [
+                "the ", "quick ", "brown ", "fox ", "jumps ", "over ", "the ", "lazy ", "dog",
+            ]
+            .map(|x| bytes::Bytes::from_static(x.as_bytes()))
+            .to_vec(),
+        );
+        let request = client
+            .insert_object("projects/_/buckets/bucket", "object", stream)
+            .http_request_builder()
+            .await?
+            .build()?;
+
+        assert_eq!(request.method(), reqwest::Method::POST);
         assert_eq!(
-            b"hello",
-            insert_object_builder.body().unwrap().as_bytes().unwrap()
+            request.url().as_str(),
+            "http://private.googleapis.com/upload/storage/v1/b/bucket/o?uploadType=media&name=object"
+        );
+        let mut request = request;
+        let body = request.body_mut().take().unwrap();
+        let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
+        assert_eq!(
+            bytes::Bytes::from_static(b"the quick brown fox jumps over the lazy dog"),
+            contents
         );
         Ok(())
     }

--- a/src/storage/src/upload_source.rs
+++ b/src/storage/src/upload_source.rs
@@ -179,7 +179,7 @@ impl StreamingSource for BytesSource {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
     use std::{collections::VecDeque, io::Write};
     use tempfile::NamedTempFile;
@@ -330,13 +330,13 @@ mod test {
         Ok(())
     }
 
-    struct VecStream {
+    pub struct VecStream {
         contents: Vec<bytes::Bytes>,
         current: VecDeque<std::io::Result<bytes::Bytes>>,
     }
 
     impl VecStream {
-        fn new(contents: Vec<bytes::Bytes>) -> Self {
+        pub fn new(contents: Vec<bytes::Bytes>) -> Self {
             let current: VecDeque<std::io::Result<_>> =
                 contents.iter().map(|x| Ok(x.clone())).collect();
             Self { contents, current }


### PR DESCRIPTION
Consume bytes as well as streaming types into `insert_object()`.

Fixes #2042
