### PR TITLE
impl(generator): methods know auto-populated fields

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -224,6 +224,13 @@ type Method struct {
 	OperationInfo *OperationInfo
 	// The routing annotations, if any
 	Routing []*RoutingInfo
+	// The auto-populated (request_id) field, if any, as defined in
+	// [AIP-4235](https://google.aip.dev/client-libraries/4235)
+	//
+	// The field must be eligible for auto-population, and be listed in the
+	// `google.api.MethodSettings.auto_populated_fields` entry in
+	// `google.api.Publishing.method_settings` in the service config file.
+	AutoPopulated []*Field
 	// The model this method belongs to, mustache templates use this field to
 	// navigate the data structure.
 	Model *API
@@ -541,16 +548,15 @@ type Field struct {
 	// containing message. That triggers slightly different code generation for
 	// some languages.
 	Recursive bool
-	// AutoPopulated is true if the field meets the requirements in AIP-4235.
+	// AutoPopulated is true if the field is eligible to be auto-populated,
+	// per the requirements in AIP-4235.
+	//
 	// That is:
 	// - It has Typez == STRING_TYPE
-	// - For Protobuf, has the `google.api.field_behavior = REQUIRED` annotation
+	// - For Protobuf, does not have the `google.api.field_behavior = REQUIRED` annotation
 	// - For Protobuf, has the `google.api.field_info.format = UUID4` annotation
-	// - For OpenAPI, it is a required field
+	// - For OpenAPI, it is an optional field
 	// - For OpenAPI, it has format == "uuid"
-	// - In the service config file, it is listed in the
-	//   `google.api.MethodSettings.auto_populated_fields` entry in
-	//   `google.api.Publishing.method_settings`
 	AutoPopulated bool
 	// FieldBehavior indicates how the field behaves in requests and responses.
 	//

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -983,7 +983,7 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 		Publishing: &annotations.Publishing{
 			MethodSettings: []*annotations.MethodSettings{
 				{
-					Selector: ".test.TestService.CreateFoo",
+					Selector: "test.TestService.CreateFoo",
 					AutoPopulatedFields: []string{
 						"requestId",
 						"requestIdExplicitlyNotRequired",
@@ -1012,6 +1012,26 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.CreateFooRequest")
 	}
+	request_id := &api.Field{
+		Name:          "requestId",
+		JSONName:      "requestId",
+		Documentation: "Test-only Description",
+		Typez:         api.STRING_TYPE,
+		TypezID:       "string",
+		Synthetic:     true,
+		Optional:      true,
+		AutoPopulated: true,
+	}
+	request_id_explicit := &api.Field{
+		Name:          "requestIdExplicitlyNotRequired",
+		JSONName:      "requestIdExplicitlyNotRequired",
+		Documentation: "Test-only Description",
+		Typez:         api.STRING_TYPE,
+		TypezID:       "string",
+		Synthetic:     true,
+		Optional:      true,
+		AutoPopulated: true,
+	}
 	checkMessage(t, message, &api.Message{
 		Name:          "CreateFooRequest",
 		ID:            ".test.CreateFooRequest",
@@ -1036,26 +1056,8 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				Synthetic:     true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
-			{
-				Name:          "requestId",
-				JSONName:      "requestId",
-				Documentation: "Test-only Description",
-				Typez:         api.STRING_TYPE,
-				TypezID:       "string",
-				Synthetic:     true,
-				Optional:      true,
-				AutoPopulated: true,
-			},
-			{
-				Name:          "requestIdExplicitlyNotRequired",
-				JSONName:      "requestIdExplicitlyNotRequired",
-				Documentation: "Test-only Description",
-				Typez:         api.STRING_TYPE,
-				TypezID:       "string",
-				Synthetic:     true,
-				Optional:      true,
-				AutoPopulated: true,
-			},
+			request_id,
+			request_id_explicit,
 			{
 				Name:          "notRequestIdRequired",
 				Documentation: "Test-only Description",
@@ -1082,9 +1084,21 @@ func TestOpenAPI_AutoPopulated(t *testing.T) {
 				JSONName:      "notRequestIdMissingServiceConfig",
 				Synthetic:     true,
 				Optional:      true,
+				// This just denotes that the field is eligible
+				// to be auto-populated
+				AutoPopulated: true,
 			},
 		},
 	})
+
+	method, ok := test.State.MethodByID[".test.TestService.CreateFoo"]
+	if !ok {
+		t.Fatalf("Cannot find method %s in API State", ".test.TestService.CreateFoo")
+	}
+	want := []*api.Field{request_id, request_id_explicit}
+	if diff := cmp.Diff(want, method.AutoPopulated); diff != "" {
+		t.Errorf("incorrect auto-populated fields on method (-want, +got)\n:%s", diff)
+	}
 }
 
 func TestOpenAPI_Deprecated(t *testing.T) {

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1414,7 +1414,7 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 		Publishing: &annotations.Publishing{
 			MethodSettings: []*annotations.MethodSettings{
 				{
-					Selector: ".test.TestService.CreateFoo",
+					Selector: "test.TestService.CreateFoo",
 					AutoPopulatedFields: []string{
 						"request_id",
 						"request_id_optional",
@@ -1441,6 +1441,32 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 	message, ok := test.State.MessageByID[".test.CreateFooRequest"]
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.CreateFooRequest")
+	}
+	request_id := &api.Field{
+		Name:     "request_id",
+		JSONName: "requestId",
+		ID:       ".test.CreateFooRequest.request_id",
+		Documentation: "This is an auto-populated field. The remaining fields almost meet the\n" +
+			"requirements to be auto-populated, but fail for the reasons implied by\n" +
+			"their name.",
+		Typez:         api.STRING_TYPE,
+		AutoPopulated: true,
+	}
+	request_id_optional := &api.Field{
+		Name:          "request_id_optional",
+		ID:            ".test.CreateFooRequest.request_id_optional",
+		Typez:         api.STRING_TYPE,
+		JSONName:      "requestIdOptional",
+		Optional:      true,
+		AutoPopulated: true,
+	}
+	request_id_with_field_behavior := &api.Field{
+		Name:          "request_id_with_field_behavior",
+		ID:            ".test.CreateFooRequest.request_id_with_field_behavior",
+		Typez:         api.STRING_TYPE,
+		JSONName:      "requestIdWithFieldBehavior",
+		AutoPopulated: true,
+		Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_OPTIONAL, api.FIELD_BEHAVIOR_INPUT_ONLY},
 	}
 	checkMessage(t, message, &api.Message{
 		Name:          "CreateFooRequest",
@@ -1474,33 +1500,9 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 				Optional:      true,
 				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_REQUIRED},
 			},
-			{
-				Name:     "request_id",
-				JSONName: "requestId",
-				ID:       ".test.CreateFooRequest.request_id",
-				Documentation: "This is an auto-populated field. The remaining fields almost meet the\n" +
-					"requirements to be auto-populated, but fail for the reasons implied by\n" +
-					"their name.",
-				Typez:         api.STRING_TYPE,
-				AutoPopulated: true,
-			},
-			{
-				Name:          "request_id_optional",
-				ID:            ".test.CreateFooRequest.request_id_optional",
-				Typez:         api.STRING_TYPE,
-				JSONName:      "requestIdOptional",
-				Optional:      true,
-				AutoPopulated: true,
-			},
-			{
-				Name:          "request_id_with_field_behavior",
-				ID:            ".test.CreateFooRequest.request_id_with_field_behavior",
-				Typez:         api.STRING_TYPE,
-				JSONName:      "requestIdWithFieldBehavior",
-				AutoPopulated: true,
-				Behavior:      []api.FieldBehavior{api.FIELD_BEHAVIOR_OPTIONAL, api.FIELD_BEHAVIOR_INPUT_ONLY},
-			},
-
+			request_id,
+			request_id_optional,
+			request_id_with_field_behavior,
 			{
 				Name:     "not_request_id_bad_type",
 				ID:       ".test.CreateFooRequest.not_request_id_bad_type",
@@ -1544,9 +1546,21 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 				ID:       ".test.CreateFooRequest.not_request_id_missing_service_config",
 				Typez:    api.STRING_TYPE,
 				JSONName: "notRequestIdMissingServiceConfig",
+				// This just denotes that the field is eligible
+				// to be auto-populated
+				AutoPopulated: true,
 			},
 		},
 	})
+
+	method, ok := test.State.MethodByID[".test.TestService.CreateFoo"]
+	if !ok {
+		t.Fatalf("Cannot find method %s in API State", ".test.TestService.CreateFoo")
+	}
+	want := []*api.Field{request_id, request_id_optional, request_id_with_field_behavior}
+	if diff := cmp.Diff(want, method.AutoPopulated); diff != "" {
+		t.Errorf("incorrect auto-populated fields on method (-want, +got)\n:%s", diff)
+	}
 }
 
 func TestProtobuf_Deprecated(t *testing.T) {


### PR DESCRIPTION
Part of the work for #439 

Capture auto-populated fields on the method.

Just flagging a field is not really what we want. Two methods could use the same request. In one method the field could be auto-populated, and in the other it may not be. (This is farfetched, but allowed by the spec). Also the code we are going to generate is scoped to a method.

I considered only keeping a single `*Field`, as it really doesn't make sense for a request to be tied to multiple UUIDs.... but the spec allows for it, so we will allow for it in the model. :shrug: 

Selectors in practice do not start with a leading period. We need to remove those:

https://github.com/googleapis/googleapis/blob/acb0511f2c402f14f1e0c97864a9c27a850ff235/google/storage/control/v2/storage_v2.yaml#L53