### PR TITLE
impl(storage): retry resumable sessions

### DIFF
--- a/src/storage/src/client.rs
+++ b/src/storage/src/client.rs
@@ -482,7 +482,7 @@ fn apply_customer_supplied_encryption_headers(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
     use test_case::test_case;
 
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
@@ -497,6 +497,13 @@ mod tests {
         config.endpoint = config
             .endpoint
             .or_else(|| Some("http://private.googleapis.com".into()));
+        // For unit tests we want really fast backoffs
+        config.backoff_policy = Some(Arc::new(
+            gax::exponential_backoff::ExponentialBackoffBuilder::new()
+                .with_initial_delay(Duration::from_millis(1))
+                .with_maximum_delay(Duration::from_millis(2))
+                .clamp(),
+        ));
         Arc::new(StorageInner::new(client, config))
     }
 

--- a/src/storage/src/client/upload_object.rs
+++ b/src/storage/src/client/upload_object.rs
@@ -586,8 +586,7 @@ impl<T> UploadObject<T> {
             // Creating a resumable upload is always idempotent. There are no
             // **observable** side-effects if executed multiple times. Any extra
             // sessions created in the retry loop are simply lost and eventually
-            // garbage collected. There are no `list` operations, or billing, or
-            // cause any other side-effect that applications may observe.
+            // garbage collected.
             true,
             self.inner.retry_throttler.clone(),
             self.inner.retry_policy.clone(),


### PR DESCRIPTION
When creating a new resumable upload session we should retry in case of
transient failures.

Part of the work for #2057