### PR TITLE
chore(auth): temporarily use `-rc1` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.22.0"
+version = "0.22.0-rc1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,7 +334,7 @@ tokio-stream   = { default-features = false, version = "0.1" }
 tokio-test     = { default-features = false, version = "0.4" }
 
 # Local packages used as dependencies
-auth                          = { version = "0.22", path = "src/auth", package = "google-cloud-auth" }
+auth                          = { version = "0.22.0-rc1", path = "src/auth", package = "google-cloud-auth" }
 gax                           = { version = "0.23.1-rc1", path = "src/gax", package = "google-cloud-gax" }
 gaxi                          = { version = "0.4.0-rc1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.4.1-rc1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-auth"
-version     = "0.22.0"
+version     = "0.22.0-rc1"
 description = "Google Cloud Client Libraries for Rust - Authentication"
 build       = "build.rs"
 # Inherit other attributes from the workspace.


### PR DESCRIPTION
We want to test all the versions in a `*-rc1` release because too many
versions changed manually.
