### PR TITLE
cleanup(generator/rust): pare package codec

### DIFF
--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -1102,7 +1102,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 	api.CrossReference(model)
 	api.LabelRecursiveFields(model)
 	codec, err := newCodec(true, map[string]string{
-		"package:wkt": "force-used=true,package=google-cloud-wkt,path=src/wkt,source=google.protobuf,version=0.2",
+		"package:wkt": "force-used=true,package=google-cloud-wkt,source=google.protobuf",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -151,8 +151,7 @@ type packageOption struct {
 func parsePackageOption(key, definition string) (*packageOption, error) {
 	var specificationPackages []string
 	pkg := &packagez{
-		name:            strings.TrimPrefix(key, "package:"),
-		defaultFeatures: true,
+		name: strings.TrimPrefix(key, "package:"),
 	}
 	for _, element := range strings.Split(definition, ",") {
 		s := strings.SplitN(element, "=", 2)
@@ -162,20 +161,10 @@ func parsePackageOption(key, definition string) (*packageOption, error) {
 		switch s[0] {
 		case "package":
 			pkg.packageName = s[1]
-		case "path":
-			pkg.path = s[1]
-		case "version":
-			pkg.version = s[1]
 		case "source":
 			specificationPackages = append(specificationPackages, s[1])
 		case "feature":
-			pkg.features = append(pkg.features, strings.Split(s[1], ",")...)
-		case "default-features":
-			value, err := strconv.ParseBool(s[1])
-			if err != nil {
-				return nil, fmt.Errorf("cannot convert `default-features` value %q (part of %q) to boolean: %w", definition, s[1], err)
-			}
-			pkg.defaultFeatures = value
+			pkg.features = append(pkg.features, s[1])
 		case "ignore":
 			value, err := strconv.ParseBool(s[1])
 			if err != nil {
@@ -264,10 +253,6 @@ type packagez struct {
 	ignore bool
 	// What the Rust package calls itself.
 	packageName string
-	// The path to file the package locally, unused if empty.
-	path string
-	// The version of the package, unused if empty.
-	version string
 	// Optional features enabled for the package.
 	features []string
 	// If true, this package was referenced by a generated message, service, or
@@ -277,8 +262,6 @@ type packagez struct {
 	// present. For example, the LRO support helpers are used if LROs are found,
 	// and the service support functions are used if any service is found.
 	usedIf []string
-	// If true, the default features are enabled.
-	defaultFeatures bool
 }
 
 var wellKnownMessages = []*api.Message{

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -31,7 +31,6 @@ func createRustCodec() *codec {
 	wkt := &packagez{
 		name:        "wkt",
 		packageName: "types",
-		path:        "../../types",
 	}
 
 	return &codec{
@@ -49,9 +48,9 @@ func TestParseOptionsProtobuf(t *testing.T) {
 		"package-name-override":     "test-only",
 		"copyright-year":            "2035",
 		"module-path":               "alternative::generated",
-		"package:wkt":               "package=types,path=src/wkt,source=google.protobuf,source=test-only",
-		"package:gax":               "package=gax,path=src/gax,feature=unstable-sdk-client",
-		"package:serde_with":        "package=serde_with,version=2.3.4,default-features=false",
+		"package:wkt":               "package=types,source=google.protobuf,source=test-only",
+		"package:gax":               "package=gax,feature=unstable-sdk-client",
+		"package:serde_with":        "package=serde_with",
 		"include-grpc-only-methods": "true",
 		"per-service-features":      "true",
 	}
@@ -60,10 +59,8 @@ func TestParseOptionsProtobuf(t *testing.T) {
 		t.Fatal(err)
 	}
 	gp := &packagez{
-		name:            "wkt",
-		packageName:     "types",
-		path:            "src/wkt",
-		defaultFeatures: true,
+		name:        "wkt",
+		packageName: "types",
 	}
 	want := &codec{
 		version:             "1.2.3",
@@ -76,17 +73,13 @@ func TestParseOptionsProtobuf(t *testing.T) {
 			{
 				name:        "gax",
 				packageName: "gax",
-				path:        "src/gax",
 				features: []string{
 					"unstable-sdk-client",
 				},
-				defaultFeatures: true,
 			},
 			{
-				name:            "serde_with",
-				packageName:     "serde_with",
-				version:         "2.3.4",
-				defaultFeatures: false,
+				name:        "serde_with",
+				packageName: "serde_with",
 			},
 		},
 		packageMapping: map[string]*packagez{
@@ -1297,12 +1290,10 @@ func TestFormatDocCommentsCrossLinks(t *testing.T) {
 	wkt := &packagez{
 		name:        "wkt",
 		packageName: "google-cloud-wkt",
-		path:        "src/wkt",
 	}
 	iam := &packagez{
 		name:        "iam_v1",
 		packageName: "gcp-sdk-iam-v1",
-		path:        "src/generated/iam/v1",
 	}
 	c := &codec{
 		modulePath: "crate::model",
@@ -1359,12 +1350,10 @@ func TestFormatDocCommentsRelativeCrossLinks(t *testing.T) {
 	wkt := &packagez{
 		name:        "wkt",
 		packageName: "google-cloud-wkt",
-		path:        "src/wkt",
 	}
 	iam := &packagez{
 		name:        "iam_v1",
 		packageName: "gcp-sdk-iam-v1",
-		path:        "src/generated/iam/v1",
 	}
 	c := &codec{
 		modulePath: "crate::model",
@@ -1421,12 +1410,10 @@ implied enum value reference [SomeMessage.SomeEnum.ENUM_VALUE][]
 	wkt := &packagez{
 		name:        "wkt",
 		packageName: "google-cloud-wkt",
-		path:        "src/wkt",
 	}
 	iam := &packagez{
 		name:        "iam_v1",
 		packageName: "gcp-sdk-iam-v1",
-		path:        "src/generated/iam/v1",
 	}
 	c := &codec{
 		modulePath: "crate::model",
@@ -1622,12 +1609,10 @@ Hyperlink: <a href="https://hyperlink.com">Content</a>`
 	wkt := &packagez{
 		name:        "wkt",
 		packageName: "google-cloud-wkt",
-		path:        "src/wkt",
 	}
 	iam := &packagez{
 		name:        "iam_v1",
 		packageName: "gcp-sdk-iam-v1",
-		path:        "src/generated/iam/v1",
 	}
 	c := &codec{
 		modulePath: "model",

--- a/generator/internal/rust/used_by_test.go
+++ b/generator/internal/rust/used_by_test.go
@@ -29,8 +29,8 @@ func TestUsedByServicesWithServices(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
 	c, err := newCodec(true, map[string]string{
-		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
-		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
+		"package:tracing":  "used-if=services,package=tracing",
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -39,19 +39,14 @@ func TestUsedByServicesWithServices(t *testing.T) {
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
-			name:            "location",
-			packageName:     "gcp-sdk-location",
-			path:            "src/generated/cloud/location",
-			version:         "0.1.0",
-			defaultFeatures: true,
+			name:        "location",
+			packageName: "gcp-sdk-location",
 		},
 		{
-			name:            "tracing",
-			packageName:     "tracing",
-			version:         "0.1.41",
-			used:            true,
-			usedIf:          []string{"services"},
-			defaultFeatures: true,
+			name:        "tracing",
+			packageName: "tracing",
+			used:        true,
+			usedIf:      []string{"services"},
 		},
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
@@ -63,8 +58,8 @@ func TestUsedByServicesWithServices(t *testing.T) {
 func TestUsedByServicesNoServices(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c, err := newCodec(true, map[string]string{
-		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
-		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
+		"package:tracing":  "used-if=services,package=tracing",
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -73,18 +68,13 @@ func TestUsedByServicesNoServices(t *testing.T) {
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
-			name:            "location",
-			packageName:     "gcp-sdk-location",
-			path:            "src/generated/cloud/location",
-			version:         "0.1.0",
-			defaultFeatures: true,
+			name:        "location",
+			packageName: "gcp-sdk-location",
 		},
 		{
-			name:            "tracing",
-			packageName:     "tracing",
-			version:         "0.1.41",
-			usedIf:          []string{"services"},
-			defaultFeatures: true,
+			name:        "tracing",
+			packageName: "tracing",
+			usedIf:      []string{"services"},
 		},
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
@@ -105,8 +95,8 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
 	c, err := newCodec(true, map[string]string{
-		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
-		"package:lro":      "used-if=lro,package=google-cloud-lro,path=src/lro,version=0.1.0",
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
+		"package:lro":      "used-if=lro,package=google-cloud-lro",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -115,20 +105,14 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
-			name:            "location",
-			packageName:     "gcp-sdk-location",
-			path:            "src/generated/cloud/location",
-			version:         "0.1.0",
-			defaultFeatures: true,
+			name:        "location",
+			packageName: "gcp-sdk-location",
 		},
 		{
-			name:            "lro",
-			packageName:     "google-cloud-lro",
-			path:            "src/lro",
-			version:         "0.1.0",
-			used:            true,
-			usedIf:          []string{"lro"},
-			defaultFeatures: true,
+			name:        "lro",
+			packageName: "google-cloud-lro",
+			used:        true,
+			usedIf:      []string{"lro"},
 		},
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
@@ -148,8 +132,8 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
 	c, err := newCodec(true, map[string]string{
-		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
-		"package:lro":      "used-if=lro,package=google-cloud-lro,path=src/lro,version=0.1.0",
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
+		"package:lro":      "used-if=lro,package=google-cloud-lro",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -158,20 +142,14 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 	resolveUsedPackages(model, c.extraPackages)
 	want := []*packagez{
 		{
-			name:            "location",
-			packageName:     "gcp-sdk-location",
-			path:            "src/generated/cloud/location",
-			version:         "0.1.0",
-			defaultFeatures: true,
+			name:        "location",
+			packageName: "gcp-sdk-location",
 		},
 		{
-			name:            "lro",
-			packageName:     "google-cloud-lro",
-			path:            "src/lro",
-			version:         "0.1.0",
-			used:            false,
-			usedIf:          []string{"lro"},
-			defaultFeatures: true,
+			name:        "lro",
+			packageName: "google-cloud-lro",
+			used:        false,
+			usedIf:      []string{"lro"},
 		},
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
@@ -184,8 +162,8 @@ func TestRequiredPackages(t *testing.T) {
 	options := map[string]string{
 		"package:async-trait": "package=async-trait,force-used=true",
 		"package:serde_with":  "package=serde_with,force-used=true,feature=base64,feature=macro,feature=std",
-		"package:gtype":       "package=gcp-sdk-type,path=src/generated/type,source=google.type,source=test-only",
-		"package:gax":         "package=gcp-sdk-gax,path=src/gax,version=1.2.3,force-used=true",
+		"package:gtype":       "package=gcp-sdk-type,source=google.type,source=test-only",
+		"package:gax":         "package=gcp-sdk-gax,force-used=true",
 		"package:auth":        "ignore=true",
 	}
 	c, err := newCodec(true, options)
@@ -208,7 +186,7 @@ func TestRequiredPackagesLocal(t *testing.T) {
 	// This is not a thing we expect to do in the Rust repository, but the
 	// behavior is consistent.
 	options := map[string]string{
-		"package:gtype": "package=types,path=src/generated/type,source=google.type,source=test-only,force-used=true",
+		"package:gtype": "package=types,source=google.type,source=test-only,force-used=true",
 	}
 	c, err := newCodec(true, options)
 	if err != nil {
@@ -259,8 +237,8 @@ func TestFindUsedPackages(t *testing.T) {
 	}
 
 	c, err := newCodec(true, map[string]string{
-		"package:common":      "package=google-cloud-common,source=google.cloud.common,path=src/generated/cloud/common,version=0.2",
-		"package:longrunning": "package=google-longrunning,source=google.longrunning,path=src/generated/longrunning,version=0.2",
+		"package:common":      "package=google-cloud-common,source=google.cloud.common",
+		"package:longrunning": "package=google-longrunning,source=google.longrunning",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -269,20 +247,14 @@ func TestFindUsedPackages(t *testing.T) {
 	findUsedPackages(model, c)
 	want := []*packagez{
 		{
-			name:            "common",
-			packageName:     "google-cloud-common",
-			path:            "src/generated/cloud/common",
-			version:         "0.2",
-			defaultFeatures: true,
-			used:            true,
+			name:        "common",
+			packageName: "google-cloud-common",
+			used:        true,
 		},
 		{
-			name:            "longrunning",
-			packageName:     "google-longrunning",
-			path:            "src/generated/longrunning",
-			version:         "0.2",
-			defaultFeatures: true,
-			used:            true,
+			name:        "longrunning",
+			packageName: "google-longrunning",
+			used:        true,
 		},
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }

--- a/generator/internal/sidekick/cmdline_test.go
+++ b/generator/internal/sidekick/cmdline_test.go
@@ -40,8 +40,8 @@ func TestParseArgs(t *testing.T) {
 		"-output", outputDir,
 		"-codec-option", "copyright-year=2024",
 		"-codec-option", "package-name-override=secretmanager-golden-openapi",
-		"-codec-option", "package:wkt=package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
-		"-codec-option", "package:gax=package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client",
+		"-codec-option", "package:wkt=package=google-cloud-wkt,source=google.protobuf",
+		"-codec-option", "package:gax=package=gcp-sdk-gax,feature=unstable-sdk-client",
 	}
 	cmd, _, args := cmdSidekick.lookup(args)
 	if cmd.name() != "generate" {
@@ -66,8 +66,8 @@ func TestParseArgs(t *testing.T) {
 		Codec: map[string]string{
 			"copyright-year":        "2024",
 			"package-name-override": "secretmanager-golden-openapi",
-			"package:wkt":           "package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
-			"package:gax":           "package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client",
+			"package:wkt":           "package=google-cloud-wkt,source=google.protobuf",
+			"package:gax":           "package=gcp-sdk-gax,feature=unstable-sdk-client",
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/generator/internal/sidekick/sidekick_rust_prost_convert_test.go
+++ b/generator/internal/sidekick/sidekick_rust_prost_convert_test.go
@@ -40,7 +40,7 @@ func TestRustProstConvert(t *testing.T) {
 			Name:          "rpc",
 			ExtraOptions: map[string]string{
 				"module-path": "crate::error::rpc::generated",
-				"package:wkt": "package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
+				"package:wkt": "package=google-cloud-wkt,source=google.protobuf",
 			},
 		},
 	}

--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -57,8 +57,8 @@ func TestRustFromOpenAPI(t *testing.T) {
 			"not-for-publication":       "true",
 			"copyright-year":            "2024",
 			"package-name-override":     "secretmanager-golden-openapi",
-			"package:wkt":               "package=google-cloud-wkt,path=../src/wkt,source=google.protobuf",
-			"package:gax":               "package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client",
+			"package:wkt":               "package=google-cloud-wkt,source=google.protobuf",
+			"package:gax":               "package=gcp-sdk-gax,feature=unstable-sdk-client",
 			"disabled-rustdoc-warnings": "redundant_explicit_links",
 		},
 	}
@@ -108,7 +108,7 @@ func TestRustFromProtobuf(t *testing.T) {
 			Source: "googleapis/google/iam/v1",
 			Name:   "iam/v1",
 			ExtraOptions: map[string]string{
-				"package:gtype":             fmt.Sprintf("package=type-golden-protobuf,path=%s/rust/protobuf/golden/type,source=google.type", testdataDir),
+				"package:gtype":             "package=type-golden-protobuf,source=google.type",
 				"disabled-rustdoc-warnings": "redundant_explicit_links,broken_intra_doc_links",
 			},
 		},
@@ -117,8 +117,8 @@ func TestRustFromProtobuf(t *testing.T) {
 			ServiceConfig: secretManagerServiceConfig,
 			Name:          "secretmanager",
 			ExtraOptions: map[string]string{
-				"package:iam":               fmt.Sprintf("package=iam-v1-golden-protobuf,path=%s/rust/protobuf/golden/iam/v1,source=google.iam.v1", testdataDir),
-				"package:location":          fmt.Sprintf("package=location-golden-protobuf,path=%s/rust/protobuf/golden/location,source=google.cloud.location", testdataDir),
+				"package:iam":               "package=iam-v1-golden-protobuf,source=google.iam.v1",
+				"package:location":          "package=location-golden-protobuf,source=google.cloud.location",
 				"disabled-rustdoc-warnings": "broken_intra_doc_links",
 			},
 		},
@@ -145,8 +145,8 @@ func TestRustFromProtobuf(t *testing.T) {
 				"not-for-publication":   "true",
 				"copyright-year":        "2024",
 				"package-name-override": strings.Replace(config.Name, "/", "-", -1) + "-golden-protobuf",
-				"package:wkt":           "package=google-cloud-wkt,path=../src/wkt,source=google.protobuf",
-				"package:gax":           "package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client",
+				"package:wkt":           "package=google-cloud-wkt,source=google.protobuf",
+				"package:gax":           "package=gcp-sdk-gax,feature=unstable-sdk-client",
 			},
 		}
 		for k, v := range config.ExtraOptions {
@@ -190,7 +190,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 			Name:          "rpc",
 			ExtraOptions: map[string]string{
 				"module-path": "crate::error::rpc::generated",
-				"package:wkt": "package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
+				"package:wkt": "package=google-cloud-wkt,source=google.protobuf",
 			},
 		},
 		{


### PR DESCRIPTION
Noticed while doing #439 

We define all of our dependent packages in the top-level `Cargo.toml` (including our own common crates).

In generated crates, we can just reference `foo.workspace = true` to pick up these crates.

We don't need to support `path` / `version` / `defaultFeatures` via the codec. They don't factor into the generated code:

https://github.com/googleapis/google-cloud-rust/blob/040c93c395529cf1aaf8d8b4a09ed7ed353922a1/generator/internal/rust/codec.go#L1344-L1350