### PR TITLE
impl(generator/rust): uuid dep if auto-population

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -58,7 +58,7 @@ disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links"
 # Only used if LROs are present
 'package:lro' = 'used-if=lro,package=google-cloud-lro'
 # Only used if a service has auto-populated fields
-'package:uuid' = 'used-if=autopopulated,package=uuid,feature=v4'
+'package:uuid' = 'used-if=autopopulated,package=uuid'
 # I (coryan@) got lazy, it is tedious to auto-detect if this is used in `sidekick`.
 # OTOH, the only case where this is not used is a crate without any messages, i.e., just enums.
 'package:wkt' = 'force-used=true,package=google-cloud-wkt,source=google.protobuf'

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -57,6 +57,8 @@ disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links"
 'package:tracing'     = 'used-if=services,package=tracing'
 # Only used if LROs are present
 'package:lro' = 'used-if=lro,package=google-cloud-lro'
+# Only used if a service has auto-populated fields
+'package:uuid' = 'used-if=autopopulated,package=uuid,feature=v4'
 # I (coryan@) got lazy, it is tedious to auto-detect if this is used in `sidekick`.
 # OTOH, the only case where this is not used is a crate without any messages, i.e., just enums.
 'package:wkt' = 'force-used=true,package=google-cloud-wkt,source=google.protobuf'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,6 +4109,7 @@ dependencies = [
  "serde_with",
  "tokio-test",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -6816,6 +6817,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,7 @@ tonic-build        = { default-features = false, version = "0.13" }
 tracing            = { default-features = false, version = "0.1", features = ["attributes"] }
 tracing-subscriber = { default-features = false, version = "0.3" }
 url                = { default-features = false, version = "2" }
+uuid               = { default-features = false, version = "1", features = ["v4"] }
 # Test packages
 anyhow         = { default-features = false, version = "1" }
 axum           = { default-features = false, version = "0.8" }

--- a/generator/internal/rust/used_by_test.go
+++ b/generator/internal/rust/used_by_test.go
@@ -190,7 +190,7 @@ func TestUsedByUuidWithAutoPopulation(t *testing.T) {
 			name:        "uuid",
 			packageName: "uuid",
 			used:        true,
-			usedIf:      []string{"uuid"},
+			usedIf:      []string{"autopopulated"},
 			features:    []string{"v4"},
 		},
 	}
@@ -228,7 +228,7 @@ func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
 			name:        "uuid",
 			packageName: "uuid",
 			used:        false,
-			usedIf:      []string{"uuid"},
+			usedIf:      []string{"autopopulated"},
 			features:    []string{"v4"},
 		},
 	}

--- a/generator/internal/rust/used_by_test.go
+++ b/generator/internal/rust/used_by_test.go
@@ -51,7 +51,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
 	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
 	}
 }
 
@@ -79,7 +79,7 @@ func TestUsedByServicesNoServices(t *testing.T) {
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
 	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
 	}
 }
 
@@ -117,7 +117,7 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
 	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
 	}
 }
 
@@ -154,7 +154,87 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
 	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUsedByUuidWithAutoPopulation(t *testing.T) {
+	request_id := &api.Field{
+		AutoPopulated: true,
+	}
+	method := &api.Method{
+		Name:          "CreateResource",
+		AutoPopulated: []*api.Field{request_id},
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(true, map[string]string{
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
+		"package:uuid":     "used-if=autopopulated,package=uuid,feature=v4",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadWellKnownTypes(model.State)
+	resolveUsedPackages(model, c.extraPackages)
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "uuid",
+			packageName: "uuid",
+			used:        true,
+			usedIf:      []string{"uuid"},
+			features:    []string{"v4"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUsedByUuidWithoutAutoPopulation(t *testing.T) {
+	method := &api.Method{
+		Name: "CreateResource",
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newCodec(true, map[string]string{
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location",
+		"package:uuid":     "used-if=autopopulated,package=uuid,feature=v4",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadWellKnownTypes(model.State)
+	resolveUsedPackages(model, c.extraPackages)
+	want := []*packagez{
+		{
+			name:        "location",
+			packageName: "gcp-sdk-location",
+		},
+		{
+			name:        "uuid",
+			packageName: "uuid",
+			used:        false,
+			usedIf:      []string{"uuid"},
+			features:    []string{"v4"},
+		},
+	}
+	less := func(a, b *packagez) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
 	}
 }
 
@@ -259,6 +339,6 @@ func TestFindUsedPackages(t *testing.T) {
 	}
 	less := func(a, b *packagez) bool { return a.name < b.name }
 	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(packagez{}), cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+		t.Errorf("mismatched packagez (-want, +got):\n%s", diff)
 	}
 }

--- a/src/generated/showcase/Cargo.toml
+++ b/src/generated/showcase/Cargo.toml
@@ -43,6 +43,7 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 tracing.workspace    = true
+uuid.workspace       = true
 wkt.workspace        = true
 
 [dev-dependencies]

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -33,6 +33,7 @@ extern crate serde_json;
 extern crate serde_with;
 extern crate std;
 extern crate tracing;
+extern crate uuid;
 extern crate wkt;
 
 #[derive(Clone, Debug, Default, PartialEq)]


### PR DESCRIPTION
Part of the work for #439 

Take a dependency on `uuid` if a crate has an RPC with an auto-populated field.

At the moment, the only service with auto-populated fields has a handwritten `Cargo.toml`. Still, it doesn't hurt to put this piece in place for later.