### PR TITLE
refactor(generator/rust): more targeted crate detection

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -46,9 +46,6 @@ type modelAnnotations struct {
 	Services          []*api.Service
 	NameToLower       string
 	NotForPublication bool
-	// When bootstrapping the well-known types crate the templates add some
-	// ad-hoc code.
-	IsWktCrate bool
 	// If true, disable rustdoc warnings known to be triggered by our generated
 	// documentation.
 	DisabledRustdocWarnings []string
@@ -58,6 +55,12 @@ type modelAnnotations struct {
 	PerServiceFeatures bool
 	// If true, at lease one service has a method we cannot wrap (yet).
 	Incomplete bool
+}
+
+// When bootstrapping the well-known types crate the templates add some
+// ad-hoc code.
+func (m *modelAnnotations) IsWktCrate() bool {
+	return m.PackageName == "google-cloud-wkt"
 }
 
 // HasServices returns true if there are any services in the model
@@ -477,7 +480,6 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		Services:                servicesSubset,
 		NameToLower:             strings.ToLower(model.Name),
 		NotForPublication:       codec.doNotPublish,
-		IsWktCrate:              model.PackageName == "google.protobuf",
 		DisabledRustdocWarnings: codec.disabledRustdocWarnings,
 		PerServiceFeatures:      codec.perServiceFeatures && len(servicesSubset) > 0,
 		Incomplete: slices.ContainsFunc(model.Services, func(s *api.Service) bool {

--- a/src/wkt/src/generated/.sidekick.toml
+++ b/src/wkt/src/generated/.sidekick.toml
@@ -20,6 +20,7 @@ roots        = 'protobuf-src'
 include-list = "api.proto,source_context.proto,type.proto,descriptor.proto"
 
 [codec]
-copyright-year    = '2025'
-template-override = 'templates/mod'
-module-path       = 'crate'
+copyright-year        = '2025'
+template-override     = 'templates/mod'
+module-path           = 'crate'
+package-name-override = 'google-cloud-wkt'


### PR DESCRIPTION
I need something like this for `gaxi`, and the simplest way to achieve it is to tell the codec which crate we are in via the `package-name-override`.