### PR TITLE
impl(storage-control): auto-populate request IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,6 +4259,7 @@ dependencies = [
  "tokio-test",
  "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5216,6 +5217,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -6825,6 +6827,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -245,6 +245,10 @@ func (m *Method) HasRouting() bool {
 	return len(m.Routing) != 0
 }
 
+func (m *Method) HasAutoPopulatedFields() bool {
+	return len(m.AutoPopulated) != 0
+}
+
 // Normalized request path information.
 type PathInfo struct {
 	// The list of bindings, including the top-level binding.

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -149,7 +149,13 @@ pub mod {{Codec.ModuleName}} {
                 traits (e.g. `std::clone::Clone`) making the call ambiguous.
                 Using `*self.0.stub` makes the call not-ambiguous.
             }}
+            {{#HasAutoPopulatedFields}}
+            let req = Self::auto_populate(self.0.request, false);
+            (*self.0.stub).{{Codec.Name}}(req, self.0.options).await.map(gax::response::Response::into_body)
+            {{/HasAutoPopulatedFields}}
+            {{^HasAutoPopulatedFields}}
             (*self.0.stub).{{Codec.Name}}(self.0.request, self.0.options).await.map(gax::response::Response::into_body)
+            {{/HasAutoPopulatedFields}}
         }
         {{#Pagination}}
 
@@ -164,6 +170,19 @@ pub mod {{Codec.ModuleName}} {
             {{/Optional}}
             let execute = move |token: String| {
                 let mut builder = self.clone();
+                {{#HasAutoPopulatedFields}}
+                {{!
+                    If we have a new page token, this is a new request. New
+                    requests need new request IDs.
+                }}
+                {{^Optional}}
+                let initial = builder.0.request.{{Codec.FieldName}} == token;
+                {{/Optional}}
+                {{#Optional}}
+                let initial = builder.0.request.{{Codec.FieldName}}.as_deref().is_none_or(|s| s == token);
+                {{/Optional}}
+                builder.0.request = Self::auto_populate(builder.0.request, !initial);
+                {{/HasAutoPopulatedFields}}
                 builder.0.request = builder.0.request.set_{{Codec.SetterName}}(token);
                 builder.send()
             };
@@ -234,6 +253,22 @@ pub mod {{Codec.ModuleName}} {
             {{/Codec.BothAreEmpty}}
         }
         {{/OperationInfo}}
+        {{#HasAutoPopulatedFields}}
+
+        fn auto_populate(mut req: {{InputType.Codec.QualifiedName}}, force: bool) -> {{InputType.Codec.QualifiedName}} {
+            {{#AutoPopulated}}
+            {{#Optional}}
+            if force || req.{{Codec.FieldName}}.is_none() {
+            {{/Optional}}
+            {{^Optional}}
+            if force || req.{{Codec.FieldName}}.is_empty() {
+            {{/Optional}}
+                req = req.set_{{Codec.SetterName}}(uuid::Uuid::new_v4().to_string())
+            }
+            {{/AutoPopulated}}
+            req
+        }
+        {{/HasAutoPopulatedFields}}
         {{#InputType.Codec.BasicFields}}
 
         /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -74,6 +74,12 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         {{/Codec.HasBindingSubstitutions}}
+        {{#HasAutoPopulatedFields}}
+        let options = gax::options::internal::set_default_idempotency(
+            options,
+            true,
+        );
+        {{/HasAutoPopulatedFields}}
         let (builder, method) = None
         {{#PathInfo.Bindings}}
         .or_else(|| {
@@ -128,6 +134,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         })??;
         let options = gax::options::internal::set_default_idempotency(
             options,
+            {{! TODO(#2588) - return idempotency from the above closure }}
             gaxi::http::default_idempotency(&method),
         );
         let builder = builder

--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -97,7 +97,13 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         use gaxi::prost::ToProto;
         let options = gax::options::internal::set_default_idempotency(
             options,
+            {{! TODO(#2588) - resolve this in the model }}
+            {{#HasAutoPopulatedFields}}
+            true,
+            {{/HasAutoPopulatedFields}}
+            {{^HasAutoPopulatedFields}}
             {{PathInfo.Codec.IsIdempotent}},
+            {{/HasAutoPopulatedFields}}
         );
         let extensions = {
             let mut e = tonic::Extensions::new();

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -2444,10 +2444,24 @@ pub mod echo {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::EchoResponse> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .echo(self.0.request, self.0.options)
+                .echo(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::EchoRequest,
+            force: bool,
+        ) -> crate::model::EchoRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            if force || req.other_request_id.is_none() {
+                req = req.set_other_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [severity][crate::model::EchoRequest::severity].

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -1585,6 +1585,7 @@ impl super::stub::Echo for Echo {
     ) -> Result<gax::response::Response<crate::model::EchoResponse>> {
         use gax::error::binding::BindingError;
         use gaxi::path_parameter::PathMismatchBuilder;
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let (builder, method) = None
             .or_else(|| {
                 let path = "/v1beta1/echo:echo".to_string();

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -43,6 +43,7 @@ serde_json.workspace  = true
 tokio                 = { workspace = true, features = ["process"] }
 tracing.workspace     = true
 tracing-subscriber    = { workspace = true, optional = true, features = ["fmt", "std"] }
+uuid                  = { workspace = true, features = ["std", "v4"] }
 wkt.workspace         = true
 
 [dependencies.aiplatform]

--- a/src/integration-tests/tests/auto_populated.rs
+++ b/src/integration-tests/tests/auto_populated.rs
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod test {
+    use anyhow::Result;
+    use gax::error::Error;
+    use gax::paginator::Paginator;
+    use std::collections::HashSet;
+
+    mockall::mock! {
+        #[derive(Debug)]
+        StorageControl {}
+        impl storage_control::stub::StorageControl for StorageControl {
+            async fn create_folder(&self, req: storage_control::model::CreateFolderRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<storage_control::model::Folder>>;
+            async fn list_anywhere_caches(&self, req: storage_control::model::ListAnywhereCachesRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<storage_control::model::ListAnywhereCachesResponse>>;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn one_request_id_per_retry_loop() -> Result<()> {
+        let mut mock = MockStorageControl::new();
+        mock.expect_create_folder()
+            .once()
+            // The retry loop lives within a stub. If this stub is given a
+            // request ID, it must be set for the entire loop.
+            .withf(|r, _| !r.request_id.is_empty())
+            .return_once(|_, _| Err(unavailable()));
+
+        let client = storage_control::client::StorageControl::from_stub(mock);
+        let _ = client.create_folder().send().await;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pagination() -> Result<()> {
+        // Each subsequent request should have a new request ID.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(HashSet::new()));
+
+        let mut mock = MockStorageControl::new();
+        let mut seq = mockall::Sequence::new();
+        let page_tokens = vec!["", "page-001", "page-002", "page-003", ""];
+        for i in 1..page_tokens.len() {
+            let current = page_tokens[i - 1];
+            let next = page_tokens[i];
+            let seen_clone = seen.clone();
+
+            mock.expect_list_anywhere_caches()
+                .once()
+                .in_sequence(&mut seq)
+                .withf(move |r, _| r.page_token == current)
+                .return_once(move |r, _| {
+                    tracing::info!("attempt={i}, request ID={}", r.request_id);
+                    assert!(
+                        seen_clone.lock().unwrap().insert(r.request_id),
+                        "Request ID repeated for a request with different contents."
+                    );
+                    Ok(gax::response::Response::from(
+                        storage_control::model::ListAnywhereCachesResponse::default()
+                            .set_next_page_token(next),
+                    ))
+                });
+        }
+
+        let client = storage_control::client::StorageControl::from_stub(mock);
+        let mut paginator = client.list_anywhere_caches().by_page();
+        while let Some(_) = paginator.next().await.transpose()? {}
+
+        // Just to be overly cautious, verify we made N calls, with N different request IDs.
+        let seen = seen.lock().unwrap();
+        assert!(seen.len() == page_tokens.len() - 1, "{seen:?}");
+
+        Ok(())
+    }
+
+    fn unavailable() -> Error {
+        use gax::error::rpc::{Code, Status};
+        Error::service(
+            Status::default()
+                .set_code(Code::Unavailable)
+                .set_message("try-again"),
+        )
+    }
+}

--- a/src/storage-control/Cargo.toml
+++ b/src/storage-control/Cargo.toml
@@ -47,6 +47,7 @@ iam_v1.workspace      = true
 longrunning.workspace = true
 lro.workspace         = true
 rpc.workspace         = true
+uuid.workspace        = true
 wkt.workspace         = true
 
 [dev-dependencies]

--- a/src/storage-control/src/generated/gapic_control/builder.rs
+++ b/src/storage-control/src/generated/gapic_control/builder.rs
@@ -81,10 +81,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Folder> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .create_folder(self.0.request, self.0.options)
+                .create_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::CreateFolderRequest,
+            force: bool,
+        ) -> crate::model::CreateFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [parent][crate::model::CreateFolderRequest::parent].
@@ -186,10 +197,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<()> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .delete_folder(self.0.request, self.0.options)
+                .delete_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::DeleteFolderRequest,
+            force: bool,
+        ) -> crate::model::DeleteFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::DeleteFolderRequest::name].
@@ -294,10 +316,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Folder> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .get_folder(self.0.request, self.0.options)
+                .get_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::GetFolderRequest,
+            force: bool,
+        ) -> crate::model::GetFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::GetFolderRequest::name].
@@ -541,8 +574,9 @@ pub mod storage_control {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [rename_folder][crate::client::StorageControl::rename_folder].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .rename_folder(self.0.request, self.0.options)
+                .rename_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
         }
@@ -578,6 +612,16 @@ pub mod storage_control {
             };
 
             lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::RenameFolderRequest,
+            force: bool,
+        ) -> crate::model::RenameFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::RenameFolderRequest::name].
@@ -693,10 +737,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::StorageLayout> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .get_storage_layout(self.0.request, self.0.options)
+                .get_storage_layout(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::GetStorageLayoutRequest,
+            force: bool,
+        ) -> crate::model::GetStorageLayoutRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::GetStorageLayoutRequest::name].
@@ -771,10 +826,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ManagedFolder> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .create_managed_folder(self.0.request, self.0.options)
+                .create_managed_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::CreateManagedFolderRequest,
+            force: bool,
+        ) -> crate::model::CreateManagedFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [parent][crate::model::CreateManagedFolderRequest::parent].
@@ -873,10 +939,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<()> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .delete_managed_folder(self.0.request, self.0.options)
+                .delete_managed_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::DeleteManagedFolderRequest,
+            force: bool,
+        ) -> crate::model::DeleteManagedFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::DeleteManagedFolderRequest::name].
@@ -990,10 +1067,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ManagedFolder> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .get_managed_folder(self.0.request, self.0.options)
+                .get_managed_folder(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::GetManagedFolderRequest,
+            force: bool,
+        ) -> crate::model::GetManagedFolderRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::GetManagedFolderRequest::name].
@@ -1105,8 +1193,9 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListManagedFoldersResponse> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .list_managed_folders(self.0.request, self.0.options)
+                .list_managed_folders(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
         }
@@ -1120,6 +1209,8 @@ pub mod storage_control {
             let token = self.0.request.page_token.clone();
             let execute = move |token: String| {
                 let mut builder = self.clone();
+                let initial = builder.0.request.page_token == token;
+                builder.0.request = Self::auto_populate(builder.0.request, !initial);
                 builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
@@ -1135,6 +1226,16 @@ pub mod storage_control {
         > {
             use gax::paginator::Paginator;
             self.by_page().items()
+        }
+
+        fn auto_populate(
+            mut req: crate::model::ListManagedFoldersRequest,
+            force: bool,
+        ) -> crate::model::ListManagedFoldersRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [parent][crate::model::ListManagedFoldersRequest::parent].
@@ -1227,8 +1328,9 @@ pub mod storage_control {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_anywhere_cache][crate::client::StorageControl::create_anywhere_cache].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .create_anywhere_cache(self.0.request, self.0.options)
+                .create_anywhere_cache(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
         }
@@ -1267,6 +1369,16 @@ pub mod storage_control {
             };
 
             lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::CreateAnywhereCacheRequest,
+            force: bool,
+        ) -> crate::model::CreateAnywhereCacheRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [parent][crate::model::CreateAnywhereCacheRequest::parent].
@@ -1363,8 +1475,9 @@ pub mod storage_control {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_anywhere_cache][crate::client::StorageControl::update_anywhere_cache].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .update_anywhere_cache(self.0.request, self.0.options)
+                .update_anywhere_cache(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
         }
@@ -1403,6 +1516,16 @@ pub mod storage_control {
             };
 
             lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::UpdateAnywhereCacheRequest,
+            force: bool,
+        ) -> crate::model::UpdateAnywhereCacheRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [anywhere_cache][crate::model::UpdateAnywhereCacheRequest::anywhere_cache].
@@ -1507,10 +1630,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AnywhereCache> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .disable_anywhere_cache(self.0.request, self.0.options)
+                .disable_anywhere_cache(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::DisableAnywhereCacheRequest,
+            force: bool,
+        ) -> crate::model::DisableAnywhereCacheRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::DisableAnywhereCacheRequest::name].
@@ -1579,10 +1713,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AnywhereCache> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .pause_anywhere_cache(self.0.request, self.0.options)
+                .pause_anywhere_cache(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::PauseAnywhereCacheRequest,
+            force: bool,
+        ) -> crate::model::PauseAnywhereCacheRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::PauseAnywhereCacheRequest::name].
@@ -1651,10 +1796,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AnywhereCache> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .resume_anywhere_cache(self.0.request, self.0.options)
+                .resume_anywhere_cache(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::ResumeAnywhereCacheRequest,
+            force: bool,
+        ) -> crate::model::ResumeAnywhereCacheRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::ResumeAnywhereCacheRequest::name].
@@ -1723,10 +1879,21 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AnywhereCache> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .get_anywhere_cache(self.0.request, self.0.options)
+                .get_anywhere_cache(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
+        }
+
+        fn auto_populate(
+            mut req: crate::model::GetAnywhereCacheRequest,
+            force: bool,
+        ) -> crate::model::GetAnywhereCacheRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [name][crate::model::GetAnywhereCacheRequest::name].
@@ -1799,8 +1966,9 @@ pub mod storage_control {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListAnywhereCachesResponse> {
+            let req = Self::auto_populate(self.0.request, false);
             (*self.0.stub)
-                .list_anywhere_caches(self.0.request, self.0.options)
+                .list_anywhere_caches(req, self.0.options)
                 .await
                 .map(gax::response::Response::into_body)
         }
@@ -1814,6 +1982,8 @@ pub mod storage_control {
             let token = self.0.request.page_token.clone();
             let execute = move |token: String| {
                 let mut builder = self.clone();
+                let initial = builder.0.request.page_token == token;
+                builder.0.request = Self::auto_populate(builder.0.request, !initial);
                 builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
@@ -1829,6 +1999,16 @@ pub mod storage_control {
         > {
             use gax::paginator::Paginator;
             self.by_page().items()
+        }
+
+        fn auto_populate(
+            mut req: crate::model::ListAnywhereCachesRequest,
+            force: bool,
+        ) -> crate::model::ListAnywhereCachesRequest {
+            if force || req.request_id.is_empty() {
+                req = req.set_request_id(uuid::Uuid::new_v4().to_string())
+            }
+            req
         }
 
         /// Sets the value of [parent][crate::model::ListAnywhereCachesRequest::parent].

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -63,7 +63,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Folder>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -109,7 +109,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -160,7 +160,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Folder>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -257,7 +257,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -308,7 +308,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StorageLayout>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -359,7 +359,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ManagedFolder>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -405,7 +405,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -456,7 +456,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ManagedFolder>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -507,7 +507,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListManagedFoldersResponse>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -553,7 +553,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -599,7 +599,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -653,7 +653,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnywhereCache>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -704,7 +704,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnywhereCache>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -755,7 +755,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnywhereCache>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -806,7 +806,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnywhereCache>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -857,7 +857,7 @@ impl super::stub::StorageControl for StorageControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAnywhereCachesResponse>> {
         use gaxi::prost::ToProto;
-        let options = gax::options::internal::set_default_idempotency(options, false);
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(


### PR DESCRIPTION
Fixes #439 

Adds support for auto-populating request ID fields over both HTTP and gRPC.

At the moment, only storage-control is impacted. We use that in our tests.

I noticed that paginated requests should each have a different request ID. While not explicitly stated in [AIP-4235](https://google.aip.dev/client-libraries/4235), I think it can be inferred from:
> Client libraries must reuse automatically populated values for retries of the same request. In other words, the automatically populated fields must not be regenerated for each RPC attempt with the same request message.

## Notes

- The builder template could be simplified to always say `let req = self.0.request;`. I didn't do it just to keep the diff down.
- I am taking some TODOs on cleaning up idempotency handling.
- Testing one request ID per client operation is hard
  - Mocks do not have retry loops, so they are insufficient.
  - gapic-showcase only returns the request ID if a request is successful. That is insufficient to check that the same request ID is sent with each attempt.
  - We'd have to spin up a server.
  - I settled for an argument: If the request ID is set outside of the retry loop, we can assume it is the same for the whole retry loop. :shrug: 
- While gapic-showcase is again underwhelming, if we ever moved the auto-population from the builder -> transport, we would not have to rewrite the test. We would have to rewrite the tests involving mock stubs.