### PR TITLE
fix(auth)!: Remove option for loading any credential type from json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ tokio-test     = { default-features = false, version = "0.4" }
 num-bigint-dig = { default-features = false, version = "0.8" }
 
 # Local packages used as dependencies
-auth                          = { version = "0.21", path = "src/auth", package = "google-cloud-auth" }
+auth                          = { version = "0.22", path = "src/auth", package = "google-cloud-auth" }
 gax                           = { version = "0.23.0", path = "src/gax", package = "google-cloud-gax" }
 gaxi                          = { version = "0.3", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.4", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-auth"
-version     = "0.21.0"
+version     = "0.22.0"
 description = "Google Cloud Client Libraries for Rust - Authentication"
 # Inherit other attributes from the workspace.
 authors.workspace      = true


### PR DESCRIPTION
Removing the option for loading arbitrary credential json in order to prevent misuse.

Users can still use ADC and can still load json through credential specific builders. 