### PR TITLE
refactor(storage): consolidate upload methods

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -47,8 +47,8 @@ pub async fn objects(builder: storage::client::ClientBuilder) -> Result<()> {
     tracing::info!("testing insert_object()");
     const CONTENTS: &str = "the quick brown fox jumps over the lazy dog";
     let insert = client
-        .upload_object_unbuffered(&bucket.name, "quick.text", CONTENTS)
-        .send()
+        .upload_object(&bucket.name, "quick.text", CONTENTS)
+        .send_unbuffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
 
@@ -104,9 +104,9 @@ pub async fn objects_customer_supplied_encryption(
     const CONTENTS: &str = "the quick brown fox jumps over the lazy dog";
     let key = vec![b'a'; 32];
     let insert = client
-        .upload_object_unbuffered(&bucket.name, "quick.text", CONTENTS)
+        .upload_object(&bucket.name, "quick.text", CONTENTS)
         .with_key(storage::client::KeyAes256::new(&key)?)
-        .send()
+        .send_unbuffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
 
@@ -166,12 +166,12 @@ pub async fn objects_large_file(builder: storage::client::ClientBuilder) -> Resu
 
     tracing::info!("testing insert_object()");
     let insert = client
-        .upload_object_unbuffered(
+        .upload_object(
             &bucket.name,
             "quick.text",
             bytes::Bytes::from_owner(contents.clone()),
         )
-        .send()
+        .send_unbuffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
 
@@ -251,7 +251,7 @@ pub async fn objects_upload_buffered(builder: storage::client::ClientBuilder) ->
 
     tracing::info!("testing upload_object_buffered() [1]");
     let insert = client
-        .upload_object_buffered(&bucket.name, "empty.txt", "")
+        .upload_object(&bucket.name, "empty.txt", "")
         .with_if_generation_match(0)
         .send()
         .await?;
@@ -261,7 +261,7 @@ pub async fn objects_upload_buffered(builder: storage::client::ClientBuilder) ->
     let payload = bytes::Bytes::from_owner(Vec::from_iter((0..128 * 1024).map(|_| 0_u8)));
     tracing::info!("testing upload_object_buffered() [2]");
     let insert = client
-        .upload_object_buffered(&bucket.name, "128K.txt", payload)
+        .upload_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .send()
         .await?;
@@ -271,7 +271,7 @@ pub async fn objects_upload_buffered(builder: storage::client::ClientBuilder) ->
     let payload = bytes::Bytes::from_owner(Vec::from_iter((0..512 * 1024).map(|_| 0_u8)));
     tracing::info!("testing upload_object_buffered() [3]");
     let insert = client
-        .upload_object_buffered(&bucket.name, "512K.txt", payload)
+        .upload_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .send()
         .await?;

--- a/src/storage/src/client.rs
+++ b/src/storage/src/client.rs
@@ -16,8 +16,7 @@ pub use crate::Error;
 pub use crate::Result;
 pub use control::model::Object;
 pub use read_object::ReadObject;
-pub use upload_object_buffered::UploadObjectBuffered;
-pub use upload_object_unbuffered::UploadObjectUnbuffered;
+pub use upload_object::UploadObject;
 
 use crate::upload_source::{InsertPayload, Seek, StreamingSource};
 use auth::credentials::CacheableResource;
@@ -27,8 +26,7 @@ use http::Extensions;
 use sha2::{Digest, Sha256};
 
 mod read_object;
-mod upload_object_buffered;
-mod upload_object_unbuffered;
+mod upload_object;
 mod v1;
 
 /// Implements a client for the Cloud Storage API.
@@ -136,43 +134,12 @@ impl Storage {
     /// # use google_cloud_storage::client::Storage;
     /// # let client = Storage::builder().build().await?;
     /// let response = client
-    ///     .upload_object_buffered("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .send()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok::<(), anyhow::Error>(()) });
     /// ```
-    ///
-    /// # Parameters
-    /// * `bucket` - the bucket name containing the object. In
-    ///   `projects/_/buckets/{bucket_id}` format.
-    /// * `object` - the object name.
-    /// * `payload` - the object data.
-    pub fn upload_object_buffered<B, O, T, P>(
-        &self,
-        bucket: B,
-        object: O,
-        payload: T,
-    ) -> UploadObjectBuffered<P>
-    where
-        B: Into<String>,
-        O: Into<String>,
-        T: Into<InsertPayload<P>>,
-        InsertPayload<P>: StreamingSource + Seek,
-    {
-        UploadObjectBuffered::new(self.inner.clone(), bucket, object, payload)
-    }
-
-    /// Upload an object without local buffering.
-    ///
-    /// If the data source implements [Seek], the client library can perform
-    /// uploads without local data buffering, and without any need to
-    /// periodically flush the data. Such data flushing can introduce stalls in
-    /// the upload and reduce effective throughput.
-    ///
-    /// The most common sources that support such uploads are in-memory buffers,
-    /// local files, data from object storage systems and simple transformations
-    /// of these sources.
     ///
     /// # Example
     /// ```
@@ -180,8 +147,8 @@ impl Storage {
     /// # use google_cloud_storage::client::Storage;
     /// # let client = Storage::builder().build().await?;
     /// let response = client
-    ///     .upload_object_unbuffered("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .send()
+    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .send_unbuffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok::<(), anyhow::Error>(()) });
@@ -192,20 +159,14 @@ impl Storage {
     ///   `projects/_/buckets/{bucket_id}` format.
     /// * `object` - the object name.
     /// * `payload` - the object data.
-    ///
-    pub fn upload_object_unbuffered<B, O, T, P>(
-        &self,
-        bucket: B,
-        object: O,
-        payload: T,
-    ) -> UploadObjectUnbuffered<P>
+    pub fn upload_object<B, O, T, P>(&self, bucket: B, object: O, payload: T) -> UploadObject<P>
     where
         B: Into<String>,
         O: Into<String>,
         T: Into<InsertPayload<P>>,
         InsertPayload<P>: StreamingSource + Seek,
     {
-        UploadObjectUnbuffered::new(self.inner.clone(), bucket, object, payload)
+        UploadObject::new(self.inner.clone(), bucket, object, payload)
     }
 
     /// A simple download into a buffer.

--- a/src/storage/src/client/upload_object/unbuffered.rs
+++ b/src/storage/src/client/upload_object/unbuffered.rs
@@ -13,62 +13,8 @@
 // limitations under the License.
 
 use super::*;
-use futures::stream::unfold;
 
-pub struct UploadObjectUnbuffered<T> {
-    inner: std::sync::Arc<StorageInner>,
-    resource: control::model::Object,
-    params: Option<control::model::CommonObjectRequestParams>,
-    payload: InsertPayload<T>,
-}
-
-impl<T> UploadObjectUnbuffered<T> {
-    /// The encryption key used with the Customer-Supplied Encryption Keys
-    /// feature. In raw bytes format (not base64-encoded).
-    ///
-    /// # Example
-    /// ```
-    /// # tokio_test::block_on(async {
-    /// # use google_cloud_storage::client::Storage;
-    /// # use google_cloud_storage::client::KeyAes256;
-    /// # let client = Storage::builder().build().await?;
-    /// let key: &[u8] = &[97; 32];
-    /// let response = client
-    ///     .upload_object_unbuffered("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .with_key(KeyAes256::new(key)?)
-    ///     .send()
-    ///     .await?;
-    /// println!("response details={response:?}");
-    /// # Ok::<(), anyhow::Error>(()) });
-    /// ```
-    pub fn with_key(mut self, v: KeyAes256) -> Self {
-        self.params = Some(v.into());
-        self
-    }
-
-    pub(crate) fn new<B, O, P>(
-        inner: std::sync::Arc<StorageInner>,
-        bucket: B,
-        object: O,
-        payload: P,
-    ) -> Self
-    where
-        B: Into<String>,
-        O: Into<String>,
-        P: Into<InsertPayload<T>>,
-    {
-        UploadObjectUnbuffered {
-            inner,
-            resource: control::model::Object::new()
-                .set_bucket(bucket)
-                .set_name(object),
-            params: None,
-            payload: payload.into(),
-        }
-    }
-}
-
-impl<T> UploadObjectUnbuffered<T>
+impl<T> UploadObject<T>
 where
     T: StreamingSource + Send + Sync + 'static,
     T::Error: std::error::Error + Send + Sync + 'static,
@@ -81,13 +27,13 @@ where
     /// # use google_cloud_storage::client::Storage;
     /// # let client = Storage::builder().build().await?;
     /// let response = client
-    ///     .upload_object_unbuffered("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .send()
+    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .send_unbuffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok::<(), anyhow::Error>(()) });
     /// ```
-    pub async fn send(self) -> crate::Result<Object> {
+    pub async fn send_unbuffered(self) -> crate::Result<Object> {
         let builder = self.http_request_builder().await?;
         let response = builder.send().await.map_err(Error::io)?;
         if !response.status().is_success() {
@@ -139,17 +85,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::create_key_helper;
-    use super::super::tests::test_inner_client;
     use super::*;
+    use crate::client::tests::create_key_helper;
+    use crate::client::tests::test_inner_client;
     use crate::upload_source::test::VecStream;
     use httptest::{Expectation, Server, matchers::*, responders::status_code};
-    use test_case::test_case;
 
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[tokio::test]
-    async fn upload_object_unbuffered_normal() -> Result {
+    async fn send_unbuffered_normal() -> Result {
         let payload = serde_json::json!({
             "name": "test-object",
             "bucket": "test-bucket",
@@ -179,8 +124,8 @@ mod tests {
             .build()
             .await?;
         let response = client
-            .upload_object_unbuffered("projects/_/buckets/test-bucket", "test-object", "")
-            .send()
+            .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+            .send_unbuffered()
             .await?;
         assert_eq!(response.name, "test-object");
         assert_eq!(response.bucket, "projects/_/buckets/test-bucket");
@@ -193,7 +138,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn insert_object_not_found() -> Result {
+    async fn send_unbuffered_not_found() -> Result {
         let server = Server::run();
         server.expect(
             Expectation::matching(all_of![
@@ -211,8 +156,8 @@ mod tests {
             .build()
             .await?;
         let err = client
-            .upload_object_unbuffered("projects/_/buckets/test-bucket", "test-object", "")
-            .send()
+            .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+            .send_unbuffered()
             .await
             .expect_err("expected a not found error");
         assert_eq!(err.http_status_code(), Some(404));
@@ -221,13 +166,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_object_unbuffered() -> Result {
+    async fn send_unbuffered_bytes() -> Result {
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
-        let mut request =
-            UploadObjectUnbuffered::new(inner, "projects/_/buckets/bucket", "object", "hello")
-                .http_request_builder()
-                .await?
-                .build()?;
+        let mut request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+            .http_request_builder()
+            .await?
+            .build()?;
 
         assert_eq!(request.method(), reqwest::Method::POST);
         assert_eq!(
@@ -241,7 +185,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_object_unbuffered_stream() -> Result {
+    async fn send_unbuffered_stream() -> Result {
         let stream = VecStream::new(
             [
                 "the ", "quick ", "brown ", "fox ", "jumps ", "over ", "the ", "lazy ", "dog",
@@ -250,11 +194,10 @@ mod tests {
             .to_vec(),
         );
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
-        let mut request =
-            UploadObjectUnbuffered::new(inner, "projects/_/buckets/bucket", "object", stream)
-                .http_request_builder()
-                .await?
-                .build()?;
+        let mut request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", stream)
+            .http_request_builder()
+            .await?
+            .build()?;
 
         assert_eq!(request.method(), reqwest::Method::POST);
         assert_eq!(
@@ -268,13 +211,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_object_unbuffered_error_credentials() -> Result {
+    async fn send_unbuffered_error_credentials() -> Result {
         let config = gaxi::options::ClientConfig {
             cred: Some(auth::credentials::testing::error_credentials(false)),
             ..Default::default()
         };
         let inner = test_inner_client(config);
-        let _ = UploadObjectUnbuffered::new(inner, "projects/_/buckets/bucket", "object", "hello")
+        let _ = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .http_request_builder()
             .await
             .inspect_err(|e| assert!(e.is_authentication()))
@@ -283,9 +226,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_object_unbuffered_bad_bucket() -> Result {
+    async fn send_unbuffered_bad_bucket() -> Result {
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
-        UploadObjectUnbuffered::new(inner, "malformed", "object", "hello")
+        UploadObject::new(inner, "malformed", "object", "hello")
             .http_request_builder()
             .await
             .expect_err("malformed bucket string should error");
@@ -293,17 +236,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_object_unbuffered_headers() -> Result {
+    async fn send_unbuffered_headers() -> Result {
         // Make a 32-byte key.
         let (key, key_base64, _, key_sha256_base64) = create_key_helper();
 
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
-        let request =
-            UploadObjectUnbuffered::new(inner, "projects/_/buckets/bucket", "object", "hello")
-                .with_key(KeyAes256::new(&key)?)
-                .http_request_builder()
-                .await?
-                .build()?;
+        let request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+            .with_key(KeyAes256::new(&key)?)
+            .http_request_builder()
+            .await?
+            .build()?;
 
         assert_eq!(request.method(), reqwest::Method::POST);
         assert_eq!(
@@ -323,39 +265,6 @@ mod tests {
                 bytes::Bytes::from(value)
             );
         }
-        Ok(())
-    }
-
-    #[test_case("projects/p", "projects%2Fp")]
-    #[test_case("kebab-case", "kebab-case")]
-    #[test_case("dot.name", "dot.name")]
-    #[test_case("under_score", "under_score")]
-    #[test_case("tilde~123", "tilde~123")]
-    #[test_case("exclamation!point!", "exclamation%21point%21")]
-    #[test_case("spaces   spaces", "spaces%20%20%20spaces")]
-    #[test_case("preserve%percent%21", "preserve%percent%21")]
-    #[test_case(
-        "testall !#$&'()*+,/:;=?@[]",
-        "testall%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
-    )]
-    #[tokio::test]
-    async fn test_percent_encoding_object_name(name: &str, want: &str) -> Result {
-        let inner = test_inner_client(gaxi::options::ClientConfig::default());
-        let request =
-            UploadObjectUnbuffered::new(inner, "projects/_/buckets/bucket", name, "hello")
-                .http_request_builder()
-                .await?
-                .build()?;
-
-        let got = request
-            .url()
-            .query_pairs()
-            .find_map(|(key, val)| match key.to_string().as_str() {
-                "name" => Some(val.to_string()),
-                _ => None,
-            })
-            .unwrap();
-        assert_eq!(got, want);
         Ok(())
     }
 }

--- a/src/storage/src/client/upload_object/unbuffered.rs
+++ b/src/storage/src/client/upload_object/unbuffered.rs
@@ -166,7 +166,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_unbuffered_bytes() -> Result {
+    async fn upload_object_bytes() -> Result {
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
         let mut request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .http_request_builder()
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_unbuffered_stream() -> Result {
+    async fn upload_object_stream() -> Result {
         let stream = VecStream::new(
             [
                 "the ", "quick ", "brown ", "fox ", "jumps ", "over ", "the ", "lazy ", "dog",
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_unbuffered_error_credentials() -> Result {
+    async fn upload_object_error_credentials() -> Result {
         let config = gaxi::options::ClientConfig {
             cred: Some(auth::credentials::testing::error_credentials(false)),
             ..Default::default()
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_unbuffered_bad_bucket() -> Result {
+    async fn upload_object_bad_bucket() -> Result {
         let inner = test_inner_client(gaxi::options::ClientConfig::default());
         UploadObject::new(inner, "malformed", "object", "hello")
             .http_request_builder()
@@ -236,7 +236,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_unbuffered_headers() -> Result {
+    async fn upload_object_headers() -> Result {
         // Make a 32-byte key.
         let (key, key_base64, _, key_sha256_base64) = create_key_helper();
 


### PR DESCRIPTION
Use a single method in the `Storage` client to upload objects. Then
implement two different methods in the request builder:

- `send()` uses buffered uploads, probably the most common case.
- `send_unbuffered()` skips any local buffering.

Part of the work for #2043
