### PR TITLE
cleanup: no typos when "onboarding"

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -50,10 +50,6 @@ go -C generator/ run ./cmd/sidekick rust-generate \
     -service-config ${yaml}
 ```
 
-Often we identify typos in the Protobuf comments. Add the typos to the ignore
-list on `.typos.toml` and fix the problem upstream. Do not treat this as a
-blocker.
-
 Commit all these changes and send a PR to merge them:
 
 ```bash


### PR DESCRIPTION
Follow up to #2570, `typos` is no longer an error case when generating a new library.