### PR TITLE
impl(storage): only use `WriteObjectSpec`

### DIFF
--- a/src/storage/src/storage/upload_object/unbuffered.rs
+++ b/src/storage/src/storage/upload_object/unbuffered.rs
@@ -68,13 +68,13 @@ where
         let payload = self.payload.clone();
         payload.lock().await.seek(0).await.map_err(Error::ser)?;
 
-        let bucket = &self.resource.bucket;
+        let bucket = &self.resource().bucket;
         let bucket_id = bucket.strip_prefix("projects/_/buckets/").ok_or_else(|| {
             Error::binding(format!(
                 "malformed bucket name, it must start with `projects/_/buckets/`: {bucket}"
             ))
         })?;
-        let object = &self.resource.name;
+        let object = &self.resource().name;
         let builder = self
             .inner
             .client
@@ -102,9 +102,10 @@ where
             }
             None
         }));
-        let metadata = reqwest::multipart::Part::text(v1::insert_body(&self.resource).to_string())
-            .mime_str("application/json; charset=UTF-8")
-            .map_err(Error::ser)?;
+        let metadata =
+            reqwest::multipart::Part::text(v1::insert_body(&self.resource()).to_string())
+                .mime_str("application/json; charset=UTF-8")
+                .map_err(Error::ser)?;
         let form = reqwest::multipart::Form::new()
             .part("metadata", metadata)
             .part(

--- a/src/storage/src/storage/upload_object/unbuffered.rs
+++ b/src/storage/src/storage/upload_object/unbuffered.rs
@@ -103,7 +103,7 @@ where
             None
         }));
         let metadata =
-            reqwest::multipart::Part::text(v1::insert_body(&self.resource()).to_string())
+            reqwest::multipart::Part::text(v1::insert_body(self.resource()).to_string())
                 .mime_str("application/json; charset=UTF-8")
                 .map_err(Error::ser)?;
         let form = reqwest::multipart::Form::new()

--- a/src/storage/src/storage/upload_object/unbuffered.rs
+++ b/src/storage/src/storage/upload_object/unbuffered.rs
@@ -102,10 +102,9 @@ where
             }
             None
         }));
-        let metadata =
-            reqwest::multipart::Part::text(v1::insert_body(self.resource()).to_string())
-                .mime_str("application/json; charset=UTF-8")
-                .map_err(Error::ser)?;
+        let metadata = reqwest::multipart::Part::text(v1::insert_body(self.resource()).to_string())
+            .mime_str("application/json; charset=UTF-8")
+            .map_err(Error::ser)?;
         let form = reqwest::multipart::Form::new()
             .part("metadata", metadata)
             .part(


### PR DESCRIPTION
Change `UploadObject` to use the `self.spec.resource` field to keep
object metadata information. This will make it easier to write the
idempotency policies.

Part of the changes for #2056 