### PR TITLE
impl(storage): checkpoint buffered uploads

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -230,6 +230,59 @@ pub async fn objects_large_file(builder: storage::client::ClientBuilder) -> Resu
     Ok(())
 }
 
+pub async fn objects_upload_buffered(builder: storage::client::ClientBuilder) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    // Create a temporary bucket for the test.
+    let (control, bucket) = create_test_bucket().await?;
+    let client = builder.build().await?;
+
+    tracing::info!("testing upload_object_buffered() [1]");
+    let insert = client
+        .upload_object_buffered(&bucket.name, "empty.txt", "")
+        .with_if_generation_match(0)
+        .send()
+        .await?;
+    tracing::info!("success with insert={insert:?}");
+    assert_eq!(insert.size, 0_i64);
+
+    let payload = bytes::Bytes::from_owner(Vec::from_iter((0..128 * 1024).map(|_| 0_u8)));
+    tracing::info!("testing upload_object_buffered() [2]");
+    let insert = client
+        .upload_object_buffered(&bucket.name, "128K.txt", payload)
+        .with_if_generation_match(0)
+        .send()
+        .await?;
+    tracing::info!("success with insert={insert:?}");
+    assert_eq!(insert.size, 128 * 1024_i64);
+
+    let payload = bytes::Bytes::from_owner(Vec::from_iter((0..512 * 1024).map(|_| 0_u8)));
+    tracing::info!("testing upload_object_buffered() [3]");
+    let insert = client
+        .upload_object_buffered(&bucket.name, "512K.txt", payload)
+        .with_if_generation_match(0)
+        .send()
+        .await?;
+    tracing::info!("success with insert={insert:?}");
+    assert_eq!(insert.size, 512 * 1024_i64);
+
+    cleanup_bucket(control, bucket.name).await?;
+
+    Ok(())
+}
+
 pub async fn create_test_bucket() -> Result<(StorageControl, Bucket)> {
     let project_id = crate::project_id()?;
     let client = StorageControl::builder()

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -137,6 +137,16 @@ mod driver {
 
     #[test_case(Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_storage_objects_upload_buffered(
+        builder: storage::client::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::storage::objects_upload_buffered(builder)
+            .await
+            .map_err(integration_tests::report_error)
+    }
+
+    #[test_case(Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects_with_key(
         builder: storage::client::ClientBuilder,
     ) -> integration_tests::Result<()> {

--- a/src/storage/src/client/upload_object_buffered.rs
+++ b/src/storage/src/client/upload_object_buffered.rs
@@ -1581,17 +1581,29 @@ mod tests {
             .map(|i| new_line_string(i, LEN))
             .collect::<Vec<_>>()
             .join("");
-        let stream = VecStream::new(vec![bytes::Bytes::from_owner(buffer.clone()), new_line(3, LEN)]);
+        let stream = VecStream::new(vec![
+            bytes::Bytes::from_owner(buffer.clone()),
+            new_line(3, LEN),
+        ]);
         let mut payload = InsertPayload::from(stream);
 
         let remainder = None;
         let (vec, remainder) = super::next_chunk(&mut payload, remainder, 2 * LEN).await?;
         assert!(remainder.is_some());
-        assert_eq!(vec, vec![bytes::Bytes::from_owner(buffer.clone()).slice(0..(2*LEN))]);
+        assert_eq!(
+            vec,
+            vec![bytes::Bytes::from_owner(buffer.clone()).slice(0..(2 * LEN))]
+        );
 
         let (vec, remainder) = super::next_chunk(&mut payload, remainder, 2 * LEN).await?;
         assert!(remainder.is_none());
-        assert_eq!(vec, vec![bytes::Bytes::from_owner(buffer.clone()).slice((2*LEN)..), new_line(3, LEN)]);
+        assert_eq!(
+            vec,
+            vec![
+                bytes::Bytes::from_owner(buffer.clone()).slice((2 * LEN)..),
+                new_line(3, LEN)
+            ]
+        );
 
         Ok(())
     }

--- a/src/storage/src/client/upload_object_buffered.rs
+++ b/src/storage/src/client/upload_object_buffered.rs
@@ -670,7 +670,8 @@ where
         let mut remainder = None;
         let mut offset = 0_usize;
         loop {
-            let (chunk, chunk_size, r) = self::next_chunk(&mut self.payload, remainder, target_size).await?;
+            let (chunk, chunk_size, r) =
+                self::next_chunk(&mut self.payload, remainder, target_size).await?;
             let full_size = if chunk_size < target_size {
                 Some(offset + chunk_size)
             } else {
@@ -1475,7 +1476,13 @@ mod tests {
             a
         });
         let (builder, size) = upload
-            .partial_upload_request("http://localhost/chunk-finalize", 4 * LEN, chunk, LEN, Some(5 * LEN))
+            .partial_upload_request(
+                "http://localhost/chunk-finalize",
+                4 * LEN,
+                chunk,
+                LEN,
+                Some(5 * LEN),
+            )
             .await?;
         assert_eq!(size, LEN);
         let mut request = builder.build()?;
@@ -1528,7 +1535,8 @@ mod tests {
         let stream = VecStream::new((0..5).map(|i| new_line(i, LEN)).collect::<Vec<_>>());
         let mut payload = InsertPayload::from(stream);
 
-        let (vec, size, remainder) = super::next_chunk(&mut payload, None, LEN * 2 + LEN / 2).await?;
+        let (vec, size, remainder) =
+            super::next_chunk(&mut payload, None, LEN * 2 + LEN / 2).await?;
         assert_eq!(remainder, Some(new_line(2, LEN).split_off(LEN / 2)));
         assert_eq!(
             vec,

--- a/src/storage/src/client/upload_object_buffered.rs
+++ b/src/storage/src/client/upload_object_buffered.rs
@@ -1746,6 +1746,18 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn parse_range_invalid_range() -> Result {
+        let response = http::Response::builder()
+            .header("range", "bytes=100-999")
+            .status(RESUME_INCOMPLETE)
+            .body(Vec::new())?;
+        let response = reqwest::Response::from(response);
+        let err = super::parse_range(response, 1234).await.expect_err("invalid range should create an error");
+        assert!(err.http_status_code().is_some(), "{err:?}");
+        Ok(())
+    }
+
     #[test_case(None, Some(0))]
     #[test_case(Some("bytes=0-12345"), Some(12345))]
     #[test_case(Some("bytes=0-1"), Some(1))]

--- a/src/storage/src/client/upload_object_buffered.rs
+++ b/src/storage/src/client/upload_object_buffered.rs
@@ -1753,7 +1753,9 @@ mod tests {
             .status(RESUME_INCOMPLETE)
             .body(Vec::new())?;
         let response = reqwest::Response::from(response);
-        let err = super::parse_range(response, 1234).await.expect_err("invalid range should create an error");
+        let err = super::parse_range(response, 1234)
+            .await
+            .expect_err("invalid range should create an error");
         assert!(err.http_status_code().is_some(), "{err:?}");
         Ok(())
     }

--- a/src/storage/src/client/upload_object_buffered.rs
+++ b/src/storage/src/client/upload_object_buffered.rs
@@ -14,6 +14,7 @@
 
 use super::*;
 use futures::stream::unfold;
+use std::collections::VecDeque;
 
 /// A request builder for uploads without rewind.
 pub struct UploadObjectBuffered<T> {
@@ -612,6 +613,12 @@ where
     /// ```
     pub async fn send(self) -> crate::Result<Object> {
         let upload_url = self.start_resumable_upload().await?;
+        // TODO(#2043) - make this configurable
+        if self.payload.size_hint().0 > RESUMABLE_UPLOAD_QUANTUM as u64 {
+            return self
+                .upload_by_chunks(&upload_url, RESUMABLE_UPLOAD_QUANTUM)
+                .await;
+        }
         let builder = self.upload_request(upload_url).await?;
         let response = builder.send().await.map_err(Error::io)?;
         if !response.status().is_success() {
@@ -658,30 +665,83 @@ where
         Ok(builder)
     }
 
-    async fn upload_request(self, upload_url: String) -> Result<reqwest::RequestBuilder> {
+    async fn upload_by_chunks(mut self, upload_url: &str, target_size: usize) -> Result<Object> {
+        let mut remainder = None;
+        let mut offset = 0_usize;
+        loop {
+            let (chunk, r) = self::next_chunk(&mut self.payload, remainder, target_size).await?;
+            let (builder, chunk_size) = self
+                .partial_upload_request(upload_url, offset, chunk, target_size)
+                .await?;
+            let response = builder.send().await.map_err(Error::io)?;
+            match self::partial_upload_handle_response(response, offset + chunk_size).await? {
+                PartialUpload::Finalized(o) => {
+                    return Ok(*o);
+                }
+                PartialUpload::Partial {
+                    persisted_size,
+                    chunk_remainder,
+                } => {
+                    offset = persisted_size;
+                    // TODO(#2043) - handle partial uploads
+                    assert_eq!(chunk_remainder, 0);
+                    remainder = r;
+                }
+            }
+        }
+    }
+
+    async fn partial_upload_request(
+        &self,
+        upload_url: &str,
+        offset: usize,
+        chunk: VecDeque<bytes::Bytes>,
+        target_size: usize,
+    ) -> Result<(reqwest::RequestBuilder, usize)> {
+        let chunk_size = chunk.iter().fold(0, |s, b| s + b.len());
+        let range = match chunk_size {
+            0 => format!("bytes */{offset}"),
+            n if n == target_size => format!("bytes {}-{}/*", offset, offset + n - 1),
+            n => format!("bytes {}-{}/{}", offset, offset + n - 1, offset + n),
+        };
         let builder = self
             .inner
             .client
             .request(reqwest::Method::PUT, upload_url)
             .header("content-type", "application/octet-stream")
-            .header("Content-Range", "bytes */*")
+            .header("Content-Range", range)
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&self::info::X_GOOG_API_CLIENT_HEADER),
             );
 
-        let builder = apply_customer_supplied_encryption_headers(builder, self.params);
+        let builder = apply_customer_supplied_encryption_headers(builder, self.params.clone());
         let builder = self.inner.apply_auth_headers(builder).await?;
-        let stream = Box::pin(unfold(Some(self.payload), move |state| async move {
-            use crate::upload_source::StreamingSource;
+        let stream = unfold(Some(chunk), move |state| async move {
             if let Some(mut payload) = state {
-                if let Some(next) = payload.next().await {
-                    return Some((next, Some(payload)));
+                if let Some(next) = payload.pop_front() {
+                    return Some((Ok::<bytes::Bytes, Error>(next), Some(payload)));
                 }
             }
             None
-        }));
-        let builder = builder.body(reqwest::Body::wrap_stream(stream));
+        });
+        Ok((builder.body(reqwest::Body::wrap_stream(stream)), chunk_size))
+    }
+
+    async fn upload_request(mut self, upload_url: String) -> Result<reqwest::RequestBuilder> {
+        let (chunk, target_size) = {
+            let mut chunk = VecDeque::new();
+            let mut size = 0_usize;
+            while let Some(b) = self.payload.next().await.transpose().map_err(Error::io)? {
+                size += b.len();
+                chunk.push_back(b);
+            }
+            (chunk, size)
+        };
+        let target_size = target_size.div_ceil(RESUMABLE_UPLOAD_QUANTUM);
+        let (builder, _size) = self
+            .partial_upload_request(upload_url.as_str(), 0, chunk, target_size)
+            .await?;
         Ok(builder)
     }
 
@@ -730,6 +790,91 @@ async fn handle_start_resumable_upload_response(response: reqwest::Response) -> 
     location.to_str().map_err(Error::deser).map(str::to_string)
 }
 
+async fn next_chunk<T>(
+    payload: &mut InsertPayload<T>,
+    partial: Option<bytes::Bytes>,
+    target_size: usize,
+) -> Result<(VecDeque<bytes::Bytes>, Option<bytes::Bytes>)>
+where
+    T: StreamingSource,
+{
+    let mut partial: VecDeque<_> = partial.into_iter().collect();
+    let mut size = partial.iter().fold(0, |s, b| s + b.len());
+    while size < target_size
+        && let Some(mut b) = payload.next().await.transpose().map_err(Error::io)?
+    {
+        match size + b.len() {
+            n if n > target_size => {
+                let remainder = b.split_off(n - target_size);
+                partial.push_back(b);
+                return Ok((partial, Some(remainder)));
+            }
+            n if n == target_size => {
+                partial.push_back(b);
+                return Ok((partial, None));
+            }
+            _ => {
+                size += b.len();
+                partial.push_back(b);
+            }
+        };
+    }
+    Ok((partial, None))
+}
+
+async fn partial_upload_handle_response(
+    response: reqwest::Response,
+    expected_offset: usize,
+) -> Result<PartialUpload> {
+    if response.status() == self::RESUME_INCOMPLETE {
+        return self::parse_range(response, expected_offset).await;
+    }
+    if !response.status().is_success() {
+        return gaxi::http::to_http_error(response).await;
+    }
+    let response = response.json::<v1::Object>().await.map_err(Error::io)?;
+    Ok(PartialUpload::Finalized(Box::new(Object::from(response))))
+}
+
+async fn parse_range(response: reqwest::Response, expected_offset: usize) -> Result<PartialUpload> {
+    let Some(end) = self::parse_range_end(response.headers()) else {
+        return gaxi::http::to_http_error(response).await;
+    };
+    // The `Range` header returns an inclusive range, i.e. bytes=0-999 means "1000 bytes".
+    let (persisted_size, chunk_remainder) = match (expected_offset, end) {
+        (o, 0) => (0, o),
+        (o, e) if o < e + 1 => panic!("more data persistent than sent {response:?}"),
+        (o, e) => (e + 1, o - e - 1),
+    };
+    Ok(PartialUpload::Partial {
+        persisted_size,
+        chunk_remainder,
+    })
+}
+
+fn parse_range_end(headers: &reqwest::header::HeaderMap) -> Option<usize> {
+    let Some(range) = headers.get("range") else {
+        // A missing `Range:` header indicates that no bytes are persisted.
+        return Some(0_usize);
+    };
+    let end = std::str::from_utf8(range.as_bytes().strip_prefix(b"bytes=0-")?).ok()?;
+    end.parse::<usize>().ok()
+}
+
+#[derive(Debug, PartialEq)]
+enum PartialUpload {
+    Finalized(Box<Object>),
+    Partial {
+        persisted_size: usize,
+        chunk_remainder: usize,
+    },
+}
+
+const RESUME_INCOMPLETE: reqwest::StatusCode = reqwest::StatusCode::PERMANENT_REDIRECT;
+// Resumable uploads chunks (except for the last chunk) *must* be sized to a
+// multiple of 256 KiB.
+const RESUMABLE_UPLOAD_QUANTUM: usize = 256 * 1024;
+
 #[cfg(test)]
 mod tests {
     use super::super::tests::create_key_helper;
@@ -772,7 +917,11 @@ mod tests {
         );
 
         server.expect(
-            Expectation::matching(all_of![request::method_path("PUT", path)]).respond_with(
+            Expectation::matching(all_of![
+                request::method_path("PUT", path),
+                request::headers(contains(("content-range", "bytes */0")))
+            ])
+            .respond_with(
                 status_code(200)
                     .append_header("content-type", "application/json")
                     .body(payload),
@@ -1037,6 +1186,8 @@ mod tests {
 
     #[tokio::test]
     async fn upload_request() -> Result {
+        use reqwest::header::HeaderValue;
+
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
         let mut request =
             UploadObjectBuffered::new(inner, "projects/_/buckets/bucket", "object", "hello")
@@ -1046,6 +1197,10 @@ mod tests {
 
         assert_eq!(request.method(), reqwest::Method::PUT);
         assert_eq!(request.url().as_str(), SESSION);
+        assert_eq!(
+            request.headers().get("content-range"),
+            Some(&HeaderValue::from_static("bytes 0-4/5"))
+        );
         let body = request.body_mut().take().unwrap();
         let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
         assert_eq!(contents, "hello");
@@ -1105,5 +1260,431 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    fn new_line_string(i: i32, len: usize) -> String {
+        format!("{i:022} {:width$}\n", "", width = len - 22 - 2)
+    }
+
+    fn new_line(i: i32, len: usize) -> bytes::Bytes {
+        bytes::Bytes::from_owner(new_line_string(i, len))
+    }
+
+    #[tokio::test]
+    async fn upload_by_chunks() -> Result {
+        const LEN: usize = 32;
+
+        let payload = serde_json::json!({
+            "name": "test-object",
+            "bucket": "test-bucket",
+            "metadata": {
+                "is-test-object": "true",
+            }
+        })
+        .to_string();
+
+        let chunk0 = new_line_string(0, LEN) + &new_line_string(1, LEN);
+        let chunk1 = new_line_string(2, LEN) + &new_line_string(3, LEN);
+        let chunk2 = new_line_string(4, LEN);
+
+        let server = Server::run();
+        let session = server.url("/upload/session/test-only-001");
+        let path = session.path().to_string();
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("PUT", path.clone()),
+                request::headers(contains(("content-range", "bytes 0-63/*"))),
+                request::body(chunk0.clone()),
+            ])
+            .respond_with(status_code(308).append_header("range", "bytes=0-63")),
+        );
+
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("PUT", path.clone()),
+                request::headers(contains(("content-range", "bytes 64-127/*"))),
+                request::body(chunk1.clone()),
+            ])
+            .respond_with(status_code(308).append_header("range", "bytes=0-127")),
+        );
+
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("PUT", path.clone()),
+                request::headers(contains(("content-range", "bytes 128-159/160"))),
+                request::body(chunk2.clone()),
+            ])
+            .respond_with(status_code(200).body(payload.clone())),
+        );
+
+        let stream = VecStream::new((0..5).map(|i| new_line(i, LEN)).collect::<Vec<_>>());
+
+        let inner = test_inner_client(gaxi::options::ClientConfig::default());
+        let upload =
+            UploadObjectBuffered::new(inner, "projects/_/buckets/bucket", "object", stream);
+        let response = upload
+            .upload_by_chunks(session.to_string().as_str(), 2 * LEN)
+            .await?;
+        assert_eq!(response.name, "test-object");
+        assert_eq!(response.bucket, "projects/_/buckets/test-bucket");
+        assert_eq!(
+            response.metadata.get("is-test-object").map(String::as_str),
+            Some("true")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_upload_request_empty() -> Result {
+        use reqwest::header::HeaderValue;
+        const LEN: usize = 32;
+        let inner = test_inner_client(gaxi::options::ClientConfig::default());
+        let upload = UploadObjectBuffered::new(inner, "projects/_/buckets/bucket", "object", "");
+
+        let chunk = VecDeque::new();
+        let (builder, size) = upload
+            .partial_upload_request("http://localhost/chunk-0", 0_usize, chunk, 2 * LEN)
+            .await?;
+        assert_eq!(size, 0);
+        let mut request = builder.build()?;
+
+        assert_eq!(
+            request.headers().get("content-type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+        assert_eq!(
+            request.headers().get("content-range"),
+            Some(&HeaderValue::from_static("bytes */0"))
+        );
+        assert!(
+            request.headers().get("x-goog-api-client").is_some(),
+            "{request:?}"
+        );
+        let body = request.body_mut().take().unwrap();
+        let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
+        assert!(&contents.is_empty(), "{contents:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_upload_request_chunk0() -> Result {
+        use reqwest::header::HeaderValue;
+        const LEN: usize = 32;
+        let inner = test_inner_client(gaxi::options::ClientConfig::default());
+        let upload = UploadObjectBuffered::new(inner, "projects/_/buckets/bucket", "object", "");
+
+        let chunk = VecDeque::from_iter([new_line(0, LEN), new_line(1, LEN)]);
+        let expected = chunk.iter().fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b);
+            a
+        });
+        let (builder, size) = upload
+            .partial_upload_request("http://localhost/chunk-0", 0_usize, chunk, 2 * LEN)
+            .await?;
+        assert_eq!(size, 2 * LEN);
+        let mut request = builder.build()?;
+
+        assert_eq!(
+            request.headers().get("content-type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+        assert_eq!(
+            request.headers().get("content-range"),
+            Some(&HeaderValue::from_static("bytes 0-63/*"))
+        );
+        assert!(
+            request.headers().get("x-goog-api-client").is_some(),
+            "{request:?}"
+        );
+        let body = request.body_mut().take().unwrap();
+        let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
+        assert_eq!(&contents, &expected);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_upload_request_chunk1() -> Result {
+        use reqwest::header::HeaderValue;
+        const LEN: usize = 32;
+        let inner = test_inner_client(gaxi::options::ClientConfig::default());
+        let upload = UploadObjectBuffered::new(inner, "projects/_/buckets/bucket", "object", "");
+
+        let chunk = VecDeque::from_iter([new_line(2, LEN), new_line(3, LEN)]);
+        let expected = chunk.iter().fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b);
+            a
+        });
+        let (builder, size) = upload
+            .partial_upload_request("http://localhost/chunk-1", 2 * LEN, chunk, 2 * LEN)
+            .await?;
+        assert_eq!(size, 2 * LEN);
+        let mut request = builder.build()?;
+
+        assert_eq!(
+            request.headers().get("content-type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+        assert_eq!(
+            request.headers().get("content-range"),
+            Some(&HeaderValue::from_static("bytes 64-127/*"))
+        );
+        assert!(
+            request.headers().get("x-goog-api-client").is_some(),
+            "{request:?}"
+        );
+        let body = request.body_mut().take().unwrap();
+        let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
+        assert_eq!(&contents, &expected);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_upload_request_chunk_finalize() -> Result {
+        use reqwest::header::HeaderValue;
+        const LEN: usize = 32;
+        let inner = test_inner_client(gaxi::options::ClientConfig::default());
+        let upload = UploadObjectBuffered::new(inner, "projects/_/buckets/bucket", "object", "");
+
+        let chunk = VecDeque::from_iter([new_line(2, LEN)]);
+        let expected = chunk.iter().fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b);
+            a
+        });
+        let (builder, size) = upload
+            .partial_upload_request("http://localhost/chunk-finalize", 4 * LEN, chunk, 2 * LEN)
+            .await?;
+        assert_eq!(size, LEN);
+        let mut request = builder.build()?;
+
+        assert_eq!(
+            request.headers().get("content-type"),
+            Some(&HeaderValue::from_static("application/octet-stream"))
+        );
+        assert_eq!(
+            request.headers().get("content-range"),
+            Some(&HeaderValue::from_static("bytes 128-159/160"))
+        );
+        assert!(
+            request.headers().get("x-goog-api-client").is_some(),
+            "{request:?}"
+        );
+        let body = request.body_mut().take().unwrap();
+        let contents = http_body_util::BodyExt::collect(body).await?.to_bytes();
+        assert_eq!(&contents, &expected);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_chunk_success() -> Result {
+        const LEN: usize = 32;
+        let stream = VecStream::new((0..5).map(|i| new_line(i, LEN)).collect::<Vec<_>>());
+        let mut payload = InsertPayload::from(stream);
+
+        let (vec, remainder) = super::next_chunk(&mut payload, None, LEN * 2).await?;
+        assert!(remainder.is_none(), "{remainder:?}");
+        assert_eq!(vec, vec![new_line(0, LEN), new_line(1, LEN)]);
+
+        let (vec, remainder) = super::next_chunk(&mut payload, remainder, LEN * 2).await?;
+        assert!(remainder.is_none(), "{remainder:?}");
+        assert_eq!(vec, vec![new_line(2, LEN), new_line(3, LEN)]);
+
+        let (vec, remainder) = super::next_chunk(&mut payload, remainder, LEN * 2).await?;
+        assert!(remainder.is_none(), "{remainder:?}");
+        assert_eq!(vec, vec![new_line(4, LEN)]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_chunk_split() -> Result {
+        const LEN: usize = 32;
+        let stream = VecStream::new((0..5).map(|i| new_line(i, LEN)).collect::<Vec<_>>());
+        let mut payload = InsertPayload::from(stream);
+
+        let (vec, remainder) = super::next_chunk(&mut payload, None, LEN * 2 + LEN / 2).await?;
+        assert_eq!(remainder, Some(new_line(2, LEN).split_off(LEN / 2)));
+        assert_eq!(
+            vec,
+            vec![
+                new_line(0, LEN),
+                new_line(1, LEN),
+                new_line(2, LEN).split_to(LEN / 2)
+            ]
+        );
+
+        let (vec, remainder) =
+            super::next_chunk(&mut payload, remainder, LEN * 2 + LEN / 2).await?;
+        assert!(remainder.is_none());
+        assert_eq!(
+            vec,
+            vec![
+                new_line(2, LEN).split_off(LEN / 2),
+                new_line(3, LEN),
+                new_line(4, LEN)
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_chunk_done() -> Result {
+        const LEN: usize = 32;
+        let stream = VecStream::new((0..2).map(|i| new_line(i, LEN)).collect::<Vec<_>>());
+        let mut payload = InsertPayload::from(stream);
+
+        let (vec, remainder) = super::next_chunk(&mut payload, None, LEN * 4).await?;
+        assert!(remainder.is_none(), "{remainder:?}");
+        assert_eq!(vec, vec![new_line(0, LEN), new_line(1, LEN)]);
+
+        let (vec, remainder) = super::next_chunk(&mut payload, remainder, LEN * 4).await?;
+        assert!(remainder.is_none(), "{remainder:?}");
+        assert!(vec.is_empty(), "{vec:?}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_handle_response_incomplete() -> Result {
+        let response = http::Response::builder()
+            .header("range", "bytes=0-999")
+            .status(RESUME_INCOMPLETE)
+            .body(Vec::new())?;
+        let response = reqwest::Response::from(response);
+        let partial = super::partial_upload_handle_response(response, 1000).await?;
+        assert_eq!(
+            partial,
+            PartialUpload::Partial {
+                persisted_size: 1000,
+                chunk_remainder: 0
+            }
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_handle_response_err() -> Result {
+        let response = http::Response::builder()
+            .status(reqwest::StatusCode::NOT_FOUND)
+            .body(Vec::new())?;
+        let response = reqwest::Response::from(response);
+        let err = super::partial_upload_handle_response(response, 1000)
+            .await
+            .expect_err("NOT_FOUND should fail");
+        assert_eq!(err.http_status_code(), Some(404), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partial_handle_response_finalized() -> Result {
+        let response = http::Response::builder()
+            .status(reqwest::StatusCode::OK)
+            .body(
+                json!({"bucket": "test-bucket", "name": "test-object", "size": "1000"}).to_string(),
+            )?;
+        let response = reqwest::Response::from(response);
+        let partial = super::partial_upload_handle_response(response, 1000).await?;
+        assert_eq!(
+            partial,
+            PartialUpload::Finalized(Box::new(
+                Object::new()
+                    .set_name("test-object")
+                    .set_bucket("projects/_/buckets/test-bucket")
+                    .set_finalize_time(wkt::Timestamp::default())
+                    .set_create_time(wkt::Timestamp::default())
+                    .set_update_time(wkt::Timestamp::default())
+                    .set_update_storage_class_time(wkt::Timestamp::default())
+                    .set_size(1000_i64)
+            ))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_range_success() -> Result {
+        let response = http::Response::builder()
+            .header("range", "bytes=0-999")
+            .status(RESUME_INCOMPLETE)
+            .body(Vec::new())?;
+        let response = reqwest::Response::from(response);
+        let partial = super::parse_range(response, 1000).await?;
+        assert_eq!(
+            partial,
+            PartialUpload::Partial {
+                persisted_size: 1000,
+                chunk_remainder: 0
+            }
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_range_partial() -> Result {
+        let response = http::Response::builder()
+            .header("range", "bytes=0-999")
+            .status(RESUME_INCOMPLETE)
+            .body(Vec::new())?;
+        let response = reqwest::Response::from(response);
+        let partial = super::parse_range(response, 1234).await?;
+        assert_eq!(
+            partial,
+            PartialUpload::Partial {
+                persisted_size: 1000,
+                chunk_remainder: 234
+            }
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn parse_range_bad_end() {
+        let response = http::Response::builder()
+            .header("range", "bytes=0-999")
+            .status(RESUME_INCOMPLETE)
+            .body(Vec::new())
+            .unwrap();
+        let response = reqwest::Response::from(response);
+        let _ = super::parse_range(response, 500).await;
+    }
+
+    #[tokio::test]
+    async fn parse_range_missing_range() -> Result {
+        let response = http::Response::builder()
+            .status(RESUME_INCOMPLETE)
+            .body(Vec::new())?;
+        let response = reqwest::Response::from(response);
+        let partial = super::parse_range(response, 1234).await?;
+        assert_eq!(
+            partial,
+            PartialUpload::Partial {
+                persisted_size: 0,
+                chunk_remainder: 1234
+            }
+        );
+        Ok(())
+    }
+
+    #[test_case(None, Some(0))]
+    #[test_case(Some("bytes=0-12345"), Some(12345))]
+    #[test_case(Some("bytes=0-1"), Some(1))]
+    #[test_case(Some("bytes=0-0"), Some(0))]
+    #[test_case(Some("bytes=1-12345"), None)]
+    #[test_case(Some(""), None)]
+    fn range_end(input: Option<&str>, want: Option<usize>) {
+        use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+        let headers = HeaderMap::from_iter(input.into_iter().map(|s| {
+            (
+                HeaderName::from_static("range"),
+                HeaderValue::from_str(s).unwrap(),
+            )
+        }));
+        assert_eq!(super::parse_range_end(&headers), want, "{headers:?}");
+    }
+
+    #[test]
+    fn validate_status_code() {
+        assert_eq!(RESUME_INCOMPLETE, 308);
     }
 }


### PR DESCRIPTION
Split "large" uploads in multiple PUT calls, checkpointing each PUT will allow
us to resume the upload with a limited buffer.

Part of the work for #2043
