### PR TITLE
fix(wkt): no private types in public traits

### DIFF
--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -27,16 +27,20 @@ pub trait Message: serde::ser::Serialize + serde::de::DeserializeOwned {
     fn typename() -> &'static str;
 
     /// Returns the serializer for this message type.
-    #[doc(hidden)]
-    #[allow(private_interfaces)]
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn serializer() -> impl MessageSerializer<Self> {
         DefaultSerializer::<Self>::new()
     }
 }
 
+pub(crate) mod sealed {
+    pub trait MessageSerializer {}
+}
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 /// Internal API for message serialization.
 /// This is not intended for direct use by consumers of this crate.
-pub(crate) trait MessageSerializer<T> {
+pub trait MessageSerializer<T>: sealed::MessageSerializer {
     /// Store the value into a JSON object.
     fn serialize_to_map(&self, message: &T) -> Result<Map, Error>;
 
@@ -56,6 +60,9 @@ impl<T> DefaultSerializer<T> {
         }
     }
 }
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl<T> sealed::MessageSerializer for DefaultSerializer<T> {}
 
 impl<T> MessageSerializer<T> for DefaultSerializer<T>
 where
@@ -82,6 +89,9 @@ impl<T> ValueSerializer<T> {
         }
     }
 }
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl<T> sealed::MessageSerializer for ValueSerializer<T> {}
 
 impl<T> MessageSerializer<T> for ValueSerializer<T>
 where

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -121,7 +121,6 @@ macro_rules! impl_message {
                 concat!("type.googleapis.com/google.protobuf.", stringify!($t))
             }
 
-            #[allow(private_interfaces)]
             fn serializer() -> impl crate::message::MessageSerializer<Self> {
                 crate::message::ValueSerializer::<Self>::new()
             }
@@ -163,13 +162,15 @@ impl crate::message::Message for UInt64Value {
         "type.googleapis.com/google.protobuf.UInt64Value"
     }
 
-    #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         UInt64ValueSerializer
     }
 }
 
 struct UInt64ValueSerializer;
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl crate::message::sealed::MessageSerializer for UInt64ValueSerializer {}
 
 impl crate::message::MessageSerializer<UInt64Value> for UInt64ValueSerializer {
     fn serialize_to_map(
@@ -197,7 +198,6 @@ impl crate::message::Message for Int64Value {
         "type.googleapis.com/google.protobuf.Int64Value"
     }
 
-    #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self>
     where
         Self: Sized + serde::ser::Serialize,
@@ -207,6 +207,9 @@ impl crate::message::Message for Int64Value {
 }
 
 struct Int64ValueSerializer;
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl crate::message::sealed::MessageSerializer for Int64ValueSerializer {}
 
 impl crate::message::MessageSerializer<Int64Value> for Int64ValueSerializer {
     fn serialize_to_map(
@@ -234,7 +237,6 @@ impl crate::message::Message for FloatValue {
         "type.googleapis.com/google.protobuf.FloatValue"
     }
 
-    #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self>
     where
         Self: Sized + serde::ser::Serialize,
@@ -244,6 +246,9 @@ impl crate::message::Message for FloatValue {
 }
 
 struct FloatValueSerializer;
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl crate::message::sealed::MessageSerializer for FloatValueSerializer {}
 
 impl crate::message::MessageSerializer<FloatValue> for FloatValueSerializer {
     fn serialize_to_map(
@@ -271,7 +276,6 @@ impl crate::message::Message for DoubleValue {
         "type.googleapis.com/google.protobuf.DoubleValue"
     }
 
-    #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self>
     where
         Self: Sized + serde::ser::Serialize,
@@ -281,6 +285,9 @@ impl crate::message::Message for DoubleValue {
 }
 
 struct DoubleValueSerializer;
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl crate::message::sealed::MessageSerializer for DoubleValueSerializer {}
 
 impl crate::message::MessageSerializer<DoubleValue> for DoubleValueSerializer {
     fn serialize_to_map(
@@ -308,13 +315,15 @@ impl crate::message::Message for BytesValue {
         "type.googleapis.com/google.protobuf.BytesValue"
     }
 
-    #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         BytesValueSerializer
     }
 }
 
 struct BytesValueSerializer;
+
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+impl crate::message::sealed::MessageSerializer for BytesValueSerializer {}
 
 impl crate::message::MessageSerializer<BytesValue> for BytesValueSerializer {
     fn serialize_to_map(


### PR DESCRIPTION
Related to #1609 

`rustc --version == 1.90` starts to flag this as an [E0446](https://doc.rust-lang.org/error_codes/E0446.html). See [a failed build](https://github.com/googleapis/google-cloud-rust/actions/runs/16347121498/job/46183704836?pr=2708) against 1.90.

We can make the trait public, but sealed. No downstream crates can implement it. It remains hidden from our docs, as it is an implementation detail.

This is not a breaking change, as the `MessageSerializer` trait was previously un-implementable outside of `wkt`.

Tested locally with: `cargo +nightly doc -p google-cloud-kms-v1`