### PR TITLE
cleanup(storage): hide generated implementation details

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -160,6 +160,8 @@ type messageAnnotation struct {
 	// If set, this message is only enabled when some features are enabled.
 	FeatureGates   []string
 	FeatureGatesOp string
+	// If true, this message's visibility should only be `pub(crate)`
+	Internal bool
 }
 
 type methodAnnotation struct {
@@ -643,6 +645,7 @@ func (c *codec) annotateMessage(m *api.Message, state *api.APIState, sourceSpeci
 		HasNestedTypes:     language.HasNestedTypes(m),
 		BasicFields:        basicFields,
 		HasSyntheticFields: hasSyntheticFields,
+		Internal:           slices.Contains(c.internalTypes, m.ID),
 	}
 }
 

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -1503,3 +1503,38 @@ func TestBindingSubstitutionTemplates(t *testing.T) {
 		t.Errorf("TemplateAsArray() failed. want=`%s`, got=`%s`", want, got)
 	}
 }
+
+func TestInternalMessageOverrides(t *testing.T) {
+	public := &api.Message{
+		Name: "Public",
+		ID:   ".test.Public",
+	}
+	private1 := &api.Message{
+		Name: "Private1",
+		ID:   ".test.Private1",
+	}
+	private2 := &api.Message{
+		Name: "Private2",
+		ID:   ".test.Private2",
+	}
+	model := api.NewTestAPI([]*api.Message{public, private1, private2},
+		[]*api.Enum{},
+		[]*api.Service{})
+	codec, err := newCodec(true, map[string]string{
+		"internal-types": ".test.Private1,.test.Private2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	annotateModel(model, codec)
+
+	if public.Codec.(*messageAnnotation).Internal {
+		t.Errorf("Public method should not be flagged as internal")
+	}
+	if !private1.Codec.(*messageAnnotation).Internal {
+		t.Errorf("Private method should not be flagged as internal")
+	}
+	if !private2.Codec.(*messageAnnotation).Internal {
+		t.Errorf("Private method should not be flagged as internal")
+	}
+}

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -136,6 +136,8 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 				return nil, fmt.Errorf("cannot convert `has-veneer` value %q to boolean: %w", definition, err)
 			}
 			codec.hasVeneer = value
+		case key == "internal-types":
+			codec.internalTypes = strings.Split(definition, ",")
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -228,7 +230,7 @@ type codec struct {
 	disabledRustdocWarnings []string
 	// The default system parameters included in all requests.
 	systemParameters []systemParameter
-	// Overrides the template sudirectory.
+	// Overrides the template subdirectory.
 	templateOverride string
 	// If true, this includes gRPC-only methods, such as methods without HTTP
 	// annotations.
@@ -237,6 +239,15 @@ type codec struct {
 	perServiceFeatures bool
 	// If true, there is a handwritten client surface.
 	hasVeneer bool
+	// A list of types which should only be `pub(crate)`.
+	//
+	// In rare cases, it is easiest to manage type visibility via the codec
+	// instead of a handwritten `lib.rs`. One such example is `storage`,
+	// where we want to export all types (50+, and growing) except for a
+	// few, which are only implementation details.
+	//
+	// Only supports messages.
+	internalTypes []string
 }
 
 type systemParameter struct {

--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -24,7 +24,12 @@ limitations under the License.
 {{#Deprecated}}
 #[deprecated]
 {{/Deprecated}}
+{{#Codec.Internal}}
+pub(crate) struct {{Codec.Name}} {
+{{/Codec.Internal}}
+{{^Codec.Internal}}
 pub struct {{Codec.Name}} {
+{{/Codec.Internal}}
     {{#Codec.BasicFields}}
 
     {{#Codec.DocLines}}

--- a/src/storage/src/control.rs
+++ b/src/storage/src/control.rs
@@ -22,11 +22,6 @@ pub mod builder {
     pub use crate::control::generated::gapic_control::builder::storage_control::*;
 }
 pub mod model {
-    // TODO(#2403) - Do not leak `ReadObjectRequest`, `WriteObjectSpec`
-    // Note that there are 55 types captured by this `*`. Ugh.
-    //
-    // We should flag the types we don't want to export as `pub(crate)` via
-    // annotations in the Rust codec.
     pub use crate::control::generated::gapic::model::*;
     pub use crate::control::generated::gapic_control::model::*;
 }

--- a/src/storage/src/control/generated/gapic/.sidekick.toml
+++ b/src/storage/src/control/generated/gapic/.sidekick.toml
@@ -47,3 +47,7 @@ package-name-override     = 'google-cloud-storage'
 name-overrides            = '.google.storage.v2.Storage=StorageControl'
 include-grpc-only-methods = 'true'
 has-veneer                = 'true'
+internal-types            = """\
+    .google.storage.v2.ReadObjectRequest,\
+    .google.storage.v2.WriteObjectSpec\
+    """

--- a/src/storage/src/control/generated/gapic/model.rs
+++ b/src/storage/src/control/generated/gapic/model.rs
@@ -3746,7 +3746,7 @@ impl serde::ser::Serialize for RestoreObjectRequest {
 /// Request message for ReadObject.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
-pub struct ReadObjectRequest {
+pub(crate) struct ReadObjectRequest {
     /// Required. The name of the bucket containing the object to read.
     pub bucket: std::string::String,
 
@@ -4970,7 +4970,7 @@ impl serde::ser::Serialize for GetObjectRequest {
 /// Describes an attempt to insert an object, possibly over multiple requests.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
-pub struct WriteObjectSpec {
+pub(crate) struct WriteObjectSpec {
     /// Required. Destination object, including its name and its metadata.
     pub resource: std::option::Option<crate::model::Object>,
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -46,25 +46,19 @@ pub mod client {
 /// Request builders.
 pub mod builder {
     pub mod storage {
-        // TODO(#2403) - Move `ClientBuilder` into a scoped namespace within the
-        // builder mod, like we do for GAPICs.
         pub use crate::storage::client::ClientBuilder;
         pub use crate::storage::read_object::ReadObject;
         pub use crate::storage::upload_object::UploadObject;
     }
     pub mod storage_control {
         pub use crate::control::builder::*;
-        // TODO(#2403) - Move `ClientBuilder` into a scoped namespace within the
-        // builder mod, like we do for GAPICs.
         pub use crate::control::client::ClientBuilder;
     }
 }
-// TODO(#2403) - This includes implementation details like `ReadObjectRequest`.
-// We do not want to expose those in the long run.
+/// The messages and enums that are part of this client library.
 pub use crate::control::model;
 pub use crate::control::stub;
 
-// TODO(#2403) - move into control.rs ?
 pub(crate) mod google {
     pub mod iam {
         pub mod v1 {


### PR DESCRIPTION
Fixes #2403 

Hides `ReadObjectRequest`, `WriteObjectSpec` from the public API.

Note that if we enumerated the types we want to expose from `storage/v2`, we would have to manually maintain that list.

If we exclude the two types via the codec, we are not broken if existing `storage/v2` requests gain new message fields.

---

I might still move things around internally, but the public API is stable, and what we want. [meme](https://cdn-useast1.kapwing.com/static/templates/homer-simpsons-back-fat-meme-template-thumbnail-9f5dc0bb.webp)