### PR TITLE
chore: improve deserde of errors from Status

### DIFF
--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -390,11 +390,7 @@ impl From<&rpc::model::Status> for Status {
         Self {
             code: value.code.into(),
             message: value.message.clone(),
-            details: value
-                .details
-                .iter()
-                .map(|d| StatusDetails::from(d))
-                .collect(),
+            details: value.details.iter().map(StatusDetails::from).collect(),
         }
     }
 }

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -390,7 +390,11 @@ impl From<&rpc::model::Status> for Status {
         Self {
             code: value.code.into(),
             message: value.message.clone(),
-            details: value.details.iter().map(|d| StatusDetails::from(d)).collect(),
+            details: value
+                .details
+                .iter()
+                .map(|d| StatusDetails::from(d))
+                .collect(),
         }
     }
 }
@@ -427,7 +431,6 @@ pub enum StatusDetails {
     #[serde(untagged)]
     Other(wkt::Any),
 }
-
 
 impl From<wkt::Any> for StatusDetails {
     fn from(value: wkt::Any) -> Self {
@@ -809,7 +812,9 @@ mod tests {
             .set_message("try-again")
             .set_details(vec![wkt::Any::from_msg(&detail).unwrap()]);
 
-        let status = Status::from(&input);
+        let from_ref = Status::from(&input);
+        let status = Status::from(input);
+        assert_eq!(from_ref, status);
         assert_eq!(status.code, Code::Unavailable);
         assert_eq!(status.message, "try-again");
 
@@ -824,7 +829,9 @@ mod tests {
             .set_code(Code::Unavailable as i32)
             .set_message("try-again")
             .set_details(vec![any.clone()]);
-        let got = Status::from(&input);
+        let from_ref = Status::from(&input);
+        let got = Status::from(input);
+        assert_eq!(from_ref, got);
         assert_eq!(got.code, Code::Unavailable);
         assert_eq!(got.message, "try-again");
 

--- a/src/integration-tests/src/showcase/echo.rs
+++ b/src/integration-tests/src/showcase/echo.rs
@@ -77,7 +77,7 @@ async fn echo_error_details(client: &showcase::client::Echo) -> Result<()> {
         .and_then(|f| f.error)
         .and_then(|f| f.details)
         .expect("has single_detail with error and any");
-    if let StatusDetails::ErrorInfo(info) = StatusDetails::from(any) {
+    if let StatusDetails::ErrorInfo(info) = StatusDetails::from(&any) {
         assert_eq!(info.reason.as_str(), TEXT);
     }
     Ok(())

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -253,7 +253,7 @@ pub async fn manual(
         match result {
             LR::Error(status) => {
                 println!("LRO completed with error {status:?}");
-                let status = gax::error::rpc::Status::from(&*status);
+                let status = gax::error::rpc::Status::from(*status);
                 return Err(anyhow::Error::from(gax::error::Error::service(status)));
             }
             LR::Response(any) => {

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -253,7 +253,7 @@ pub async fn manual(
         match result {
             LR::Error(status) => {
                 println!("LRO completed with error {status:?}");
-                let status = gax::error::rpc::Status::from(*status);
+                let status = gax::error::rpc::Status::from(&*status);
                 return Err(anyhow::Error::from(gax::error::Error::service(status)));
             }
             LR::Response(any) => {
@@ -290,7 +290,7 @@ pub async fn manual(
         match result {
             LR::Error(status) => {
                 println!("LRO completed with error {status:?}");
-                let status = gax::error::rpc::Status::from(*status);
+                let status = gax::error::rpc::Status::from(&*status);
                 return Err(anyhow::Error::from(gax::error::Error::service(status)));
             }
             LR::Response(any) => {

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -153,7 +153,7 @@ where
     // invariants required by the receiving type.
     match (op.response(), op.error()) {
         (Some(any), None) => any.to_msg::<R>().map_err(Error::deser),
-        (None, Some(e)) => Err(Error::service(gax::error::rpc::Status::from(e.clone()))),
+        (None, Some(e)) => Err(Error::service(gax::error::rpc::Status::from(e))),
         (None, None) => Err(Error::deser("neither result nor error set in LRO result")),
         (Some(_), Some(_)) => unreachable!("result and error held in a oneof"),
     }


### PR DESCRIPTION
Fixes #2440 

Implements `impl From<&rpc::model::Status> for Status` to avoid cloning before converting