### PR TITLE
impl(gax): relax retry loop requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax"
-version     = "0.23.2"
+version     = "0.23.3"
 description = "Google Cloud Client Libraries for Rust"
 # Inherit other attributes from the workspace.
 authors.workspace      = true

--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -48,7 +48,7 @@ impl RetryLoopAttempt {
 /// In between calls the function waits the amount of time prescribed by the
 /// backoff policy, using `sleep` to implement any sleep.
 pub async fn retry_loop<F, S, Response>(
-    inner: F,
+    mut inner: F,
     sleep: S,
     idempotent: bool,
     retry_throttler: Arc<Mutex<dyn RetryThrottler>>,
@@ -56,7 +56,7 @@ pub async fn retry_loop<F, S, Response>(
     backoff_policy: Arc<dyn BackoffPolicy>,
 ) -> Result<Response>
 where
-    F: AsyncFn(Option<Duration>) -> Result<Response> + Send,
+    F: AsyncFnMut(Option<Duration>) -> Result<Response> + Send,
     S: AsyncFn(Duration) -> () + Send,
 {
     let loop_start = tokio::time::Instant::now().into_std();


### PR DESCRIPTION
The retry loop can consume `AsyncFnMut`, that is less restrictive than
`AsyncFn` and therefore this is not a breaking change.

Bump the version number for `gax`. No need to bump any deps because they
do not depend on the newer version.

Part of the work for #2057 