### PR TITLE
cleanup(auth): add test for programmatic credential

### DIFF
--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -61,8 +61,8 @@ enum CredentialSourceFile {
     Executable {
         executable: ExecutableConfig,
     },
-    File {},
-    Aws {},
+    File,
+    Aws,
 }
 
 /// A representation of a [external account config file].
@@ -212,8 +212,8 @@ impl ExternalAccountConfigBuilder {
 enum CredentialSource {
     Url(UrlSourcedCredentials),
     Executable(ExecutableSourcedCredentials),
-    File {},
-    Aws {},
+    File,
+    Aws,
     Programmatic(ProgrammaticSourcedCredentials),
 }
 
@@ -1357,6 +1357,60 @@ mod test {
             fmt.contains("test-quota-project"),
             "Expected 'test-quota-project', got: {fmt}"
         );
+    }
+
+    #[tokio::test]
+    async fn programmatic_builder_returns_correct_headers() {
+        let provider = Arc::new(TestSubjectTokenProvider);
+        let sts_server = Server::run();
+        let builder = ProgrammaticBuilder::new(provider)
+            .with_audience("test-audience")
+            .with_subject_token_type("test-token-type")
+            .with_token_url(sts_server.url("/token").to_string())
+            .with_quota_project_id("test-quota-project");
+
+        let creds = builder.build().unwrap();
+
+        sts_server.expect(
+            Expectation::matching(all_of![
+                request::method_path("POST", "/token"),
+                request::body(url_decoded(contains((
+                    "grant_type",
+                    TOKEN_EXCHANGE_GRANT_TYPE
+                )))),
+                request::body(url_decoded(contains((
+                    "subject_token",
+                    "test-subject-token"
+                )))),
+                request::body(url_decoded(contains((
+                    "requested_token_type",
+                    ACCESS_TOKEN_TYPE
+                )))),
+                request::body(url_decoded(contains((
+                    "subject_token_type",
+                    "test-token-type"
+                )))),
+                request::body(url_decoded(contains(("audience", "test-audience")))),
+                request::body(url_decoded(contains(("scope", DEFAULT_SCOPE)))),
+            ])
+            .respond_with(json_encoded(json!({
+                "access_token": "sts-only-token",
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }))),
+        );
+
+        let headers = creds.headers(Extensions::new()).await.unwrap();
+        match headers {
+            CacheableResource::New { data, .. } => {
+                let token = data.get("authorization").unwrap().to_str().unwrap();
+                assert_eq!(token, "Bearer sts-only-token");
+                let quota_project = data.get("x-goog-user-project").unwrap().to_str().unwrap();
+                assert_eq!(quota_project, "test-quota-project");
+            }
+            CacheableResource::NotModified => panic!("Expected new headers"),
+        }
     }
 
     #[tokio::test]

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -110,10 +110,10 @@ impl From<CredentialSourceFile> for CredentialSource {
             CredentialSourceFile::Executable { executable } => {
                 Self::Executable(ExecutableSourcedCredentials::new(executable))
             }
-            CredentialSourceFile::File { .. } => {
+            CredentialSourceFile::File => {
                 unimplemented!("file sourced credential not supported yet")
             }
-            CredentialSourceFile::Aws { .. } => {
+            CredentialSourceFile::Aws => {
                 unimplemented!("AWS sourced credential not supported yet")
             }
         }
@@ -230,10 +230,10 @@ impl ExternalAccountConfig {
             CredentialSource::Programmatic(source) => {
                 Self::make_credentials_from_source(source, config, quota_project_id)
             }
-            CredentialSource::File { .. } => {
+            CredentialSource::File => {
                 unimplemented!("file sourced credential not supported yet")
             }
-            CredentialSource::Aws { .. } => {
+            CredentialSource::Aws => {
                 unimplemented!("AWS sourced credential not supported yet")
             }
         }


### PR DESCRIPTION
As a follow up on https://github.com/googleapis/google-cloud-rust/pull/2541 I added another unit test in programmatic sourced credentials and remove the extra braces in the credential sources