### PR TITLE
cleanup(auth/gax): simplify examples

### DIFF
--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -188,9 +188,8 @@ impl Builder {
     ///
     /// ```
     /// # use google_cloud_auth::credentials::mds::Builder;
-    /// # use gax::retry_policy;
-    /// # use gax::retry_policy::RetryPolicyExt;
     /// # tokio_test::block_on(async {
+    /// use gax::retry_policy::{self, RetryPolicyExt};
     /// let credentials = Builder::default()
     ///     .with_retry_policy(retry_policy::AlwaysRetry.with_attempt_limit(3))
     ///     .build();
@@ -207,14 +206,10 @@ impl Builder {
     ///
     /// ```
     /// # use google_cloud_auth::credentials::mds::Builder;
-    /// # use gax::exponential_backoff::ExponentialBackoffBuilder;
     /// # use std::time::Duration;
     /// # tokio_test::block_on(async {
-    /// let policy = ExponentialBackoffBuilder::new()
-    ///     .with_initial_delay(Duration::from_millis(100))
-    ///     .with_maximum_delay(Duration::from_secs(5))
-    ///     .with_scaling(4.0)
-    ///     .build().expect("well-known policy values should succeed");
+    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// let policy = ExponentialBackoff::default();
     /// let credentials = Builder::default()
     ///     .with_backoff_policy(policy)
     ///     .build();
@@ -238,11 +233,10 @@ impl Builder {
     ///
     /// ```
     /// # use google_cloud_auth::credentials::mds::Builder;
-    /// # use gax::retry_throttler::AdaptiveThrottler;
     /// # tokio_test::block_on(async {
+    /// use gax::retry_throttler::AdaptiveThrottler;
     /// let credentials = Builder::default()
-    ///     .with_retry_throttler(AdaptiveThrottler::new(2.0)
-    ///         .expect("well-known policy values should succeed"))
+    ///     .with_retry_throttler(AdaptiveThrottler::default())
     ///     .build();
     /// # });
     /// ```

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -189,9 +189,9 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::mds::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{self, RetryPolicyExt};
+    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let credentials = Builder::default()
-    ///     .with_retry_policy(retry_policy::AlwaysRetry.with_attempt_limit(3))
+    ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
     ///     .build();
     /// # });
     /// ```

--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -201,8 +201,8 @@ impl Builder {
     ///
     /// ```
     /// # use google_cloud_auth::credentials::user_account::Builder;
-    /// use gax::retry_policy::{self, RetryPolicyExt};
     /// # tokio_test::block_on(async {
+    /// use gax::retry_policy::{self, RetryPolicyExt};
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",
@@ -225,9 +225,9 @@ impl Builder {
     ///
     /// ```
     /// # use google_cloud_auth::credentials::user_account::Builder;
-    /// use gax::exponential_backoff::ExponentialBackoff;
     /// # use std::time::Duration;
     /// # tokio_test::block_on(async {
+    /// use gax::exponential_backoff::ExponentialBackoff;
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",
@@ -257,8 +257,8 @@ impl Builder {
     ///
     /// ```
     /// # use google_cloud_auth::credentials::user_account::Builder;
-    /// use gax::retry_throttler::AdaptiveThrottler;
     /// # tokio_test::block_on(async {
+    /// use gax::retry_throttler::AdaptiveThrottler;
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",

--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -202,7 +202,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::user_account::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{self, RetryPolicyExt};
+    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",
@@ -210,7 +210,7 @@ impl Builder {
     ///     "type": "authorized_user",
     /// });
     /// let credentials = Builder::new(authorized_user)
-    ///     .with_retry_policy(retry_policy::AlwaysRetry.with_attempt_limit(3))
+    ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
     ///     .build();
     /// # });
     /// ```

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -262,8 +262,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
-    /// use gax::retry_policy;
-    /// use gax::retry_policy::RetryPolicyExt;
+    /// use gax::retry_policy::{self, RetryPolicyExt};
     /// let client = Client::builder()
     ///     .with_retry_policy(retry_policy::AlwaysRetry.with_attempt_limit(3))
     ///     .build().await?;
@@ -285,13 +284,9 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
-    /// use gax::exponential_backoff::ExponentialBackoffBuilder;
+    /// use gax::exponential_backoff::ExponentialBackoff;
     /// use std::time::Duration;
-    /// let policy = ExponentialBackoffBuilder::new()
-    ///     .with_initial_delay(Duration::from_millis(100))
-    ///     .with_maximum_delay(Duration::from_secs(5))
-    ///     .with_scaling(4.0)
-    ///     .build().expect("well-known policy values should succeed");
+    /// let policy = ExponentialBackoff::default();
     /// let client = Client::builder()
     ///     .with_backoff_policy(policy)
     ///     .build().await?;
@@ -321,8 +316,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// use examples::Client; // Placeholder for examples
     /// use gax::retry_throttler::AdaptiveThrottler;
     /// let client = Client::builder()
-    ///     .with_retry_throttler(AdaptiveThrottler::new(2.0)
-    ///         .expect("well-known policy values should succeed"))
+    ///     .with_retry_throttler(AdaptiveThrottler::default())
     ///     .build().await?;
     /// # Result::<()>::Ok(()) });
     /// ```
@@ -374,13 +368,9 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
-    /// use gax::exponential_backoff::ExponentialBackoffBuilder;
+    /// use gax::exponential_backoff::ExponentialBackoff;
     /// use std::time::Duration;
-    /// let policy = ExponentialBackoffBuilder::new()
-    ///     .with_initial_delay(Duration::from_millis(100))
-    ///     .with_maximum_delay(Duration::from_secs(5))
-    ///     .with_scaling(4.0)
-    ///     .build().expect("well-known policy values should succeed");
+    /// let policy = ExponentialBackoffBuilder::default();
     /// let client = Client::builder()
     ///     .with_polling_backoff_policy(policy)
     ///     .build().await?;

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -262,9 +262,9 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
-    /// use gax::retry_policy::{self, RetryPolicyExt};
+    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let client = Client::builder()
-    ///     .with_retry_policy(retry_policy::AlwaysRetry.with_attempt_limit(3))
+    ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
     ///     .build().await?;
     /// # Result::<()>::Ok(()) });
     /// ```

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -370,7 +370,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// use examples::Client; // Placeholder for examples
     /// use gax::exponential_backoff::ExponentialBackoff;
     /// use std::time::Duration;
-    /// let policy = ExponentialBackoffBuilder::default();
+    /// let policy = ExponentialBackoff::default();
     /// let client = Client::builder()
     ///     .with_polling_backoff_policy(policy)
     ///     .build().await?;

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -379,8 +379,7 @@ impl ClientBuilder {
     /// # async fn sample() -> anyhow::Result<()> {
     /// use gax::exponential_backoff::ExponentialBackoff;
     /// use std::time::Duration;
-    /// let policy = ExponentialBackoff::default()
-    ///     .build()?;
+    /// let policy = ExponentialBackoff::default();
     /// let client = Storage::builder()
     ///     .with_backoff_policy(policy)
     ///     .build()

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -377,12 +377,9 @@ impl ClientBuilder {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// use gax::exponential_backoff::ExponentialBackoffBuilder;
+    /// use gax::exponential_backoff::ExponentialBackoff;
     /// use std::time::Duration;
-    /// let policy = ExponentialBackoffBuilder::new()
-    ///     .with_initial_delay(Duration::from_millis(100))
-    ///     .with_maximum_delay(Duration::from_secs(5))
-    ///     .with_scaling(4.0)
+    /// let policy = ExponentialBackoff::default()
     ///     .build()?;
     /// let client = Storage::builder()
     ///     .with_backoff_policy(policy)

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -594,7 +594,6 @@ impl<T> UploadObject<T> {
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_backoff_policy(ExponentialBackoff::default())
     ///         .build()?,
-    ///     )
     ///     .send()
     ///     .await?;
     /// println!("response details={response:?}");

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -593,7 +593,6 @@ impl<T> UploadObject<T> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_backoff_policy(ExponentialBackoff::default())
-    ///         .build()?,
     ///     .send()
     ///     .await?;
     /// println!("response details={response:?}");

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -589,12 +589,10 @@ impl<T> UploadObject<T> {
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use std::time::Duration;
-    /// use gax::exponential_backoff::ExponentialBackoffBuilder;
+    /// use gax::exponential_backoff::ExponentialBackoff;
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .with_backoff_policy(ExponentialBackoffBuilder::new()
-    ///         .with_initial_delay(Duration::from_secs(2))
-    ///         .with_maximum_delay(Duration::from_secs(300))
+    ///     .with_backoff_policy(ExponentialBackoff::default())
     ///         .build()?,
     ///     )
     ///     .send()


### PR DESCRIPTION
As a followup to https://github.com/googleapis/google-cloud-rust/pull/2659 simplify examples at the other places.