### PR TITLE
cleanup: helpful errors for mustache substitutions

### DIFF
--- a/generator/internal/language/generate.go
+++ b/generator/internal/language/generate.go
@@ -62,6 +62,7 @@ func GenerateFromModel(outdir string, model *api.API, provider TemplateProvider,
 			impl:    provider,
 			dirname: filepath.Dir(gen.TemplatePath),
 		}
+		mustache.AllowMissingVariables = false
 		s, err := mustache.RenderPartials(templateContents, &nestedProvider, model)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
If mustache cannot look something up, it will surface an error instead of printing an empty string.

This doesn't seem to apply to `#`/`^` blocks. So you can still gate code blocks:
```
{{#SkipThisBlock}}
{{#Foos}}
  {{#Bars}}
    // Baz = {{Baz}}
  {{/Bars}}
{{/Foos}}
{{/SkipThisBlock}}
```