### PR TITLE
feat(auth): add retry for impersonated cred

### DIFF
--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -67,12 +67,14 @@ use crate::errors::{self, CredentialsError};
 use crate::headers_util::{
     self, ACCESS_TOKEN_REQUEST_TYPE, build_cacheable_headers, metrics_header_value,
 };
-
-const IMPERSONATED_CREDENTIAL_TYPE: &str = "imp";
+use crate::retry::{Builder as RetryTokenProviderBuilder, TokenProviderWithRetry};
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, Result};
 use async_trait::async_trait;
+use gax::backoff_policy::BackoffPolicyArg;
+use gax::retry_policy::RetryPolicyArg;
+use gax::retry_throttler::RetryThrottlerArg;
 use http::{Extensions, HeaderMap};
 use reqwest::Client;
 use serde_json::Value;
@@ -81,6 +83,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::time::Instant;
+
+const IMPERSONATED_CREDENTIAL_TYPE: &str = "imp";
 
 pub(crate) const DEFAULT_LIFETIME: Duration = Duration::from_secs(3600);
 const MSG: &str = "failed to fetch token";
@@ -116,6 +120,7 @@ pub struct Builder {
     scopes: Option<Vec<String>>,
     quota_project_id: Option<String>,
     lifetime: Option<Duration>,
+    retry_builder: RetryTokenProviderBuilder,
 }
 
 impl Builder {
@@ -134,6 +139,7 @@ impl Builder {
             scopes: None,
             quota_project_id: None,
             lifetime: None,
+            retry_builder: RetryTokenProviderBuilder::default(),
         }
     }
 
@@ -162,6 +168,7 @@ impl Builder {
             scopes: None,
             quota_project_id: None,
             lifetime: None,
+            retry_builder: RetryTokenProviderBuilder::default(),
         }
     }
 
@@ -290,6 +297,76 @@ impl Builder {
         self
     }
 
+    /// Configure the retry policy for fetching tokens.
+    ///
+    /// The retry policy controls how to handle retries, and sets limits on
+    /// the number of attempts or the total time spent retrying.
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::impersonated;
+    /// # use serde_json::json;
+    /// # tokio_test::block_on(async {
+    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// let impersonated_credential = json!({ /* add details here */ });
+    /// let credentials = Builder::new(impersonated_credential.into())
+    ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_retry_policy<V: Into<RetryPolicyArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_retry_policy(v.into());
+        self
+    }
+
+    /// Configure the retry backoff policy.
+    ///
+    /// The backoff policy controls how long to wait in between retry attempts.
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::impersonated;
+    /// # use serde_json::json;
+    /// # use std::time::Duration;
+    /// # tokio_test::block_on(async {
+    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// let policy = ExponentialBackoff::default();
+    /// let impersonated_credential = json!({ /* add details here */ });
+    /// let credentials = Builder::new(impersonated_credential.into())
+    ///     .with_backoff_policy(policy)
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_backoff_policy<V: Into<BackoffPolicyArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_backoff_policy(v.into());
+        self
+    }
+
+    /// Configure the retry throttler.
+    ///
+    /// Advanced applications may want to configure a retry throttler to
+    /// [Address Cascading Failures] and when [Handling Overload] conditions.
+    /// The authentication library throttles its retry loop, using a policy to
+    /// control the throttling algorithm. Use this method to fine tune or
+    /// customize the default retry throttler.
+    ///
+    /// [Handling Overload]: https://sre.google/sre-book/handling-overload/
+    /// [Address Cascading Failures]: https://sre.google/sre-book/addressing-cascading-failures/
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::impersonated;
+    /// # use serde_json::json;
+    /// # tokio_test::block_on(async {
+    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// let impersonated_credential = json!({ /* add details here */ });
+    /// let credentials = Builder::new(impersonated_credential.into())
+    ///     .with_retry_throttler(AdaptiveThrottler::default())
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_retry_throttler<V: Into<RetryThrottlerArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_retry_throttler(v.into());
+        self
+    }
+
     /// Returns a [Credentials] instance with the configured settings.
     ///
     /// # Errors
@@ -316,7 +393,12 @@ impl Builder {
         })
     }
 
-    fn build_components(self) -> BuildResult<(ImpersonatedTokenProvider, Option<String>)> {
+    fn build_components(
+        self,
+    ) -> BuildResult<(
+        TokenProviderWithRetry<ImpersonatedTokenProvider>,
+        Option<String>,
+    )> {
         let (source_credentials, service_account_impersonation_url, delegates, quota_project_id) =
             match self.source {
                 BuilderSource::FromJson(json) => {
@@ -369,6 +451,7 @@ impl Builder {
             scopes,
             lifetime: self.lifetime.unwrap_or(DEFAULT_LIFETIME),
         };
+        let token_provider = self.retry_builder.build(token_provider);
         Ok((token_provider, quota_project_id))
     }
 }
@@ -524,6 +607,10 @@ mod tests {
     use super::*;
     use httptest::{Expectation, Server, matchers::*, responders::*};
     use serde_json::json;
+    use crate::credentials::tests::{
+        get_mock_auth_retry_policy, get_mock_backoff_policy, get_mock_retry_throttler,
+    };
+    use httptest::cycle;
 
     type TestResult = anyhow::Result<()>;
 
@@ -1317,7 +1404,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            token_provider.service_account_impersonation_url,
+            token_provider
+                .inner
+                .service_account_impersonation_url,
             "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/test-principal@example.iam.gserviceaccount.com:generateAccessToken"
         );
     }
@@ -1498,6 +1587,118 @@ mod tests {
         assert_eq!(token.token, "test-impersonated-token");
         assert_eq!(token.token_type, "Bearer");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_impersonated_retries_for_success() -> TestResult {
+        let mut server = Server::run();
+        // Source credential token endpoint
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/token")).respond_with(
+                json_encoded(json!({
+                    "access_token": "test-user-account-token",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                })),
+            ),
+        );
+
+        let expire_time = (OffsetDateTime::now_utc() + time::Duration::hours(1))
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+
+        // Impersonation endpoint
+        let impersonation_path =
+            "/v1/projects/-/serviceAccounts/test-principal:generateAccessToken";
+        server.expect(
+            Expectation::matching(request::method_path("POST", impersonation_path))
+                .times(3)
+                .respond_with(cycle![
+                    status_code(503).body("try-again"),
+                    status_code(503).body("try-again"),
+                    status_code(200)
+                        .append_header("Content-Type", "application/json")
+                        .body(
+                            json!({
+                                "accessToken": "test-impersonated-token",
+                                "expireTime": expire_time
+                            })
+                            .to_string()
+                        ),
+                ]),
+        );
+
+        let impersonated_credential = json!({
+            "type": "impersonated_service_account",
+            "service_account_impersonation_url": server.url(impersonation_path).to_string(),
+            "source_credentials": {
+                "type": "authorized_user",
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "refresh_token": "test-refresh-token",
+                "token_uri": server.url("/token").to_string()
+            }
+        });
+
+        let (token_provider, _) = Builder::new(impersonated_credential)
+            .with_retry_policy(get_mock_auth_retry_policy(3))
+            .with_backoff_policy(get_mock_backoff_policy())
+            .with_retry_throttler(get_mock_retry_throttler())
+            .build_components()?;
+
+        let token = token_provider.token().await?;
+        assert_eq!(token.token, "test-impersonated-token");
+
+        server.verify_and_clear();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_impersonated_does_not_retry_on_non_transient_failures() -> TestResult {
+        let mut server = Server::run();
+        // Source credential token endpoint
+        server.expect(
+            Expectation::matching(request::method_path("POST", "/token")).respond_with(
+                json_encoded(json!({
+                    "access_token": "test-user-account-token",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                })),
+            ),
+        );
+
+        // Impersonation endpoint
+        let impersonation_path =
+            "/v1/projects/-/serviceAccounts/test-principal:generateAccessToken";
+        server.expect(
+            Expectation::matching(request::method_path("POST", impersonation_path))
+                .times(1)
+                .respond_with(status_code(401)),
+        );
+
+        let impersonated_credential = json!({
+            "type": "impersonated_service_account",
+            "service_account_impersonation_url": server.url(impersonation_path).to_string(),
+            "source_credentials": {
+                "type": "authorized_user",
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "refresh_token": "test-refresh-token",
+                "token_uri": server.url("/token").to_string()
+            }
+        });
+
+        let (token_provider, _) = Builder::new(impersonated_credential)
+            .with_retry_policy(get_mock_auth_retry_policy(3))
+            .with_backoff_policy(get_mock_backoff_policy())
+            .with_retry_throttler(get_mock_retry_throttler())
+            .build_components()?;
+
+        let err = token_provider.token().await.unwrap_err();
+        assert!(!err.is_transient());
+
+        server.verify_and_clear();
         Ok(())
     }
 }

--- a/src/auth/src/retry.rs
+++ b/src/auth/src/retry.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
 pub(crate) struct TokenProviderWithRetry<T: TokenProvider> {
-    inner: Arc<T>,
+    pub(crate) inner: Arc<T>,
     retry_policy: Option<Arc<dyn RetryPolicy>>,
     backoff_policy: Arc<dyn BackoffPolicy>,
     retry_throttler: SharedRetryThrottler,


### PR DESCRIPTION
This PR introduces the ability for users to configure custom retry, backoff, and throttling policies for the impersonated credentials.

A future PR will be created to update the documentation of all the public mods to show how to use these builders.