### PR TITLE
feat(auth): add retry for external cred 

### DIFF
--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -1220,7 +1220,7 @@ mod tests {
     };
     use crate::errors::SubjectTokenProviderError;
     use httptest::{
-        cycle, Expectation, Server,
+        Expectation, Server, cycle,
         matchers::{all_of, contains, request, url_decoded},
         responders::{json_encoded, status_code},
     };

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -81,9 +81,13 @@ use crate::credentials::external_account_sources::programmatic_sourced::Programm
 use crate::credentials::subject_token::dynamic;
 use crate::errors::non_retryable;
 use crate::headers_util::build_cacheable_headers;
+use crate::retry::Builder as RetryTokenProviderBuilder;
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, Result};
+use gax::backoff_policy::BackoffPolicyArg;
+use gax::retry_policy::RetryPolicyArg;
+use gax::retry_throttler::RetryThrottlerArg;
 use http::{Extensions, HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -181,7 +185,7 @@ impl From<CredentialSourceFile> for CredentialSource {
 }
 
 #[derive(Debug, Clone)]
-struct ExternalAccountConfig {
+pub(crate) struct ExternalAccountConfig {
     audience: String,
     subject_token_type: String,
     token_url: String,
@@ -192,7 +196,7 @@ struct ExternalAccountConfig {
     credential_source: CredentialSource,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct ExternalAccountConfigBuilder {
     audience: Option<String>,
     subject_token_type: Option<String>,
@@ -278,20 +282,24 @@ enum CredentialSource {
 }
 
 impl ExternalAccountConfig {
-    fn make_credentials(self, quota_project_id: Option<String>) -> Credentials {
+    fn make_credentials(
+        self,
+        quota_project_id: Option<String>,
+        retry_builder: RetryTokenProviderBuilder,
+    ) -> Credentials {
         let config = self.clone();
         match self.credential_source {
             CredentialSource::Url(source) => {
-                Self::make_credentials_from_source(source, config, quota_project_id)
+                Self::make_credentials_from_source(source, config, quota_project_id, retry_builder)
             }
             CredentialSource::Executable(source) => {
-                Self::make_credentials_from_source(source, config, quota_project_id)
+                Self::make_credentials_from_source(source, config, quota_project_id, retry_builder)
             }
             CredentialSource::Programmatic(source) => {
-                Self::make_credentials_from_source(source, config, quota_project_id)
+                Self::make_credentials_from_source(source, config, quota_project_id, retry_builder)
             }
             CredentialSource::File(source) => {
-                Self::make_credentials_from_source(source, config, quota_project_id)
+                Self::make_credentials_from_source(source, config, quota_project_id, retry_builder)
             }
             CredentialSource::Aws => {
                 unimplemented!("AWS sourced credential not supported yet")
@@ -303,6 +311,7 @@ impl ExternalAccountConfig {
         subject_token_provider: T,
         config: ExternalAccountConfig,
         quota_project_id: Option<String>,
+        retry_builder: RetryTokenProviderBuilder,
     ) -> Credentials
     where
         T: dynamic::SubjectTokenProvider + 'static,
@@ -311,7 +320,8 @@ impl ExternalAccountConfig {
             subject_token_provider,
             config,
         };
-        let cache = TokenCache::new(token_provider);
+        let token_provider_with_retry = retry_builder.build(token_provider);
+        let cache = TokenCache::new(token_provider_with_retry);
         Credentials {
             inner: Arc::new(ExternalAccountCredentials {
                 token_provider: cache,
@@ -453,6 +463,7 @@ pub struct Builder {
     external_account_config: Value,
     quota_project_id: Option<String>,
     scopes: Option<Vec<String>>,
+    retry_builder: RetryTokenProviderBuilder,
 }
 
 impl Builder {
@@ -464,6 +475,7 @@ impl Builder {
             external_account_config,
             quota_project_id: None,
             scopes: None,
+            retry_builder: Default::default(),
         }
     }
 
@@ -492,6 +504,91 @@ impl Builder {
         self
     }
 
+    /// Configure the retry policy for fetching tokens.
+    ///
+    /// The retry policy controls how to handle retries, and sets limits on
+    /// the number of attempts or the total time spent retrying.
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::external_account::Builder;
+    /// # tokio_test::block_on(async {
+    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// let config = serde_json::json!({
+    ///     "type": "external_account",
+    ///     "audience": "audience",
+    ///     "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    ///     "token_url": "https://sts.googleapis.com/v1beta/token",
+    ///     "credential_source": { "file": "/path/to/your/oidc/token.jwt" }
+    /// });
+    /// let credentials = Builder::new(config)
+    ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_retry_policy<V: Into<RetryPolicyArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_retry_policy(v.into());
+        self
+    }
+
+    /// Configure the retry backoff policy.
+    ///
+    /// The backoff policy controls how long to wait in between retry attempts.
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::external_account::Builder;
+    /// # use std::time::Duration;
+    /// # tokio_test::block_on(async {
+    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// let config = serde_json::json!({
+    ///     "type": "external_account",
+    ///     "audience": "audience",
+    ///     "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    ///     "token_url": "https://sts.googleapis.com/v1beta/token",
+    ///     "credential_source": { "file": "/path/to/your/oidc/token.jwt" }
+    /// });
+    /// let policy = ExponentialBackoff::default();
+    /// let credentials = Builder::new(config)
+    ///     .with_backoff_policy(policy)
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_backoff_policy<V: Into<BackoffPolicyArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_backoff_policy(v.into());
+        self
+    }
+
+    /// Configure the retry throttler.
+    ///
+    /// Advanced applications may want to configure a retry throttler to
+    /// [Address Cascading Failures] and when [Handling Overload] conditions.
+    /// The authentication library throttles its retry loop, using a policy to
+    /// control the throttling algorithm. Use this method to fine tune or
+    /// customize the default retry throttler.
+    ///
+    /// [Handling Overload]: https://sre.google/sre-book/handling-overload/
+    /// [Address Cascading Failures]: https://sre.google/sre-book/addressing-cascading-failures/
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::external_account::Builder;
+    /// # tokio_test::block_on(async {
+    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// let config = serde_json::json!({
+    ///     "type": "external_account",
+    ///     "audience": "audience",
+    ///     "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    ///     "token_url": "https://sts.googleapis.com/v1beta/token",
+    ///     "credential_source": { "file": "/path/to/your/oidc/token.jwt" }
+    /// });
+    /// let credentials = Builder::new(config)
+    ///     .with_retry_throttler(AdaptiveThrottler::default())
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_retry_throttler<V: Into<RetryThrottlerArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_retry_throttler(v.into());
+        self
+    }
+
     /// Returns a [Credentials] instance with the configured settings.
     ///
     /// # Errors
@@ -514,7 +611,7 @@ impl Builder {
 
         let config: ExternalAccountConfig = file.into();
 
-        Ok(config.make_credentials(self.quota_project_id))
+        Ok(config.make_credentials(self.quota_project_id, self.retry_builder))
     }
 }
 
@@ -568,6 +665,7 @@ impl Builder {
 pub struct ProgrammaticBuilder {
     quota_project_id: Option<String>,
     config: ExternalAccountConfigBuilder,
+    retry_builder: RetryTokenProviderBuilder,
 }
 
 impl ProgrammaticBuilder {
@@ -612,6 +710,7 @@ impl ProgrammaticBuilder {
         Self {
             quota_project_id: None,
             config,
+            retry_builder: Default::default(),
         }
     }
 
@@ -934,6 +1033,144 @@ impl ProgrammaticBuilder {
         self
     }
 
+    /// Configure the retry policy for fetching tokens.
+    ///
+    /// The retry policy controls how to handle retries, and sets limits on
+    /// the number of attempts or the total time spent retrying.
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::external_account::ProgrammaticBuilder;
+    /// # use google_cloud_auth::credentials::subject_token::{SubjectTokenProvider, SubjectToken, Builder as SubjectTokenBuilder};
+    /// # use google_cloud_auth::errors::SubjectTokenProviderError;
+    /// # use std::error::Error;
+    /// # use std::fmt;
+    /// # use std::sync::Arc;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyTokenProvider;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyProviderError;
+    /// # impl fmt::Display for MyProviderError { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "MyProviderError") } }
+    /// # impl Error for MyProviderError {}
+    /// # impl SubjectTokenProviderError for MyProviderError { fn is_transient(&self) -> bool { false } }
+    /// #
+    /// # impl SubjectTokenProvider for MyTokenProvider {
+    /// #     type Error = MyProviderError;
+    /// #     async fn subject_token(&self) -> Result<SubjectToken, Self::Error> {
+    /// #         Ok(SubjectTokenBuilder::new("my-programmatic-token".to_string()).build())
+    /// #     }
+    /// # }
+    /// #
+    /// # tokio_test::block_on(async {
+    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// let provider = Arc::new(MyTokenProvider);
+    /// let credentials = ProgrammaticBuilder::new(provider)
+    ///     .with_audience("test-audience")
+    ///     .with_subject_token_type("test-token-type")
+    ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_retry_policy<V: Into<RetryPolicyArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_retry_policy(v.into());
+        self
+    }
+
+    /// Configure the retry backoff policy.
+    ///
+    /// The backoff policy controls how long to wait in between retry attempts.
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::external_account::ProgrammaticBuilder;
+    /// # use google_cloud_auth::credentials::subject_token::{SubjectTokenProvider, SubjectToken, Builder as SubjectTokenBuilder};
+    /// # use google_cloud_auth::errors::SubjectTokenProviderError;
+    /// # use std::error::Error;
+    /// # use std::fmt;
+    /// # use std::sync::Arc;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyTokenProvider;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyProviderError;
+    /// # impl fmt::Display for MyProviderError { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "MyProviderError") } }
+    /// # impl Error for MyProviderError {}
+    /// # impl SubjectTokenProviderError for MyProviderError { fn is_transient(&self) -> bool { false } }
+    /// #
+    /// # impl SubjectTokenProvider for MyTokenProvider {
+    /// #     type Error = MyProviderError;
+    /// #     async fn subject_token(&self) -> Result<SubjectToken, Self::Error> {
+    /// #         Ok(SubjectTokenBuilder::new("my-programmatic-token".to_string()).build())
+    /// #     }
+    /// # }
+    /// #
+    /// # tokio_test::block_on(async {
+    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// let provider = Arc::new(MyTokenProvider);
+    /// let policy = ExponentialBackoff::default();
+    /// let credentials = ProgrammaticBuilder::new(provider)
+    ///     .with_audience("test-audience")
+    ///     .with_subject_token_type("test-token-type")
+    ///     .with_backoff_policy(policy)
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_backoff_policy<V: Into<BackoffPolicyArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_backoff_policy(v.into());
+        self
+    }
+
+    /// Configure the retry throttler.
+    ///
+    /// Advanced applications may want to configure a retry throttler to
+    /// [Address Cascading Failures] and when [Handling Overload] conditions.
+    /// The authentication library throttles its retry loop, using a policy to
+    /// control the throttling algorithm. Use this method to fine tune or
+    /// customize the default retry throttler.
+    ///
+    /// [Handling Overload]: https://sre.google/sre-book/handling-overload/
+    /// [Address Cascading Failures]: https://sre.google/sre-book/addressing-cascading-failures/
+    ///
+    /// ```
+    /// # use google_cloud_auth::credentials::external_account::ProgrammaticBuilder;
+    /// # use google_cloud_auth::credentials::subject_token::{SubjectTokenProvider, SubjectToken, Builder as SubjectTokenBuilder};
+    /// # use google_cloud_auth::errors::SubjectTokenProviderError;
+    /// # use std::error::Error;
+    /// # use std::fmt;
+    /// # use std::sync::Arc;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyTokenProvider;
+    /// #
+    /// # #[derive(Debug)]
+    /// # struct MyProviderError;
+    /// # impl fmt::Display for MyProviderError { fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "MyProviderError") } }
+    /// # impl Error for MyProviderError {}
+    /// # impl SubjectTokenProviderError for MyProviderError { fn is_transient(&self) -> bool { false } }
+    /// #
+    /// # impl SubjectTokenProvider for MyTokenProvider {
+    /// #     type Error = MyProviderError;
+    /// #     async fn subject_token(&self) -> Result<SubjectToken, Self::Error> {
+    /// #         Ok(SubjectTokenBuilder::new("my-programmatic-token".to_string()).build())
+    /// #     }
+    /// # }
+    /// #
+    /// # tokio_test::block_on(async {
+    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// let provider = Arc::new(MyTokenProvider);
+    /// let credentials = ProgrammaticBuilder::new(provider)
+    ///     .with_audience("test-audience")
+    ///     .with_subject_token_type("test-token-type")
+    ///     .with_retry_throttler(AdaptiveThrottler::default())
+    ///     .build();
+    /// # });
+    /// ```
+    pub fn with_retry_throttler<V: Into<RetryThrottlerArg>>(mut self, v: V) -> Self {
+        self.retry_builder = self.retry_builder.with_retry_throttler(v.into());
+        self
+    }
+
     /// Returns a [Credentials] instance with the configured settings.
     ///
     /// # Errors
@@ -943,11 +1180,11 @@ impl ProgrammaticBuilder {
     pub fn build(self) -> BuildResult<Credentials> {
         let quota_project_id = self.quota_project_id.clone();
         let config = self.build_config()?;
-        Ok(config.make_credentials(quota_project_id))
+        Ok(config.make_credentials(quota_project_id, self.retry_builder))
     }
 
-    fn build_config(self) -> BuildResult<ExternalAccountConfig> {
-        let mut config_builder = self.config;
+    pub(crate) fn build_config(&self) -> BuildResult<ExternalAccountConfig> {
+        let mut config_builder = self.config.clone();
         if config_builder.scopes.is_none() {
             config_builder = config_builder.with_scopes(vec![DEFAULT_SCOPE.to_string()]);
         }
@@ -978,9 +1215,12 @@ mod tests {
     use crate::credentials::subject_token::{
         Builder as SubjectTokenBuilder, SubjectToken, SubjectTokenProvider,
     };
+    use crate::credentials::tests::{
+        get_mock_auth_retry_policy, get_mock_backoff_policy, get_mock_retry_throttler,
+    };
     use crate::errors::SubjectTokenProviderError;
     use httptest::{
-        Expectation, Server,
+        cycle, Expectation, Server,
         matchers::{all_of, contains, request, url_decoded},
         responders::{json_encoded, status_code},
     };
@@ -1522,5 +1762,145 @@ mod tests {
             error_string.contains("missing required field: audience"),
             "Expected error about missing 'audience', got: {error_string}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_external_account_retries_on_transient_failures() {
+        let mut subject_token_server = Server::run();
+        let mut sts_server = Server::run();
+
+        let contents = json!({
+            "type": "external_account",
+            "audience": "audience",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "token_url": sts_server.url("/token").to_string(),
+            "credential_source": {
+                "url": subject_token_server.url("/subject_token").to_string(),
+            }
+        });
+
+        subject_token_server.expect(
+            Expectation::matching(request::method_path("GET", "/subject_token"))
+                .times(3)
+                .respond_with(json_encoded(json!({
+                    "access_token": "subject_token",
+                }))),
+        );
+
+        sts_server.expect(
+            Expectation::matching(request::method_path("POST", "/token"))
+                .times(3)
+                .respond_with(status_code(503)),
+        );
+
+        let creds = Builder::new(contents)
+            .with_retry_policy(get_mock_auth_retry_policy(3))
+            .with_backoff_policy(get_mock_backoff_policy())
+            .with_retry_throttler(get_mock_retry_throttler())
+            .build()
+            .unwrap();
+
+        let err = creds.headers(Extensions::new()).await.unwrap_err();
+        assert!(err.is_transient());
+        sts_server.verify_and_clear();
+        subject_token_server.verify_and_clear();
+    }
+
+    #[tokio::test]
+    async fn test_external_account_does_not_retry_on_non_transient_failures() {
+        let subject_token_server = Server::run();
+        let mut sts_server = Server::run();
+
+        let contents = json!({
+            "type": "external_account",
+            "audience": "audience",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "token_url": sts_server.url("/token").to_string(),
+            "credential_source": {
+                "url": subject_token_server.url("/subject_token").to_string(),
+            }
+        });
+
+        subject_token_server.expect(
+            Expectation::matching(request::method_path("GET", "/subject_token")).respond_with(
+                json_encoded(json!({
+                    "access_token": "subject_token",
+                })),
+            ),
+        );
+
+        sts_server.expect(
+            Expectation::matching(request::method_path("POST", "/token"))
+                .times(1)
+                .respond_with(status_code(401)),
+        );
+
+        let creds = Builder::new(contents)
+            .with_retry_policy(get_mock_auth_retry_policy(1))
+            .with_backoff_policy(get_mock_backoff_policy())
+            .with_retry_throttler(get_mock_retry_throttler())
+            .build()
+            .unwrap();
+
+        let err = creds.headers(Extensions::new()).await.unwrap_err();
+        assert!(!err.is_transient());
+        sts_server.verify_and_clear();
+    }
+
+    #[tokio::test]
+    async fn test_external_account_retries_for_success() {
+        let mut subject_token_server = Server::run();
+        let mut sts_server = Server::run();
+
+        let contents = json!({
+            "type": "external_account",
+            "audience": "audience",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "token_url": sts_server.url("/token").to_string(),
+            "credential_source": {
+                "url": subject_token_server.url("/subject_token").to_string(),
+            }
+        });
+
+        subject_token_server.expect(
+            Expectation::matching(request::method_path("GET", "/subject_token"))
+                .times(3)
+                .respond_with(json_encoded(json!({
+                    "access_token": "subject_token",
+                }))),
+        );
+
+        sts_server.expect(
+            Expectation::matching(request::method_path("POST", "/token"))
+                .times(3)
+                .respond_with(cycle![
+                    status_code(503).body("try-again"),
+                    status_code(503).body("try-again"),
+                    json_encoded(json!({
+                        "access_token": "sts-only-token",
+                        "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                        "token_type": "Bearer",
+                        "expires_in": 3600,
+                    }))
+                ]),
+        );
+
+        let creds = Builder::new(contents)
+            .with_retry_policy(get_mock_auth_retry_policy(3))
+            .with_backoff_policy(get_mock_backoff_policy())
+            .with_retry_throttler(get_mock_retry_throttler())
+            .build()
+            .unwrap();
+
+        let headers = creds.headers(Extensions::new()).await.unwrap();
+        match headers {
+            CacheableResource::New { data, .. } => {
+                let token = data.get("authorization").unwrap().to_str().unwrap();
+                assert_eq!(token, "Bearer sts-only-token");
+            }
+            CacheableResource::NotModified => panic!("Expected new headers"),
+        }
+        sts_server.verify_and_clear();
+        subject_token_server.verify_and_clear();
     }
 }


### PR DESCRIPTION
This PR introduces the ability for users to configure custom retry, backoff, and throttling policies for the external account credentials.

A future PR will be created to update the documentation of all the public mods to show how to use these builders.