### PR TITLE
feat: full error details over gRPC

### DIFF
--- a/src/gax-internal/src/grpc/status.rs
+++ b/src/gax-internal/src/grpc/status.rs
@@ -13,15 +13,13 @@
 // limitations under the License.
 
 use crate::google;
-use crate::prost::{ConvertError, FromProto, ToProto};
+use crate::prost::{FromProto, ToProto};
 
-// TODO(#1699) - use to convert a `tonic::Status`
-#[allow(dead_code)]
-fn status_from_proto(s: google::rpc::Status) -> Result<rpc::model::Status, ConvertError> {
-    Ok(rpc::model::Status::new()
+pub(crate) fn status_from_proto(s: google::rpc::Status) -> rpc::model::Status {
+    rpc::model::Status::new()
         .set_code(s.code)
         .set_message(s.message)
-        .set_details(s.details.into_iter().filter_map(any_from_prost)))
+        .set_details(s.details.into_iter().filter_map(any_from_prost))
 }
 
 pub fn any_to_prost(value: wkt::Any) -> Option<prost_types::Any> {

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -156,10 +156,20 @@ mod driver {
 
     #[test_case(ta::client::TelcoAutomation::builder().with_tracing(); "with tracing enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_error_details(
+    async fn run_error_details_http(
         builder: ta::builder::telco_automation::ClientBuilder,
     ) -> integration_tests::Result<()> {
-        integration_tests::error_details::run(builder)
+        integration_tests::error_details::error_details_http(builder)
+            .await
+            .map_err(integration_tests::report_error)
+    }
+
+    #[test_case(StorageControl::builder().with_tracing(); "with tracing enabled")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_error_details_grpc(
+        builder: storage::builder::storage_control::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::error_details::error_details_grpc(builder)
             .await
             .map_err(integration_tests::report_error)
     }


### PR DESCRIPTION
Fixes #1699 

Captures error details from tonic, and surfaces them in our `gax::error::rpc::Status`.

gRPC is weird. They send the code in `grpc-status`, and the message in `grpc-message`, and then they also encode a full `google.rpc.Status` proto (which has a `code` and `message` field) in `grpc-status-details-bin`. Seems redundant to me. I will just assume they are always the same :shrug:. If they aren't the non-binary headers will win.

https://docs.rs/tonic/0.13.1/src/tonic/status.rs.html#442-457

Added an integration test, to confirm the weirdness.