### PR TITLE
fix(auth): Implement framework for Auth Request metric headers and use in impersonated creds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rsa",
+ "rustc_version",
  "rustls",
  "rustls-pemfile",
  "scoped-env",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -16,6 +16,7 @@
 name        = "google-cloud-auth"
 version     = "0.21.0"
 description = "Google Cloud Client Libraries for Rust - Authentication"
+build       = "build.rs"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true
@@ -24,6 +25,9 @@ keywords.workspace     = true
 license.workspace      = true
 repository.workspace   = true
 rust-version.workspace = true
+
+[build-dependencies]
+rustc_version.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/src/auth/build.rs
+++ b/src/auth/build.rs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR not specified");
+    let out_path = Path::new(&out_dir).to_owned();
+
+    let rust_version = rustc_version::version().expect("Could not retrieve rustc version");
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let mut f =
+        File::create(out_path.join("build_env.rs")).expect("Could not create build_env.rs file");
+    f.write_all(format!("pub(crate) const RUSTC_VERSION: &str = \"{rust_version}\";\n").as_bytes())
+        .expect("Unable to write rust version");
+    f.write_all(format!("pub(crate) const PKG_VERSION: &str = \"{pkg_version}\";").as_bytes())
+        .expect("Unable to write pkg version");
+    f.flush().expect("failed to flush");
+}

--- a/src/auth/build.rs
+++ b/src/auth/build.rs
@@ -20,10 +20,16 @@ fn main() {
     let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR not specified");
     let out_path = Path::new(&out_dir).to_owned();
 
-    let rust_version = rustc_version::version().expect("Could not retrieve rustc version");
+    let rust_version = rustc_version::version()
+        .expect("Could not retrieve rustc version")
+        .to_string();
+
+    // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
+    // found, leave RUSTC_VERSION unchanged.
+    let rust_version = rust_version.strip_prefix("rustc ").unwrap_or(&rust_version);
     let pkg_version = env!("CARGO_PKG_VERSION");
     let mut f =
-        File::create(out_path.join("build_env.rs")).expect("Could not create build_env.rs file");
+        File::create(out_path.join("build_env.rs")).expect("Could not create build environment");
     f.write_all(format!("pub(crate) const RUSTC_VERSION: &str = \"{rust_version}\";\n").as_bytes())
         .expect("Unable to write rust version");
     f.write_all(format!("pub(crate) const PKG_VERSION: &str = \"{pkg_version}\";").as_bytes())

--- a/src/auth/src/headers_util.rs
+++ b/src/auth/src/headers_util.rs
@@ -33,14 +33,7 @@ pub(crate) const ACCESS_TOKEN_REQUEST_TYPE: &str = "at";
 
 /// Format the struct as needed for the `x-goog-api-client` header.
 pub(crate) fn metrics_header_value(request_type: &str, cred_type: &str) -> String {
-    // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
-    // found, leave RUSTC_VERSION unchanged.
     let rustc_version = build_info::RUSTC_VERSION;
-    let rustc_version = rustc_version
-        .strip_prefix("rustc ")
-        .unwrap_or(build_info::RUSTC_VERSION);
-
-    // Capture the auth version too.
     let auth_version = build_info::PKG_VERSION;
 
     format!(
@@ -364,9 +357,7 @@ mod tests {
     #[test]
     fn test_metrics_header_value() {
         let header = metrics_header_value("at", "u");
-        let rustc_version = build_info::RUSTC_VERSION
-            .strip_prefix("rustc ")
-            .unwrap_or(build_info::RUSTC_VERSION);
+        let rustc_version = build_info::RUSTC_VERSION;
         let expected = format!(
             "gl-rust/{} auth/{} auth-request-type/at cred-type/u",
             rustc_version,


### PR DESCRIPTION
Metrics headers from auth and client libraries are sent through `x-goog-api-client` header. These headers are used for auth requests to get token as well as while using the auth tokens and making an API call.

This PR focuses on the headers for the auth requests only.

There will be future PRs for auth request headers for other cred types and for token usage through grpc and http requests. 