### PR TITLE
refactor(tests): split debug test into two

### DIFF
--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -344,12 +344,11 @@ impl std::fmt::Debug for {{Codec.Name}} {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("{{Codec.Name}}");
         {{#Codec.BasicFields}}
-            debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
+        debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
         {{/Codec.BasicFields}}
         {{#OneOfs}}
-            debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
+        debug_struct.field("{{Codec.FieldName}}", &self.{{Codec.FieldName}});
         {{/OneOfs}}
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -174,7 +174,6 @@ impl std::fmt::Debug for AggregationResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AggregationResult");
         debug_struct.field("aggregate_fields", &self.aggregate_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -394,7 +393,6 @@ impl std::fmt::Debug for BitSequence {
         let mut debug_struct = f.debug_struct("BitSequence");
         debug_struct.field("bitmap", &self.bitmap);
         debug_struct.field("padding", &self.padding);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -605,7 +603,6 @@ impl std::fmt::Debug for BloomFilter {
         let mut debug_struct = f.debug_struct("BloomFilter");
         debug_struct.field("bits", &self.bits);
         debug_struct.field("hash_count", &self.hash_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -763,7 +760,6 @@ impl std::fmt::Debug for DocumentMask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DocumentMask");
         debug_struct.field("field_paths", &self.field_paths);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -994,7 +990,6 @@ impl std::fmt::Debug for Precondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Precondition");
         debug_struct.field("condition_type", &self.condition_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1274,7 +1269,6 @@ impl std::fmt::Debug for TransactionOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TransactionOptions");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1455,7 +1449,6 @@ pub mod transaction_options {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReadWrite");
             debug_struct.field("retry_transaction", &self.retry_transaction);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1652,7 +1645,6 @@ pub mod transaction_options {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReadOnly");
             debug_struct.field("consistency_selector", &self.consistency_selector);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1994,7 +1986,6 @@ impl std::fmt::Debug for Document {
         debug_struct.field("fields", &self.fields);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2710,7 +2701,6 @@ impl std::fmt::Debug for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Value");
         debug_struct.field("value_type", &self.value_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2958,7 +2948,6 @@ impl std::fmt::Debug for ArrayValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ArrayValue");
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3116,7 +3105,6 @@ impl std::fmt::Debug for MapValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MapValue");
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3441,7 +3429,6 @@ impl std::fmt::Debug for GetDocumentRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("mask", &self.mask);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3983,7 +3970,6 @@ impl std::fmt::Debug for ListDocumentsRequest {
         debug_struct.field("mask", &self.mask);
         debug_struct.field("show_missing", &self.show_missing);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4207,7 +4193,6 @@ impl std::fmt::Debug for ListDocumentsResponse {
         let mut debug_struct = f.debug_struct("ListDocumentsResponse");
         debug_struct.field("documents", &self.documents);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4484,7 +4469,6 @@ impl std::fmt::Debug for CreateDocumentRequest {
         debug_struct.field("document_id", &self.document_id);
         debug_struct.field("document", &self.document);
         debug_struct.field("mask", &self.mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4761,7 +4745,6 @@ impl std::fmt::Debug for UpdateDocumentRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("mask", &self.mask);
         debug_struct.field("current_document", &self.current_document);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4945,7 +4928,6 @@ impl std::fmt::Debug for DeleteDocumentRequest {
         let mut debug_struct = f.debug_struct("DeleteDocumentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("current_document", &self.current_document);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5356,7 +5338,6 @@ impl std::fmt::Debug for BatchGetDocumentsRequest {
         debug_struct.field("documents", &self.documents);
         debug_struct.field("mask", &self.mask);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5727,7 +5708,6 @@ impl std::fmt::Debug for BatchGetDocumentsResponse {
         debug_struct.field("transaction", &self.transaction);
         debug_struct.field("read_time", &self.read_time);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5941,7 +5921,6 @@ impl std::fmt::Debug for BeginTransactionRequest {
         let mut debug_struct = f.debug_struct("BeginTransactionRequest");
         debug_struct.field("database", &self.database);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6104,7 +6083,6 @@ impl std::fmt::Debug for BeginTransactionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BeginTransactionResponse");
         debug_struct.field("transaction", &self.transaction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6322,7 +6300,6 @@ impl std::fmt::Debug for CommitRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("writes", &self.writes);
         debug_struct.field("transaction", &self.transaction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6511,7 +6488,6 @@ impl std::fmt::Debug for CommitResponse {
         let mut debug_struct = f.debug_struct("CommitResponse");
         debug_struct.field("write_results", &self.write_results);
         debug_struct.field("commit_time", &self.commit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6699,7 +6675,6 @@ impl std::fmt::Debug for RollbackRequest {
         let mut debug_struct = f.debug_struct("RollbackRequest");
         debug_struct.field("database", &self.database);
         debug_struct.field("transaction", &self.transaction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7156,7 +7131,6 @@ impl std::fmt::Debug for RunQueryRequest {
         debug_struct.field("explain_options", &self.explain_options);
         debug_struct.field("query_type", &self.query_type);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7625,7 +7599,6 @@ impl std::fmt::Debug for RunQueryResponse {
         debug_struct.field("skipped_results", &self.skipped_results);
         debug_struct.field("explain_metrics", &self.explain_metrics);
         debug_struct.field("continuation_selector", &self.continuation_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8115,7 +8088,6 @@ impl std::fmt::Debug for RunAggregationQueryRequest {
         debug_struct.field("explain_options", &self.explain_options);
         debug_struct.field("query_type", &self.query_type);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8467,7 +8439,6 @@ impl std::fmt::Debug for RunAggregationQueryResponse {
         debug_struct.field("transaction", &self.transaction);
         debug_struct.field("read_time", &self.read_time);
         debug_struct.field("explain_metrics", &self.explain_metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8904,7 +8875,6 @@ impl std::fmt::Debug for PartitionQueryRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("query_type", &self.query_type);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9158,7 +9128,6 @@ impl std::fmt::Debug for PartitionQueryResponse {
         let mut debug_struct = f.debug_struct("PartitionQueryResponse");
         debug_struct.field("partitions", &self.partitions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9467,7 +9436,6 @@ impl std::fmt::Debug for WriteRequest {
         debug_struct.field("writes", &self.writes);
         debug_struct.field("stream_token", &self.stream_token);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9728,7 +9696,6 @@ impl std::fmt::Debug for WriteResponse {
         debug_struct.field("stream_token", &self.stream_token);
         debug_struct.field("write_results", &self.write_results);
         debug_struct.field("commit_time", &self.commit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10048,7 +10015,6 @@ impl std::fmt::Debug for ListenRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("target_change", &self.target_change);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10493,7 +10459,6 @@ impl std::fmt::Debug for ListenResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListenResponse");
         debug_struct.field("response_type", &self.response_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11082,7 +11047,6 @@ impl std::fmt::Debug for Target {
         debug_struct.field("expected_count", &self.expected_count);
         debug_struct.field("target_type", &self.target_type);
         debug_struct.field("resume_type", &self.resume_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11238,7 +11202,6 @@ pub mod target {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DocumentsTarget");
             debug_struct.field("documents", &self.documents);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11464,7 +11427,6 @@ pub mod target {
             let mut debug_struct = f.debug_struct("QueryTarget");
             debug_struct.field("parent", &self.parent);
             debug_struct.field("query_type", &self.query_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11884,7 +11846,6 @@ impl std::fmt::Debug for TargetChange {
         debug_struct.field("cause", &self.cause);
         debug_struct.field("resume_token", &self.resume_token);
         debug_struct.field("read_time", &self.read_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12341,7 +12302,6 @@ impl std::fmt::Debug for ListCollectionIdsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("consistency_selector", &self.consistency_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12544,7 +12504,6 @@ impl std::fmt::Debug for ListCollectionIdsResponse {
         let mut debug_struct = f.debug_struct("ListCollectionIdsResponse");
         debug_struct.field("collection_ids", &self.collection_ids);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12758,7 +12717,6 @@ impl std::fmt::Debug for BatchWriteRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("writes", &self.writes);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12941,7 +12899,6 @@ impl std::fmt::Debug for BatchWriteResponse {
         let mut debug_struct = f.debug_struct("BatchWriteResponse");
         debug_struct.field("write_results", &self.write_results);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13500,7 +13457,6 @@ impl std::fmt::Debug for StructuredQuery {
         debug_struct.field("offset", &self.offset);
         debug_struct.field("limit", &self.limit);
         debug_struct.field("find_nearest", &self.find_nearest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13683,7 +13639,6 @@ pub mod structured_query {
             let mut debug_struct = f.debug_struct("CollectionSelector");
             debug_struct.field("collection_id", &self.collection_id);
             debug_struct.field("all_descendants", &self.all_descendants);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14001,7 +13956,6 @@ pub mod structured_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Filter");
             debug_struct.field("filter_type", &self.filter_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14234,7 +14188,6 @@ pub mod structured_query {
             let mut debug_struct = f.debug_struct("CompositeFilter");
             debug_struct.field("op", &self.op);
             debug_struct.field("filters", &self.filters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14600,7 +14553,6 @@ pub mod structured_query {
             debug_struct.field("field", &self.field);
             debug_struct.field("op", &self.op);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15067,7 +15019,6 @@ pub mod structured_query {
             let mut debug_struct = f.debug_struct("UnaryFilter");
             debug_struct.field("op", &self.op);
             debug_struct.field("operand_type", &self.operand_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15438,7 +15389,6 @@ pub mod structured_query {
             let mut debug_struct = f.debug_struct("Order");
             debug_struct.field("field", &self.field);
             debug_struct.field("direction", &self.direction);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15592,7 +15542,6 @@ pub mod structured_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FieldReference");
             debug_struct.field("field_path", &self.field_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15749,7 +15698,6 @@ pub mod structured_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Projection");
             debug_struct.field("fields", &self.fields);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16135,7 +16083,6 @@ pub mod structured_query {
             debug_struct.field("limit", &self.limit);
             debug_struct.field("distance_result_field", &self.distance_result_field);
             debug_struct.field("distance_threshold", &self.distance_threshold);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16662,7 +16609,6 @@ impl std::fmt::Debug for StructuredAggregationQuery {
         let mut debug_struct = f.debug_struct("StructuredAggregationQuery");
         debug_struct.field("aggregations", &self.aggregations);
         debug_struct.field("query_type", &self.query_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17045,7 +16991,6 @@ pub mod structured_aggregation_query {
             let mut debug_struct = f.debug_struct("Aggregation");
             debug_struct.field("alias", &self.alias);
             debug_struct.field("operator", &self.operator);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17253,7 +17198,6 @@ pub mod structured_aggregation_query {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Count");
                 debug_struct.field("up_to", &self.up_to);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17434,7 +17378,6 @@ pub mod structured_aggregation_query {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Sum");
                 debug_struct.field("field", &self.field);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17605,7 +17548,6 @@ pub mod structured_aggregation_query {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Avg");
                 debug_struct.field("field", &self.field);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17837,7 +17779,6 @@ impl std::fmt::Debug for Cursor {
         let mut debug_struct = f.debug_struct("Cursor");
         debug_struct.field("values", &self.values);
         debug_struct.field("before", &self.before);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17985,7 +17926,6 @@ impl std::fmt::Debug for ExplainOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExplainOptions");
         debug_struct.field("analyze", &self.analyze);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18181,7 +18121,6 @@ impl std::fmt::Debug for ExplainMetrics {
         let mut debug_struct = f.debug_struct("ExplainMetrics");
         debug_struct.field("plan_summary", &self.plan_summary);
         debug_struct.field("execution_stats", &self.execution_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18333,7 +18272,6 @@ impl std::fmt::Debug for PlanSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PlanSummary");
         debug_struct.field("indexes_used", &self.indexes_used);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18626,7 +18564,6 @@ impl std::fmt::Debug for ExecutionStats {
         debug_struct.field("execution_duration", &self.execution_duration);
         debug_struct.field("read_operations", &self.read_operations);
         debug_struct.field("debug_stats", &self.debug_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19030,7 +18967,6 @@ impl std::fmt::Debug for Write {
         debug_struct.field("update_transforms", &self.update_transforms);
         debug_struct.field("current_document", &self.current_document);
         debug_struct.field("operation", &self.operation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19245,7 +19181,6 @@ impl std::fmt::Debug for DocumentTransform {
         let mut debug_struct = f.debug_struct("DocumentTransform");
         debug_struct.field("document", &self.document);
         debug_struct.field("field_transforms", &self.field_transforms);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19745,7 +19680,6 @@ pub mod document_transform {
             let mut debug_struct = f.debug_struct("FieldTransform");
             debug_struct.field("field_path", &self.field_path);
             debug_struct.field("transform_type", &self.transform_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20183,7 +20117,6 @@ impl std::fmt::Debug for WriteResult {
         let mut debug_struct = f.debug_struct("WriteResult");
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("transform_results", &self.transform_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20460,7 +20393,6 @@ impl std::fmt::Debug for DocumentChange {
         debug_struct.field("document", &self.document);
         debug_struct.field("target_ids", &self.target_ids);
         debug_struct.field("removed_target_ids", &self.removed_target_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20710,7 +20642,6 @@ impl std::fmt::Debug for DocumentDelete {
         debug_struct.field("document", &self.document);
         debug_struct.field("removed_target_ids", &self.removed_target_ids);
         debug_struct.field("read_time", &self.read_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20961,7 +20892,6 @@ impl std::fmt::Debug for DocumentRemove {
         debug_struct.field("document", &self.document);
         debug_struct.field("removed_target_ids", &self.removed_target_ids);
         debug_struct.field("read_time", &self.read_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21225,7 +21155,6 @@ impl std::fmt::Debug for ExistenceFilter {
         debug_struct.field("target_id", &self.target_id);
         debug_struct.field("count", &self.count);
         debug_struct.field("unchanged_names", &self.unchanged_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/api/apikeys/v2/src/model.rs
+++ b/src/generated/api/apikeys/v2/src/model.rs
@@ -238,7 +238,6 @@ impl std::fmt::Debug for CreateKeyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("key", &self.key);
         debug_struct.field("key_id", &self.key_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -477,7 +476,6 @@ impl std::fmt::Debug for ListKeysRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -662,7 +660,6 @@ impl std::fmt::Debug for ListKeysResponse {
         let mut debug_struct = f.debug_struct("ListKeysResponse");
         debug_struct.field("keys", &self.keys);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -804,7 +801,6 @@ impl std::fmt::Debug for GetKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -946,7 +942,6 @@ impl std::fmt::Debug for GetKeyStringRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKeyStringRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1089,7 +1084,6 @@ impl std::fmt::Debug for GetKeyStringResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKeyStringResponse");
         debug_struct.field("key_string", &self.key_string);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1287,7 +1281,6 @@ impl std::fmt::Debug for UpdateKeyRequest {
         let mut debug_struct = f.debug_struct("UpdateKeyRequest");
         debug_struct.field("key", &self.key);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1455,7 +1448,6 @@ impl std::fmt::Debug for DeleteKeyRequest {
         let mut debug_struct = f.debug_struct("DeleteKeyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1597,7 +1589,6 @@ impl std::fmt::Debug for UndeleteKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1740,7 +1731,6 @@ impl std::fmt::Debug for LookupKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupKeyRequest");
         debug_struct.field("key_string", &self.key_string);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1908,7 +1898,6 @@ impl std::fmt::Debug for LookupKeyResponse {
         let mut debug_struct = f.debug_struct("LookupKeyResponse");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2352,7 +2341,6 @@ impl std::fmt::Debug for Key {
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("restrictions", &self.restrictions);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2748,7 +2736,6 @@ impl std::fmt::Debug for Restrictions {
         let mut debug_struct = f.debug_struct("Restrictions");
         debug_struct.field("api_targets", &self.api_targets);
         debug_struct.field("client_restrictions", &self.client_restrictions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2917,7 +2904,6 @@ impl std::fmt::Debug for BrowserKeyRestrictions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BrowserKeyRestrictions");
         debug_struct.field("allowed_referrers", &self.allowed_referrers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3064,7 +3050,6 @@ impl std::fmt::Debug for ServerKeyRestrictions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServerKeyRestrictions");
         debug_struct.field("allowed_ips", &self.allowed_ips);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3215,7 +3200,6 @@ impl std::fmt::Debug for AndroidKeyRestrictions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AndroidKeyRestrictions");
         debug_struct.field("allowed_applications", &self.allowed_applications);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3390,7 +3374,6 @@ impl std::fmt::Debug for AndroidApplication {
         let mut debug_struct = f.debug_struct("AndroidApplication");
         debug_struct.field("sha1_fingerprint", &self.sha1_fingerprint);
         debug_struct.field("package_name", &self.package_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3536,7 +3519,6 @@ impl std::fmt::Debug for IosKeyRestrictions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IosKeyRestrictions");
         debug_struct.field("allowed_bundle_ids", &self.allowed_bundle_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3717,7 +3699,6 @@ impl std::fmt::Debug for ApiTarget {
         let mut debug_struct = f.debug_struct("ApiTarget");
         debug_struct.field("service", &self.service);
         debug_struct.field("methods", &self.methods);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/api/cloudquotas/v1/src/model.rs
+++ b/src/generated/api/cloudquotas/v1/src/model.rs
@@ -242,7 +242,6 @@ impl std::fmt::Debug for ListQuotaInfosRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -429,7 +428,6 @@ impl std::fmt::Debug for ListQuotaInfosResponse {
         let mut debug_struct = f.debug_struct("ListQuotaInfosResponse");
         debug_struct.field("quota_infos", &self.quota_infos);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -574,7 +572,6 @@ impl std::fmt::Debug for GetQuotaInfoRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQuotaInfoRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -857,7 +854,6 @@ impl std::fmt::Debug for ListQuotaPreferencesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1076,7 +1072,6 @@ impl std::fmt::Debug for ListQuotaPreferencesResponse {
         debug_struct.field("quota_preferences", &self.quota_preferences);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1221,7 +1216,6 @@ impl std::fmt::Debug for GetQuotaPreferenceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQuotaPreferenceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1467,7 +1461,6 @@ impl std::fmt::Debug for CreateQuotaPreferenceRequest {
         debug_struct.field("quota_preference_id", &self.quota_preference_id);
         debug_struct.field("quota_preference", &self.quota_preference);
         debug_struct.field("ignore_safety_checks", &self.ignore_safety_checks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1751,7 +1744,6 @@ impl std::fmt::Debug for UpdateQuotaPreferenceRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("ignore_safety_checks", &self.ignore_safety_checks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2339,7 +2331,6 @@ impl std::fmt::Debug for QuotaInfo {
         debug_struct.field("dimensions_infos", &self.dimensions_infos);
         debug_struct.field("is_concurrent", &self.is_concurrent);
         debug_struct.field("service_request_quota_uri", &self.service_request_quota_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2662,7 +2653,6 @@ impl std::fmt::Debug for QuotaIncreaseEligibility {
         let mut debug_struct = f.debug_struct("QuotaIncreaseEligibility");
         debug_struct.field("is_eligible", &self.is_eligible);
         debug_struct.field("ineligibility_reason", &self.ineligibility_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3292,7 +3282,6 @@ impl std::fmt::Debug for QuotaPreference {
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("justification", &self.justification);
         debug_struct.field("contact_email", &self.contact_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3634,7 +3623,6 @@ impl std::fmt::Debug for QuotaConfig {
         debug_struct.field("trace_id", &self.trace_id);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("request_origin", &self.request_origin);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4001,7 +3989,6 @@ impl std::fmt::Debug for DimensionsInfo {
         debug_struct.field("dimensions", &self.dimensions);
         debug_struct.field("details", &self.details);
         debug_struct.field("applicable_locations", &self.applicable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4200,7 +4187,6 @@ impl std::fmt::Debug for QuotaDetails {
         let mut debug_struct = f.debug_struct("QuotaDetails");
         debug_struct.field("value", &self.value);
         debug_struct.field("rollout_info", &self.rollout_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4343,7 +4329,6 @@ impl std::fmt::Debug for RolloutInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RolloutInfo");
         debug_struct.field("ongoing_rollout", &self.ongoing_rollout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -267,7 +267,6 @@ impl std::fmt::Debug for CheckError {
         debug_struct.field("subject", &self.subject);
         debug_struct.field("detail", &self.detail);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1213,7 +1212,6 @@ impl std::fmt::Debug for Distribution {
         debug_struct.field("bucket_counts", &self.bucket_counts);
         debug_struct.field("exemplars", &self.exemplars);
         debug_struct.field("bucket_option", &self.bucket_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1476,7 +1474,6 @@ pub mod distribution {
             debug_struct.field("num_finite_buckets", &self.num_finite_buckets);
             debug_struct.field("width", &self.width);
             debug_struct.field("offset", &self.offset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1737,7 +1734,6 @@ pub mod distribution {
             debug_struct.field("num_finite_buckets", &self.num_finite_buckets);
             debug_struct.field("growth_factor", &self.growth_factor);
             debug_struct.field("scale", &self.scale);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1926,7 +1922,6 @@ pub mod distribution {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ExplicitBuckets");
             debug_struct.field("bounds", &self.bounds);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2580,7 +2575,6 @@ impl std::fmt::Debug for HttpRequest {
         );
         debug_struct.field("cache_fill_bytes", &self.cache_fill_bytes);
         debug_struct.field("protocol", &self.protocol);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3153,7 +3147,6 @@ impl std::fmt::Debug for LogEntry {
         debug_struct.field("operation", &self.operation);
         debug_struct.field("source_location", &self.source_location);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3395,7 +3388,6 @@ impl std::fmt::Debug for LogEntryOperation {
         debug_struct.field("producer", &self.producer);
         debug_struct.field("first", &self.first);
         debug_struct.field("last", &self.last);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3613,7 +3605,6 @@ impl std::fmt::Debug for LogEntrySourceLocation {
         debug_struct.field("file", &self.file);
         debug_struct.field("line", &self.line);
         debug_struct.field("function", &self.function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4153,7 +4144,6 @@ impl std::fmt::Debug for MetricValue {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4351,7 +4341,6 @@ impl std::fmt::Debug for MetricValueSet {
         let mut debug_struct = f.debug_struct("MetricValueSet");
         debug_struct.field("metric_name", &self.metric_name);
         debug_struct.field("metric_values", &self.metric_values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4824,7 +4813,6 @@ impl std::fmt::Debug for Operation {
         debug_struct.field("log_entries", &self.log_entries);
         debug_struct.field("importance", &self.importance);
         debug_struct.field("extensions", &self.extensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5173,7 +5161,6 @@ impl std::fmt::Debug for AllocateQuotaRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("allocate_operation", &self.allocate_operation);
         debug_struct.field("service_config_id", &self.service_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5497,7 +5484,6 @@ impl std::fmt::Debug for QuotaOperation {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("quota_metrics", &self.quota_metrics);
         debug_struct.field("quota_mode", &self.quota_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5923,7 +5909,6 @@ impl std::fmt::Debug for AllocateQuotaResponse {
         debug_struct.field("allocate_errors", &self.allocate_errors);
         debug_struct.field("quota_metrics", &self.quota_metrics);
         debug_struct.field("service_config_id", &self.service_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6160,7 +6145,6 @@ impl std::fmt::Debug for QuotaError {
         debug_struct.field("subject", &self.subject);
         debug_struct.field("description", &self.description);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6542,7 +6526,6 @@ impl std::fmt::Debug for CheckRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("operation", &self.operation);
         debug_struct.field("service_config_id", &self.service_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6817,7 +6800,6 @@ impl std::fmt::Debug for CheckResponse {
         debug_struct.field("service_config_id", &self.service_config_id);
         debug_struct.field("service_rollout_id", &self.service_rollout_id);
         debug_struct.field("check_info", &self.check_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7039,7 +7021,6 @@ pub mod check_response {
             debug_struct.field("unused_arguments", &self.unused_arguments);
             debug_struct.field("consumer_info", &self.consumer_info);
             debug_struct.field("api_key_uid", &self.api_key_uid);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7288,7 +7269,6 @@ pub mod check_response {
             debug_struct.field("project_number", &self.project_number);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("consumer_number", &self.consumer_number);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7668,7 +7648,6 @@ impl std::fmt::Debug for ReportRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("operations", &self.operations);
         debug_struct.field("service_config_id", &self.service_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7889,7 +7868,6 @@ impl std::fmt::Debug for ReportResponse {
         debug_struct.field("report_errors", &self.report_errors);
         debug_struct.field("service_config_id", &self.service_config_id);
         debug_struct.field("service_rollout_id", &self.service_rollout_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8089,7 +8067,6 @@ pub mod report_response {
             let mut debug_struct = f.debug_struct("ReportError");
             debug_struct.field("operation_id", &self.operation_id);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/api/servicecontrol/v2/src/model.rs
+++ b/src/generated/api/servicecontrol/v2/src/model.rs
@@ -292,7 +292,6 @@ impl std::fmt::Debug for CheckRequest {
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("resources", &self.resources);
         debug_struct.field("flags", &self.flags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -546,7 +545,6 @@ impl std::fmt::Debug for ResourceInfo {
         debug_struct.field("permission", &self.permission);
         debug_struct.field("container", &self.container);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -739,7 +737,6 @@ impl std::fmt::Debug for CheckResponse {
         let mut debug_struct = f.debug_struct("CheckResponse");
         debug_struct.field("status", &self.status);
         debug_struct.field("headers", &self.headers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -952,7 +949,6 @@ impl std::fmt::Debug for ReportRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("service_config_id", &self.service_config_id);
         debug_struct.field("operations", &self.operations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1067,7 +1063,6 @@ impl serde::ser::Serialize for ReportResponse {
 impl std::fmt::Debug for ReportResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReportResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1212,7 +1207,6 @@ impl std::fmt::Debug for ResourceInfoList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceInfoList");
         debug_struct.field("resources", &self.resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -201,7 +201,6 @@ impl std::fmt::Debug for ManagedService {
         let mut debug_struct = f.debug_struct("ManagedService");
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("producer_project_id", &self.producer_project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -462,7 +461,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("steps", &self.steps);
         debug_struct.field("progress_percentage", &self.progress_percentage);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -642,7 +640,6 @@ pub mod operation_metadata {
             let mut debug_struct = f.debug_struct("Step");
             debug_struct.field("description", &self.description);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -990,7 +987,6 @@ impl std::fmt::Debug for Diagnostic {
         debug_struct.field("location", &self.location);
         debug_struct.field("kind", &self.kind);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1295,7 +1291,6 @@ impl std::fmt::Debug for ConfigSource {
         let mut debug_struct = f.debug_struct("ConfigSource");
         debug_struct.field("id", &self.id);
         debug_struct.field("files", &self.files);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1510,7 +1505,6 @@ impl std::fmt::Debug for ConfigFile {
         debug_struct.field("file_path", &self.file_path);
         debug_struct.field("file_contents", &self.file_contents);
         debug_struct.field("file_type", &self.file_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1823,7 +1817,6 @@ impl std::fmt::Debug for ConfigRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConfigRef");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1976,7 +1969,6 @@ impl std::fmt::Debug for ChangeReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ChangeReport");
         debug_struct.field("config_changes", &self.config_changes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2388,7 +2380,6 @@ impl std::fmt::Debug for Rollout {
         debug_struct.field("status", &self.status);
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("strategy", &self.strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2614,7 +2605,6 @@ pub mod rollout {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TrafficPercentStrategy");
             debug_struct.field("percentages", &self.percentages);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2732,7 +2722,6 @@ pub mod rollout {
     impl std::fmt::Debug for DeleteServiceStrategy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DeleteServiceStrategy");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3160,7 +3149,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("consumer_id", &self.consumer_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3349,7 +3337,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3493,7 +3480,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("service_name", &self.service_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3647,7 +3633,6 @@ impl std::fmt::Debug for CreateServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateServiceRequest");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3792,7 +3777,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceRequest");
         debug_struct.field("service_name", &self.service_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3937,7 +3921,6 @@ impl std::fmt::Debug for UndeleteServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteServiceRequest");
         debug_struct.field("service_name", &self.service_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4091,7 +4074,6 @@ impl std::fmt::Debug for UndeleteServiceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteServiceResponse");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4296,7 +4278,6 @@ impl std::fmt::Debug for GetServiceConfigRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("config_id", &self.config_id);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4645,7 +4626,6 @@ impl std::fmt::Debug for ListServiceConfigsRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4831,7 +4811,6 @@ impl std::fmt::Debug for ListServiceConfigsResponse {
         let mut debug_struct = f.debug_struct("ListServiceConfigsResponse");
         debug_struct.field("service_configs", &self.service_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5013,7 +4992,6 @@ impl std::fmt::Debug for CreateServiceConfigRequest {
         let mut debug_struct = f.debug_struct("CreateServiceConfigRequest");
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("service_config", &self.service_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5223,7 +5201,6 @@ impl std::fmt::Debug for SubmitConfigSourceRequest {
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("config_source", &self.config_source);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5377,7 +5354,6 @@ impl std::fmt::Debug for SubmitConfigSourceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SubmitConfigSourceResponse");
         debug_struct.field("service_config", &self.service_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5558,7 +5534,6 @@ impl std::fmt::Debug for CreateServiceRolloutRequest {
         let mut debug_struct = f.debug_struct("CreateServiceRolloutRequest");
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("rollout", &self.rollout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5808,7 +5783,6 @@ impl std::fmt::Debug for ListServiceRolloutsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5993,7 +5967,6 @@ impl std::fmt::Debug for ListServiceRolloutsResponse {
         let mut debug_struct = f.debug_struct("ListServiceRolloutsResponse");
         debug_struct.field("rollouts", &self.rollouts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6164,7 +6137,6 @@ impl std::fmt::Debug for GetServiceRolloutRequest {
         let mut debug_struct = f.debug_struct("GetServiceRolloutRequest");
         debug_struct.field("service_name", &self.service_name);
         debug_struct.field("rollout_id", &self.rollout_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6278,7 +6250,6 @@ impl serde::ser::Serialize for EnableServiceResponse {
 impl std::fmt::Debug for EnableServiceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableServiceResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6485,7 +6456,6 @@ impl std::fmt::Debug for GenerateConfigReportRequest {
         let mut debug_struct = f.debug_struct("GenerateConfigReportRequest");
         debug_struct.field("new_config", &self.new_config);
         debug_struct.field("old_config", &self.old_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6713,7 +6683,6 @@ impl std::fmt::Debug for GenerateConfigReportResponse {
         debug_struct.field("id", &self.id);
         debug_struct.field("change_reports", &self.change_reports);
         debug_struct.field("diagnostics", &self.diagnostics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -264,7 +264,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("config", &self.config);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -711,7 +710,6 @@ impl std::fmt::Debug for ServiceConfig {
         debug_struct.field("endpoints", &self.endpoints);
         debug_struct.field("monitored_resources", &self.monitored_resources);
         debug_struct.field("monitoring", &self.monitoring);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -858,7 +856,6 @@ impl std::fmt::Debug for OperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OperationMetadata");
         debug_struct.field("resource_names", &self.resource_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1010,7 +1007,6 @@ impl std::fmt::Debug for EnableServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1165,7 +1161,6 @@ impl std::fmt::Debug for EnableServiceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableServiceResponse");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1390,7 +1385,6 @@ impl std::fmt::Debug for DisableServiceRequest {
             "check_if_service_has_usage",
             &self.check_if_service_has_usage,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1688,7 +1682,6 @@ impl std::fmt::Debug for DisableServiceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableServiceResponse");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1834,7 +1827,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2078,7 +2070,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2264,7 +2255,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2450,7 +2440,6 @@ impl std::fmt::Debug for BatchEnableServicesRequest {
         let mut debug_struct = f.debug_struct("BatchEnableServicesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_ids", &self.service_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2632,7 +2621,6 @@ impl std::fmt::Debug for BatchEnableServicesResponse {
         let mut debug_struct = f.debug_struct("BatchEnableServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("failures", &self.failures);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2812,7 +2800,6 @@ pub mod batch_enable_services_response {
             let mut debug_struct = f.debug_struct("EnableFailure");
             debug_struct.field("service_id", &self.service_id);
             debug_struct.field("error_message", &self.error_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2992,7 +2979,6 @@ impl std::fmt::Debug for BatchGetServicesRequest {
         let mut debug_struct = f.debug_struct("BatchGetServicesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3137,7 +3123,6 @@ impl std::fmt::Debug for BatchGetServicesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchGetServicesResponse");
         debug_struct.field("services", &self.services);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -214,7 +214,6 @@ impl std::fmt::Debug for Authentication {
         let mut debug_struct = f.debug_struct("Authentication");
         debug_struct.field("rules", &self.rules);
         debug_struct.field("providers", &self.providers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -467,7 +466,6 @@ impl std::fmt::Debug for AuthenticationRule {
         debug_struct.field("oauth", &self.oauth);
         debug_struct.field("allow_without_credential", &self.allow_without_credential);
         debug_struct.field("requirements", &self.requirements);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -761,7 +759,6 @@ impl std::fmt::Debug for JwtLocation {
         let mut debug_struct = f.debug_struct("JwtLocation");
         debug_struct.field("value_prefix", &self.value_prefix);
         debug_struct.field("r#in", &self.r#in);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1116,7 +1113,6 @@ impl std::fmt::Debug for AuthProvider {
         debug_struct.field("audiences", &self.audiences);
         debug_struct.field("authorization_url", &self.authorization_url);
         debug_struct.field("jwt_locations", &self.jwt_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1287,7 +1283,6 @@ impl std::fmt::Debug for OAuthRequirements {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OAuthRequirements");
         debug_struct.field("canonical_scopes", &self.canonical_scopes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1485,7 +1480,6 @@ impl std::fmt::Debug for AuthRequirement {
         let mut debug_struct = f.debug_struct("AuthRequirement");
         debug_struct.field("provider_id", &self.provider_id);
         debug_struct.field("audiences", &self.audiences);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1632,7 +1626,6 @@ impl std::fmt::Debug for Backend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Backend");
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2219,7 +2212,6 @@ impl std::fmt::Debug for BackendRule {
             &self.overrides_by_request_protocol,
         );
         debug_struct.field("authentication", &self.authentication);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2623,7 +2615,6 @@ impl std::fmt::Debug for Billing {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Billing");
         debug_struct.field("consumer_destinations", &self.consumer_destinations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2814,7 +2805,6 @@ pub mod billing {
             let mut debug_struct = f.debug_struct("BillingDestination");
             debug_struct.field("monitored_resource", &self.monitored_resource);
             debug_struct.field("metrics", &self.metrics);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3040,7 +3030,6 @@ impl std::fmt::Debug for CommonLanguageSettings {
             "selective_gapic_generation",
             &self.selective_gapic_generation,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3538,7 +3527,6 @@ impl std::fmt::Debug for ClientLibrarySettings {
         debug_struct.field("dotnet_settings", &self.dotnet_settings);
         debug_struct.field("ruby_settings", &self.ruby_settings);
         debug_struct.field("go_settings", &self.go_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4000,7 +3988,6 @@ impl std::fmt::Debug for Publishing {
             "rest_reference_documentation_uri",
             &self.rest_reference_documentation_uri,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4239,7 +4226,6 @@ impl std::fmt::Debug for JavaSettings {
         debug_struct.field("library_package", &self.library_package);
         debug_struct.field("service_class_names", &self.service_class_names);
         debug_struct.field("common", &self.common);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4392,7 +4378,6 @@ impl std::fmt::Debug for CppSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CppSettings");
         debug_struct.field("common", &self.common);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4545,7 +4530,6 @@ impl std::fmt::Debug for PhpSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PhpSettings");
         debug_struct.field("common", &self.common);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4737,7 +4721,6 @@ impl std::fmt::Debug for PythonSettings {
         let mut debug_struct = f.debug_struct("PythonSettings");
         debug_struct.field("common", &self.common);
         debug_struct.field("experimental_features", &self.experimental_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4977,7 +4960,6 @@ pub mod python_settings {
                 "unversioned_package_disabled",
                 &self.unversioned_package_disabled,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5131,7 +5113,6 @@ impl std::fmt::Debug for NodeSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodeSettings");
         debug_struct.field("common", &self.common);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5462,7 +5443,6 @@ impl std::fmt::Debug for DotnetSettings {
         debug_struct.field("ignored_resources", &self.ignored_resources);
         debug_struct.field("forced_namespace_aliases", &self.forced_namespace_aliases);
         debug_struct.field("handwritten_signatures", &self.handwritten_signatures);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5615,7 +5595,6 @@ impl std::fmt::Debug for RubySettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RubySettings");
         debug_struct.field("common", &self.common);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5812,7 +5791,6 @@ impl std::fmt::Debug for GoSettings {
         let mut debug_struct = f.debug_struct("GoSettings");
         debug_struct.field("common", &self.common);
         debug_struct.field("renamed_services", &self.renamed_services);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6057,7 +6035,6 @@ impl std::fmt::Debug for MethodSettings {
         debug_struct.field("selector", &self.selector);
         debug_struct.field("long_running", &self.long_running);
         debug_struct.field("auto_populated_fields", &self.auto_populated_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6348,7 +6325,6 @@ pub mod method_settings {
             debug_struct.field("poll_delay_multiplier", &self.poll_delay_multiplier);
             debug_struct.field("max_poll_delay", &self.max_poll_delay);
             debug_struct.field("total_poll_timeout", &self.total_poll_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6537,7 +6513,6 @@ impl std::fmt::Debug for SelectiveGapicGeneration {
             "generate_omitted_as_internal",
             &self.generate_omitted_as_internal,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6805,7 +6780,6 @@ impl std::fmt::Debug for ConfigChange {
         debug_struct.field("new_value", &self.new_value);
         debug_struct.field("change_type", &self.change_type);
         debug_struct.field("advices", &self.advices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6949,7 +6923,6 @@ impl std::fmt::Debug for Advice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Advice");
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7111,7 +7084,6 @@ impl std::fmt::Debug for ProjectProperties {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProjectProperties");
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7313,7 +7285,6 @@ impl std::fmt::Debug for Property {
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7651,7 +7622,6 @@ impl std::fmt::Debug for Context {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Context");
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7934,7 +7904,6 @@ impl std::fmt::Debug for ContextRule {
             "allowed_response_extensions",
             &self.allowed_response_extensions,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8114,7 +8083,6 @@ impl std::fmt::Debug for Control {
         let mut debug_struct = f.debug_struct("Control");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("method_policies", &self.method_policies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8569,7 +8537,6 @@ impl std::fmt::Debug for Distribution {
         debug_struct.field("bucket_options", &self.bucket_options);
         debug_struct.field("bucket_counts", &self.bucket_counts);
         debug_struct.field("exemplars", &self.exemplars);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8780,7 +8747,6 @@ pub mod distribution {
             let mut debug_struct = f.debug_struct("Range");
             debug_struct.field("min", &self.min);
             debug_struct.field("max", &self.max);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9108,7 +9074,6 @@ pub mod distribution {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BucketOptions");
             debug_struct.field("options", &self.options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9389,7 +9354,6 @@ pub mod distribution {
                 debug_struct.field("num_finite_buckets", &self.num_finite_buckets);
                 debug_struct.field("width", &self.width);
                 debug_struct.field("offset", &self.offset);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9668,7 +9632,6 @@ pub mod distribution {
                 debug_struct.field("num_finite_buckets", &self.num_finite_buckets);
                 debug_struct.field("growth_factor", &self.growth_factor);
                 debug_struct.field("scale", &self.scale);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9862,7 +9825,6 @@ pub mod distribution {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Explicit");
                 debug_struct.field("bounds", &self.bounds);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -10121,7 +10083,6 @@ pub mod distribution {
             debug_struct.field("value", &self.value);
             debug_struct.field("timestamp", &self.timestamp);
             debug_struct.field("attachments", &self.attachments);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10453,7 +10414,6 @@ impl std::fmt::Debug for Documentation {
         debug_struct.field("documentation_root_url", &self.documentation_root_url);
         debug_struct.field("service_root_url", &self.service_root_url);
         debug_struct.field("overview", &self.overview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10658,7 +10618,6 @@ impl std::fmt::Debug for DocumentationRule {
         debug_struct.field("selector", &self.selector);
         debug_struct.field("description", &self.description);
         debug_struct.field("deprecation_description", &self.deprecation_description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10864,7 +10823,6 @@ impl std::fmt::Debug for Page {
         debug_struct.field("name", &self.name);
         debug_struct.field("content", &self.content);
         debug_struct.field("subpages", &self.subpages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11118,7 +11076,6 @@ impl std::fmt::Debug for Endpoint {
         debug_struct.field("aliases", &self.aliases);
         debug_struct.field("target", &self.target);
         debug_struct.field("allow_cors", &self.allow_cors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11295,7 +11252,6 @@ impl std::fmt::Debug for FieldInfo {
         let mut debug_struct = f.debug_struct("FieldInfo");
         debug_struct.field("format", &self.format);
         debug_struct.field("referenced_types", &self.referenced_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11614,7 +11570,6 @@ impl std::fmt::Debug for TypeReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TypeReference");
         debug_struct.field("type_name", &self.type_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11809,7 +11764,6 @@ impl std::fmt::Debug for Http {
             "fully_decode_reserved_expansion",
             &self.fully_decode_reserved_expansion,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12616,7 +12570,6 @@ impl std::fmt::Debug for HttpRule {
         debug_struct.field("response_body", &self.response_body);
         debug_struct.field("additional_bindings", &self.additional_bindings);
         debug_struct.field("pattern", &self.pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12813,7 +12766,6 @@ impl std::fmt::Debug for CustomHttpPattern {
         let mut debug_struct = f.debug_struct("CustomHttpPattern");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13075,7 +13027,6 @@ impl std::fmt::Debug for HttpBody {
         debug_struct.field("content_type", &self.content_type);
         debug_struct.field("data", &self.data);
         debug_struct.field("extensions", &self.extensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13269,7 +13220,6 @@ impl std::fmt::Debug for LabelDescriptor {
         debug_struct.field("key", &self.key);
         debug_struct.field("value_type", &self.value_type);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13648,7 +13598,6 @@ impl std::fmt::Debug for LogDescriptor {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13867,7 +13816,6 @@ impl std::fmt::Debug for Logging {
         let mut debug_struct = f.debug_struct("Logging");
         debug_struct.field("producer_destinations", &self.producer_destinations);
         debug_struct.field("consumer_destinations", &self.consumer_destinations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14059,7 +14007,6 @@ pub mod logging {
             let mut debug_struct = f.debug_struct("LoggingDestination");
             debug_struct.field("monitored_resource", &self.monitored_resource);
             debug_struct.field("logs", &self.logs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14640,7 +14587,6 @@ impl std::fmt::Debug for MetricDescriptor {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("launch_stage", &self.launch_stage);
         debug_struct.field("monitored_resource_types", &self.monitored_resource_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14921,7 +14867,6 @@ pub mod metric_descriptor {
                 "time_series_resource_hierarchy_level",
                 &self.time_series_resource_hierarchy_level,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15566,7 +15511,6 @@ impl std::fmt::Debug for Metric {
         let mut debug_struct = f.debug_struct("Metric");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15872,7 +15816,6 @@ impl std::fmt::Debug for MonitoredResourceDescriptor {
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("launch_stage", &self.launch_stage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16079,7 +16022,6 @@ impl std::fmt::Debug for MonitoredResource {
         let mut debug_struct = f.debug_struct("MonitoredResource");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16288,7 +16230,6 @@ impl std::fmt::Debug for MonitoredResourceMetadata {
         let mut debug_struct = f.debug_struct("MonitoredResourceMetadata");
         debug_struct.field("system_labels", &self.system_labels);
         debug_struct.field("user_labels", &self.user_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16534,7 +16475,6 @@ impl std::fmt::Debug for Monitoring {
         let mut debug_struct = f.debug_struct("Monitoring");
         debug_struct.field("producer_destinations", &self.producer_destinations);
         debug_struct.field("consumer_destinations", &self.consumer_destinations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16725,7 +16665,6 @@ pub mod monitoring {
             let mut debug_struct = f.debug_struct("MonitoringDestination");
             debug_struct.field("monitored_resource", &self.monitored_resource);
             debug_struct.field("metrics", &self.metrics);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16942,7 +16881,6 @@ impl std::fmt::Debug for FieldPolicy {
         debug_struct.field("selector", &self.selector);
         debug_struct.field("resource_permission", &self.resource_permission);
         debug_struct.field("resource_type", &self.resource_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17122,7 +17060,6 @@ impl std::fmt::Debug for MethodPolicy {
         let mut debug_struct = f.debug_struct("MethodPolicy");
         debug_struct.field("selector", &self.selector);
         debug_struct.field("request_policies", &self.request_policies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17350,7 +17287,6 @@ impl std::fmt::Debug for Quota {
         let mut debug_struct = f.debug_struct("Quota");
         debug_struct.field("limits", &self.limits);
         debug_struct.field("metric_rules", &self.metric_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17565,7 +17501,6 @@ impl std::fmt::Debug for MetricRule {
         let mut debug_struct = f.debug_struct("MetricRule");
         debug_struct.field("selector", &self.selector);
         debug_struct.field("metric_costs", &self.metric_costs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18080,7 +18015,6 @@ impl std::fmt::Debug for QuotaLimit {
         debug_struct.field("unit", &self.unit);
         debug_struct.field("values", &self.values);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18502,7 +18436,6 @@ impl std::fmt::Debug for ResourceDescriptor {
         debug_struct.field("plural", &self.plural);
         debug_struct.field("singular", &self.singular);
         debug_struct.field("style", &self.style);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18982,7 +18915,6 @@ impl std::fmt::Debug for ResourceReference {
         let mut debug_struct = f.debug_struct("ResourceReference");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("child_type", &self.child_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19547,7 +19479,6 @@ impl std::fmt::Debug for RoutingRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RoutingRule");
         debug_struct.field("routing_parameters", &self.routing_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19776,7 +19707,6 @@ impl std::fmt::Debug for RoutingParameter {
         let mut debug_struct = f.debug_struct("RoutingParameter");
         debug_struct.field("field", &self.field);
         debug_struct.field("path_template", &self.path_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20850,7 +20780,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("source_info", &self.source_info);
         debug_struct.field("publishing", &self.publishing);
         debug_struct.field("config_version", &self.config_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20998,7 +20927,6 @@ impl std::fmt::Debug for SourceInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceInfo");
         debug_struct.field("source_files", &self.source_files);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21183,7 +21111,6 @@ impl std::fmt::Debug for SystemParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SystemParameters");
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21368,7 +21295,6 @@ impl std::fmt::Debug for SystemParameterRule {
         let mut debug_struct = f.debug_struct("SystemParameterRule");
         debug_struct.field("selector", &self.selector);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21569,7 +21495,6 @@ impl std::fmt::Debug for SystemParameter {
         debug_struct.field("name", &self.name);
         debug_struct.field("http_header", &self.http_header);
         debug_struct.field("url_query_parameter", &self.url_query_parameter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21798,7 +21723,6 @@ impl std::fmt::Debug for Usage {
             "producer_notification_channel",
             &self.producer_notification_channel,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22031,7 +21955,6 @@ impl std::fmt::Debug for UsageRule {
         debug_struct.field("selector", &self.selector);
         debug_struct.field("allow_unregistered_calls", &self.allow_unregistered_calls);
         debug_struct.field("skip_service_control", &self.skip_service_control);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22206,7 +22129,6 @@ impl std::fmt::Debug for Visibility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Visibility");
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22395,7 +22317,6 @@ impl std::fmt::Debug for VisibilityRule {
         let mut debug_struct = f.debug_struct("VisibilityRule");
         debug_struct.field("selector", &self.selector);
         debug_struct.field("restriction", &self.restriction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -281,7 +281,6 @@ impl std::fmt::Debug for ApiConfigHandler {
         debug_struct.field("script", &self.script);
         debug_struct.field("security_level", &self.security_level);
         debug_struct.field("url", &self.url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -477,7 +476,6 @@ impl std::fmt::Debug for ErrorHandler {
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("static_file", &self.static_file);
         debug_struct.field("mime_type", &self.mime_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1088,7 +1086,6 @@ impl std::fmt::Debug for UrlMap {
             &self.redirect_http_response_code,
         );
         debug_struct.field("handler_type", &self.handler_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1603,7 +1600,6 @@ impl std::fmt::Debug for StaticFilesHandler {
         debug_struct.field("expiration", &self.expiration);
         debug_struct.field("require_matching_file", &self.require_matching_file);
         debug_struct.field("application_readable", &self.application_readable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1746,7 +1742,6 @@ impl std::fmt::Debug for ScriptHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScriptHandler");
         debug_struct.field("script_path", &self.script_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1889,7 +1884,6 @@ impl std::fmt::Debug for ApiEndpointHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApiEndpointHandler");
         debug_struct.field("script_path", &self.script_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2271,7 +2265,6 @@ impl std::fmt::Debug for HealthCheck {
         debug_struct.field("restart_threshold", &self.restart_threshold);
         debug_struct.field("check_interval", &self.check_interval);
         debug_struct.field("timeout", &self.timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2644,7 +2637,6 @@ impl std::fmt::Debug for ReadinessCheck {
         debug_struct.field("check_interval", &self.check_interval);
         debug_struct.field("timeout", &self.timeout);
         debug_struct.field("app_start_timeout", &self.app_start_timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3015,7 +3007,6 @@ impl std::fmt::Debug for LivenessCheck {
         debug_struct.field("check_interval", &self.check_interval);
         debug_struct.field("timeout", &self.timeout);
         debug_struct.field("initial_delay", &self.initial_delay);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3182,7 +3173,6 @@ impl std::fmt::Debug for Library {
         let mut debug_struct = f.debug_struct("Library");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3324,7 +3314,6 @@ impl std::fmt::Debug for GetApplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3477,7 +3466,6 @@ impl std::fmt::Debug for CreateApplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateApplicationRequest");
         debug_struct.field("application", &self.application);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3692,7 +3680,6 @@ impl std::fmt::Debug for UpdateApplicationRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("application", &self.application);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3834,7 +3821,6 @@ impl std::fmt::Debug for RepairApplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RepairApplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4046,7 +4032,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4231,7 +4216,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4373,7 +4357,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4626,7 +4609,6 @@ impl std::fmt::Debug for UpdateServiceRequest {
         debug_struct.field("service", &self.service);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("migrate_traffic", &self.migrate_traffic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4768,7 +4750,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5006,7 +4987,6 @@ impl std::fmt::Debug for ListVersionsRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5191,7 +5171,6 @@ impl std::fmt::Debug for ListVersionsResponse {
         let mut debug_struct = f.debug_struct("ListVersionsResponse");
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5359,7 +5338,6 @@ impl std::fmt::Debug for GetVersionRequest {
         let mut debug_struct = f.debug_struct("GetVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5538,7 +5516,6 @@ impl std::fmt::Debug for CreateVersionRequest {
         let mut debug_struct = f.debug_struct("CreateVersionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5755,7 +5732,6 @@ impl std::fmt::Debug for UpdateVersionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5898,7 +5874,6 @@ impl std::fmt::Debug for DeleteVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6111,7 +6086,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6296,7 +6270,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         let mut debug_struct = f.debug_struct("ListInstancesResponse");
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6439,7 +6412,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6582,7 +6554,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6757,7 +6728,6 @@ impl std::fmt::Debug for DebugInstanceRequest {
         let mut debug_struct = f.debug_struct("DebugInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("ssh_key", &self.ssh_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7001,7 +6971,6 @@ impl std::fmt::Debug for ListIngressRulesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("matching_address", &self.matching_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7187,7 +7156,6 @@ impl std::fmt::Debug for ListIngressRulesResponse {
         let mut debug_struct = f.debug_struct("ListIngressRulesResponse");
         debug_struct.field("ingress_rules", &self.ingress_rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7359,7 +7327,6 @@ impl std::fmt::Debug for BatchUpdateIngressRulesRequest {
         let mut debug_struct = f.debug_struct("BatchUpdateIngressRulesRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("ingress_rules", &self.ingress_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7505,7 +7472,6 @@ impl std::fmt::Debug for BatchUpdateIngressRulesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchUpdateIngressRulesResponse");
         debug_struct.field("ingress_rules", &self.ingress_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7693,7 +7659,6 @@ impl std::fmt::Debug for CreateIngressRuleRequest {
         let mut debug_struct = f.debug_struct("CreateIngressRuleRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7836,7 +7801,6 @@ impl std::fmt::Debug for GetIngressRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetIngressRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8052,7 +8016,6 @@ impl std::fmt::Debug for UpdateIngressRuleRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("rule", &self.rule);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8195,7 +8158,6 @@ impl std::fmt::Debug for DeleteIngressRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIngressRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8407,7 +8369,6 @@ impl std::fmt::Debug for ListAuthorizedDomainsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8596,7 +8557,6 @@ impl std::fmt::Debug for ListAuthorizedDomainsResponse {
         let mut debug_struct = f.debug_struct("ListAuthorizedDomainsResponse");
         debug_struct.field("domains", &self.domains);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8834,7 +8794,6 @@ impl std::fmt::Debug for ListAuthorizedCertificatesRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9023,7 +8982,6 @@ impl std::fmt::Debug for ListAuthorizedCertificatesResponse {
         let mut debug_struct = f.debug_struct("ListAuthorizedCertificatesResponse");
         debug_struct.field("certificates", &self.certificates);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9192,7 +9150,6 @@ impl std::fmt::Debug for GetAuthorizedCertificateRequest {
         let mut debug_struct = f.debug_struct("GetAuthorizedCertificateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9370,7 +9327,6 @@ impl std::fmt::Debug for CreateAuthorizedCertificateRequest {
         let mut debug_struct = f.debug_struct("CreateAuthorizedCertificateRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("certificate", &self.certificate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9588,7 +9544,6 @@ impl std::fmt::Debug for UpdateAuthorizedCertificateRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("certificate", &self.certificate);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9731,7 +9686,6 @@ impl std::fmt::Debug for DeleteAuthorizedCertificateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAuthorizedCertificateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9943,7 +9897,6 @@ impl std::fmt::Debug for ListDomainMappingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10129,7 +10082,6 @@ impl std::fmt::Debug for ListDomainMappingsResponse {
         let mut debug_struct = f.debug_struct("ListDomainMappingsResponse");
         debug_struct.field("domain_mappings", &self.domain_mappings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10272,7 +10224,6 @@ impl std::fmt::Debug for GetDomainMappingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDomainMappingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10479,7 +10430,6 @@ impl std::fmt::Debug for CreateDomainMappingRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("domain_mapping", &self.domain_mapping);
         debug_struct.field("override_strategy", &self.override_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10697,7 +10647,6 @@ impl std::fmt::Debug for UpdateDomainMappingRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("domain_mapping", &self.domain_mapping);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10840,7 +10789,6 @@ impl std::fmt::Debug for DeleteDomainMappingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDomainMappingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11425,7 +11373,6 @@ impl std::fmt::Debug for Application {
         debug_struct.field("gcr_domain", &self.gcr_domain);
         debug_struct.field("database_type", &self.database_type);
         debug_struct.field("feature_settings", &self.feature_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11684,7 +11631,6 @@ pub mod application {
                 "oauth2_client_secret_sha256",
                 &self.oauth2_client_secret_sha256,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11871,7 +11817,6 @@ pub mod application {
                 "use_container_optimized_os",
                 &self.use_container_optimized_os,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12351,7 +12296,6 @@ impl std::fmt::Debug for UrlDispatchRule {
         debug_struct.field("domain", &self.domain);
         debug_struct.field("path", &self.path);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12599,7 +12543,6 @@ impl std::fmt::Debug for AuditData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AuditData");
         debug_struct.field("method", &self.method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12771,7 +12714,6 @@ impl std::fmt::Debug for UpdateServiceMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateServiceMethod");
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12924,7 +12866,6 @@ impl std::fmt::Debug for CreateVersionMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateVersionMethod");
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13370,7 +13311,6 @@ impl std::fmt::Debug for AuthorizedCertificate {
         debug_struct.field("managed_certificate", &self.managed_certificate);
         debug_struct.field("visible_domain_mappings", &self.visible_domain_mappings);
         debug_struct.field("domain_mappings_count", &self.domain_mappings_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13547,7 +13487,6 @@ impl std::fmt::Debug for CertificateRawData {
         let mut debug_struct = f.debug_struct("CertificateRawData");
         debug_struct.field("public_certificate", &self.public_certificate);
         debug_struct.field("private_key", &self.private_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13737,7 +13676,6 @@ impl std::fmt::Debug for ManagedCertificate {
         let mut debug_struct = f.debug_struct("ManagedCertificate");
         debug_struct.field("last_renewal_time", &self.last_renewal_time);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14007,7 +13945,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("container", &self.container);
         debug_struct.field("zip", &self.zip);
         debug_struct.field("cloud_build_options", &self.cloud_build_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14207,7 +14144,6 @@ impl std::fmt::Debug for FileInfo {
         debug_struct.field("source_url", &self.source_url);
         debug_struct.field("sha1_sum", &self.sha1_sum);
         debug_struct.field("mime_type", &self.mime_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14353,7 +14289,6 @@ impl std::fmt::Debug for ContainerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ContainerInfo");
         debug_struct.field("image", &self.image);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14542,7 +14477,6 @@ impl std::fmt::Debug for CloudBuildOptions {
         let mut debug_struct = f.debug_struct("CloudBuildOptions");
         debug_struct.field("app_yaml_path", &self.app_yaml_path);
         debug_struct.field("cloud_build_timeout", &self.cloud_build_timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14733,7 +14667,6 @@ impl std::fmt::Debug for ZipInfo {
         let mut debug_struct = f.debug_struct("ZipInfo");
         debug_struct.field("source_url", &self.source_url);
         debug_struct.field("files_count", &self.files_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14906,7 +14839,6 @@ impl std::fmt::Debug for AuthorizedDomain {
         let mut debug_struct = f.debug_struct("AuthorizedDomain");
         debug_struct.field("name", &self.name);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15152,7 +15084,6 @@ impl std::fmt::Debug for DomainMapping {
         debug_struct.field("id", &self.id);
         debug_struct.field("ssl_settings", &self.ssl_settings);
         debug_struct.field("resource_records", &self.resource_records);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15385,7 +15316,6 @@ impl std::fmt::Debug for SslSettings {
             "pending_managed_certificate_id",
             &self.pending_managed_certificate_id,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15721,7 +15651,6 @@ impl std::fmt::Debug for ResourceRecord {
         debug_struct.field("name", &self.name);
         debug_struct.field("rrdata", &self.rrdata);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16114,7 +16043,6 @@ impl std::fmt::Debug for FirewallRule {
         debug_struct.field("action", &self.action);
         debug_struct.field("source_range", &self.source_range);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16929,7 +16857,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("vm_debug_enabled", &self.vm_debug_enabled);
         debug_struct.field("vm_ip", &self.vm_ip);
         debug_struct.field("vm_liveness", &self.vm_liveness);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17051,7 +16978,6 @@ pub mod instance {
     impl std::fmt::Debug for Liveness {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Liveness");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17571,7 +17497,6 @@ impl std::fmt::Debug for LocationMetadata {
             &self.flexible_environment_available,
         );
         debug_struct.field("search_api_available", &self.search_api_available);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17722,7 +17647,6 @@ impl std::fmt::Debug for NetworkSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkSettings");
         debug_struct.field("ingress_traffic_allowed", &self.ingress_traffic_allowed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18288,7 +18212,6 @@ impl std::fmt::Debug for OperationMetadataV1 {
         debug_struct.field("ephemeral_message", &self.ephemeral_message);
         debug_struct.field("warning", &self.warning);
         debug_struct.field("method_metadata", &self.method_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18450,7 +18373,6 @@ impl std::fmt::Debug for CreateVersionMetadataV1 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateVersionMetadataV1");
         debug_struct.field("cloud_build_id", &self.cloud_build_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18745,7 +18667,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("split", &self.split);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("network_settings", &self.network_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18960,7 +18881,6 @@ impl std::fmt::Debug for TrafficSplit {
         let mut debug_struct = f.debug_struct("TrafficSplit");
         debug_struct.field("shard_by", &self.shard_by);
         debug_struct.field("allocations", &self.allocations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20662,7 +20582,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("entrypoint", &self.entrypoint);
         debug_struct.field("vpc_access_connector", &self.vpc_access_connector);
         debug_struct.field("scaling", &self.scaling);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20936,7 +20855,6 @@ impl std::fmt::Debug for EndpointsApiService {
         debug_struct.field("config_id", &self.config_id);
         debug_struct.field("rollout_strategy", &self.rollout_strategy);
         debug_struct.field("disable_trace_sampling", &self.disable_trace_sampling);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21745,7 +21663,6 @@ impl std::fmt::Debug for AutomaticScaling {
             "standard_scheduler_settings",
             &self.standard_scheduler_settings,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21948,7 +21865,6 @@ impl std::fmt::Debug for BasicScaling {
         let mut debug_struct = f.debug_struct("BasicScaling");
         debug_struct.field("idle_timeout", &self.idle_timeout);
         debug_struct.field("max_instances", &self.max_instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22112,7 +22028,6 @@ impl std::fmt::Debug for ManualScaling {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ManualScaling");
         debug_struct.field("instances", &self.instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22316,7 +22231,6 @@ impl std::fmt::Debug for CpuUtilization {
         let mut debug_struct = f.debug_struct("CpuUtilization");
         debug_struct.field("aggregation_window_length", &self.aggregation_window_length);
         debug_struct.field("target_utilization", &self.target_utilization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22544,7 +22458,6 @@ impl std::fmt::Debug for RequestUtilization {
             "target_concurrent_requests",
             &self.target_concurrent_requests,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22882,7 +22795,6 @@ impl std::fmt::Debug for DiskUtilization {
             "target_read_ops_per_second",
             &self.target_read_ops_per_second,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23226,7 +23138,6 @@ impl std::fmt::Debug for NetworkUtilization {
             "target_received_packets_per_second",
             &self.target_received_packets_per_second,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23538,7 +23449,6 @@ impl std::fmt::Debug for StandardSchedulerSettings {
         );
         debug_struct.field("min_instances", &self.min_instances);
         debug_struct.field("max_instances", &self.max_instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23812,7 +23722,6 @@ impl std::fmt::Debug for Network {
         debug_struct.field("name", &self.name);
         debug_struct.field("subnetwork_name", &self.subnetwork_name);
         debug_struct.field("session_affinity", &self.session_affinity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24025,7 +23934,6 @@ impl std::fmt::Debug for Volume {
         debug_struct.field("name", &self.name);
         debug_struct.field("volume_type", &self.volume_type);
         debug_struct.field("size_gb", &self.size_gb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24331,7 +24239,6 @@ impl std::fmt::Debug for Resources {
         debug_struct.field("memory_gb", &self.memory_gb);
         debug_struct.field("volumes", &self.volumes);
         debug_struct.field("kms_key_reference", &self.kms_key_reference);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24508,7 +24415,6 @@ impl std::fmt::Debug for VpcAccessConnector {
         let mut debug_struct = f.debug_struct("VpcAccessConnector");
         debug_struct.field("name", &self.name);
         debug_struct.field("egress_setting", &self.egress_setting);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24828,7 +24734,6 @@ impl std::fmt::Debug for Entrypoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Entrypoint");
         debug_struct.field("command", &self.command);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/calendar/src/model.rs
+++ b/src/generated/apps/script/calendar/src/model.rs
@@ -357,7 +357,6 @@ impl std::fmt::Debug for CalendarAddOnManifest {
         debug_struct.field("event_open_trigger", &self.event_open_trigger);
         debug_struct.field("event_update_trigger", &self.event_update_trigger);
         debug_struct.field("current_event_access", &self.current_event_access);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -741,7 +740,6 @@ impl std::fmt::Debug for ConferenceSolution {
         debug_struct.field("id", &self.id);
         debug_struct.field("name", &self.name);
         debug_struct.field("logo_url", &self.logo_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -885,7 +883,6 @@ impl std::fmt::Debug for CalendarExtensionPoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CalendarExtensionPoint");
         debug_struct.field("run_function", &self.run_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/docs/src/model.rs
+++ b/src/generated/apps/script/docs/src/model.rs
@@ -224,7 +224,6 @@ impl std::fmt::Debug for DocsAddOnManifest {
             "on_file_scope_granted_trigger",
             &self.on_file_scope_granted_trigger,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -367,7 +366,6 @@ impl std::fmt::Debug for DocsExtensionPoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DocsExtensionPoint");
         debug_struct.field("run_function", &self.run_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/drive/src/model.rs
+++ b/src/generated/apps/script/drive/src/model.rs
@@ -213,7 +213,6 @@ impl std::fmt::Debug for DriveAddOnManifest {
         let mut debug_struct = f.debug_struct("DriveAddOnManifest");
         debug_struct.field("homepage_trigger", &self.homepage_trigger);
         debug_struct.field("on_items_selected_trigger", &self.on_items_selected_trigger);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -358,7 +357,6 @@ impl std::fmt::Debug for DriveExtensionPoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DriveExtensionPoint");
         debug_struct.field("run_function", &self.run_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -332,7 +332,6 @@ impl std::fmt::Debug for GmailAddOnManifest {
             "authorization_check_function",
             &self.authorization_check_function,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -591,7 +590,6 @@ impl std::fmt::Debug for UniversalAction {
         let mut debug_struct = f.debug_struct("UniversalAction");
         debug_struct.field("text", &self.text);
         debug_struct.field("action_type", &self.action_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -787,7 +785,6 @@ impl std::fmt::Debug for ComposeTrigger {
         let mut debug_struct = f.debug_struct("ComposeTrigger");
         debug_struct.field("actions", &self.actions);
         debug_struct.field("draft_access", &self.draft_access);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1153,7 +1150,6 @@ impl std::fmt::Debug for ContextualTrigger {
         let mut debug_struct = f.debug_struct("ContextualTrigger");
         debug_struct.field("on_trigger_function", &self.on_trigger_function);
         debug_struct.field("trigger", &self.trigger);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1282,7 +1278,6 @@ impl serde::ser::Serialize for UnconditionalTrigger {
 impl std::fmt::Debug for UnconditionalTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UnconditionalTrigger");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -166,7 +166,6 @@ impl std::fmt::Debug for AddOnWidgetSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddOnWidgetSet");
         debug_struct.field("used_widgets", &self.used_widgets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -540,7 +539,6 @@ impl std::fmt::Debug for MenuItemExtensionPoint {
         debug_struct.field("run_function", &self.run_function);
         debug_struct.field("label", &self.label);
         debug_struct.field("logo_url", &self.logo_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -725,7 +723,6 @@ impl std::fmt::Debug for HomepageExtensionPoint {
         let mut debug_struct = f.debug_struct("HomepageExtensionPoint");
         debug_struct.field("run_function", &self.run_function);
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -986,7 +983,6 @@ impl std::fmt::Debug for UniversalActionExtensionPoint {
         let mut debug_struct = f.debug_struct("UniversalActionExtensionPoint");
         debug_struct.field("label", &self.label);
         debug_struct.field("action_type", &self.action_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1393,7 +1389,6 @@ impl std::fmt::Debug for CommonAddOnManifest {
         debug_struct.field("homepage_trigger", &self.homepage_trigger);
         debug_struct.field("universal_actions", &self.universal_actions);
         debug_struct.field("open_link_url_prefixes", &self.open_link_url_prefixes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1568,7 +1563,6 @@ impl std::fmt::Debug for LayoutProperties {
         let mut debug_struct = f.debug_struct("LayoutProperties");
         debug_struct.field("primary_color", &self.primary_color);
         debug_struct.field("secondary_color", &self.secondary_color);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1714,7 +1708,6 @@ impl std::fmt::Debug for HttpOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HttpOptions");
         debug_struct.field("authorization_header", &self.authorization_header);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/sheets/src/model.rs
+++ b/src/generated/apps/script/sheets/src/model.rs
@@ -224,7 +224,6 @@ impl std::fmt::Debug for SheetsAddOnManifest {
             "on_file_scope_granted_trigger",
             &self.on_file_scope_granted_trigger,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -367,7 +366,6 @@ impl std::fmt::Debug for SheetsExtensionPoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SheetsExtensionPoint");
         debug_struct.field("run_function", &self.run_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/apps/script/slides/src/model.rs
+++ b/src/generated/apps/script/slides/src/model.rs
@@ -224,7 +224,6 @@ impl std::fmt::Debug for SlidesAddOnManifest {
             "on_file_scope_granted_trigger",
             &self.on_file_scope_granted_trigger,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -367,7 +366,6 @@ impl std::fmt::Debug for SlidesExtensionPoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SlidesExtensionPoint");
         debug_struct.field("run_function", &self.run_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -273,7 +273,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("clusters", &self.clusters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -416,7 +415,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -585,7 +583,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         let mut debug_struct = f.debug_struct("ListInstancesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -790,7 +787,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("failed_locations", &self.failed_locations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -981,7 +977,6 @@ impl std::fmt::Debug for PartialUpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("PartialUpdateInstanceRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1124,7 +1119,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1332,7 +1326,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("cluster", &self.cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1475,7 +1468,6 @@ impl std::fmt::Debug for GetClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1647,7 +1639,6 @@ impl std::fmt::Debug for ListClustersRequest {
         let mut debug_struct = f.debug_struct("ListClustersRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1851,7 +1842,6 @@ impl std::fmt::Debug for ListClustersResponse {
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("failed_locations", &self.failed_locations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1994,7 +1984,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2222,7 +2211,6 @@ impl std::fmt::Debug for CreateInstanceMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2450,7 +2438,6 @@ impl std::fmt::Debug for UpdateInstanceMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2724,7 +2711,6 @@ impl std::fmt::Debug for CreateClusterMetadata {
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
         debug_struct.field("tables", &self.tables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2973,7 +2959,6 @@ pub mod create_cluster_metadata {
             debug_struct.field("estimated_size_bytes", &self.estimated_size_bytes);
             debug_struct.field("estimated_copied_bytes", &self.estimated_copied_bytes);
             debug_struct.field("state", &self.state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3357,7 +3342,6 @@ impl std::fmt::Debug for UpdateClusterMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3585,7 +3569,6 @@ impl std::fmt::Debug for PartialUpdateClusterMetadata {
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
         debug_struct.field("original_request", &self.original_request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3776,7 +3759,6 @@ impl std::fmt::Debug for PartialUpdateClusterRequest {
         let mut debug_struct = f.debug_struct("PartialUpdateClusterRequest");
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4011,7 +3993,6 @@ impl std::fmt::Debug for CreateAppProfileRequest {
         debug_struct.field("app_profile_id", &self.app_profile_id);
         debug_struct.field("app_profile", &self.app_profile);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4154,7 +4135,6 @@ impl std::fmt::Debug for GetAppProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAppProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4378,7 +4358,6 @@ impl std::fmt::Debug for ListAppProfilesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4598,7 +4577,6 @@ impl std::fmt::Debug for ListAppProfilesResponse {
         debug_struct.field("app_profiles", &self.app_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("failed_locations", &self.failed_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4816,7 +4794,6 @@ impl std::fmt::Debug for UpdateAppProfileRequest {
         debug_struct.field("app_profile", &self.app_profile);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4986,7 +4963,6 @@ impl std::fmt::Debug for DeleteAppProfileRequest {
         let mut debug_struct = f.debug_struct("DeleteAppProfileRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5100,7 +5076,6 @@ impl serde::ser::Serialize for UpdateAppProfileMetadata {
 impl std::fmt::Debug for UpdateAppProfileMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateAppProfileMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5401,7 +5376,6 @@ impl std::fmt::Debug for ListHotTabletsRequest {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5593,7 +5567,6 @@ impl std::fmt::Debug for ListHotTabletsResponse {
         let mut debug_struct = f.debug_struct("ListHotTabletsResponse");
         debug_struct.field("hot_tablets", &self.hot_tablets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5800,7 +5773,6 @@ impl std::fmt::Debug for CreateLogicalViewRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("logical_view_id", &self.logical_view_id);
         debug_struct.field("logical_view", &self.logical_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6029,7 +6001,6 @@ impl std::fmt::Debug for CreateLogicalViewMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6172,7 +6143,6 @@ impl std::fmt::Debug for GetLogicalViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLogicalViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6391,7 +6361,6 @@ impl std::fmt::Debug for ListLogicalViewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6578,7 +6547,6 @@ impl std::fmt::Debug for ListLogicalViewsResponse {
         let mut debug_struct = f.debug_struct("ListLogicalViewsResponse");
         debug_struct.field("logical_views", &self.logical_views);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6773,7 +6741,6 @@ impl std::fmt::Debug for UpdateLogicalViewRequest {
         let mut debug_struct = f.debug_struct("UpdateLogicalViewRequest");
         debug_struct.field("logical_view", &self.logical_view);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7002,7 +6969,6 @@ impl std::fmt::Debug for UpdateLogicalViewMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7174,7 +7140,6 @@ impl std::fmt::Debug for DeleteLogicalViewRequest {
         let mut debug_struct = f.debug_struct("DeleteLogicalViewRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7385,7 +7350,6 @@ impl std::fmt::Debug for CreateMaterializedViewRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("materialized_view_id", &self.materialized_view_id);
         debug_struct.field("materialized_view", &self.materialized_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7616,7 +7580,6 @@ impl std::fmt::Debug for CreateMaterializedViewMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7760,7 +7723,6 @@ impl std::fmt::Debug for GetMaterializedViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMaterializedViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7979,7 +7941,6 @@ impl std::fmt::Debug for ListMaterializedViewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8170,7 +8131,6 @@ impl std::fmt::Debug for ListMaterializedViewsResponse {
         let mut debug_struct = f.debug_struct("ListMaterializedViewsResponse");
         debug_struct.field("materialized_views", &self.materialized_views);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8366,7 +8326,6 @@ impl std::fmt::Debug for UpdateMaterializedViewRequest {
         let mut debug_struct = f.debug_struct("UpdateMaterializedViewRequest");
         debug_struct.field("materialized_view", &self.materialized_view);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8597,7 +8556,6 @@ impl std::fmt::Debug for UpdateMaterializedViewMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8769,7 +8727,6 @@ impl std::fmt::Debug for DeleteMaterializedViewRequest {
         let mut debug_struct = f.debug_struct("DeleteMaterializedViewRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9008,7 +8965,6 @@ impl std::fmt::Debug for RestoreTableRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9364,7 +9320,6 @@ impl std::fmt::Debug for RestoreTableMetadata {
         );
         debug_struct.field("progress", &self.progress);
         debug_struct.field("source_info", &self.source_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9563,7 +9518,6 @@ impl std::fmt::Debug for OptimizeRestoredTableMetadata {
         let mut debug_struct = f.debug_struct("OptimizeRestoredTableMetadata");
         debug_struct.field("name", &self.name);
         debug_struct.field("progress", &self.progress);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9821,7 +9775,6 @@ impl std::fmt::Debug for CreateTableRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("table", &self.table);
         debug_struct.field("initial_splits", &self.initial_splits);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9994,7 +9947,6 @@ pub mod create_table_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Split");
             debug_struct.field("key", &self.key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10202,7 +10154,6 @@ impl std::fmt::Debug for CreateTableFromSnapshotRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("source_snapshot", &self.source_snapshot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10487,7 +10438,6 @@ impl std::fmt::Debug for DropRowRangeRequest {
         let mut debug_struct = f.debug_struct("DropRowRangeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10754,7 +10704,6 @@ impl std::fmt::Debug for ListTablesRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10944,7 +10893,6 @@ impl std::fmt::Debug for ListTablesResponse {
         let mut debug_struct = f.debug_struct("ListTablesResponse");
         debug_struct.field("tables", &self.tables);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11117,7 +11065,6 @@ impl std::fmt::Debug for GetTableRequest {
         let mut debug_struct = f.debug_struct("GetTableRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11349,7 +11296,6 @@ impl std::fmt::Debug for UpdateTableRequest {
         debug_struct.field("table", &self.table);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11568,7 +11514,6 @@ impl std::fmt::Debug for UpdateTableMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11715,7 +11660,6 @@ impl std::fmt::Debug for DeleteTableRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTableRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11862,7 +11806,6 @@ impl std::fmt::Debug for UndeleteTableRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteTableRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12081,7 +12024,6 @@ impl std::fmt::Debug for UndeleteTableMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12291,7 +12233,6 @@ impl std::fmt::Debug for ModifyColumnFamiliesRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("modifications", &self.modifications);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12650,7 +12591,6 @@ pub mod modify_column_families_request {
             debug_struct.field("id", &self.id);
             debug_struct.field("update_mask", &self.update_mask);
             debug_struct.field("r#mod", &self.r#mod);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12819,7 +12759,6 @@ impl std::fmt::Debug for GenerateConsistencyTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateConsistencyTokenRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12968,7 +12907,6 @@ impl std::fmt::Debug for GenerateConsistencyTokenResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateConsistencyTokenResponse");
         debug_struct.field("consistency_token", &self.consistency_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13281,7 +13219,6 @@ impl std::fmt::Debug for CheckConsistencyRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("consistency_token", &self.consistency_token);
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13417,7 +13354,6 @@ impl serde::ser::Serialize for StandardReadRemoteWrites {
 impl std::fmt::Debug for StandardReadRemoteWrites {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StandardReadRemoteWrites");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13532,7 +13468,6 @@ impl serde::ser::Serialize for DataBoostReadLocalWrites {
 impl std::fmt::Debug for DataBoostReadLocalWrites {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataBoostReadLocalWrites");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13678,7 +13613,6 @@ impl std::fmt::Debug for CheckConsistencyResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CheckConsistencyResponse");
         debug_struct.field("consistent", &self.consistent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13949,7 +13883,6 @@ impl std::fmt::Debug for SnapshotTableRequest {
         debug_struct.field("snapshot_id", &self.snapshot_id);
         debug_struct.field("ttl", &self.ttl);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14101,7 +14034,6 @@ impl std::fmt::Debug for GetSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14326,7 +14258,6 @@ impl std::fmt::Debug for ListSnapshotsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14521,7 +14452,6 @@ impl std::fmt::Debug for ListSnapshotsResponse {
         let mut debug_struct = f.debug_struct("ListSnapshotsResponse");
         debug_struct.field("snapshots", &self.snapshots);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14673,7 +14603,6 @@ impl std::fmt::Debug for DeleteSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14906,7 +14835,6 @@ impl std::fmt::Debug for SnapshotTableMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15142,7 +15070,6 @@ impl std::fmt::Debug for CreateTableFromSnapshotMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15356,7 +15283,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_id", &self.backup_id);
         debug_struct.field("backup", &self.backup);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15601,7 +15527,6 @@ impl std::fmt::Debug for CreateBackupMetadata {
         debug_struct.field("source_table", &self.source_table);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15802,7 +15727,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupRequest");
         debug_struct.field("backup", &self.backup);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15949,7 +15873,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16096,7 +16019,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16428,7 +16350,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16620,7 +16541,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         let mut debug_struct = f.debug_struct("ListBackupsResponse");
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16871,7 +16791,6 @@ impl std::fmt::Debug for CopyBackupRequest {
         debug_struct.field("backup_id", &self.backup_id);
         debug_struct.field("source_backup", &self.source_backup);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17096,7 +17015,6 @@ impl std::fmt::Debug for CopyBackupMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("source_backup_info", &self.source_backup_info);
         debug_struct.field("progress", &self.progress);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17313,7 +17231,6 @@ impl std::fmt::Debug for CreateAuthorizedViewRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("authorized_view_id", &self.authorized_view_id);
         debug_struct.field("authorized_view", &self.authorized_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17542,7 +17459,6 @@ impl std::fmt::Debug for CreateAuthorizedViewMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17798,7 +17714,6 @@ impl std::fmt::Debug for ListAuthorizedViewsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17993,7 +17908,6 @@ impl std::fmt::Debug for ListAuthorizedViewsResponse {
         let mut debug_struct = f.debug_struct("ListAuthorizedViewsResponse");
         debug_struct.field("authorized_views", &self.authorized_views);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18171,7 +18085,6 @@ impl std::fmt::Debug for GetAuthorizedViewRequest {
         let mut debug_struct = f.debug_struct("GetAuthorizedViewRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18402,7 +18315,6 @@ impl std::fmt::Debug for UpdateAuthorizedViewRequest {
         debug_struct.field("authorized_view", &self.authorized_view);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18634,7 +18546,6 @@ impl std::fmt::Debug for UpdateAuthorizedViewMetadata {
         debug_struct.field("original_request", &self.original_request);
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("finish_time", &self.finish_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18809,7 +18720,6 @@ impl std::fmt::Debug for DeleteAuthorizedViewRequest {
         let mut debug_struct = f.debug_struct("DeleteAuthorizedViewRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19023,7 +18933,6 @@ impl std::fmt::Debug for CreateSchemaBundleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("schema_bundle_id", &self.schema_bundle_id);
         debug_struct.field("schema_bundle", &self.schema_bundle);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19244,7 +19153,6 @@ impl std::fmt::Debug for CreateSchemaBundleMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19472,7 +19380,6 @@ impl std::fmt::Debug for UpdateSchemaBundleRequest {
         debug_struct.field("schema_bundle", &self.schema_bundle);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("ignore_warnings", &self.ignore_warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19693,7 +19600,6 @@ impl std::fmt::Debug for UpdateSchemaBundleMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19840,7 +19746,6 @@ impl std::fmt::Debug for GetSchemaBundleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSchemaBundleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20063,7 +19968,6 @@ impl std::fmt::Debug for ListSchemaBundlesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20253,7 +20157,6 @@ impl std::fmt::Debug for ListSchemaBundlesResponse {
         let mut debug_struct = f.debug_struct("ListSchemaBundlesResponse");
         debug_struct.field("schema_bundles", &self.schema_bundles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20427,7 +20330,6 @@ impl std::fmt::Debug for DeleteSchemaBundleRequest {
         let mut debug_struct = f.debug_struct("DeleteSchemaBundleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20666,7 +20568,6 @@ impl std::fmt::Debug for OperationProgress {
         debug_struct.field("progress_percent", &self.progress_percent);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21050,7 +20951,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21557,7 +21457,6 @@ impl std::fmt::Debug for AutoscalingTargets {
             "storage_utilization_gib_per_node",
             &self.storage_utilization_gib_per_node,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21764,7 +21663,6 @@ impl std::fmt::Debug for AutoscalingLimits {
         let mut debug_struct = f.debug_struct("AutoscalingLimits");
         debug_struct.field("min_serve_nodes", &self.min_serve_nodes);
         debug_struct.field("max_serve_nodes", &self.max_serve_nodes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22177,7 +22075,6 @@ impl std::fmt::Debug for Cluster {
         debug_struct.field("default_storage_type", &self.default_storage_type);
         debug_struct.field("encryption_config", &self.encryption_config);
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22376,7 +22273,6 @@ pub mod cluster {
             let mut debug_struct = f.debug_struct("ClusterAutoscalingConfig");
             debug_struct.field("autoscaling_limits", &self.autoscaling_limits);
             debug_struct.field("autoscaling_targets", &self.autoscaling_targets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22549,7 +22445,6 @@ pub mod cluster {
                 "cluster_autoscaling_config",
                 &self.cluster_autoscaling_config,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22708,7 +22603,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EncryptionConfig");
             debug_struct.field("kms_key_name", &self.kms_key_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23546,7 +23440,6 @@ impl std::fmt::Debug for AppProfile {
         debug_struct.field("description", &self.description);
         debug_struct.field("routing_policy", &self.routing_policy);
         debug_struct.field("isolation", &self.isolation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23798,7 +23691,6 @@ pub mod app_profile {
             let mut debug_struct = f.debug_struct("MultiClusterRoutingUseAny");
             debug_struct.field("cluster_ids", &self.cluster_ids);
             debug_struct.field("affinity", &self.affinity);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23931,7 +23823,6 @@ pub mod app_profile {
         impl std::fmt::Debug for RowAffinity {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("RowAffinity");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -24138,7 +24029,6 @@ pub mod app_profile {
                 "allow_transactional_writes",
                 &self.allow_transactional_writes,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24285,7 +24175,6 @@ pub mod app_profile {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StandardIsolation");
             debug_struct.field("priority", &self.priority);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24452,7 +24341,6 @@ pub mod app_profile {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DataBoostIsolationReadOnly");
             debug_struct.field("compute_billing_owner", &self.compute_billing_owner);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25110,7 +24998,6 @@ impl std::fmt::Debug for HotTablet {
         debug_struct.field("start_key", &self.start_key);
         debug_struct.field("end_key", &self.end_key);
         debug_struct.field("node_cpu_usage_percent", &self.node_cpu_usage_percent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25333,7 +25220,6 @@ impl std::fmt::Debug for LogicalView {
         debug_struct.field("query", &self.query);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("deletion_protection", &self.deletion_protection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25556,7 +25442,6 @@ impl std::fmt::Debug for MaterializedView {
         debug_struct.field("query", &self.query);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("deletion_protection", &self.deletion_protection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25772,7 +25657,6 @@ impl std::fmt::Debug for RestoreInfo {
         let mut debug_struct = f.debug_struct("RestoreInfo");
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("source_info", &self.source_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25945,7 +25829,6 @@ impl std::fmt::Debug for ChangeStreamConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ChangeStreamConfig");
         debug_struct.field("retention_period", &self.retention_period);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26478,7 +26361,6 @@ impl std::fmt::Debug for Table {
         debug_struct.field("deletion_protection", &self.deletion_protection);
         debug_struct.field("row_key_schema", &self.row_key_schema);
         debug_struct.field("automated_backup_config", &self.automated_backup_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26673,7 +26555,6 @@ pub mod table {
             let mut debug_struct = f.debug_struct("ClusterState");
             debug_struct.field("replication_state", &self.replication_state);
             debug_struct.field("encryption_info", &self.encryption_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27040,7 +26921,6 @@ pub mod table {
             let mut debug_struct = f.debug_struct("AutomatedBackupPolicy");
             debug_struct.field("retention_period", &self.retention_period);
             debug_struct.field("frequency", &self.frequency);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27607,7 +27487,6 @@ impl std::fmt::Debug for AuthorizedView {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("deletion_protection", &self.deletion_protection);
         debug_struct.field("authorized_view", &self.authorized_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27853,7 +27732,6 @@ pub mod authorized_view {
             let mut debug_struct = f.debug_struct("FamilySubsets");
             debug_struct.field("qualifiers", &self.qualifiers);
             debug_struct.field("qualifier_prefixes", &self.qualifier_prefixes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28074,7 +27952,6 @@ pub mod authorized_view {
             let mut debug_struct = f.debug_struct("SubsetView");
             debug_struct.field("row_prefixes", &self.row_prefixes);
             debug_struct.field("family_subsets", &self.family_subsets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28428,7 +28305,6 @@ impl std::fmt::Debug for ColumnFamily {
         let mut debug_struct = f.debug_struct("ColumnFamily");
         debug_struct.field("gc_rule", &self.gc_rule);
         debug_struct.field("value_type", &self.value_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28774,7 +28650,6 @@ impl std::fmt::Debug for GcRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcRule");
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28927,7 +28802,6 @@ pub mod gc_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Intersection");
             debug_struct.field("rules", &self.rules);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29075,7 +28949,6 @@ pub mod gc_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Union");
             debug_struct.field("rules", &self.rules);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29311,7 +29184,6 @@ impl std::fmt::Debug for EncryptionInfo {
         debug_struct.field("encryption_type", &self.encryption_type);
         debug_struct.field("encryption_status", &self.encryption_status);
         debug_struct.field("kms_key_version", &self.kms_key_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29822,7 +29694,6 @@ impl std::fmt::Debug for Snapshot {
         debug_struct.field("delete_time", &self.delete_time);
         debug_struct.field("state", &self.state);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30474,7 +30345,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("encryption_info", &self.encryption_info);
         debug_struct.field("backup_type", &self.backup_type);
         debug_struct.field("hot_to_standard_time", &self.hot_to_standard_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31023,7 +30893,6 @@ impl std::fmt::Debug for BackupInfo {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("source_table", &self.source_table);
         debug_struct.field("source_backup", &self.source_backup);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31201,7 +31070,6 @@ impl std::fmt::Debug for ProtoSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProtoSchema");
         debug_struct.field("proto_descriptors", &self.proto_descriptors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31443,7 +31311,6 @@ impl std::fmt::Debug for SchemaBundle {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32320,7 +32187,6 @@ impl std::fmt::Debug for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Type");
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32482,7 +32348,6 @@ pub mod r#type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Bytes");
             debug_struct.field("encoding", &self.encoding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32692,7 +32557,6 @@ pub mod r#type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Encoding");
                 debug_struct.field("encoding", &self.encoding);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -32827,7 +32691,6 @@ pub mod r#type {
             impl std::fmt::Debug for Raw {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Raw");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -32994,7 +32857,6 @@ pub mod r#type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("String");
             debug_struct.field("encoding", &self.encoding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33275,7 +33137,6 @@ pub mod r#type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Encoding");
                 debug_struct.field("encoding", &self.encoding);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -33407,7 +33268,6 @@ pub mod r#type {
             impl std::fmt::Debug for Utf8Raw {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Utf8Raw");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -33546,7 +33406,6 @@ pub mod r#type {
             impl std::fmt::Debug for Utf8Bytes {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Utf8Bytes");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -33716,7 +33575,6 @@ pub mod r#type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Int64");
             debug_struct.field("encoding", &self.encoding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33990,7 +33848,6 @@ pub mod r#type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Encoding");
                 debug_struct.field("encoding", &self.encoding);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -34176,7 +34033,6 @@ pub mod r#type {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("BigEndianBytes");
                     debug_struct.field("bytes_type", &self.bytes_type);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -34307,7 +34163,6 @@ pub mod r#type {
             impl std::fmt::Debug for OrderedCodeBytes {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("OrderedCodeBytes");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -34441,7 +34296,6 @@ pub mod r#type {
     impl std::fmt::Debug for Bool {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Bool");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34559,7 +34413,6 @@ pub mod r#type {
     impl std::fmt::Debug for Float32 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Float32");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34677,7 +34530,6 @@ pub mod r#type {
     impl std::fmt::Debug for Float64 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Float64");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34835,7 +34687,6 @@ pub mod r#type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Timestamp");
             debug_struct.field("encoding", &self.encoding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35043,7 +34894,6 @@ pub mod r#type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Encoding");
                 debug_struct.field("encoding", &self.encoding);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35181,7 +35031,6 @@ pub mod r#type {
     impl std::fmt::Debug for Date {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Date");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35374,7 +35223,6 @@ pub mod r#type {
             let mut debug_struct = f.debug_struct("Struct");
             debug_struct.field("fields", &self.fields);
             debug_struct.field("encoding", &self.encoding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35572,7 +35420,6 @@ pub mod r#type {
                 let mut debug_struct = f.debug_struct("Field");
                 debug_struct.field("field_name", &self.field_name);
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35903,7 +35750,6 @@ pub mod r#type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Encoding");
                 debug_struct.field("encoding", &self.encoding);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -36035,7 +35881,6 @@ pub mod r#type {
             impl std::fmt::Debug for Singleton {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Singleton");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -36239,7 +36084,6 @@ pub mod r#type {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("DelimitedBytes");
                     debug_struct.field("delimiter", &self.delimiter);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -36404,7 +36248,6 @@ pub mod r#type {
             impl std::fmt::Debug for OrderedCodeBytes {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("OrderedCodeBytes");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -36602,7 +36445,6 @@ pub mod r#type {
             let mut debug_struct = f.debug_struct("Proto");
             debug_struct.field("schema_bundle_id", &self.schema_bundle_id);
             debug_struct.field("message_name", &self.message_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36779,7 +36621,6 @@ pub mod r#type {
             let mut debug_struct = f.debug_struct("Enum");
             debug_struct.field("schema_bundle_id", &self.schema_bundle_id);
             debug_struct.field("enum_name", &self.enum_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36937,7 +36778,6 @@ pub mod r#type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Array");
             debug_struct.field("element_type", &self.element_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37138,7 +36978,6 @@ pub mod r#type {
             let mut debug_struct = f.debug_struct("Map");
             debug_struct.field("key_type", &self.key_type);
             debug_struct.field("value_type", &self.value_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37584,7 +37423,6 @@ pub mod r#type {
             debug_struct.field("input_type", &self.input_type);
             debug_struct.field("state_type", &self.state_type);
             debug_struct.field("aggregator", &self.aggregator);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37711,7 +37549,6 @@ pub mod r#type {
         impl std::fmt::Debug for Sum {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Sum");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -37833,7 +37670,6 @@ pub mod r#type {
         impl std::fmt::Debug for Max {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Max");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -37955,7 +37791,6 @@ pub mod r#type {
         impl std::fmt::Debug for Min {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Min");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -38082,7 +37917,6 @@ pub mod r#type {
         impl std::fmt::Debug for HyperLogLogPlusPlusUniqueCount {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("HyperLogLogPlusPlusUniqueCount");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -235,7 +235,6 @@ impl std::fmt::Debug for AccessLocations {
             "principal_physical_location_country",
             &self.principal_physical_location_country,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -402,7 +401,6 @@ impl std::fmt::Debug for AccessReason {
         let mut debug_struct = f.debug_struct("AccessReason");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -867,7 +865,6 @@ impl std::fmt::Debug for SignatureInfo {
         let mut debug_struct = f.debug_struct("SignatureInfo");
         debug_struct.field("signature", &self.signature);
         debug_struct.field("verification_info", &self.verification_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1176,7 +1173,6 @@ impl std::fmt::Debug for ApproveDecision {
         debug_struct.field("invalidate_time", &self.invalidate_time);
         debug_struct.field("signature_info", &self.signature_info);
         debug_struct.field("auto_approved", &self.auto_approved);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1357,7 +1353,6 @@ impl std::fmt::Debug for DismissDecision {
         let mut debug_struct = f.debug_struct("DismissDecision");
         debug_struct.field("dismiss_time", &self.dismiss_time);
         debug_struct.field("implicit", &self.implicit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1501,7 +1496,6 @@ impl std::fmt::Debug for ResourceProperties {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceProperties");
         debug_struct.field("excludes_descendants", &self.excludes_descendants);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1997,7 +1991,6 @@ impl std::fmt::Debug for ApprovalRequest {
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("requested_expiration", &self.requested_expiration);
         debug_struct.field("decision", &self.decision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2246,7 +2239,6 @@ impl std::fmt::Debug for EnrolledService {
         let mut debug_struct = f.debug_struct("EnrolledService");
         debug_struct.field("cloud_product", &self.cloud_product);
         debug_struct.field("enrollment_level", &self.enrollment_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2603,7 +2595,6 @@ impl std::fmt::Debug for AccessApprovalSettings {
             &self.ancestor_has_active_key_version,
         );
         debug_struct.field("invalid_key_version", &self.invalid_key_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2775,7 +2766,6 @@ impl std::fmt::Debug for AccessApprovalServiceAccount {
         let mut debug_struct = f.debug_struct("AccessApprovalServiceAccount");
         debug_struct.field("name", &self.name);
         debug_struct.field("account_email", &self.account_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3024,7 +3014,6 @@ impl std::fmt::Debug for ListApprovalRequestsMessage {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3214,7 +3203,6 @@ impl std::fmt::Debug for ListApprovalRequestsResponse {
         let mut debug_struct = f.debug_struct("ListApprovalRequestsResponse");
         debug_struct.field("approval_requests", &self.approval_requests);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3358,7 +3346,6 @@ impl std::fmt::Debug for GetApprovalRequestMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApprovalRequestMessage");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3537,7 +3524,6 @@ impl std::fmt::Debug for ApproveApprovalRequestMessage {
         let mut debug_struct = f.debug_struct("ApproveApprovalRequestMessage");
         debug_struct.field("name", &self.name);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3679,7 +3665,6 @@ impl std::fmt::Debug for DismissApprovalRequestMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DismissApprovalRequestMessage");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3821,7 +3806,6 @@ impl std::fmt::Debug for InvalidateApprovalRequestMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InvalidateApprovalRequestMessage");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3964,7 +3948,6 @@ impl std::fmt::Debug for GetAccessApprovalSettingsMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAccessApprovalSettingsMessage");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4163,7 +4146,6 @@ impl std::fmt::Debug for UpdateAccessApprovalSettingsMessage {
         let mut debug_struct = f.debug_struct("UpdateAccessApprovalSettingsMessage");
         debug_struct.field("settings", &self.settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4305,7 +4287,6 @@ impl std::fmt::Debug for DeleteAccessApprovalSettingsMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAccessApprovalSettingsMessage");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4448,7 +4429,6 @@ impl std::fmt::Debug for GetAccessApprovalServiceAccountMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAccessApprovalServiceAccountMessage");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -299,7 +299,6 @@ impl std::fmt::Debug for Notification {
         debug_struct.field("messages", &self.messages);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("notification_type", &self.notification_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -498,7 +497,6 @@ impl std::fmt::Debug for Text {
         debug_struct.field("en_text", &self.en_text);
         debug_struct.field("localized_text", &self.localized_text);
         debug_struct.field("localization_state", &self.localization_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -651,7 +649,6 @@ impl std::fmt::Debug for Subject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Subject");
         debug_struct.field("text", &self.text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -906,7 +903,6 @@ impl std::fmt::Debug for Message {
         debug_struct.field("attachments", &self.attachments);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("localization_time", &self.localization_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1067,7 +1063,6 @@ pub mod message {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Body");
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1273,7 +1268,6 @@ impl std::fmt::Debug for Attachment {
         let mut debug_struct = f.debug_struct("Attachment");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1463,7 +1457,6 @@ impl std::fmt::Debug for Csv {
         let mut debug_struct = f.debug_struct("Csv");
         debug_struct.field("headers", &self.headers);
         debug_struct.field("data_rows", &self.data_rows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1617,7 +1610,6 @@ pub mod csv {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CsvRow");
             debug_struct.field("entries", &self.entries);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1894,7 +1886,6 @@ impl std::fmt::Debug for ListNotificationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2124,7 +2115,6 @@ impl std::fmt::Debug for ListNotificationsResponse {
         debug_struct.field("notifications", &self.notifications);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2299,7 +2289,6 @@ impl std::fmt::Debug for GetNotificationRequest {
         let mut debug_struct = f.debug_struct("GetNotificationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2512,7 +2501,6 @@ impl std::fmt::Debug for Settings {
         debug_struct.field("name", &self.name);
         debug_struct.field("notification_settings", &self.notification_settings);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2654,7 +2642,6 @@ impl std::fmt::Debug for NotificationSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NotificationSettings");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2799,7 +2786,6 @@ impl std::fmt::Debug for GetSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2952,7 +2938,6 @@ impl std::fmt::Debug for UpdateSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateSettingsRequest");
         debug_struct.field("settings", &self.settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/alloydb/connectors/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/connectors/v1/src/model.rs
@@ -224,7 +224,6 @@ impl std::fmt::Debug for MetadataExchangeRequest {
         debug_struct.field("user_agent", &self.user_agent);
         debug_struct.field("auth_type", &self.auth_type);
         debug_struct.field("oauth2_token", &self.oauth2_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -539,7 +538,6 @@ impl std::fmt::Debug for MetadataExchangeResponse {
         let mut debug_struct = f.debug_struct("MetadataExchangeResponse");
         debug_struct.field("response_code", &self.response_code);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -241,7 +241,6 @@ impl std::fmt::Debug for CloudSQLBackupRunSource {
         debug_struct.field("project", &self.project);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("backup_run_id", &self.backup_run_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -525,7 +524,6 @@ impl std::fmt::Debug for RestoreFromCloudSQLRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -717,7 +715,6 @@ impl std::fmt::Debug for SqlResult {
         let mut debug_struct = f.debug_struct("SqlResult");
         debug_struct.field("columns", &self.columns);
         debug_struct.field("rows", &self.rows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -886,7 +883,6 @@ impl std::fmt::Debug for SqlResultColumn {
         let mut debug_struct = f.debug_struct("SqlResultColumn");
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1035,7 +1031,6 @@ impl std::fmt::Debug for SqlResultRow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlResultRow");
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1225,7 +1220,6 @@ impl std::fmt::Debug for SqlResultValue {
         let mut debug_struct = f.debug_struct("SqlResultValue");
         debug_struct.field("value", &self.value);
         debug_struct.field("null_value", &self.null_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1393,7 +1387,6 @@ impl std::fmt::Debug for UserPassword {
         let mut debug_struct = f.debug_struct("UserPassword");
         debug_struct.field("user", &self.user);
         debug_struct.field("password", &self.password);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1598,7 +1591,6 @@ impl std::fmt::Debug for MigrationSource {
         debug_struct.field("host_port", &self.host_port);
         debug_struct.field("reference_id", &self.reference_id);
         debug_struct.field("source_type", &self.source_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1875,7 +1867,6 @@ impl std::fmt::Debug for EncryptionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptionConfig");
         debug_struct.field("kms_key_name", &self.kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2049,7 +2040,6 @@ impl std::fmt::Debug for EncryptionInfo {
         let mut debug_struct = f.debug_struct("EncryptionInfo");
         debug_struct.field("encryption_type", &self.encryption_type);
         debug_struct.field("kms_key_versions", &self.kms_key_versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2365,7 +2355,6 @@ impl std::fmt::Debug for SslConfig {
         let mut debug_struct = f.debug_struct("SslConfig");
         debug_struct.field("ssl_mode", &self.ssl_mode);
         debug_struct.field("ca_source", &self.ca_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3192,7 +3181,6 @@ impl std::fmt::Debug for AutomatedBackupPolicy {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("schedule", &self.schedule);
         debug_struct.field("retention", &self.retention);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3388,7 +3376,6 @@ pub mod automated_backup_policy {
             let mut debug_struct = f.debug_struct("WeeklySchedule");
             debug_struct.field("start_times", &self.start_times);
             debug_struct.field("days_of_week", &self.days_of_week);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3546,7 +3533,6 @@ pub mod automated_backup_policy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TimeBasedRetention");
             debug_struct.field("retention_period", &self.retention_period);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3710,7 +3696,6 @@ pub mod automated_backup_policy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QuantityBasedRetention");
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3987,7 +3972,6 @@ impl std::fmt::Debug for ContinuousBackupConfig {
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("recovery_window_days", &self.recovery_window_days);
         debug_struct.field("encryption_config", &self.encryption_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4258,7 +4242,6 @@ impl std::fmt::Debug for ContinuousBackupInfo {
         debug_struct.field("enabled_time", &self.enabled_time);
         debug_struct.field("schedule", &self.schedule);
         debug_struct.field("earliest_restorable_time", &self.earliest_restorable_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4431,7 +4414,6 @@ impl std::fmt::Debug for BackupSource {
         let mut debug_struct = f.debug_struct("BackupSource");
         debug_struct.field("backup_uid", &self.backup_uid);
         debug_struct.field("backup_name", &self.backup_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4612,7 +4594,6 @@ impl std::fmt::Debug for ContinuousBackupSource {
         let mut debug_struct = f.debug_struct("ContinuousBackupSource");
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("point_in_time", &self.point_in_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4797,7 +4778,6 @@ impl std::fmt::Debug for MaintenanceUpdatePolicy {
         let mut debug_struct = f.debug_struct("MaintenanceUpdatePolicy");
         debug_struct.field("maintenance_windows", &self.maintenance_windows);
         debug_struct.field("deny_maintenance_periods", &self.deny_maintenance_periods);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4985,7 +4965,6 @@ pub mod maintenance_update_policy {
             let mut debug_struct = f.debug_struct("MaintenanceWindow");
             debug_struct.field("day", &self.day);
             debug_struct.field("start_time", &self.start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5229,7 +5208,6 @@ pub mod maintenance_update_policy {
             debug_struct.field("start_date", &self.start_date);
             debug_struct.field("end_date", &self.end_date);
             debug_struct.field("time", &self.time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5388,7 +5366,6 @@ impl std::fmt::Debug for MaintenanceSchedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaintenanceSchedule");
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6774,7 +6751,6 @@ impl std::fmt::Debug for Cluster {
         debug_struct.field("trial_metadata", &self.trial_metadata);
         debug_struct.field("tags", &self.tags);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6964,7 +6940,6 @@ pub mod cluster {
             let mut debug_struct = f.debug_struct("NetworkConfig");
             debug_struct.field("network", &self.network);
             debug_struct.field("allocated_ip_range", &self.allocated_ip_range);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7116,7 +7091,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SecondaryConfig");
             debug_struct.field("primary_cluster_name", &self.primary_cluster_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7272,7 +7246,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PrimaryConfig");
             debug_struct.field("secondary_cluster_names", &self.secondary_cluster_names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7478,7 +7451,6 @@ pub mod cluster {
                 "service_owned_project_number",
                 &self.service_owned_project_number,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7746,7 +7718,6 @@ pub mod cluster {
             debug_struct.field("end_time", &self.end_time);
             debug_struct.field("upgrade_time", &self.upgrade_time);
             debug_struct.field("grace_end_time", &self.grace_end_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9195,7 +9166,6 @@ impl std::fmt::Debug for Instance {
             &self.outbound_public_ip_addresses,
         );
         debug_struct.field("activation_policy", &self.activation_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9396,7 +9366,6 @@ pub mod instance {
             let mut debug_struct = f.debug_struct("MachineConfig");
             debug_struct.field("cpu_count", &self.cpu_count);
             debug_struct.field("machine_type", &self.machine_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9623,7 +9592,6 @@ pub mod instance {
             debug_struct.field("id", &self.id);
             debug_struct.field("ip", &self.ip);
             debug_struct.field("state", &self.state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9934,7 +9902,6 @@ pub mod instance {
             debug_struct.field("record_client_address", &self.record_client_address);
             debug_struct.field("query_string_length", &self.query_string_length);
             debug_struct.field("query_plans_per_minute", &self.query_plans_per_minute);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10417,7 +10384,6 @@ pub mod instance {
             debug_struct.field("record_application_tags", &self.record_application_tags);
             debug_struct.field("query_plans_per_minute", &self.query_plans_per_minute);
             debug_struct.field("track_active_queries", &self.track_active_queries);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10582,7 +10548,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReadPoolConfig");
             debug_struct.field("node_count", &self.node_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10766,7 +10731,6 @@ pub mod instance {
             let mut debug_struct = f.debug_struct("ClientConnectionConfig");
             debug_struct.field("require_connectors", &self.require_connectors);
             debug_struct.field("ssl_config", &self.ssl_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10929,7 +10893,6 @@ pub mod instance {
                 "network_attachment_resource",
                 &self.network_attachment_resource,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11220,7 +11183,6 @@ pub mod instance {
             debug_struct.field("ip_address", &self.ip_address);
             debug_struct.field("status", &self.status);
             debug_struct.field("consumer_network_status", &self.consumer_network_status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11513,7 +11475,6 @@ pub mod instance {
             debug_struct.field("psc_dns_name", &self.psc_dns_name);
             debug_struct.field("psc_interface_configs", &self.psc_interface_configs);
             debug_struct.field("psc_auto_connections", &self.psc_auto_connections);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11806,7 +11767,6 @@ pub mod instance {
                 "allocated_ip_range_override",
                 &self.allocated_ip_range_override,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11965,7 +11925,6 @@ pub mod instance {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("AuthorizedNetwork");
                 debug_struct.field("cidr_range", &self.cidr_range);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12791,7 +12750,6 @@ impl std::fmt::Debug for ConnectionInfo {
         debug_struct.field("ip_address", &self.ip_address);
         debug_struct.field("public_ip_address", &self.public_ip_address);
         debug_struct.field("instance_uid", &self.instance_uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13701,7 +13659,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("database_version", &self.database_version);
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13931,7 +13888,6 @@ pub mod backup {
             let mut debug_struct = f.debug_struct("QuantityBasedExpiry");
             debug_struct.field("retention_count", &self.retention_count);
             debug_struct.field("total_retention_count", &self.total_retention_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14845,7 +14801,6 @@ impl std::fmt::Debug for SupportedDatabaseFlag {
         debug_struct.field("scope", &self.scope);
         debug_struct.field("restrictions", &self.restrictions);
         debug_struct.field("recommended_value", &self.recommended_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15000,7 +14955,6 @@ pub mod supported_database_flag {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StringRestrictions");
             debug_struct.field("allowed_values", &self.allowed_values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15236,7 +15190,6 @@ pub mod supported_database_flag {
             let mut debug_struct = f.debug_struct("IntegerRestrictions");
             debug_struct.field("min_value", &self.min_value);
             debug_struct.field("max_value", &self.max_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15795,7 +15748,6 @@ impl std::fmt::Debug for User {
         debug_struct.field("database_roles", &self.database_roles);
         debug_struct.field("user_type", &self.user_type);
         debug_struct.field("keep_extra_roles", &self.keep_extra_roles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16131,7 +16083,6 @@ impl std::fmt::Debug for Database {
         debug_struct.field("name", &self.name);
         debug_struct.field("charset", &self.charset);
         debug_struct.field("collation", &self.collation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16399,7 +16350,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16612,7 +16562,6 @@ impl std::fmt::Debug for ListClustersResponse {
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16781,7 +16730,6 @@ impl std::fmt::Debug for GetClusterRequest {
         let mut debug_struct = f.debug_struct("GetClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17051,7 +16999,6 @@ impl std::fmt::Debug for CreateSecondaryClusterRequest {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17322,7 +17269,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17609,7 +17555,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17752,7 +17697,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18129,7 +18073,6 @@ impl std::fmt::Debug for ExportClusterRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("destination", &self.destination);
         debug_struct.field("export_options", &self.export_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18377,7 +18320,6 @@ pub mod export_cluster_request {
             debug_struct.field("field_delimiter", &self.field_delimiter);
             debug_struct.field("quote_character", &self.quote_character);
             debug_struct.field("escape_character", &self.escape_character);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18640,7 +18582,6 @@ pub mod export_cluster_request {
             debug_struct.field("schema_only", &self.schema_only);
             debug_struct.field("clean_target_objects", &self.clean_target_objects);
             debug_struct.field("if_exist_target_objects", &self.if_exist_target_objects);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18854,7 +18795,6 @@ impl std::fmt::Debug for ExportClusterResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportClusterResponse");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19226,7 +19166,6 @@ impl std::fmt::Debug for ImportClusterRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("user", &self.user);
         debug_struct.field("import_options", &self.import_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19348,7 +19287,6 @@ pub mod import_cluster_request {
     impl std::fmt::Debug for SqlImportOptions {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SqlImportOptions");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19616,7 +19554,6 @@ pub mod import_cluster_request {
             debug_struct.field("field_delimiter", &self.field_delimiter);
             debug_struct.field("quote_character", &self.quote_character);
             debug_struct.field("escape_character", &self.escape_character);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19789,7 +19726,6 @@ impl std::fmt::Debug for ImportClusterResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportClusterResponse");
         debug_struct.field("bytes_downloaded", &self.bytes_downloaded);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20052,7 +19988,6 @@ impl std::fmt::Debug for UpgradeClusterRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20256,7 +20191,6 @@ impl std::fmt::Debug for UpgradeClusterResponse {
         debug_struct.field("status", &self.status);
         debug_struct.field("message", &self.message);
         debug_struct.field("cluster_upgrade_details", &self.cluster_upgrade_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20469,7 +20403,6 @@ pub mod upgrade_cluster_response {
             debug_struct.field("stage", &self.stage);
             debug_struct.field("status", &self.status);
             debug_struct.field("logs_url", &self.logs_url);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20674,7 +20607,6 @@ pub mod upgrade_cluster_response {
             debug_struct.field("name", &self.name);
             debug_struct.field("upgrade_status", &self.upgrade_status);
             debug_struct.field("instance_type", &self.instance_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20977,7 +20909,6 @@ pub mod upgrade_cluster_response {
             debug_struct.field("database_version", &self.database_version);
             debug_struct.field("stage_info", &self.stage_info);
             debug_struct.field("instance_upgrade_details", &self.instance_upgrade_details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21577,7 +21508,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21786,7 +21716,6 @@ impl std::fmt::Debug for SwitchoverClusterRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22022,7 +21951,6 @@ impl std::fmt::Debug for PromoteClusterRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22427,7 +22355,6 @@ impl std::fmt::Debug for RestoreClusterRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22715,7 +22642,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22928,7 +22854,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23096,7 +23021,6 @@ impl std::fmt::Debug for GetInstanceRequest {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23367,7 +23291,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23638,7 +23561,6 @@ impl std::fmt::Debug for CreateSecondaryInstanceRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23791,7 +23713,6 @@ impl std::fmt::Debug for CreateInstanceRequests {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateInstanceRequests");
         debug_struct.field("create_instance_requests", &self.create_instance_requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24007,7 +23928,6 @@ impl std::fmt::Debug for BatchCreateInstancesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("requests", &self.requests);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24152,7 +24072,6 @@ impl std::fmt::Debug for BatchCreateInstancesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchCreateInstancesResponse");
         debug_struct.field("instances", &self.instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24345,7 +24264,6 @@ impl std::fmt::Debug for BatchCreateInstancesMetadata {
         let mut debug_struct = f.debug_struct("BatchCreateInstancesMetadata");
         debug_struct.field("instance_targets", &self.instance_targets);
         debug_struct.field("instance_statuses", &self.instance_statuses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24604,7 +24522,6 @@ impl std::fmt::Debug for BatchCreateInstanceStatus {
         debug_struct.field("error_msg", &self.error_msg);
         debug_struct.field("error", &self.error);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25062,7 +24979,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25298,7 +25214,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25507,7 +25422,6 @@ impl std::fmt::Debug for FailoverInstanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25747,7 +25661,6 @@ impl std::fmt::Debug for InjectFaultRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26117,7 +26030,6 @@ impl std::fmt::Debug for RestartInstanceRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("node_ids", &self.node_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26408,7 +26320,6 @@ impl std::fmt::Debug for ExecuteSqlRequest {
         debug_struct.field("user", &self.user);
         debug_struct.field("sql_statement", &self.sql_statement);
         debug_struct.field("user_credential", &self.user_credential);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26606,7 +26517,6 @@ impl std::fmt::Debug for ExecuteSqlResponse {
         let mut debug_struct = f.debug_struct("ExecuteSqlResponse");
         debug_struct.field("sql_results", &self.sql_results);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26854,7 +26764,6 @@ impl std::fmt::Debug for ExecuteSqlMetadata {
             &self.sql_statement_execution_duration,
         );
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27271,7 +27180,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27484,7 +27392,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27626,7 +27533,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27895,7 +27801,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("backup", &self.backup);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28181,7 +28086,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28416,7 +28320,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28667,7 +28570,6 @@ impl std::fmt::Debug for ListSupportedDatabaseFlagsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28859,7 +28761,6 @@ impl std::fmt::Debug for ListSupportedDatabaseFlagsResponse {
         let mut debug_struct = f.debug_struct("ListSupportedDatabaseFlagsResponse");
         debug_struct.field("supported_database_flags", &self.supported_database_flags);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29137,7 +29038,6 @@ impl std::fmt::Debug for GenerateClientCertificateRequest {
         debug_struct.field("cert_duration", &self.cert_duration);
         debug_struct.field("public_key", &self.public_key);
         debug_struct.field("use_metadata_exchange", &self.use_metadata_exchange);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29310,7 +29210,6 @@ impl std::fmt::Debug for GenerateClientCertificateResponse {
         let mut debug_struct = f.debug_struct("GenerateClientCertificateResponse");
         debug_struct.field("pem_certificate_chain", &self.pem_certificate_chain);
         debug_struct.field("ca_cert", &self.ca_cert);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29491,7 +29390,6 @@ impl std::fmt::Debug for GetConnectionInfoRequest {
         let mut debug_struct = f.debug_struct("GetConnectionInfoRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29952,7 +29850,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("request_specific", &self.request_specific);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30232,7 +30129,6 @@ impl std::fmt::Debug for UpgradeClusterStatus {
         debug_struct.field("source_version", &self.source_version);
         debug_struct.field("target_version", &self.target_version);
         debug_struct.field("stages", &self.stages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30508,7 +30404,6 @@ pub mod upgrade_cluster_status {
             debug_struct.field("stage", &self.stage);
             debug_struct.field("state", &self.state);
             debug_struct.field("stage_specific_status", &self.stage_specific_status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30684,7 +30579,6 @@ pub mod upgrade_cluster_status {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReadPoolInstancesUpgradeStageStatus");
             debug_struct.field("upgrade_stats", &self.upgrade_stats);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31007,7 +30901,6 @@ pub mod upgrade_cluster_status {
                 debug_struct.field("ongoing", &self.ongoing);
                 debug_struct.field("success", &self.success);
                 debug_struct.field("failed", &self.failed);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -31273,7 +31166,6 @@ impl std::fmt::Debug for ListUsersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31486,7 +31378,6 @@ impl std::fmt::Debug for ListUsersResponse {
         debug_struct.field("users", &self.users);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31629,7 +31520,6 @@ impl std::fmt::Debug for GetUserRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetUserRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31898,7 +31788,6 @@ impl std::fmt::Debug for CreateUserRequest {
         debug_struct.field("user", &self.user);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32183,7 +32072,6 @@ impl std::fmt::Debug for UpdateUserRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32391,7 +32279,6 @@ impl std::fmt::Debug for DeleteUserRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32634,7 +32521,6 @@ impl std::fmt::Debug for ListDatabasesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32820,7 +32706,6 @@ impl std::fmt::Debug for ListDatabasesResponse {
         let mut debug_struct = f.debug_struct("ListDatabasesResponse");
         debug_struct.field("databases", &self.databases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -359,7 +359,6 @@ impl std::fmt::Debug for Api {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("managed_service", &self.managed_service);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1007,7 +1006,6 @@ impl std::fmt::Debug for ApiConfig {
         debug_struct.field("openapi_documents", &self.openapi_documents);
         debug_struct.field("grpc_services", &self.grpc_services);
         debug_struct.field("managed_service_configs", &self.managed_service_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1206,7 +1204,6 @@ pub mod api_config {
             let mut debug_struct = f.debug_struct("File");
             debug_struct.field("path", &self.path);
             debug_struct.field("contents", &self.contents);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1362,7 +1359,6 @@ pub mod api_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("OpenApiDocument");
             debug_struct.field("document", &self.document);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1560,7 +1556,6 @@ pub mod api_config {
             let mut debug_struct = f.debug_struct("GrpcServiceDefinition");
             debug_struct.field("file_descriptor_set", &self.file_descriptor_set);
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2087,7 +2082,6 @@ impl std::fmt::Debug for Gateway {
         debug_struct.field("api_config", &self.api_config);
         debug_struct.field("state", &self.state);
         debug_struct.field("default_hostname", &self.default_hostname);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2510,7 +2504,6 @@ impl std::fmt::Debug for ListGatewaysRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2724,7 +2717,6 @@ impl std::fmt::Debug for ListGatewaysResponse {
         debug_struct.field("gateways", &self.gateways);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2867,7 +2859,6 @@ impl std::fmt::Debug for GetGatewayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGatewayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3073,7 +3064,6 @@ impl std::fmt::Debug for CreateGatewayRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("gateway_id", &self.gateway_id);
         debug_struct.field("gateway", &self.gateway);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3267,7 +3257,6 @@ impl std::fmt::Debug for UpdateGatewayRequest {
         let mut debug_struct = f.debug_struct("UpdateGatewayRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("gateway", &self.gateway);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3410,7 +3399,6 @@ impl std::fmt::Debug for DeleteGatewayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGatewayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3674,7 +3662,6 @@ impl std::fmt::Debug for ListApisRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3888,7 +3875,6 @@ impl std::fmt::Debug for ListApisResponse {
         debug_struct.field("apis", &self.apis);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4031,7 +4017,6 @@ impl std::fmt::Debug for GetApiRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApiRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4237,7 +4222,6 @@ impl std::fmt::Debug for CreateApiRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("api_id", &self.api_id);
         debug_struct.field("api", &self.api);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4431,7 +4415,6 @@ impl std::fmt::Debug for UpdateApiRequest {
         let mut debug_struct = f.debug_struct("UpdateApiRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("api", &self.api);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4574,7 +4557,6 @@ impl std::fmt::Debug for DeleteApiRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteApiRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4838,7 +4820,6 @@ impl std::fmt::Debug for ListApiConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5053,7 +5034,6 @@ impl std::fmt::Debug for ListApiConfigsResponse {
         debug_struct.field("api_configs", &self.api_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5227,7 +5207,6 @@ impl std::fmt::Debug for GetApiConfigRequest {
         let mut debug_struct = f.debug_struct("GetApiConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5571,7 +5550,6 @@ impl std::fmt::Debug for CreateApiConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("api_config_id", &self.api_config_id);
         debug_struct.field("api_config", &self.api_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5766,7 +5744,6 @@ impl std::fmt::Debug for UpdateApiConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateApiConfigRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("api_config", &self.api_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5909,7 +5886,6 @@ impl std::fmt::Debug for DeleteApiConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteApiConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6265,7 +6241,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("diagnostics", &self.diagnostics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6440,7 +6415,6 @@ pub mod operation_metadata {
             let mut debug_struct = f.debug_struct("Diagnostic");
             debug_struct.field("location", &self.location);
             debug_struct.field("message", &self.message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -242,7 +242,6 @@ impl std::fmt::Debug for ListConnectionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -429,7 +428,6 @@ impl std::fmt::Debug for ListConnectionsResponse {
         let mut debug_struct = f.debug_struct("ListConnectionsResponse");
         debug_struct.field("connections", &self.connections);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -651,7 +649,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("endpoint", &self.endpoint);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("stream_count", &self.stream_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -817,7 +814,6 @@ impl std::fmt::Debug for Cluster {
         let mut debug_struct = f.debug_struct("Cluster");
         debug_struct.field("name", &self.name);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1111,7 +1107,6 @@ impl std::fmt::Debug for EgressRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("trace_id", &self.trace_id);
         debug_struct.field("timeout", &self.timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1386,7 +1381,6 @@ impl std::fmt::Debug for Payload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Payload");
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1546,7 +1540,6 @@ impl std::fmt::Debug for StreamInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StreamInfo");
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1868,7 +1861,6 @@ impl std::fmt::Debug for EgressResponse {
         debug_struct.field("trace_id", &self.trace_id);
         debug_struct.field("endpoint", &self.endpoint);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2143,7 +2135,6 @@ impl std::fmt::Debug for HttpRequest {
         debug_struct.field("url", &self.url);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2340,7 +2331,6 @@ impl std::fmt::Debug for Url {
         debug_struct.field("scheme", &self.scheme);
         debug_struct.field("host", &self.host);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2508,7 +2498,6 @@ impl std::fmt::Debug for Header {
         let mut debug_struct = f.debug_struct("Header");
         debug_struct.field("key", &self.key);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2838,7 +2827,6 @@ impl std::fmt::Debug for HttpResponse {
         debug_struct.field("body", &self.body);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("content_length", &self.content_length);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -240,7 +240,6 @@ impl std::fmt::Debug for CreateApiRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("api_id", &self.api_id);
         debug_struct.field("api", &self.api);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -385,7 +384,6 @@ impl std::fmt::Debug for GetApiRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApiRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -581,7 +579,6 @@ impl std::fmt::Debug for UpdateApiRequest {
         let mut debug_struct = f.debug_struct("UpdateApiRequest");
         debug_struct.field("api", &self.api);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -752,7 +749,6 @@ impl std::fmt::Debug for DeleteApiRequest {
         let mut debug_struct = f.debug_struct("DeleteApiRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1069,7 +1065,6 @@ impl std::fmt::Debug for ListApisRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1257,7 +1252,6 @@ impl std::fmt::Debug for ListApisResponse {
         let mut debug_struct = f.debug_struct("ListApisResponse");
         debug_struct.field("apis", &self.apis);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1473,7 +1467,6 @@ impl std::fmt::Debug for CreateVersionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("version_id", &self.version_id);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1619,7 +1612,6 @@ impl std::fmt::Debug for GetVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1816,7 +1808,6 @@ impl std::fmt::Debug for UpdateVersionRequest {
         let mut debug_struct = f.debug_struct("UpdateVersionRequest");
         debug_struct.field("version", &self.version);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1989,7 +1980,6 @@ impl std::fmt::Debug for DeleteVersionRequest {
         let mut debug_struct = f.debug_struct("DeleteVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2296,7 +2286,6 @@ impl std::fmt::Debug for ListVersionsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2485,7 +2474,6 @@ impl std::fmt::Debug for ListVersionsResponse {
         let mut debug_struct = f.debug_struct("ListVersionsResponse");
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2702,7 +2690,6 @@ impl std::fmt::Debug for CreateSpecRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("spec_id", &self.spec_id);
         debug_struct.field("spec", &self.spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2848,7 +2835,6 @@ impl std::fmt::Debug for GetSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSpecRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3044,7 +3030,6 @@ impl std::fmt::Debug for UpdateSpecRequest {
         let mut debug_struct = f.debug_struct("UpdateSpecRequest");
         debug_struct.field("spec", &self.spec);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3190,7 +3175,6 @@ impl std::fmt::Debug for DeleteSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSpecRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3487,7 +3471,6 @@ impl std::fmt::Debug for ListSpecsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3675,7 +3658,6 @@ impl std::fmt::Debug for ListSpecsResponse {
         let mut debug_struct = f.debug_struct("ListSpecsResponse");
         debug_struct.field("specs", &self.specs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3822,7 +3804,6 @@ impl std::fmt::Debug for GetSpecContentsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSpecContentsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3969,7 +3950,6 @@ impl std::fmt::Debug for GetApiOperationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApiOperationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4258,7 +4238,6 @@ impl std::fmt::Debug for ListApiOperationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4451,7 +4430,6 @@ impl std::fmt::Debug for ListApiOperationsResponse {
         let mut debug_struct = f.debug_struct("ListApiOperationsResponse");
         debug_struct.field("api_operations", &self.api_operations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4598,7 +4576,6 @@ impl std::fmt::Debug for GetDefinitionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDefinitionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4815,7 +4792,6 @@ impl std::fmt::Debug for CreateDeploymentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("deployment_id", &self.deployment_id);
         debug_struct.field("deployment", &self.deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4961,7 +4937,6 @@ impl std::fmt::Debug for GetDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5158,7 +5133,6 @@ impl std::fmt::Debug for UpdateDeploymentRequest {
         let mut debug_struct = f.debug_struct("UpdateDeploymentRequest");
         debug_struct.field("deployment", &self.deployment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5304,7 +5278,6 @@ impl std::fmt::Debug for DeleteDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5610,7 +5583,6 @@ impl std::fmt::Debug for ListDeploymentsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5799,7 +5771,6 @@ impl std::fmt::Debug for ListDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListDeploymentsResponse");
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6016,7 +5987,6 @@ impl std::fmt::Debug for CreateAttributeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("attribute_id", &self.attribute_id);
         debug_struct.field("attribute", &self.attribute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6163,7 +6133,6 @@ impl std::fmt::Debug for GetAttributeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAttributeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6360,7 +6329,6 @@ impl std::fmt::Debug for UpdateAttributeRequest {
         let mut debug_struct = f.debug_struct("UpdateAttributeRequest");
         debug_struct.field("attribute", &self.attribute);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6507,7 +6475,6 @@ impl std::fmt::Debug for DeleteAttributeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAttributeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6797,7 +6764,6 @@ impl std::fmt::Debug for ListAttributesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6986,7 +6952,6 @@ impl std::fmt::Debug for ListAttributesResponse {
         let mut debug_struct = f.debug_struct("ListAttributesResponse");
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7287,7 +7252,6 @@ impl std::fmt::Debug for SearchResourcesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7724,7 +7688,6 @@ impl std::fmt::Debug for ApiHubResource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApiHubResource");
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7908,7 +7871,6 @@ impl std::fmt::Debug for SearchResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SearchResult");
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8103,7 +8065,6 @@ impl std::fmt::Debug for SearchResourcesResponse {
         let mut debug_struct = f.debug_struct("SearchResourcesResponse");
         debug_struct.field("search_results", &self.search_results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8320,7 +8281,6 @@ impl std::fmt::Debug for CreateDependencyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("dependency_id", &self.dependency_id);
         debug_struct.field("dependency", &self.dependency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8464,7 +8424,6 @@ impl std::fmt::Debug for GetDependencyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDependencyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8661,7 +8620,6 @@ impl std::fmt::Debug for UpdateDependencyRequest {
         let mut debug_struct = f.debug_struct("UpdateDependencyRequest");
         debug_struct.field("dependency", &self.dependency);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8808,7 +8766,6 @@ impl std::fmt::Debug for DeleteDependencyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDependencyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9090,7 +9047,6 @@ impl std::fmt::Debug for ListDependenciesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9281,7 +9237,6 @@ impl std::fmt::Debug for ListDependenciesResponse {
         let mut debug_struct = f.debug_struct("ListDependenciesResponse");
         debug_struct.field("dependencies", &self.dependencies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9500,7 +9455,6 @@ impl std::fmt::Debug for CreateExternalApiRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("external_api_id", &self.external_api_id);
         debug_struct.field("external_api", &self.external_api);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9647,7 +9601,6 @@ impl std::fmt::Debug for GetExternalApiRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetExternalApiRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9845,7 +9798,6 @@ impl std::fmt::Debug for UpdateExternalApiRequest {
         let mut debug_struct = f.debug_struct("UpdateExternalApiRequest");
         debug_struct.field("external_api", &self.external_api);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9992,7 +9944,6 @@ impl std::fmt::Debug for DeleteExternalApiRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteExternalApiRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10215,7 +10166,6 @@ impl std::fmt::Debug for ListExternalApisRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10407,7 +10357,6 @@ impl std::fmt::Debug for ListExternalApisResponse {
         let mut debug_struct = f.debug_struct("ListExternalApisResponse");
         debug_struct.field("external_apis", &self.external_apis);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11075,7 +11024,6 @@ impl std::fmt::Debug for Api {
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("api_style", &self.api_style);
         debug_struct.field("selected_version", &self.selected_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11712,7 +11660,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("accreditation", &self.accreditation);
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("selected_deployment", &self.selected_deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12250,7 +12197,6 @@ impl std::fmt::Debug for Spec {
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("documentation", &self.documentation);
         debug_struct.field("parsing_mode", &self.parsing_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12967,7 +12913,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("slo", &self.slo);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("attributes", &self.attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13293,7 +13238,6 @@ impl std::fmt::Debug for ApiOperation {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("attributes", &self.attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13677,7 +13621,6 @@ impl std::fmt::Debug for Definition {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14281,7 +14224,6 @@ impl std::fmt::Debug for Attribute {
         debug_struct.field("mandatory", &self.mandatory);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14522,7 +14464,6 @@ pub mod attribute {
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("description", &self.description);
             debug_struct.field("immutable", &self.immutable);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15164,7 +15105,6 @@ impl std::fmt::Debug for SpecContents {
         let mut debug_struct = f.debug_struct("SpecContents");
         debug_struct.field("contents", &self.contents);
         debug_struct.field("mime_type", &self.mime_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15382,7 +15322,6 @@ impl std::fmt::Debug for SpecDetails {
         let mut debug_struct = f.debug_struct("SpecDetails");
         debug_struct.field("description", &self.description);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15615,7 +15554,6 @@ impl std::fmt::Debug for OpenApiSpecDetails {
         debug_struct.field("format", &self.format);
         debug_struct.field("version", &self.version);
         debug_struct.field("owner", &self.owner);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16042,7 +15980,6 @@ impl std::fmt::Debug for OperationDetails {
         debug_struct.field("documentation", &self.documentation);
         debug_struct.field("deprecated", &self.deprecated);
         debug_struct.field("operation", &self.operation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16234,7 +16171,6 @@ impl std::fmt::Debug for HttpOperation {
         let mut debug_struct = f.debug_struct("HttpOperation");
         debug_struct.field("path", &self.path);
         debug_struct.field("method", &self.method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16581,7 +16517,6 @@ impl std::fmt::Debug for Path {
         let mut debug_struct = f.debug_struct("Path");
         debug_struct.field("path", &self.path);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16774,7 +16709,6 @@ impl std::fmt::Debug for Schema {
         let mut debug_struct = f.debug_struct("Schema");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("raw_value", &self.raw_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16942,7 +16876,6 @@ impl std::fmt::Debug for Owner {
         let mut debug_struct = f.debug_struct("Owner");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17085,7 +17018,6 @@ impl std::fmt::Debug for Documentation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Documentation");
         debug_struct.field("external_uri", &self.external_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17421,7 +17353,6 @@ impl std::fmt::Debug for AttributeValues {
         let mut debug_struct = f.debug_struct("AttributeValues");
         debug_struct.field("attribute", &self.attribute);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17578,7 +17509,6 @@ pub mod attribute_values {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EnumAttributeValues");
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17727,7 +17657,6 @@ pub mod attribute_values {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StringAttributeValues");
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18197,7 +18126,6 @@ impl std::fmt::Debug for Dependency {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("attributes", &self.attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18733,7 +18661,6 @@ impl std::fmt::Debug for DependencyEntityReference {
         let mut debug_struct = f.debug_struct("DependencyEntityReference");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("identifier", &self.identifier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18939,7 +18866,6 @@ impl std::fmt::Debug for DependencyErrorDetail {
         let mut debug_struct = f.debug_struct("DependencyErrorDetail");
         debug_struct.field("error", &self.error);
         debug_struct.field("error_time", &self.error_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19366,7 +19292,6 @@ impl std::fmt::Debug for LintResponse {
         debug_struct.field("source", &self.source);
         debug_struct.field("linter", &self.linter);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19559,7 +19484,6 @@ pub mod lint_response {
             let mut debug_struct = f.debug_struct("SummaryEntry");
             debug_struct.field("severity", &self.severity);
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19817,7 +19741,6 @@ impl std::fmt::Debug for Issue {
         debug_struct.field("message", &self.message);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("range", &self.range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20006,7 +19929,6 @@ impl std::fmt::Debug for Range {
         let mut debug_struct = f.debug_struct("Range");
         debug_struct.field("start", &self.start);
         debug_struct.field("end", &self.end);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20209,7 +20131,6 @@ impl std::fmt::Debug for Point {
         let mut debug_struct = f.debug_struct("Point");
         debug_struct.field("line", &self.line);
         debug_struct.field("character", &self.character);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20534,7 +20455,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20904,7 +20824,6 @@ impl std::fmt::Debug for ApiHubInstance {
         debug_struct.field("config", &self.config);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21061,7 +20980,6 @@ pub mod api_hub_instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Config");
             debug_struct.field("cmek_key_name", &self.cmek_key_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21624,7 +21542,6 @@ impl std::fmt::Debug for ExternalApi {
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21854,7 +21771,6 @@ impl std::fmt::Debug for CreateHostProjectRegistrationRequest {
             &self.host_project_registration_id,
         );
         debug_struct.field("host_project_registration", &self.host_project_registration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22001,7 +21917,6 @@ impl std::fmt::Debug for GetHostProjectRegistrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetHostProjectRegistrationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22293,7 +22208,6 @@ impl std::fmt::Debug for ListHostProjectRegistrationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22495,7 +22409,6 @@ impl std::fmt::Debug for ListHostProjectRegistrationsResponse {
             &self.host_project_registrations,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22709,7 +22622,6 @@ impl std::fmt::Debug for HostProjectRegistration {
         debug_struct.field("name", &self.name);
         debug_struct.field("gcp_project", &self.gcp_project);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22853,7 +22765,6 @@ impl std::fmt::Debug for GetStyleGuideRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStyleGuideRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23044,7 +22955,6 @@ impl std::fmt::Debug for UpdateStyleGuideRequest {
         let mut debug_struct = f.debug_struct("UpdateStyleGuideRequest");
         debug_struct.field("style_guide", &self.style_guide);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23189,7 +23099,6 @@ impl std::fmt::Debug for GetStyleGuideContentsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStyleGuideContentsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23333,7 +23242,6 @@ impl std::fmt::Debug for LintSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LintSpecRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23519,7 +23427,6 @@ impl std::fmt::Debug for StyleGuideContents {
         let mut debug_struct = f.debug_struct("StyleGuideContents");
         debug_struct.field("contents", &self.contents);
         debug_struct.field("mime_type", &self.mime_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23726,7 +23633,6 @@ impl std::fmt::Debug for StyleGuide {
         debug_struct.field("name", &self.name);
         debug_struct.field("linter", &self.linter);
         debug_struct.field("contents", &self.contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23991,7 +23897,6 @@ impl std::fmt::Debug for Plugin {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("description", &self.description);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24277,7 +24182,6 @@ impl std::fmt::Debug for GetPluginRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPluginRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24423,7 +24327,6 @@ impl std::fmt::Debug for EnablePluginRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnablePluginRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24569,7 +24472,6 @@ impl std::fmt::Debug for DisablePluginRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisablePluginRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24788,7 +24690,6 @@ impl std::fmt::Debug for CreateApiHubInstanceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("api_hub_instance_id", &self.api_hub_instance_id);
         debug_struct.field("api_hub_instance", &self.api_hub_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24936,7 +24837,6 @@ impl std::fmt::Debug for GetApiHubInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApiHubInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25085,7 +24985,6 @@ impl std::fmt::Debug for LookupApiHubInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupApiHubInstanceRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25244,7 +25143,6 @@ impl std::fmt::Debug for LookupApiHubInstanceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupApiHubInstanceResponse");
         debug_struct.field("api_hub_instance", &self.api_hub_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25478,7 +25376,6 @@ impl std::fmt::Debug for CreateRuntimeProjectAttachmentRequest {
             "runtime_project_attachment",
             &self.runtime_project_attachment,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25626,7 +25523,6 @@ impl std::fmt::Debug for GetRuntimeProjectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRuntimeProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25918,7 +25814,6 @@ impl std::fmt::Debug for ListRuntimeProjectAttachmentsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26124,7 +26019,6 @@ impl std::fmt::Debug for ListRuntimeProjectAttachmentsResponse {
             &self.runtime_project_attachments,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26273,7 +26167,6 @@ impl std::fmt::Debug for DeleteRuntimeProjectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteRuntimeProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26422,7 +26315,6 @@ impl std::fmt::Debug for LookupRuntimeProjectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupRuntimeProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26588,7 +26480,6 @@ impl std::fmt::Debug for LookupRuntimeProjectAttachmentResponse {
             "runtime_project_attachment",
             &self.runtime_project_attachment,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26800,7 +26691,6 @@ impl std::fmt::Debug for RuntimeProjectAttachment {
         debug_struct.field("name", &self.name);
         debug_struct.field("runtime_project", &self.runtime_project);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -171,7 +171,6 @@ impl std::fmt::Debug for LookupServiceProjectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupServiceProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -333,7 +332,6 @@ impl std::fmt::Debug for LookupServiceProjectAttachmentResponse {
             "service_project_attachment",
             &self.service_project_attachment,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -599,7 +597,6 @@ impl std::fmt::Debug for ListServiceProjectAttachmentsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -828,7 +825,6 @@ impl std::fmt::Debug for ListServiceProjectAttachmentsResponse {
         );
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1096,7 +1092,6 @@ impl std::fmt::Debug for CreateServiceProjectAttachmentRequest {
             &self.service_project_attachment,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1240,7 +1235,6 @@ impl std::fmt::Debug for GetServiceProjectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1423,7 +1417,6 @@ impl std::fmt::Debug for DeleteServiceProjectAttachmentRequest {
         let mut debug_struct = f.debug_struct("DeleteServiceProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1568,7 +1561,6 @@ impl std::fmt::Debug for DetachServiceProjectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DetachServiceProjectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1683,7 +1675,6 @@ impl serde::ser::Serialize for DetachServiceProjectAttachmentResponse {
 impl std::fmt::Debug for DetachServiceProjectAttachmentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DetachServiceProjectAttachmentResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1949,7 +1940,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2162,7 +2152,6 @@ impl std::fmt::Debug for ListServicesResponse {
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2427,7 +2416,6 @@ impl std::fmt::Debug for ListDiscoveredServicesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2645,7 +2633,6 @@ impl std::fmt::Debug for ListDiscoveredServicesResponse {
         debug_struct.field("discovered_services", &self.discovered_services);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2892,7 +2879,6 @@ impl std::fmt::Debug for CreateServiceRequest {
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("service", &self.service);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3036,7 +3022,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3180,7 +3165,6 @@ impl std::fmt::Debug for GetDiscoveredServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDiscoveredServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3350,7 +3334,6 @@ impl std::fmt::Debug for LookupDiscoveredServiceRequest {
         let mut debug_struct = f.debug_struct("LookupDiscoveredServiceRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3505,7 +3488,6 @@ impl std::fmt::Debug for LookupDiscoveredServiceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupDiscoveredServiceResponse");
         debug_struct.field("discovered_service", &self.discovered_service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3741,7 +3723,6 @@ impl std::fmt::Debug for UpdateServiceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service", &self.service);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3923,7 +3904,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
         let mut debug_struct = f.debug_struct("DeleteServiceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4188,7 +4168,6 @@ impl std::fmt::Debug for ListApplicationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4401,7 +4380,6 @@ impl std::fmt::Debug for ListApplicationsResponse {
         debug_struct.field("applications", &self.applications);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4647,7 +4625,6 @@ impl std::fmt::Debug for CreateApplicationRequest {
         debug_struct.field("application_id", &self.application_id);
         debug_struct.field("application", &self.application);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4791,7 +4768,6 @@ impl std::fmt::Debug for GetApplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetApplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5027,7 +5003,6 @@ impl std::fmt::Debug for UpdateApplicationRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("application", &self.application);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5209,7 +5184,6 @@ impl std::fmt::Debug for DeleteApplicationRequest {
         let mut debug_struct = f.debug_struct("DeleteApplicationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5475,7 +5449,6 @@ impl std::fmt::Debug for ListWorkloadsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5688,7 +5661,6 @@ impl std::fmt::Debug for ListWorkloadsResponse {
         debug_struct.field("workloads", &self.workloads);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5953,7 +5925,6 @@ impl std::fmt::Debug for ListDiscoveredWorkloadsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6171,7 +6142,6 @@ impl std::fmt::Debug for ListDiscoveredWorkloadsResponse {
         debug_struct.field("discovered_workloads", &self.discovered_workloads);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6418,7 +6388,6 @@ impl std::fmt::Debug for CreateWorkloadRequest {
         debug_struct.field("workload_id", &self.workload_id);
         debug_struct.field("workload", &self.workload);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6562,7 +6531,6 @@ impl std::fmt::Debug for GetWorkloadRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkloadRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6706,7 +6674,6 @@ impl std::fmt::Debug for GetDiscoveredWorkloadRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDiscoveredWorkloadRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6876,7 +6843,6 @@ impl std::fmt::Debug for LookupDiscoveredWorkloadRequest {
         let mut debug_struct = f.debug_struct("LookupDiscoveredWorkloadRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7030,7 +6996,6 @@ impl std::fmt::Debug for LookupDiscoveredWorkloadResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LookupDiscoveredWorkloadResponse");
         debug_struct.field("discovered_workload", &self.discovered_workload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7266,7 +7231,6 @@ impl std::fmt::Debug for UpdateWorkloadRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("workload", &self.workload);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7448,7 +7412,6 @@ impl std::fmt::Debug for DeleteWorkloadRequest {
         let mut debug_struct = f.debug_struct("DeleteWorkloadRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7775,7 +7738,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8173,7 +8135,6 @@ impl std::fmt::Debug for Application {
         debug_struct.field("scope", &self.scope);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8460,7 +8421,6 @@ impl std::fmt::Debug for Scope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Scope");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8875,7 +8835,6 @@ impl std::fmt::Debug for Attributes {
         debug_struct.field("developer_owners", &self.developer_owners);
         debug_struct.field("operator_owners", &self.operator_owners);
         debug_struct.field("business_owners", &self.business_owners);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9021,7 +8980,6 @@ impl std::fmt::Debug for Criticality {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Criticality");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9319,7 +9277,6 @@ impl std::fmt::Debug for Environment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Environment");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9640,7 +9597,6 @@ impl std::fmt::Debug for ContactInfo {
         let mut debug_struct = f.debug_struct("ContactInfo");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10106,7 +10062,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10401,7 +10356,6 @@ impl std::fmt::Debug for ServiceReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceReference");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10597,7 +10551,6 @@ impl std::fmt::Debug for ServiceProperties {
         debug_struct.field("gcp_project", &self.gcp_project);
         debug_struct.field("location", &self.location);
         debug_struct.field("zone", &self.zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10820,7 +10773,6 @@ impl std::fmt::Debug for DiscoveredService {
         debug_struct.field("name", &self.name);
         debug_struct.field("service_reference", &self.service_reference);
         debug_struct.field("service_properties", &self.service_properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11088,7 +11040,6 @@ impl std::fmt::Debug for ServiceProjectAttachment {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11701,7 +11652,6 @@ impl std::fmt::Debug for Workload {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11995,7 +11945,6 @@ impl std::fmt::Debug for WorkloadReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WorkloadReference");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12191,7 +12140,6 @@ impl std::fmt::Debug for WorkloadProperties {
         debug_struct.field("gcp_project", &self.gcp_project);
         debug_struct.field("location", &self.location);
         debug_struct.field("zone", &self.zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12414,7 +12362,6 @@ impl std::fmt::Debug for DiscoveredWorkload {
         debug_struct.field("name", &self.name);
         debug_struct.field("workload_reference", &self.workload_reference);
         debug_struct.field("workload_properties", &self.workload_properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -176,7 +176,6 @@ impl std::fmt::Debug for ResourceOwners {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceOwners");
         debug_struct.field("resource_owners", &self.resource_owners);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -331,7 +330,6 @@ impl std::fmt::Debug for AnalyzeIamPolicyLongrunningMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnalyzeIamPolicyLongrunningMetadata");
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -675,7 +673,6 @@ impl std::fmt::Debug for ExportAssetsRequest {
         debug_struct.field("content_type", &self.content_type);
         debug_struct.field("output_config", &self.output_config);
         debug_struct.field("relationship_types", &self.relationship_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -913,7 +910,6 @@ impl std::fmt::Debug for ExportAssetsResponse {
         debug_struct.field("read_time", &self.read_time);
         debug_struct.field("output_config", &self.output_config);
         debug_struct.field("output_result", &self.output_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1293,7 +1289,6 @@ impl std::fmt::Debug for ListAssetsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("relationship_types", &self.relationship_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1517,7 +1512,6 @@ impl std::fmt::Debug for ListAssetsResponse {
         debug_struct.field("read_time", &self.read_time);
         debug_struct.field("assets", &self.assets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1813,7 +1807,6 @@ impl std::fmt::Debug for BatchGetAssetsHistoryRequest {
         debug_struct.field("content_type", &self.content_type);
         debug_struct.field("read_time_window", &self.read_time_window);
         debug_struct.field("relationship_types", &self.relationship_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1958,7 +1951,6 @@ impl std::fmt::Debug for BatchGetAssetsHistoryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchGetAssetsHistoryResponse");
         debug_struct.field("assets", &self.assets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2170,7 +2162,6 @@ impl std::fmt::Debug for CreateFeedRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("feed_id", &self.feed_id);
         debug_struct.field("feed", &self.feed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2315,7 +2306,6 @@ impl std::fmt::Debug for GetFeedRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFeedRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2459,7 +2449,6 @@ impl std::fmt::Debug for ListFeedsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListFeedsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2603,7 +2592,6 @@ impl std::fmt::Debug for ListFeedsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListFeedsResponse");
         debug_struct.field("feeds", &self.feeds);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2799,7 +2787,6 @@ impl std::fmt::Debug for UpdateFeedRequest {
         let mut debug_struct = f.debug_struct("UpdateFeedRequest");
         debug_struct.field("feed", &self.feed);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2943,7 +2930,6 @@ impl std::fmt::Debug for DeleteFeedRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFeedRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3194,7 +3180,6 @@ impl std::fmt::Debug for OutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3399,7 +3384,6 @@ impl std::fmt::Debug for OutputResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OutputResult");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3559,7 +3543,6 @@ impl std::fmt::Debug for GcsOutputResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsOutputResult");
         debug_struct.field("uris", &self.uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3786,7 +3769,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("object_uri", &self.object_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4137,7 +4119,6 @@ impl std::fmt::Debug for BigQueryDestination {
             "separate_tables_per_asset_type",
             &self.separate_tables_per_asset_type,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4281,7 +4262,6 @@ impl std::fmt::Debug for PartitionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PartitionSpec");
         debug_struct.field("partition_key", &self.partition_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4573,7 +4553,6 @@ impl std::fmt::Debug for PubsubDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PubsubDestination");
         debug_struct.field("topic", &self.topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4766,7 +4745,6 @@ impl std::fmt::Debug for FeedOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FeedOutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5163,7 +5141,6 @@ impl std::fmt::Debug for Feed {
         debug_struct.field("feed_output_config", &self.feed_output_config);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("relationship_types", &self.relationship_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5648,7 +5625,6 @@ impl std::fmt::Debug for SearchAllResourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5840,7 +5816,6 @@ impl std::fmt::Debug for SearchAllResourcesResponse {
         let mut debug_struct = f.debug_struct("SearchAllResourcesResponse");
         debug_struct.field("results", &self.results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6217,7 +6192,6 @@ impl std::fmt::Debug for SearchAllIamPoliciesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("asset_types", &self.asset_types);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6409,7 +6383,6 @@ impl std::fmt::Debug for SearchAllIamPoliciesResponse {
         let mut debug_struct = f.debug_struct("SearchAllIamPoliciesResponse");
         debug_struct.field("results", &self.results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6755,7 +6728,6 @@ impl std::fmt::Debug for IamPolicyAnalysisQuery {
         debug_struct.field("access_selector", &self.access_selector);
         debug_struct.field("options", &self.options);
         debug_struct.field("condition_context", &self.condition_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6914,7 +6886,6 @@ pub mod iam_policy_analysis_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ResourceSelector");
             debug_struct.field("full_resource_name", &self.full_resource_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7072,7 +7043,6 @@ pub mod iam_policy_analysis_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IdentitySelector");
             debug_struct.field("identity", &self.identity);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7252,7 +7222,6 @@ pub mod iam_policy_analysis_query {
             let mut debug_struct = f.debug_struct("AccessSelector");
             debug_struct.field("roles", &self.roles);
             debug_struct.field("permissions", &self.permissions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7634,7 +7603,6 @@ pub mod iam_policy_analysis_query {
                 "analyze_service_account_impersonation",
                 &self.analyze_service_account_impersonation,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7829,7 +7797,6 @@ pub mod iam_policy_analysis_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConditionContext");
             debug_struct.field("time_context", &self.time_context);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8094,7 +8061,6 @@ impl std::fmt::Debug for AnalyzeIamPolicyRequest {
         debug_struct.field("analysis_query", &self.analysis_query);
         debug_struct.field("saved_analysis_query", &self.saved_analysis_query);
         debug_struct.field("execution_timeout", &self.execution_timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8331,7 +8297,6 @@ impl std::fmt::Debug for AnalyzeIamPolicyResponse {
             &self.service_account_impersonation_analysis,
         );
         debug_struct.field("fully_explored", &self.fully_explored);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8593,7 +8558,6 @@ pub mod analyze_iam_policy_response {
             debug_struct.field("analysis_results", &self.analysis_results);
             debug_struct.field("fully_explored", &self.fully_explored);
             debug_struct.field("non_critical_errors", &self.non_critical_errors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8854,7 +8818,6 @@ impl std::fmt::Debug for IamPolicyAnalysisOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IamPolicyAnalysisOutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9012,7 +8975,6 @@ pub mod iam_policy_analysis_output_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GcsDestination");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9265,7 +9227,6 @@ pub mod iam_policy_analysis_output_config {
             debug_struct.field("table_prefix", &self.table_prefix);
             debug_struct.field("partition_key", &self.partition_key);
             debug_struct.field("write_disposition", &self.write_disposition);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9660,7 +9621,6 @@ impl std::fmt::Debug for AnalyzeIamPolicyLongrunningRequest {
         debug_struct.field("analysis_query", &self.analysis_query);
         debug_struct.field("saved_analysis_query", &self.saved_analysis_query);
         debug_struct.field("output_config", &self.output_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9777,7 +9737,6 @@ impl serde::ser::Serialize for AnalyzeIamPolicyLongrunningResponse {
 impl std::fmt::Debug for AnalyzeIamPolicyLongrunningResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnalyzeIamPolicyLongrunningResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10149,7 +10108,6 @@ impl std::fmt::Debug for SavedQuery {
         debug_struct.field("last_updater", &self.last_updater);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10355,7 +10313,6 @@ pub mod saved_query {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QueryContent");
             debug_struct.field("query_content", &self.query_content);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10595,7 +10552,6 @@ impl std::fmt::Debug for CreateSavedQueryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("saved_query", &self.saved_query);
         debug_struct.field("saved_query_id", &self.saved_query_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10741,7 +10697,6 @@ impl std::fmt::Debug for GetSavedQueryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSavedQueryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10993,7 +10948,6 @@ impl std::fmt::Debug for ListSavedQueriesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11180,7 +11134,6 @@ impl std::fmt::Debug for ListSavedQueriesResponse {
         let mut debug_struct = f.debug_struct("ListSavedQueriesResponse");
         debug_struct.field("saved_queries", &self.saved_queries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11378,7 +11331,6 @@ impl std::fmt::Debug for UpdateSavedQueryRequest {
         let mut debug_struct = f.debug_struct("UpdateSavedQueryRequest");
         debug_struct.field("saved_query", &self.saved_query);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11525,7 +11477,6 @@ impl std::fmt::Debug for DeleteSavedQueryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSavedQueryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11734,7 +11685,6 @@ impl std::fmt::Debug for AnalyzeMoveRequest {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("destination_parent", &self.destination_parent);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12022,7 +11972,6 @@ impl std::fmt::Debug for AnalyzeMoveResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnalyzeMoveResponse");
         debug_struct.field("move_analysis", &self.move_analysis);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12288,7 +12237,6 @@ impl std::fmt::Debug for MoveAnalysis {
         let mut debug_struct = f.debug_struct("MoveAnalysis");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12479,7 +12427,6 @@ impl std::fmt::Debug for MoveAnalysisResult {
         let mut debug_struct = f.debug_struct("MoveAnalysisResult");
         debug_struct.field("blockers", &self.blockers);
         debug_struct.field("warnings", &self.warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12621,7 +12568,6 @@ impl std::fmt::Debug for MoveImpact {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MoveImpact");
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12777,7 +12723,6 @@ impl std::fmt::Debug for QueryAssetsOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryAssetsOutputConfig");
         debug_struct.field("bigquery_destination", &self.bigquery_destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12994,7 +12939,6 @@ pub mod query_assets_output_config {
             debug_struct.field("dataset", &self.dataset);
             debug_struct.field("table", &self.table);
             debug_struct.field("write_disposition", &self.write_disposition);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13556,7 +13500,6 @@ impl std::fmt::Debug for QueryAssetsRequest {
         debug_struct.field("output_config", &self.output_config);
         debug_struct.field("query", &self.query);
         debug_struct.field("time", &self.time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13949,7 +13892,6 @@ impl std::fmt::Debug for QueryAssetsResponse {
         debug_struct.field("job_reference", &self.job_reference);
         debug_struct.field("done", &self.done);
         debug_struct.field("response", &self.response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14225,7 +14167,6 @@ impl std::fmt::Debug for QueryResult {
         debug_struct.field("schema", &self.schema);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_rows", &self.total_rows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14374,7 +14315,6 @@ impl std::fmt::Debug for TableSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TableSchema");
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14617,7 +14557,6 @@ impl std::fmt::Debug for TableFieldSchema {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("mode", &self.mode);
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14804,7 +14743,6 @@ impl std::fmt::Debug for BatchGetEffectiveIamPoliciesRequest {
         let mut debug_struct = f.debug_struct("BatchGetEffectiveIamPoliciesRequest");
         debug_struct.field("scope", &self.scope);
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14964,7 +14902,6 @@ impl std::fmt::Debug for BatchGetEffectiveIamPoliciesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchGetEffectiveIamPoliciesResponse");
         debug_struct.field("policy_results", &self.policy_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15179,7 +15116,6 @@ pub mod batch_get_effective_iam_policies_response {
             let mut debug_struct = f.debug_struct("EffectiveIamPolicy");
             debug_struct.field("full_resource_name", &self.full_resource_name);
             debug_struct.field("policies", &self.policies);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15382,7 +15318,6 @@ pub mod batch_get_effective_iam_policies_response {
                 let mut debug_struct = f.debug_struct("PolicyInfo");
                 debug_struct.field("attached_resource", &self.attached_resource);
                 debug_struct.field("policy", &self.policy);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -15665,7 +15600,6 @@ impl std::fmt::Debug for AnalyzerOrgPolicy {
         debug_struct.field("rules", &self.rules);
         debug_struct.field("inherit_from_parent", &self.inherit_from_parent);
         debug_struct.field("reset", &self.reset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16106,7 +16040,6 @@ pub mod analyzer_org_policy {
             debug_struct.field("condition", &self.condition);
             debug_struct.field("condition_evaluation", &self.condition_evaluation);
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16296,7 +16229,6 @@ pub mod analyzer_org_policy {
                 let mut debug_struct = f.debug_struct("StringValues");
                 debug_struct.field("allowed_values", &self.allowed_values);
                 debug_struct.field("denied_values", &self.denied_values);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16577,7 +16509,6 @@ impl std::fmt::Debug for AnalyzerOrgPolicyConstraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnalyzerOrgPolicyConstraint");
         debug_struct.field("constraint_definition", &self.constraint_definition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16970,7 +16901,6 @@ pub mod analyzer_org_policy_constraint {
             debug_struct.field("description", &self.description);
             debug_struct.field("constraint_default", &self.constraint_default);
             debug_struct.field("constraint_type", &self.constraint_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17160,7 +17090,6 @@ pub mod analyzer_org_policy_constraint {
                 let mut debug_struct = f.debug_struct("ListConstraint");
                 debug_struct.field("supports_in", &self.supports_in);
                 debug_struct.field("supports_under", &self.supports_under);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17284,7 +17213,6 @@ pub mod analyzer_org_policy_constraint {
         impl std::fmt::Debug for BooleanConstraint {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("BooleanConstraint");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17774,7 +17702,6 @@ pub mod analyzer_org_policy_constraint {
             debug_struct.field("action_type", &self.action_type);
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("description", &self.description);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18387,7 +18314,6 @@ impl std::fmt::Debug for AnalyzeOrgPoliciesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18622,7 +18548,6 @@ impl std::fmt::Debug for AnalyzeOrgPoliciesResponse {
         debug_struct.field("org_policy_results", &self.org_policy_results);
         debug_struct.field("constraint", &self.constraint);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18917,7 +18842,6 @@ pub mod analyze_org_policies_response {
             debug_struct.field("project", &self.project);
             debug_struct.field("folders", &self.folders);
             debug_struct.field("organization", &self.organization);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19222,7 +19146,6 @@ impl std::fmt::Debug for AnalyzeOrgPolicyGovernedContainersRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19457,7 +19380,6 @@ impl std::fmt::Debug for AnalyzeOrgPolicyGovernedContainersResponse {
         debug_struct.field("governed_containers", &self.governed_containers);
         debug_struct.field("constraint", &self.constraint);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19850,7 +19772,6 @@ pub mod analyze_org_policy_governed_containers_response {
             debug_struct.field("folders", &self.folders);
             debug_struct.field("organization", &self.organization);
             debug_struct.field("effective_tags", &self.effective_tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20172,7 +20093,6 @@ impl std::fmt::Debug for AnalyzeOrgPolicyGovernedAssetsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20404,7 +20324,6 @@ impl std::fmt::Debug for AnalyzeOrgPolicyGovernedAssetsResponse {
         debug_struct.field("governed_assets", &self.governed_assets);
         debug_struct.field("constraint", &self.constraint);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20747,7 +20666,6 @@ pub mod analyze_org_policy_governed_assets_response {
             debug_struct.field("organization", &self.organization);
             debug_struct.field("asset_type", &self.asset_type);
             debug_struct.field("effective_tags", &self.effective_tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21061,7 +20979,6 @@ pub mod analyze_org_policy_governed_assets_response {
             debug_struct.field("folders", &self.folders);
             debug_struct.field("organization", &self.organization);
             debug_struct.field("asset_type", &self.asset_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21399,7 +21316,6 @@ pub mod analyze_org_policy_governed_assets_response {
             debug_struct.field("consolidated_policy", &self.consolidated_policy);
             debug_struct.field("policy_bundle", &self.policy_bundle);
             debug_struct.field("governed_asset", &self.governed_asset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21717,7 +21633,6 @@ impl std::fmt::Debug for TemporalAsset {
         debug_struct.field("asset", &self.asset);
         debug_struct.field("prior_asset_state", &self.prior_asset_state);
         debug_struct.field("prior_asset", &self.prior_asset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22061,7 +21976,6 @@ impl std::fmt::Debug for TimeWindow {
         let mut debug_struct = f.debug_struct("TimeWindow");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22253,7 +22167,6 @@ impl std::fmt::Debug for AssetEnrichment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AssetEnrichment");
         debug_struct.field("enrichment_data", &self.enrichment_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22961,7 +22874,6 @@ impl std::fmt::Debug for Asset {
         debug_struct.field("related_asset", &self.related_asset);
         debug_struct.field("ancestors", &self.ancestors);
         debug_struct.field("access_context_policy", &self.access_context_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23315,7 +23227,6 @@ impl std::fmt::Debug for Resource {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("data", &self.data);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23501,7 +23412,6 @@ impl std::fmt::Debug for RelatedAssets {
         let mut debug_struct = f.debug_struct("RelatedAssets");
         debug_struct.field("relationship_attributes", &self.relationship_attributes);
         debug_struct.field("assets", &self.assets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23732,7 +23642,6 @@ impl std::fmt::Debug for RelationshipAttributes {
         debug_struct.field("source_resource_type", &self.source_resource_type);
         debug_struct.field("target_resource_type", &self.target_resource_type);
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23979,7 +23888,6 @@ impl std::fmt::Debug for RelatedAsset {
         debug_struct.field("asset_type", &self.asset_type);
         debug_struct.field("ancestors", &self.ancestors);
         debug_struct.field("relationship_type", &self.relationship_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24246,7 +24154,6 @@ impl std::fmt::Debug for Tag {
         debug_struct.field("tag_key_id", &self.tag_key_id);
         debug_struct.field("tag_value", &self.tag_value);
         debug_struct.field("tag_value_id", &self.tag_value_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24445,7 +24352,6 @@ impl std::fmt::Debug for EffectiveTagDetails {
         let mut debug_struct = f.debug_struct("EffectiveTagDetails");
         debug_struct.field("attached_resource", &self.attached_resource);
         debug_struct.field("effective_tags", &self.effective_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25707,7 +25613,6 @@ impl std::fmt::Debug for ResourceSearchResult {
         debug_struct.field("enrichments", &self.enrichments);
         debug_struct.field("parent_asset_type", &self.parent_asset_type);
         debug_struct.field("scc_security_marks", &self.scc_security_marks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25902,7 +25807,6 @@ impl std::fmt::Debug for VersionedResource {
         let mut debug_struct = f.debug_struct("VersionedResource");
         debug_struct.field("version", &self.version);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26087,7 +25991,6 @@ impl std::fmt::Debug for AttachedResource {
         let mut debug_struct = f.debug_struct("AttachedResource");
         debug_struct.field("asset_type", &self.asset_type);
         debug_struct.field("versioned_resources", &self.versioned_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26237,7 +26140,6 @@ impl std::fmt::Debug for RelatedResources {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RelatedResources");
         debug_struct.field("related_resources", &self.related_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26410,7 +26312,6 @@ impl std::fmt::Debug for RelatedResource {
         let mut debug_struct = f.debug_struct("RelatedResource");
         debug_struct.field("asset_type", &self.asset_type);
         debug_struct.field("full_resource_name", &self.full_resource_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26781,7 +26682,6 @@ impl std::fmt::Debug for IamPolicySearchResult {
         debug_struct.field("organization", &self.organization);
         debug_struct.field("policy", &self.policy);
         debug_struct.field("explanation", &self.explanation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26945,7 +26845,6 @@ pub mod iam_policy_search_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Explanation");
             debug_struct.field("matched_permissions", &self.matched_permissions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27103,7 +27002,6 @@ pub mod iam_policy_search_result {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Permissions");
                 debug_struct.field("permissions", &self.permissions);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -27279,7 +27177,6 @@ impl std::fmt::Debug for IamPolicyAnalysisState {
         let mut debug_struct = f.debug_struct("IamPolicyAnalysisState");
         debug_struct.field("code", &self.code);
         debug_struct.field("cause", &self.cause);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27429,7 +27326,6 @@ impl std::fmt::Debug for ConditionEvaluation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConditionEvaluation");
         debug_struct.field("evaluation_value", &self.evaluation_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27889,7 +27785,6 @@ impl std::fmt::Debug for IamPolicyAnalysisResult {
         debug_struct.field("access_control_lists", &self.access_control_lists);
         debug_struct.field("identity_list", &self.identity_list);
         debug_struct.field("fully_explored", &self.fully_explored);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28081,7 +27976,6 @@ pub mod iam_policy_analysis_result {
             let mut debug_struct = f.debug_struct("Resource");
             debug_struct.field("full_resource_name", &self.full_resource_name);
             debug_struct.field("analysis_state", &self.analysis_state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28354,7 +28248,6 @@ pub mod iam_policy_analysis_result {
             let mut debug_struct = f.debug_struct("Access");
             debug_struct.field("analysis_state", &self.analysis_state);
             debug_struct.field("oneof_access", &self.oneof_access);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28561,7 +28454,6 @@ pub mod iam_policy_analysis_result {
             let mut debug_struct = f.debug_struct("Identity");
             debug_struct.field("name", &self.name);
             debug_struct.field("analysis_state", &self.analysis_state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28735,7 +28627,6 @@ pub mod iam_policy_analysis_result {
             let mut debug_struct = f.debug_struct("Edge");
             debug_struct.field("source_node", &self.source_node);
             debug_struct.field("target_node", &self.target_node);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29027,7 +28918,6 @@ pub mod iam_policy_analysis_result {
             debug_struct.field("accesses", &self.accesses);
             debug_struct.field("resource_edges", &self.resource_edges);
             debug_struct.field("condition_evaluation", &self.condition_evaluation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29233,7 +29123,6 @@ pub mod iam_policy_analysis_result {
             let mut debug_struct = f.debug_struct("IdentityList");
             debug_struct.field("identities", &self.identities);
             debug_struct.field("group_edges", &self.group_edges);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -232,7 +232,6 @@ impl std::fmt::Debug for CreateWorkloadRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("workload", &self.workload);
         debug_struct.field("external_id", &self.external_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -425,7 +424,6 @@ impl std::fmt::Debug for UpdateWorkloadRequest {
         let mut debug_struct = f.debug_struct("UpdateWorkloadRequest");
         debug_struct.field("workload", &self.workload);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -595,7 +593,6 @@ impl std::fmt::Debug for DeleteWorkloadRequest {
         let mut debug_struct = f.debug_struct("DeleteWorkloadRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -741,7 +738,6 @@ impl std::fmt::Debug for GetWorkloadRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkloadRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -982,7 +978,6 @@ impl std::fmt::Debug for ListWorkloadsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1167,7 +1162,6 @@ impl std::fmt::Debug for ListWorkloadsResponse {
         let mut debug_struct = f.debug_struct("ListWorkloadsResponse");
         debug_struct.field("workloads", &self.workloads);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1835,7 +1829,6 @@ impl std::fmt::Debug for Workload {
             &self.compliant_but_disallowed_services,
         );
         debug_struct.field("partner", &self.partner);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2039,7 +2032,6 @@ pub mod workload {
             let mut debug_struct = f.debug_struct("ResourceInfo");
             debug_struct.field("resource_id", &self.resource_id);
             debug_struct.field("resource_type", &self.resource_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2402,7 +2394,6 @@ pub mod workload {
             let mut debug_struct = f.debug_struct("KMSSettings");
             debug_struct.field("next_rotation_time", &self.next_rotation_time);
             debug_struct.field("rotation_period", &self.rotation_period);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2618,7 +2609,6 @@ pub mod workload {
             debug_struct.field("resource_id", &self.resource_id);
             debug_struct.field("resource_type", &self.resource_type);
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2807,7 +2797,6 @@ pub mod workload {
             let mut debug_struct = f.debug_struct("SaaEnrollmentResponse");
             debug_struct.field("setup_status", &self.setup_status);
             debug_struct.field("setup_errors", &self.setup_errors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3809,7 +3798,6 @@ impl std::fmt::Debug for CreateWorkloadOperationMetadata {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("parent", &self.parent);
         debug_struct.field("compliance_regime", &self.compliance_regime);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3984,7 +3972,6 @@ impl std::fmt::Debug for RestrictAllowedResourcesRequest {
         let mut debug_struct = f.debug_struct("RestrictAllowedResourcesRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("restriction_type", &self.restriction_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4242,7 +4229,6 @@ impl serde::ser::Serialize for RestrictAllowedResourcesResponse {
 impl std::fmt::Debug for RestrictAllowedResourcesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestrictAllowedResourcesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4451,7 +4437,6 @@ impl std::fmt::Debug for AcknowledgeViolationRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("comment", &self.comment);
         debug_struct.field("non_compliant_org_policy", &self.non_compliant_org_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4565,7 +4550,6 @@ impl serde::ser::Serialize for AcknowledgeViolationResponse {
 impl std::fmt::Debug for AcknowledgeViolationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AcknowledgeViolationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4756,7 +4740,6 @@ impl std::fmt::Debug for TimeWindow {
         let mut debug_struct = f.debug_struct("TimeWindow");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5032,7 +5015,6 @@ impl std::fmt::Debug for ListViolationsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5217,7 +5199,6 @@ impl std::fmt::Debug for ListViolationsResponse {
         let mut debug_struct = f.debug_struct("ListViolationsResponse");
         debug_struct.field("violations", &self.violations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5361,7 +5342,6 @@ impl std::fmt::Debug for GetViolationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetViolationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5924,7 +5904,6 @@ impl std::fmt::Debug for Violation {
         debug_struct.field("acknowledged", &self.acknowledged);
         debug_struct.field("acknowledgement_time", &self.acknowledgement_time);
         debug_struct.field("exception_audit_log_link", &self.exception_audit_log_link);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6151,7 +6130,6 @@ pub mod violation {
             debug_struct.field("instructions", &self.instructions);
             debug_struct.field("compliant_values", &self.compliant_values);
             debug_struct.field("remediation_type", &self.remediation_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6367,7 +6345,6 @@ pub mod violation {
                 let mut debug_struct = f.debug_struct("Instructions");
                 debug_struct.field("gcloud_instructions", &self.gcloud_instructions);
                 debug_struct.field("console_instructions", &self.console_instructions);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6605,7 +6582,6 @@ pub mod violation {
                     debug_struct.field("gcloud_commands", &self.gcloud_commands);
                     debug_struct.field("steps", &self.steps);
                     debug_struct.field("additional_links", &self.additional_links);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -6838,7 +6814,6 @@ pub mod violation {
                     debug_struct.field("console_uris", &self.console_uris);
                     debug_struct.field("steps", &self.steps);
                     debug_struct.field("additional_links", &self.additional_links);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -199,7 +199,6 @@ impl std::fmt::Debug for NetworkConfig {
         let mut debug_struct = f.debug_struct("NetworkConfig");
         debug_struct.field("network", &self.network);
         debug_struct.field("peering_mode", &self.peering_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -500,7 +499,6 @@ impl std::fmt::Debug for ManagementURI {
         let mut debug_struct = f.debug_struct("ManagementURI");
         debug_struct.field("web_ui", &self.web_ui);
         debug_struct.field("api", &self.api);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -689,7 +687,6 @@ impl std::fmt::Debug for WorkforceIdentityBasedManagementURI {
             "third_party_management_uri",
             &self.third_party_management_uri,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -884,7 +881,6 @@ impl std::fmt::Debug for WorkforceIdentityBasedOAuth2ClientID {
             "third_party_oauth2_client_id",
             &self.third_party_oauth2_client_id,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1556,7 +1552,6 @@ impl std::fmt::Debug for ManagementServer {
         debug_struct.field("ba_proxy_uri", &self.ba_proxy_uri);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2148,7 +2143,6 @@ impl std::fmt::Debug for ListManagementServersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2373,7 +2367,6 @@ impl std::fmt::Debug for ListManagementServersResponse {
         debug_struct.field("management_servers", &self.management_servers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2516,7 +2509,6 @@ impl std::fmt::Debug for GetManagementServerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetManagementServerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2769,7 +2761,6 @@ impl std::fmt::Debug for CreateManagementServerRequest {
         debug_struct.field("management_server_id", &self.management_server_id);
         debug_struct.field("management_server", &self.management_server);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2949,7 +2940,6 @@ impl std::fmt::Debug for DeleteManagementServerRequest {
         let mut debug_struct = f.debug_struct("DeleteManagementServerRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3159,7 +3149,6 @@ impl std::fmt::Debug for InitializeServiceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("resource_type", &self.resource_type);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3338,7 +3327,6 @@ impl std::fmt::Debug for InitializeServiceResponse {
         let mut debug_struct = f.debug_struct("InitializeServiceResponse");
         debug_struct.field("backup_vault_name", &self.backup_vault_name);
         debug_struct.field("backup_plan_name", &self.backup_plan_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3703,7 +3691,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("additional_info", &self.additional_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4171,7 +4158,6 @@ impl std::fmt::Debug for BackupPlan {
             "backup_vault_service_account",
             &self.backup_vault_service_account,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4599,7 +4585,6 @@ impl std::fmt::Debug for BackupRule {
         debug_struct.field("rule_id", &self.rule_id);
         debug_struct.field("backup_retention_days", &self.backup_retention_days);
         debug_struct.field("backup_schedule_oneof", &self.backup_schedule_oneof);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5063,7 +5048,6 @@ impl std::fmt::Debug for StandardSchedule {
         debug_struct.field("months", &self.months);
         debug_struct.field("backup_window", &self.backup_window);
         debug_struct.field("time_zone", &self.time_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5437,7 +5421,6 @@ impl std::fmt::Debug for BackupWindow {
         let mut debug_struct = f.debug_struct("BackupWindow");
         debug_struct.field("start_hour_of_day", &self.start_hour_of_day);
         debug_struct.field("end_hour_of_day", &self.end_hour_of_day);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5615,7 +5598,6 @@ impl std::fmt::Debug for WeekDayOfMonth {
         let mut debug_struct = f.debug_struct("WeekDayOfMonth");
         debug_struct.field("week_of_month", &self.week_of_month);
         debug_struct.field("day_of_week", &self.day_of_week);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6023,7 +6005,6 @@ impl std::fmt::Debug for CreateBackupPlanRequest {
         debug_struct.field("backup_plan_id", &self.backup_plan_id);
         debug_struct.field("backup_plan", &self.backup_plan);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6304,7 +6285,6 @@ impl std::fmt::Debug for ListBackupPlansRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6532,7 +6512,6 @@ impl std::fmt::Debug for ListBackupPlansResponse {
         debug_struct.field("backup_plans", &self.backup_plans);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6676,7 +6655,6 @@ impl std::fmt::Debug for GetBackupPlanRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupPlanRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6858,7 +6836,6 @@ impl std::fmt::Debug for DeleteBackupPlanRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupPlanRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7249,7 +7226,6 @@ impl std::fmt::Debug for BackupPlanAssociation {
         debug_struct.field("state", &self.state);
         debug_struct.field("rules_config_info", &self.rules_config_info);
         debug_struct.field("data_source", &self.data_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7666,7 +7642,6 @@ impl std::fmt::Debug for RuleConfigInfo {
             "last_successful_backup_consistency_time",
             &self.last_successful_backup_consistency_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8075,7 +8050,6 @@ impl std::fmt::Debug for CreateBackupPlanAssociationRequest {
         );
         debug_struct.field("backup_plan_association", &self.backup_plan_association);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8318,7 +8292,6 @@ impl std::fmt::Debug for ListBackupPlanAssociationsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8545,7 +8518,6 @@ impl std::fmt::Debug for ListBackupPlanAssociationsResponse {
         debug_struct.field("backup_plan_associations", &self.backup_plan_associations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8688,7 +8660,6 @@ impl std::fmt::Debug for GetBackupPlanAssociationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupPlanAssociationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8869,7 +8840,6 @@ impl std::fmt::Debug for DeleteBackupPlanAssociationRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupPlanAssociationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9076,7 +9046,6 @@ impl std::fmt::Debug for TriggerBackupRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("rule_id", &self.rule_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9775,7 +9744,6 @@ impl std::fmt::Debug for BackupVault {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("access_restriction", &self.access_restriction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10727,7 +10695,6 @@ impl std::fmt::Debug for DataSource {
         debug_struct.field("config_state", &self.config_state);
         debug_struct.field("backup_config_info", &self.backup_config_info);
         debug_struct.field("source_resource", &self.source_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11270,7 +11237,6 @@ impl std::fmt::Debug for BackupConfigInfo {
         );
         debug_struct.field("last_backup_error", &self.last_backup_error);
         debug_struct.field("backup_config", &self.backup_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11666,7 +11632,6 @@ impl std::fmt::Debug for GcpBackupConfig {
         debug_struct.field("backup_plan_description", &self.backup_plan_description);
         debug_struct.field("backup_plan_association", &self.backup_plan_association);
         debug_struct.field("backup_plan_rules", &self.backup_plan_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12009,7 +11974,6 @@ impl std::fmt::Debug for BackupApplianceBackupConfig {
         debug_struct.field("host_name", &self.host_name);
         debug_struct.field("slt_name", &self.slt_name);
         debug_struct.field("slp_name", &self.slp_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12291,7 +12255,6 @@ impl std::fmt::Debug for DataSourceGcpResource {
         debug_struct.field("location", &self.location);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("gcp_resource_properties", &self.gcp_resource_properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12667,7 +12630,6 @@ impl std::fmt::Debug for DataSourceBackupApplianceApplication {
         debug_struct.field("application_id", &self.application_id);
         debug_struct.field("hostname", &self.hostname);
         debug_struct.field("host_id", &self.host_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12811,7 +12773,6 @@ impl std::fmt::Debug for ServiceLockInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceLockInfo");
         debug_struct.field("operation", &self.operation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13217,7 +13178,6 @@ impl std::fmt::Debug for BackupApplianceLockInfo {
         debug_struct.field("backup_appliance_name", &self.backup_appliance_name);
         debug_struct.field("lock_reason", &self.lock_reason);
         debug_struct.field("lock_source", &self.lock_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13529,7 +13489,6 @@ impl std::fmt::Debug for BackupLock {
         let mut debug_struct = f.debug_struct("BackupLock");
         debug_struct.field("lock_until_time", &self.lock_until_time);
         debug_struct.field("client_lock_info", &self.client_lock_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14364,7 +14323,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("resource_size_bytes", &self.resource_size_bytes);
         debug_struct.field("backup_properties", &self.backup_properties);
         debug_struct.field("plan_info", &self.plan_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14549,7 +14507,6 @@ pub mod backup {
             let mut debug_struct = f.debug_struct("GCPBackupPlanInfo");
             debug_struct.field("backup_plan", &self.backup_plan);
             debug_struct.field("backup_plan_rule_id", &self.backup_plan_rule_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15122,7 +15079,6 @@ impl std::fmt::Debug for CreateBackupVaultRequest {
         debug_struct.field("backup_vault", &self.backup_vault);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15417,7 +15373,6 @@ impl std::fmt::Debug for ListBackupVaultsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15638,7 +15593,6 @@ impl std::fmt::Debug for ListBackupVaultsResponse {
         debug_struct.field("backup_vaults", &self.backup_vaults);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15907,7 +15861,6 @@ impl std::fmt::Debug for FetchUsableBackupVaultsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16128,7 +16081,6 @@ impl std::fmt::Debug for FetchUsableBackupVaultsResponse {
         debug_struct.field("backup_vaults", &self.backup_vaults);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16297,7 +16249,6 @@ impl std::fmt::Debug for GetBackupVaultRequest {
         let mut debug_struct = f.debug_struct("GetBackupVaultRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16583,7 +16534,6 @@ impl std::fmt::Debug for UpdateBackupVaultRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16907,7 +16857,6 @@ impl std::fmt::Debug for DeleteBackupVaultRequest {
             "ignore_backup_plan_references",
             &self.ignore_backup_plan_references,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17176,7 +17125,6 @@ impl std::fmt::Debug for ListDataSourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17397,7 +17345,6 @@ impl std::fmt::Debug for ListDataSourcesResponse {
         debug_struct.field("data_sources", &self.data_sources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17540,7 +17487,6 @@ impl std::fmt::Debug for GetDataSourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataSourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17799,7 +17745,6 @@ impl std::fmt::Debug for UpdateDataSourceRequest {
         debug_struct.field("data_source", &self.data_source);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18094,7 +18039,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18314,7 +18258,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18483,7 +18426,6 @@ impl std::fmt::Debug for GetBackupRequest {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18715,7 +18657,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("backup", &self.backup);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18895,7 +18836,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19236,7 +19176,6 @@ impl std::fmt::Debug for RestoreBackupRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("target_environment", &self.target_environment);
         debug_struct.field("instance_properties", &self.instance_properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19417,7 +19356,6 @@ impl std::fmt::Debug for RestoreBackupResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestoreBackupResponse");
         debug_struct.field("target_resource", &self.target_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19607,7 +19545,6 @@ impl std::fmt::Debug for TargetResource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TargetResource");
         debug_struct.field("target_resource_info", &self.target_resource_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19818,7 +19755,6 @@ impl std::fmt::Debug for GcpResource {
         debug_struct.field("gcp_resourcename", &self.gcp_resourcename);
         debug_struct.field("location", &self.location);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20109,7 +20045,6 @@ impl std::fmt::Debug for BackupApplianceBackupProperties {
         debug_struct.field("finalize_time", &self.finalize_time);
         debug_struct.field("recovery_range_start_time", &self.recovery_range_start_time);
         debug_struct.field("recovery_range_end_time", &self.recovery_range_end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20755,7 +20690,6 @@ impl std::fmt::Debug for ComputeInstanceBackupProperties {
         );
         debug_struct.field("source_instance", &self.source_instance);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21822,7 +21756,6 @@ impl std::fmt::Debug for ComputeInstanceRestoreProperties {
         debug_struct.field("scheduling", &self.scheduling);
         debug_struct.field("service_accounts", &self.service_accounts);
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22147,7 +22080,6 @@ impl std::fmt::Debug for ComputeInstanceTargetEnvironment {
         let mut debug_struct = f.debug_struct("ComputeInstanceTargetEnvironment");
         debug_struct.field("project", &self.project);
         debug_struct.field("zone", &self.zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22431,7 +22363,6 @@ impl std::fmt::Debug for ComputeInstanceDataSourceProperties {
         debug_struct.field("machine_type", &self.machine_type);
         debug_struct.field("total_disk_count", &self.total_disk_count);
         debug_struct.field("total_disk_size_gb", &self.total_disk_size_gb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22756,7 +22687,6 @@ impl std::fmt::Debug for AdvancedMachineFeatures {
         debug_struct.field("threads_per_core", &self.threads_per_core);
         debug_struct.field("visible_core_count", &self.visible_core_count);
         debug_struct.field("enable_uefi_networking", &self.enable_uefi_networking);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22921,7 +22851,6 @@ impl std::fmt::Debug for ConfidentialInstanceConfig {
             "enable_confidential_compute",
             &self.enable_confidential_compute,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23075,7 +23004,6 @@ impl std::fmt::Debug for DisplayDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisplayDevice");
         debug_struct.field("enable_display", &self.enable_display);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23290,7 +23218,6 @@ impl std::fmt::Debug for AcceleratorConfig {
         let mut debug_struct = f.debug_struct("AcceleratorConfig");
         debug_struct.field("accelerator_type", &self.accelerator_type);
         debug_struct.field("accelerator_count", &self.accelerator_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23611,7 +23538,6 @@ impl std::fmt::Debug for CustomerEncryptionKey {
         let mut debug_struct = f.debug_struct("CustomerEncryptionKey");
         debug_struct.field("kms_key_service_account", &self.kms_key_service_account);
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23825,7 +23751,6 @@ impl std::fmt::Debug for Entry {
         let mut debug_struct = f.debug_struct("Entry");
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23971,7 +23896,6 @@ impl std::fmt::Debug for Metadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Metadata");
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24653,7 +24577,6 @@ impl std::fmt::Debug for NetworkInterface {
         debug_struct.field("queue_count", &self.queue_count);
         debug_struct.field("nic_type", &self.nic_type);
         debug_struct.field("network_attachment", &self.network_attachment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25225,7 +25148,6 @@ impl std::fmt::Debug for NetworkPerformanceConfig {
             "total_egress_bandwidth_tier",
             &self.total_egress_bandwidth_tier,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25811,7 +25733,6 @@ impl std::fmt::Debug for AccessConfig {
         debug_struct.field("set_public_ptr", &self.set_public_ptr);
         debug_struct.field("public_ptr_domain_name", &self.public_ptr_domain_name);
         debug_struct.field("network_tier", &self.network_tier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26276,7 +26197,6 @@ impl std::fmt::Debug for AliasIpRange {
         let mut debug_struct = f.debug_struct("AliasIpRange");
         debug_struct.field("ip_cidr_range", &self.ip_cidr_range);
         debug_struct.field("subnetwork_range_name", &self.subnetwork_range_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26430,7 +26350,6 @@ impl std::fmt::Debug for InstanceParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstanceParams");
         debug_struct.field("resource_manager_tags", &self.resource_manager_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26649,7 +26568,6 @@ impl std::fmt::Debug for AllocationAffinity {
         debug_struct.field("consume_allocation_type", &self.consume_allocation_type);
         debug_struct.field("key", &self.key);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27253,7 +27171,6 @@ impl std::fmt::Debug for Scheduling {
             "local_ssd_recovery_timeout",
             &self.local_ssd_recovery_timeout,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27480,7 +27397,6 @@ pub mod scheduling {
             debug_struct.field("key", &self.key);
             debug_struct.field("operator", &self.operator);
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28259,7 +28175,6 @@ impl std::fmt::Debug for SchedulingDuration {
         let mut debug_struct = f.debug_struct("SchedulingDuration");
         debug_struct.field("seconds", &self.seconds);
         debug_struct.field("nanos", &self.nanos);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28440,7 +28355,6 @@ impl std::fmt::Debug for ServiceAccount {
         let mut debug_struct = f.debug_struct("ServiceAccount");
         debug_struct.field("email", &self.email);
         debug_struct.field("scopes", &self.scopes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28586,7 +28500,6 @@ impl std::fmt::Debug for Tags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Tags");
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29368,7 +29281,6 @@ impl std::fmt::Debug for AttachedDisk {
         debug_struct.field("saved_state", &self.saved_state);
         debug_struct.field("disk_type", &self.disk_type);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29561,7 +29473,6 @@ pub mod attached_disk {
             let mut debug_struct = f.debug_struct("InitializeParams");
             debug_struct.field("disk_name", &self.disk_name);
             debug_struct.field("replica_zones", &self.replica_zones);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30264,7 +30175,6 @@ impl std::fmt::Debug for GuestOsFeature {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GuestOsFeature");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -350,7 +350,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -464,7 +463,6 @@ impl serde::ser::Serialize for ResetInstanceResponse {
 impl std::fmt::Debug for ResetInstanceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetInstanceResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1158,7 +1156,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("login_info", &self.login_info);
         debug_struct.field("workload_profile", &self.workload_profile);
         debug_struct.field("firmware_version", &self.firmware_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1473,7 +1470,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1711,7 +1707,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1924,7 +1919,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2121,7 +2115,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("UpdateInstanceRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2290,7 +2283,6 @@ impl std::fmt::Debug for RenameInstanceRequest {
         let mut debug_struct = f.debug_struct("RenameInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("new_instance_id", &self.new_instance_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2432,7 +2424,6 @@ impl std::fmt::Debug for ResetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2574,7 +2565,6 @@ impl std::fmt::Debug for StartInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2688,7 +2678,6 @@ impl serde::ser::Serialize for StartInstanceResponse {
 impl std::fmt::Debug for StartInstanceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartInstanceResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2830,7 +2819,6 @@ impl std::fmt::Debug for StopInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2944,7 +2932,6 @@ impl serde::ser::Serialize for StopInstanceResponse {
 impl std::fmt::Debug for StopInstanceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopInstanceResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3087,7 +3074,6 @@ impl std::fmt::Debug for EnableInteractiveSerialConsoleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableInteractiveSerialConsoleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3202,7 +3188,6 @@ impl serde::ser::Serialize for EnableInteractiveSerialConsoleResponse {
 impl std::fmt::Debug for EnableInteractiveSerialConsoleResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableInteractiveSerialConsoleResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3345,7 +3330,6 @@ impl std::fmt::Debug for DisableInteractiveSerialConsoleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableInteractiveSerialConsoleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3460,7 +3444,6 @@ impl serde::ser::Serialize for DisableInteractiveSerialConsoleResponse {
 impl std::fmt::Debug for DisableInteractiveSerialConsoleResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableInteractiveSerialConsoleResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3653,7 +3636,6 @@ impl std::fmt::Debug for DetachLunRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("lun", &self.lun);
         debug_struct.field("skip_reboot", &self.skip_reboot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3867,7 +3849,6 @@ impl std::fmt::Debug for ServerNetworkTemplate {
         debug_struct.field("name", &self.name);
         debug_struct.field("applicable_instance_types", &self.applicable_instance_types);
         debug_struct.field("logical_interfaces", &self.logical_interfaces);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4076,7 +4057,6 @@ pub mod server_network_template {
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("required", &self.required);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4679,7 +4659,6 @@ impl std::fmt::Debug for Lun {
         debug_struct.field("wwid", &self.wwid);
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("instances", &self.instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5237,7 +5216,6 @@ impl std::fmt::Debug for GetLunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5450,7 +5428,6 @@ impl std::fmt::Debug for ListLunsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5663,7 +5640,6 @@ impl std::fmt::Debug for ListLunsResponse {
         debug_struct.field("luns", &self.luns);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5805,7 +5781,6 @@ impl std::fmt::Debug for EvictLunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EvictLunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6374,7 +6349,6 @@ impl std::fmt::Debug for Network {
         debug_struct.field("mount_points", &self.mount_points);
         debug_struct.field("jumbo_frames_enabled", &self.jumbo_frames_enabled);
         debug_struct.field("gateway_ip", &self.gateway_ip);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6856,7 +6830,6 @@ impl std::fmt::Debug for NetworkAddressReservation {
         debug_struct.field("start_address", &self.start_address);
         debug_struct.field("end_address", &self.end_address);
         debug_struct.field("note", &self.note);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7097,7 +7070,6 @@ impl std::fmt::Debug for Vrf {
         debug_struct.field("state", &self.state);
         debug_struct.field("qos_policy", &self.qos_policy);
         debug_struct.field("vlan_attachments", &self.vlan_attachments);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7267,7 +7239,6 @@ pub mod vrf {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QosPolicy");
             debug_struct.field("bandwidth_gbps", &self.bandwidth_gbps);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7607,7 +7578,6 @@ pub mod vrf {
             debug_struct.field("qos_policy", &self.qos_policy);
             debug_struct.field("id", &self.id);
             debug_struct.field("interconnect_attachment", &self.interconnect_attachment);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7977,7 +7947,6 @@ impl std::fmt::Debug for LogicalInterface {
         );
         debug_struct.field("name", &self.name);
         debug_struct.field("interface_index", &self.interface_index);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8235,7 +8204,6 @@ pub mod logical_interface {
             debug_struct.field("default_gateway", &self.default_gateway);
             debug_struct.field("network_type", &self.network_type);
             debug_struct.field("id", &self.id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8378,7 +8346,6 @@ impl std::fmt::Debug for GetNetworkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNetworkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8616,7 +8583,6 @@ impl std::fmt::Debug for ListNetworksRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8829,7 +8795,6 @@ impl std::fmt::Debug for ListNetworksResponse {
         debug_struct.field("networks", &self.networks);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9024,7 +8989,6 @@ impl std::fmt::Debug for UpdateNetworkRequest {
         let mut debug_struct = f.debug_struct("UpdateNetworkRequest");
         debug_struct.field("network", &self.network);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9206,7 +9170,6 @@ impl std::fmt::Debug for NetworkUsage {
         let mut debug_struct = f.debug_struct("NetworkUsage");
         debug_struct.field("network", &self.network);
         debug_struct.field("used_ips", &self.used_ips);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9348,7 +9311,6 @@ impl std::fmt::Debug for ListNetworkUsageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListNetworkUsageRequest");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9493,7 +9455,6 @@ impl std::fmt::Debug for ListNetworkUsageResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListNetworkUsageResponse");
         debug_struct.field("networks", &self.networks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9716,7 +9677,6 @@ impl std::fmt::Debug for NetworkMountPoint {
         debug_struct.field("logical_interface", &self.logical_interface);
         debug_struct.field("default_gateway", &self.default_gateway);
         debug_struct.field("ip_address", &self.ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9885,7 +9845,6 @@ impl std::fmt::Debug for RenameNetworkRequest {
         let mut debug_struct = f.debug_struct("RenameNetworkRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("new_network_id", &self.new_network_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10276,7 +10235,6 @@ impl std::fmt::Debug for NfsShare {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("requested_size_gib", &self.requested_size_gib);
         debug_struct.field("storage_type", &self.storage_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10623,7 +10581,6 @@ pub mod nfs_share {
             debug_struct.field("allow_suid", &self.allow_suid);
             debug_struct.field("no_root_squash", &self.no_root_squash);
             debug_struct.field("nfs_path", &self.nfs_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11176,7 +11133,6 @@ impl std::fmt::Debug for GetNfsShareRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNfsShareRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11414,7 +11370,6 @@ impl std::fmt::Debug for ListNfsSharesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11628,7 +11583,6 @@ impl std::fmt::Debug for ListNfsSharesResponse {
         debug_struct.field("nfs_shares", &self.nfs_shares);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11825,7 +11779,6 @@ impl std::fmt::Debug for UpdateNfsShareRequest {
         let mut debug_struct = f.debug_struct("UpdateNfsShareRequest");
         debug_struct.field("nfs_share", &self.nfs_share);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11994,7 +11947,6 @@ impl std::fmt::Debug for RenameNfsShareRequest {
         let mut debug_struct = f.debug_struct("RenameNfsShareRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("new_nfsshare_id", &self.new_nfsshare_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12173,7 +12125,6 @@ impl std::fmt::Debug for CreateNfsShareRequest {
         let mut debug_struct = f.debug_struct("CreateNfsShareRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("nfs_share", &self.nfs_share);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12315,7 +12266,6 @@ impl std::fmt::Debug for DeleteNfsShareRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteNfsShareRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12581,7 +12531,6 @@ impl std::fmt::Debug for OSImage {
             "supported_network_templates",
             &self.supported_network_templates,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12796,7 +12745,6 @@ impl std::fmt::Debug for ListOSImagesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12983,7 +12931,6 @@ impl std::fmt::Debug for ListOSImagesResponse {
         let mut debug_struct = f.debug_struct("ListOSImagesResponse");
         debug_struct.field("os_images", &self.os_images);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13496,7 +13443,6 @@ impl std::fmt::Debug for ProvisioningConfig {
         debug_struct.field("vpc_sc_enabled", &self.vpc_sc_enabled);
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("custom_id", &self.custom_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13878,7 +13824,6 @@ impl std::fmt::Debug for SubmitProvisioningConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("provisioning_config", &self.provisioning_config);
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14032,7 +13977,6 @@ impl std::fmt::Debug for SubmitProvisioningConfigResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SubmitProvisioningConfigResponse");
         debug_struct.field("provisioning_config", &self.provisioning_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14599,7 +14543,6 @@ impl std::fmt::Debug for ProvisioningQuota {
         debug_struct.field("available_count", &self.available_count);
         debug_struct.field("quota", &self.quota);
         debug_struct.field("availability", &self.availability);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14979,7 +14922,6 @@ impl std::fmt::Debug for ListProvisioningQuotasRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15170,7 +15112,6 @@ impl std::fmt::Debug for ListProvisioningQuotasResponse {
         let mut debug_struct = f.debug_struct("ListProvisioningQuotasResponse");
         debug_struct.field("provisioning_quotas", &self.provisioning_quotas);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15684,7 +15625,6 @@ impl std::fmt::Debug for InstanceConfig {
         debug_struct.field("network_template", &self.network_template);
         debug_struct.field("logical_interfaces", &self.logical_interfaces);
         debug_struct.field("ssh_key_names", &self.ssh_key_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15889,7 +15829,6 @@ pub mod instance_config {
             debug_struct.field("network_id", &self.network_id);
             debug_struct.field("address", &self.address);
             debug_struct.field("existing_network_id", &self.existing_network_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16493,7 +16432,6 @@ impl std::fmt::Debug for VolumeConfig {
         debug_struct.field("user_note", &self.user_note);
         debug_struct.field("gcp_service", &self.gcp_service);
         debug_struct.field("performance_tier", &self.performance_tier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16705,7 +16643,6 @@ pub mod volume_config {
             let mut debug_struct = f.debug_struct("LunRange");
             debug_struct.field("quantity", &self.quantity);
             debug_struct.field("size_gb", &self.size_gb);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17082,7 +17019,6 @@ pub mod volume_config {
             debug_struct.field("allow_suid", &self.allow_suid);
             debug_struct.field("allow_dev", &self.allow_dev);
             debug_struct.field("client", &self.client);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17913,7 +17849,6 @@ impl std::fmt::Debug for NetworkConfig {
         debug_struct.field("gcp_service", &self.gcp_service);
         debug_struct.field("vlan_same_project", &self.vlan_same_project);
         debug_struct.field("jumbo_frames_enabled", &self.jumbo_frames_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18089,7 +18024,6 @@ pub mod network_config {
             let mut debug_struct = f.debug_struct("IntakeVlanAttachment");
             debug_struct.field("id", &self.id);
             debug_struct.field("pairing_key", &self.pairing_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18785,7 +18719,6 @@ impl std::fmt::Debug for InstanceQuota {
         debug_struct.field("gcp_service", &self.gcp_service);
         debug_struct.field("location", &self.location);
         debug_struct.field("available_machine_count", &self.available_machine_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18927,7 +18860,6 @@ impl std::fmt::Debug for GetProvisioningConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProvisioningConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19133,7 +19065,6 @@ impl std::fmt::Debug for CreateProvisioningConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("provisioning_config", &self.provisioning_config);
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19350,7 +19281,6 @@ impl std::fmt::Debug for UpdateProvisioningConfigRequest {
         debug_struct.field("provisioning_config", &self.provisioning_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19519,7 +19449,6 @@ impl std::fmt::Debug for SSHKey {
         let mut debug_struct = f.debug_struct("SSHKey");
         debug_struct.field("name", &self.name);
         debug_struct.field("public_key", &self.public_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19732,7 +19661,6 @@ impl std::fmt::Debug for ListSSHKeysRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19919,7 +19847,6 @@ impl std::fmt::Debug for ListSSHKeysResponse {
         let mut debug_struct = f.debug_struct("ListSSHKeysResponse");
         debug_struct.field("ssh_keys", &self.ssh_keys);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20128,7 +20055,6 @@ impl std::fmt::Debug for CreateSSHKeyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("ssh_key", &self.ssh_key);
         debug_struct.field("ssh_key_id", &self.ssh_key_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20271,7 +20197,6 @@ impl std::fmt::Debug for DeleteSSHKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSSHKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21234,7 +21159,6 @@ impl std::fmt::Debug for Volume {
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("instances", &self.instances);
         debug_struct.field("attached", &self.attached);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21575,7 +21499,6 @@ pub mod volume {
                 &self.reserved_space_remaining_gib,
             );
             debug_struct.field("reserved_space_percent", &self.reserved_space_percent);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22414,7 +22337,6 @@ impl std::fmt::Debug for GetVolumeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVolumeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22652,7 +22574,6 @@ impl std::fmt::Debug for ListVolumesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22865,7 +22786,6 @@ impl std::fmt::Debug for ListVolumesResponse {
         debug_struct.field("volumes", &self.volumes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23060,7 +22980,6 @@ impl std::fmt::Debug for UpdateVolumeRequest {
         let mut debug_struct = f.debug_struct("UpdateVolumeRequest");
         debug_struct.field("volume", &self.volume);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23229,7 +23148,6 @@ impl std::fmt::Debug for RenameVolumeRequest {
         let mut debug_struct = f.debug_struct("RenameVolumeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("new_volume_id", &self.new_volume_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23371,7 +23289,6 @@ impl std::fmt::Debug for EvictVolumeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EvictVolumeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23557,7 +23474,6 @@ impl std::fmt::Debug for ResizeVolumeRequest {
         let mut debug_struct = f.debug_struct("ResizeVolumeRequest");
         debug_struct.field("volume", &self.volume);
         debug_struct.field("size_gib", &self.size_gib);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23843,7 +23759,6 @@ impl std::fmt::Debug for VolumeSnapshot {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("storage_volume", &self.storage_volume);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24123,7 +24038,6 @@ impl std::fmt::Debug for GetVolumeSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVolumeSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24336,7 +24250,6 @@ impl std::fmt::Debug for ListVolumeSnapshotsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24554,7 +24467,6 @@ impl std::fmt::Debug for ListVolumeSnapshotsResponse {
         debug_struct.field("volume_snapshots", &self.volume_snapshots);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24696,7 +24608,6 @@ impl std::fmt::Debug for DeleteVolumeSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteVolumeSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24876,7 +24787,6 @@ impl std::fmt::Debug for CreateVolumeSnapshotRequest {
         let mut debug_struct = f.debug_struct("CreateVolumeSnapshotRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("volume_snapshot", &self.volume_snapshot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25020,7 +24930,6 @@ impl std::fmt::Debug for RestoreVolumeSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestoreVolumeSnapshotRequest");
         debug_struct.field("volume_snapshot", &self.volume_snapshot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -299,7 +299,6 @@ impl std::fmt::Debug for ListAppConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -514,7 +513,6 @@ impl std::fmt::Debug for ListAppConnectionsResponse {
         debug_struct.field("app_connections", &self.app_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -657,7 +655,6 @@ impl std::fmt::Debug for GetAppConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAppConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -935,7 +932,6 @@ impl std::fmt::Debug for CreateAppConnectionRequest {
         debug_struct.field("app_connection", &self.app_connection);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1225,7 +1221,6 @@ impl std::fmt::Debug for UpdateAppConnectionRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1433,7 +1428,6 @@ impl std::fmt::Debug for DeleteAppConnectionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1683,7 +1677,6 @@ impl std::fmt::Debug for ResolveAppConnectionsRequest {
         debug_struct.field("app_connector_id", &self.app_connector_id);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1899,7 +1892,6 @@ impl std::fmt::Debug for ResolveAppConnectionsResponse {
         debug_struct.field("app_connection_details", &self.app_connection_details);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2092,7 +2084,6 @@ pub mod resolve_app_connections_response {
             let mut debug_struct = f.debug_struct("AppConnectionDetails");
             debug_struct.field("app_connection", &self.app_connection);
             debug_struct.field("recent_mig_vms", &self.recent_mig_vms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2559,7 +2550,6 @@ impl std::fmt::Debug for AppConnection {
         debug_struct.field("connectors", &self.connectors);
         debug_struct.field("state", &self.state);
         debug_struct.field("gateway", &self.gateway);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2752,7 +2742,6 @@ pub mod app_connection {
             let mut debug_struct = f.debug_struct("ApplicationEndpoint");
             debug_struct.field("host", &self.host);
             debug_struct.field("port", &self.port);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3001,7 +2990,6 @@ pub mod app_connection {
             debug_struct.field("uri", &self.uri);
             debug_struct.field("ingress_port", &self.ingress_port);
             debug_struct.field("app_gateway", &self.app_gateway);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3742,7 +3730,6 @@ impl std::fmt::Debug for AppConnectionOperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -303,7 +303,6 @@ impl std::fmt::Debug for AppConnectorInstanceConfig {
         debug_struct.field("instance_config", &self.instance_config);
         debug_struct.field("notification_config", &self.notification_config);
         debug_struct.field("image_config", &self.image_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -496,7 +495,6 @@ impl std::fmt::Debug for NotificationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NotificationConfig");
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -650,7 +648,6 @@ pub mod notification_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudPubSubNotificationConfig");
             debug_struct.field("pubsub_subscription", &self.pubsub_subscription);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -831,7 +828,6 @@ impl std::fmt::Debug for ImageConfig {
         let mut debug_struct = f.debug_struct("ImageConfig");
         debug_struct.field("target_image", &self.target_image);
         debug_struct.field("stable_image", &self.stable_image);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1104,7 +1100,6 @@ impl std::fmt::Debug for ListAppConnectorsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1319,7 +1314,6 @@ impl std::fmt::Debug for ListAppConnectorsResponse {
         debug_struct.field("app_connectors", &self.app_connectors);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1462,7 +1456,6 @@ impl std::fmt::Debug for GetAppConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAppConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1740,7 +1733,6 @@ impl std::fmt::Debug for CreateAppConnectorRequest {
         debug_struct.field("app_connector", &self.app_connector);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2002,7 +1994,6 @@ impl std::fmt::Debug for UpdateAppConnectorRequest {
         debug_struct.field("app_connector", &self.app_connector);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2210,7 +2201,6 @@ impl std::fmt::Debug for DeleteAppConnectorRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2456,7 +2446,6 @@ impl std::fmt::Debug for ReportStatusRequest {
         debug_struct.field("resource_info", &self.resource_info);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2866,7 +2855,6 @@ impl std::fmt::Debug for AppConnector {
         debug_struct.field("state", &self.state);
         debug_struct.field("principal_info", &self.principal_info);
         debug_struct.field("resource_info", &self.resource_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3069,7 +3057,6 @@ pub mod app_connector {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PrincipalInfo");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3222,7 +3209,6 @@ pub mod app_connector {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ServiceAccount");
                 debug_struct.field("email", &self.email);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3712,7 +3698,6 @@ impl std::fmt::Debug for AppConnectorOperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3990,7 +3975,6 @@ impl std::fmt::Debug for ResourceInfo {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("time", &self.time);
         debug_struct.field("sub", &self.sub);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -299,7 +299,6 @@ impl std::fmt::Debug for ListAppGatewaysRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -514,7 +513,6 @@ impl std::fmt::Debug for ListAppGatewaysResponse {
         debug_struct.field("app_gateways", &self.app_gateways);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -657,7 +655,6 @@ impl std::fmt::Debug for GetAppGatewayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAppGatewayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -932,7 +929,6 @@ impl std::fmt::Debug for CreateAppGatewayRequest {
         debug_struct.field("app_gateway", &self.app_gateway);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1140,7 +1136,6 @@ impl std::fmt::Debug for DeleteAppGatewayRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1589,7 +1584,6 @@ impl std::fmt::Debug for AppGateway {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("allocated_connections", &self.allocated_connections);
         debug_struct.field("host_type", &self.host_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1785,7 +1779,6 @@ pub mod app_gateway {
             let mut debug_struct = f.debug_struct("AllocatedConnection");
             debug_struct.field("psc_uri", &self.psc_uri);
             debug_struct.field("ingress_port", &self.ingress_port);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2517,7 +2510,6 @@ impl std::fmt::Debug for AppGatewayOperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -377,7 +377,6 @@ impl std::fmt::Debug for ClientConnectorService {
         debug_struct.field("ingress", &self.ingress);
         debug_struct.field("egress", &self.egress);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -583,7 +582,6 @@ pub mod client_connector_service {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Ingress");
             debug_struct.field("ingress_config", &self.ingress_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -781,7 +779,6 @@ pub mod client_connector_service {
                 let mut debug_struct = f.debug_struct("Config");
                 debug_struct.field("transport_protocol", &self.transport_protocol);
                 debug_struct.field("destination_routes", &self.destination_routes);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -981,7 +978,6 @@ pub mod client_connector_service {
                     let mut debug_struct = f.debug_struct("DestinationRoute");
                     debug_struct.field("address", &self.address);
                     debug_struct.field("netmask", &self.netmask);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -1322,7 +1318,6 @@ pub mod client_connector_service {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Egress");
             debug_struct.field("destination_type", &self.destination_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1481,7 +1476,6 @@ pub mod client_connector_service {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("PeeredVpc");
                 debug_struct.field("network_vpc", &self.network_vpc);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1916,7 +1910,6 @@ impl std::fmt::Debug for ListClientConnectorServicesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2138,7 +2131,6 @@ impl std::fmt::Debug for ListClientConnectorServicesResponse {
         debug_struct.field("client_connector_services", &self.client_connector_services);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2280,7 +2272,6 @@ impl std::fmt::Debug for GetClientConnectorServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClientConnectorServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2572,7 +2563,6 @@ impl std::fmt::Debug for CreateClientConnectorServiceRequest {
         debug_struct.field("client_connector_service", &self.client_connector_service);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2862,7 +2852,6 @@ impl std::fmt::Debug for UpdateClientConnectorServiceRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3069,7 +3058,6 @@ impl std::fmt::Debug for DeleteClientConnectorServiceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3395,7 +3383,6 @@ impl std::fmt::Debug for ClientConnectorServiceOperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -326,7 +326,6 @@ impl std::fmt::Debug for ClientGateway {
         debug_struct.field("state", &self.state);
         debug_struct.field("id", &self.id);
         debug_struct.field("client_connector_service", &self.client_connector_service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -757,7 +756,6 @@ impl std::fmt::Debug for ListClientGatewaysRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -971,7 +969,6 @@ impl std::fmt::Debug for ListClientGatewaysResponse {
         debug_struct.field("client_gateways", &self.client_gateways);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1113,7 +1110,6 @@ impl std::fmt::Debug for GetClientGatewayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClientGatewayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1390,7 +1386,6 @@ impl std::fmt::Debug for CreateClientGatewayRequest {
         debug_struct.field("client_gateway", &self.client_gateway);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1597,7 +1592,6 @@ impl std::fmt::Debug for DeleteClientGatewayRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1922,7 +1916,6 @@ impl std::fmt::Debug for ClientGatewayOperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -506,7 +506,6 @@ impl std::fmt::Debug for DataExchange {
             "log_linked_dataset_query_user_email",
             &self.log_linked_dataset_query_user_email,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -761,7 +760,6 @@ impl std::fmt::Debug for SharingEnvironmentConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SharingEnvironmentConfig");
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -883,7 +881,6 @@ pub mod sharing_environment_config {
     impl std::fmt::Debug for DefaultExchangeConfig {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DefaultExchangeConfig");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1115,7 +1112,6 @@ pub mod sharing_environment_config {
                 "single_linked_dataset_per_cleanroom",
                 &self.single_linked_dataset_per_cleanroom,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1298,7 +1294,6 @@ impl std::fmt::Debug for DataProvider {
         let mut debug_struct = f.debug_struct("DataProvider");
         debug_struct.field("name", &self.name);
         debug_struct.field("primary_contact", &self.primary_contact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1467,7 +1462,6 @@ impl std::fmt::Debug for Publisher {
         let mut debug_struct = f.debug_struct("Publisher");
         debug_struct.field("name", &self.name);
         debug_struct.field("primary_contact", &self.primary_contact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1637,7 +1631,6 @@ impl std::fmt::Debug for DestinationDatasetReference {
         let mut debug_struct = f.debug_struct("DestinationDatasetReference");
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1931,7 +1924,6 @@ impl std::fmt::Debug for DestinationDataset {
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2085,7 +2077,6 @@ impl std::fmt::Debug for DestinationPubSubSubscription {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DestinationPubSubSubscription");
         debug_struct.field("pubsub_subscription", &self.pubsub_subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2918,7 +2909,6 @@ impl std::fmt::Debug for Listing {
             &self.allow_only_metadata_sharing,
         );
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3156,7 +3146,6 @@ pub mod listing {
             debug_struct.field("dataset", &self.dataset);
             debug_struct.field("selected_resources", &self.selected_resources);
             debug_struct.field("restricted_export_policy", &self.restricted_export_policy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3399,7 +3388,6 @@ pub mod listing {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("SelectedResource");
                 debug_struct.field("resource", &self.resource);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3682,7 +3670,6 @@ pub mod listing {
                     &self.restrict_direct_table_access,
                 );
                 debug_struct.field("restrict_query_result", &self.restrict_query_result);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3860,7 +3847,6 @@ pub mod listing {
             let mut debug_struct = f.debug_struct("PubSubTopicSource");
             debug_struct.field("topic", &self.topic);
             debug_struct.field("data_affinity_regions", &self.data_affinity_regions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4073,7 +4059,6 @@ pub mod listing {
                 &self.restrict_direct_table_access,
             );
             debug_struct.field("restrict_query_result", &self.restrict_query_result);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4237,7 +4222,6 @@ pub mod listing {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CommercialInfo");
             debug_struct.field("cloud_marketplace", &self.cloud_marketplace);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4443,7 +4427,6 @@ pub mod listing {
                 let mut debug_struct = f.debug_struct("GoogleCloudMarketplaceInfo");
                 debug_struct.field("service", &self.service);
                 debug_struct.field("commercial_state", &self.commercial_state);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5640,7 +5623,6 @@ impl std::fmt::Debug for Subscription {
         );
         debug_struct.field("destination_dataset", &self.destination_dataset);
         debug_struct.field("resource_name", &self.resource_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5915,7 +5897,6 @@ pub mod subscription {
             let mut debug_struct = f.debug_struct("LinkedResource");
             debug_struct.field("listing", &self.listing);
             debug_struct.field("reference", &self.reference);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6096,7 +6077,6 @@ pub mod subscription {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CommercialInfo");
             debug_struct.field("cloud_marketplace", &self.cloud_marketplace);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6249,7 +6229,6 @@ pub mod subscription {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("GoogleCloudMarketplaceInfo");
                 debug_struct.field("order", &self.order);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6618,7 +6597,6 @@ impl std::fmt::Debug for ListDataExchangesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6804,7 +6782,6 @@ impl std::fmt::Debug for ListDataExchangesResponse {
         let mut debug_struct = f.debug_struct("ListDataExchangesResponse");
         debug_struct.field("data_exchanges", &self.data_exchanges);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7020,7 +6997,6 @@ impl std::fmt::Debug for ListOrgDataExchangesRequest {
         debug_struct.field("organization", &self.organization);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7207,7 +7183,6 @@ impl std::fmt::Debug for ListOrgDataExchangesResponse {
         let mut debug_struct = f.debug_struct("ListOrgDataExchangesResponse");
         debug_struct.field("data_exchanges", &self.data_exchanges);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7350,7 +7325,6 @@ impl std::fmt::Debug for GetDataExchangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataExchangeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7561,7 +7535,6 @@ impl std::fmt::Debug for CreateDataExchangeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("data_exchange_id", &self.data_exchange_id);
         debug_struct.field("data_exchange", &self.data_exchange);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7754,7 +7727,6 @@ impl std::fmt::Debug for UpdateDataExchangeRequest {
         let mut debug_struct = f.debug_struct("UpdateDataExchangeRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("data_exchange", &self.data_exchange);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7897,7 +7869,6 @@ impl std::fmt::Debug for DeleteDataExchangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDataExchangeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8112,7 +8083,6 @@ impl std::fmt::Debug for ListListingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8297,7 +8267,6 @@ impl std::fmt::Debug for ListListingsResponse {
         let mut debug_struct = f.debug_struct("ListListingsResponse");
         debug_struct.field("listings", &self.listings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8440,7 +8409,6 @@ impl std::fmt::Debug for GetListingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetListingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8647,7 +8615,6 @@ impl std::fmt::Debug for CreateListingRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("listing_id", &self.listing_id);
         debug_struct.field("listing", &self.listing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8839,7 +8806,6 @@ impl std::fmt::Debug for UpdateListingRequest {
         let mut debug_struct = f.debug_struct("UpdateListingRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("listing", &self.listing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9010,7 +8976,6 @@ impl std::fmt::Debug for DeleteListingRequest {
         let mut debug_struct = f.debug_struct("DeleteListingRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("delete_commercial", &self.delete_commercial);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9289,7 +9254,6 @@ impl std::fmt::Debug for SubscribeListingRequest {
         let mut debug_struct = f.debug_struct("SubscribeListingRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9459,7 +9423,6 @@ impl std::fmt::Debug for SubscribeListingResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SubscribeListingResponse");
         debug_struct.field("subscription", &self.subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9720,7 +9683,6 @@ impl std::fmt::Debug for SubscribeDataExchangeRequest {
         debug_struct.field("destination_dataset", &self.destination_dataset);
         debug_struct.field("subscription", &self.subscription);
         debug_struct.field("subscriber_contact", &self.subscriber_contact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9873,7 +9835,6 @@ impl std::fmt::Debug for SubscribeDataExchangeResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SubscribeDataExchangeResponse");
         debug_struct.field("subscription", &self.subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10016,7 +9977,6 @@ impl std::fmt::Debug for RefreshSubscriptionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RefreshSubscriptionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10169,7 +10129,6 @@ impl std::fmt::Debug for RefreshSubscriptionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RefreshSubscriptionResponse");
         debug_struct.field("subscription", &self.subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10312,7 +10271,6 @@ impl std::fmt::Debug for GetSubscriptionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSubscriptionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10564,7 +10522,6 @@ impl std::fmt::Debug for ListSubscriptionsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10749,7 +10706,6 @@ impl std::fmt::Debug for ListSubscriptionsResponse {
         let mut debug_struct = f.debug_struct("ListSubscriptionsResponse");
         debug_struct.field("subscriptions", &self.subscriptions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11002,7 +10958,6 @@ impl std::fmt::Debug for ListSharedResourceSubscriptionsRequest {
         );
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11199,7 +11154,6 @@ impl std::fmt::Debug for ListSharedResourceSubscriptionsResponse {
             &self.shared_resource_subscriptions,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11370,7 +11324,6 @@ impl std::fmt::Debug for RevokeSubscriptionRequest {
         let mut debug_struct = f.debug_struct("RevokeSubscriptionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("revoke_commercial", &self.revoke_commercial);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11485,7 +11438,6 @@ impl serde::ser::Serialize for RevokeSubscriptionResponse {
 impl std::fmt::Debug for RevokeSubscriptionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RevokeSubscriptionResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11628,7 +11580,6 @@ impl std::fmt::Debug for DeleteSubscriptionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSubscriptionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11953,7 +11904,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12695,7 +12645,6 @@ impl std::fmt::Debug for PubSubSubscription {
             &self.enable_exactly_once_delivery,
         );
         debug_struct.field("message_transforms", &self.message_transforms);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12899,7 +12848,6 @@ impl std::fmt::Debug for RetryPolicy {
         let mut debug_struct = f.debug_struct("RetryPolicy");
         debug_struct.field("minimum_backoff", &self.minimum_backoff);
         debug_struct.field("maximum_backoff", &self.maximum_backoff);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13114,7 +13062,6 @@ impl std::fmt::Debug for DeadLetterPolicy {
         let mut debug_struct = f.debug_struct("DeadLetterPolicy");
         debug_struct.field("dead_letter_topic", &self.dead_letter_topic);
         debug_struct.field("max_delivery_attempts", &self.max_delivery_attempts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13272,7 +13219,6 @@ impl std::fmt::Debug for ExpirationPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExpirationPolicy");
         debug_struct.field("ttl", &self.ttl);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13681,7 +13627,6 @@ impl std::fmt::Debug for PushConfig {
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("authentication_method", &self.authentication_method);
         debug_struct.field("wrapper", &self.wrapper);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13872,7 +13817,6 @@ pub mod push_config {
             let mut debug_struct = f.debug_struct("OidcToken");
             debug_struct.field("service_account_email", &self.service_account_email);
             debug_struct.field("audience", &self.audience);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13991,7 +13935,6 @@ pub mod push_config {
     impl std::fmt::Debug for PubsubWrapper {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PubsubWrapper");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14139,7 +14082,6 @@ pub mod push_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NoWrapper");
             debug_struct.field("write_metadata", &self.write_metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14460,7 +14402,6 @@ impl std::fmt::Debug for BigQueryConfig {
         debug_struct.field("drop_unknown_fields", &self.drop_unknown_fields);
         debug_struct.field("use_table_schema", &self.use_table_schema);
         debug_struct.field("service_account_email", &self.service_account_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15000,7 +14941,6 @@ impl std::fmt::Debug for CloudStorageConfig {
         debug_struct.field("max_messages", &self.max_messages);
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("output_format", &self.output_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15124,7 +15064,6 @@ pub mod cloud_storage_config {
     impl std::fmt::Debug for TextConfig {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TextConfig");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15303,7 +15242,6 @@ pub mod cloud_storage_config {
             let mut debug_struct = f.debug_struct("AvroConfig");
             debug_struct.field("write_metadata", &self.write_metadata);
             debug_struct.field("use_topic_schema", &self.use_topic_schema);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15563,7 +15501,6 @@ impl std::fmt::Debug for MessageTransform {
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("transform", &self.transform);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15777,7 +15714,6 @@ impl std::fmt::Debug for JavaScriptUDF {
         let mut debug_struct = f.debug_struct("JavaScriptUDF");
         debug_struct.field("function_name", &self.function_name);
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -231,7 +231,6 @@ impl std::fmt::Debug for CreateConnectionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("connection_id", &self.connection_id);
         debug_struct.field("connection", &self.connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -377,7 +376,6 @@ impl std::fmt::Debug for GetConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -593,7 +591,6 @@ impl std::fmt::Debug for ListConnectionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -781,7 +778,6 @@ impl std::fmt::Debug for ListConnectionsResponse {
         let mut debug_struct = f.debug_struct("ListConnectionsResponse");
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("connections", &self.connections);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1000,7 +996,6 @@ impl std::fmt::Debug for UpdateConnectionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("connection", &self.connection);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1143,7 +1138,6 @@ impl std::fmt::Debug for DeleteConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1848,7 +1842,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("last_modified_time", &self.last_modified_time);
         debug_struct.field("has_credential", &self.has_credential);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2144,7 +2137,6 @@ impl std::fmt::Debug for CloudSqlProperties {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("credential", &self.credential);
         debug_struct.field("service_account_id", &self.service_account_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2449,7 +2441,6 @@ impl std::fmt::Debug for CloudSqlCredential {
         let mut debug_struct = f.debug_struct("CloudSqlCredential");
         debug_struct.field("username", &self.username);
         debug_struct.field("password", &self.password);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2765,7 +2756,6 @@ impl std::fmt::Debug for CloudSpannerProperties {
         debug_struct.field("use_serverless_analytics", &self.use_serverless_analytics);
         debug_struct.field("use_data_boost", &self.use_data_boost);
         debug_struct.field("database_role", &self.database_role);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3014,7 +3004,6 @@ impl std::fmt::Debug for AwsProperties {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsProperties");
         debug_struct.field("authentication_method", &self.authentication_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3234,7 +3223,6 @@ impl std::fmt::Debug for AwsCrossAccountRole {
         debug_struct.field("iam_role_id", &self.iam_role_id);
         debug_struct.field("iam_user_id", &self.iam_user_id);
         debug_struct.field("external_id", &self.external_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3405,7 +3393,6 @@ impl std::fmt::Debug for AwsAccessRole {
         let mut debug_struct = f.debug_struct("AwsAccessRole");
         debug_struct.field("iam_role_id", &self.iam_role_id);
         debug_struct.field("identity", &self.identity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3722,7 +3709,6 @@ impl std::fmt::Debug for AzureProperties {
             &self.federated_application_client_id,
         );
         debug_struct.field("identity", &self.identity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3879,7 +3865,6 @@ impl std::fmt::Debug for CloudResourceProperties {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudResourceProperties");
         debug_struct.field("service_account_id", &self.service_account_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4029,7 +4014,6 @@ impl std::fmt::Debug for MetastoreServiceConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MetastoreServiceConfig");
         debug_struct.field("metastore_service", &self.metastore_service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4180,7 +4164,6 @@ impl std::fmt::Debug for SparkHistoryServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SparkHistoryServerConfig");
         debug_struct.field("dataproc_cluster", &self.dataproc_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4423,7 +4406,6 @@ impl std::fmt::Debug for SparkProperties {
             "spark_history_server_config",
             &self.spark_history_server_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4619,7 +4601,6 @@ impl std::fmt::Debug for SalesforceDataCloudProperties {
         debug_struct.field("instance_uri", &self.instance_uri);
         debug_struct.field("identity", &self.identity);
         debug_struct.field("tenant_id", &self.tenant_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -204,7 +204,6 @@ impl std::fmt::Debug for CreateDataPolicyRequest {
         let mut debug_struct = f.debug_struct("CreateDataPolicyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("data_policy", &self.data_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -403,7 +402,6 @@ impl std::fmt::Debug for UpdateDataPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateDataPolicyRequest");
         debug_struct.field("data_policy", &self.data_policy);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -575,7 +573,6 @@ impl std::fmt::Debug for RenameDataPolicyRequest {
         let mut debug_struct = f.debug_struct("RenameDataPolicyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("new_data_policy_id", &self.new_data_policy_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -718,7 +715,6 @@ impl std::fmt::Debug for DeleteDataPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDataPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -861,7 +857,6 @@ impl std::fmt::Debug for GetDataPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1109,7 +1104,6 @@ impl std::fmt::Debug for ListDataPoliciesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1296,7 +1290,6 @@ impl std::fmt::Debug for ListDataPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListDataPoliciesResponse");
         debug_struct.field("data_policies", &self.data_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1635,7 +1628,6 @@ impl std::fmt::Debug for DataPolicy {
         debug_struct.field("data_policy_id", &self.data_policy_id);
         debug_struct.field("matching_label", &self.matching_label);
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2034,7 +2026,6 @@ impl std::fmt::Debug for DataMaskingPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataMaskingPolicy");
         debug_struct.field("masking_expression", &self.masking_expression);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/datapolicies/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v2/src/model.rs
@@ -232,7 +232,6 @@ impl std::fmt::Debug for CreateDataPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("data_policy_id", &self.data_policy_id);
         debug_struct.field("data_policy", &self.data_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -458,7 +457,6 @@ impl std::fmt::Debug for UpdateDataPolicyRequest {
         debug_struct.field("data_policy", &self.data_policy);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -640,7 +638,6 @@ impl std::fmt::Debug for AddGranteesRequest {
         let mut debug_struct = f.debug_struct("AddGranteesRequest");
         debug_struct.field("data_policy", &self.data_policy);
         debug_struct.field("grantees", &self.grantees);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -822,7 +819,6 @@ impl std::fmt::Debug for RemoveGranteesRequest {
         let mut debug_struct = f.debug_struct("RemoveGranteesRequest");
         debug_struct.field("data_policy", &self.data_policy);
         debug_struct.field("grantees", &self.grantees);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -965,7 +961,6 @@ impl std::fmt::Debug for DeleteDataPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDataPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1108,7 +1103,6 @@ impl std::fmt::Debug for GetDataPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1355,7 +1349,6 @@ impl std::fmt::Debug for ListDataPoliciesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1542,7 +1535,6 @@ impl std::fmt::Debug for ListDataPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListDataPoliciesResponse");
         debug_struct.field("data_policies", &self.data_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1945,7 +1937,6 @@ impl std::fmt::Debug for DataPolicy {
         debug_struct.field("grantees", &self.grantees);
         debug_struct.field("version", &self.version);
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2477,7 +2468,6 @@ impl std::fmt::Debug for DataMaskingPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataMaskingPolicy");
         debug_struct.field("masking_expression", &self.masking_expression);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -635,7 +635,6 @@ impl std::fmt::Debug for DataSourceParameter {
         debug_struct.field("immutable", &self.immutable);
         debug_struct.field("recurse", &self.recurse);
         debug_struct.field("deprecated", &self.deprecated);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1515,7 +1514,6 @@ impl std::fmt::Debug for DataSource {
         );
         debug_struct.field("manual_runs_disabled", &self.manual_runs_disabled);
         debug_struct.field("minimum_schedule_interval", &self.minimum_schedule_interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1944,7 +1942,6 @@ impl std::fmt::Debug for GetDataSourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataSourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2162,7 +2159,6 @@ impl std::fmt::Debug for ListDataSourcesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2351,7 +2347,6 @@ impl std::fmt::Debug for ListDataSourcesResponse {
         let mut debug_struct = f.debug_struct("ListDataSourcesResponse");
         debug_struct.field("data_sources", &self.data_sources);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2666,7 +2661,6 @@ impl std::fmt::Debug for CreateTransferConfigRequest {
         debug_struct.field("authorization_code", &self.authorization_code);
         debug_struct.field("version_info", &self.version_info);
         debug_struct.field("service_account_name", &self.service_account_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2985,7 +2979,6 @@ impl std::fmt::Debug for UpdateTransferConfigRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("version_info", &self.version_info);
         debug_struct.field("service_account_name", &self.service_account_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3129,7 +3122,6 @@ impl std::fmt::Debug for GetTransferConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTransferConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3274,7 +3266,6 @@ impl std::fmt::Debug for DeleteTransferConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTransferConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3419,7 +3410,6 @@ impl std::fmt::Debug for GetTransferRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTransferRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3564,7 +3554,6 @@ impl std::fmt::Debug for DeleteTransferRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTransferRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3811,7 +3800,6 @@ impl std::fmt::Debug for ListTransferConfigsRequest {
         debug_struct.field("data_source_ids", &self.data_source_ids);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4004,7 +3992,6 @@ impl std::fmt::Debug for ListTransferConfigsResponse {
         let mut debug_struct = f.debug_struct("ListTransferConfigsResponse");
         debug_struct.field("transfer_configs", &self.transfer_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4284,7 +4271,6 @@ impl std::fmt::Debug for ListTransferRunsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("run_attempt", &self.run_attempt);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4604,7 +4590,6 @@ impl std::fmt::Debug for ListTransferRunsResponse {
         let mut debug_struct = f.debug_struct("ListTransferRunsResponse");
         debug_struct.field("transfer_runs", &self.transfer_runs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4856,7 +4841,6 @@ impl std::fmt::Debug for ListTransferLogsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("message_types", &self.message_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5049,7 +5033,6 @@ impl std::fmt::Debug for ListTransferLogsResponse {
         let mut debug_struct = f.debug_struct("ListTransferLogsResponse");
         debug_struct.field("transfer_messages", &self.transfer_messages);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5198,7 +5181,6 @@ impl std::fmt::Debug for CheckValidCredsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CheckValidCredsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5341,7 +5323,6 @@ impl std::fmt::Debug for CheckValidCredsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CheckValidCredsResponse");
         debug_struct.field("has_valid_creds", &self.has_valid_creds);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5561,7 +5542,6 @@ impl std::fmt::Debug for ScheduleTransferRunsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5706,7 +5686,6 @@ impl std::fmt::Debug for ScheduleTransferRunsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScheduleTransferRunsResponse");
         debug_struct.field("runs", &self.runs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5981,7 +5960,6 @@ impl std::fmt::Debug for StartManualTransferRunsRequest {
         let mut debug_struct = f.debug_struct("StartManualTransferRunsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("time", &self.time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6187,7 +6165,6 @@ pub mod start_manual_transfer_runs_request {
             let mut debug_struct = f.debug_struct("TimeRange");
             debug_struct.field("start_time", &self.start_time);
             debug_struct.field("end_time", &self.end_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6352,7 +6329,6 @@ impl std::fmt::Debug for StartManualTransferRunsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartManualTransferRunsResponse");
         debug_struct.field("runs", &self.runs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6526,7 +6502,6 @@ impl std::fmt::Debug for EnrollDataSourcesRequest {
         let mut debug_struct = f.debug_struct("EnrollDataSourcesRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("data_source_ids", &self.data_source_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6700,7 +6675,6 @@ impl std::fmt::Debug for UnenrollDataSourcesRequest {
         let mut debug_struct = f.debug_struct("UnenrollDataSourcesRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("data_source_ids", &self.data_source_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6844,7 +6818,6 @@ impl std::fmt::Debug for EmailPreferences {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EmailPreferences");
         debug_struct.field("enable_failure_email", &self.enable_failure_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7071,7 +7044,6 @@ impl std::fmt::Debug for ScheduleOptions {
         debug_struct.field("disable_auto_scheduling", &self.disable_auto_scheduling);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7383,7 +7355,6 @@ impl std::fmt::Debug for ScheduleOptionsV2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScheduleOptionsV2");
         debug_struct.field("schedule", &self.schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7640,7 +7611,6 @@ impl std::fmt::Debug for TimeBasedSchedule {
         debug_struct.field("schedule", &self.schedule);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7754,7 +7724,6 @@ impl serde::ser::Serialize for ManualSchedule {
 impl std::fmt::Debug for ManualSchedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ManualSchedule");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7902,7 +7871,6 @@ impl std::fmt::Debug for EventDrivenSchedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EventDrivenSchedule");
         debug_struct.field("pubsub_subscription", &self.pubsub_subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8055,7 +8023,6 @@ impl std::fmt::Debug for UserInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserInfo");
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8930,7 +8897,6 @@ impl std::fmt::Debug for TransferConfig {
         debug_struct.field("encryption_configuration", &self.encryption_configuration);
         debug_struct.field("error", &self.error);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9098,7 +9064,6 @@ impl std::fmt::Debug for EncryptionConfiguration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptionConfiguration");
         debug_struct.field("kms_key_name", &self.kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9778,7 +9743,6 @@ impl std::fmt::Debug for TransferRun {
         debug_struct.field("notification_pubsub_topic", &self.notification_pubsub_topic);
         debug_struct.field("email_preferences", &self.email_preferences);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10002,7 +9966,6 @@ impl std::fmt::Debug for TransferMessage {
         debug_struct.field("message_time", &self.message_time);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("message_text", &self.message_text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -335,7 +335,6 @@ impl std::fmt::Debug for MigrationWorkflow {
         debug_struct.field("state", &self.state);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("last_update_time", &self.last_update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1200,7 +1199,6 @@ impl std::fmt::Debug for MigrationTask {
             &self.total_resource_error_count,
         );
         debug_struct.field("task_details", &self.task_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1827,7 +1825,6 @@ impl std::fmt::Debug for MigrationSubtask {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("last_update_time", &self.last_update_time);
         debug_struct.field("metrics", &self.metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2188,7 +2185,6 @@ impl std::fmt::Debug for MigrationTaskResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MigrationTaskResult");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2381,7 +2377,6 @@ impl std::fmt::Debug for TranslationTaskResult {
         let mut debug_struct = f.debug_struct("TranslationTaskResult");
         debug_struct.field("translated_literals", &self.translated_literals);
         debug_struct.field("report_log_messages", &self.report_log_messages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2610,7 +2605,6 @@ impl std::fmt::Debug for ResourceErrorDetail {
         debug_struct.field("resource_info", &self.resource_info);
         debug_struct.field("error_details", &self.error_details);
         debug_struct.field("error_count", &self.error_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2801,7 +2795,6 @@ impl std::fmt::Debug for ErrorDetail {
         let mut debug_struct = f.debug_struct("ErrorDetail");
         debug_struct.field("location", &self.location);
         debug_struct.field("error_info", &self.error_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3006,7 +2999,6 @@ impl std::fmt::Debug for ErrorLocation {
         let mut debug_struct = f.debug_struct("ErrorLocation");
         debug_struct.field("line", &self.line);
         debug_struct.field("column", &self.column);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3244,7 +3236,6 @@ impl std::fmt::Debug for TimeSeries {
         debug_struct.field("value_type", &self.value_type);
         debug_struct.field("metric_kind", &self.metric_kind);
         debug_struct.field("points", &self.points);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3441,7 +3432,6 @@ impl std::fmt::Debug for Point {
         let mut debug_struct = f.debug_struct("Point");
         debug_struct.field("interval", &self.interval);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3636,7 +3626,6 @@ impl std::fmt::Debug for TimeInterval {
         let mut debug_struct = f.debug_struct("TimeInterval");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4049,7 +4038,6 @@ impl std::fmt::Debug for TypedValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TypedValue");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4254,7 +4242,6 @@ impl std::fmt::Debug for CreateMigrationWorkflowRequest {
         let mut debug_struct = f.debug_struct("CreateMigrationWorkflowRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("migration_workflow", &self.migration_workflow);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4434,7 +4421,6 @@ impl std::fmt::Debug for GetMigrationWorkflowRequest {
         let mut debug_struct = f.debug_struct("GetMigrationWorkflowRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4689,7 +4675,6 @@ impl std::fmt::Debug for ListMigrationWorkflowsRequest {
         debug_struct.field("read_mask", &self.read_mask);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4880,7 +4865,6 @@ impl std::fmt::Debug for ListMigrationWorkflowsResponse {
         let mut debug_struct = f.debug_struct("ListMigrationWorkflowsResponse");
         debug_struct.field("migration_workflows", &self.migration_workflows);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5023,7 +5007,6 @@ impl std::fmt::Debug for DeleteMigrationWorkflowRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteMigrationWorkflowRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5166,7 +5149,6 @@ impl std::fmt::Debug for StartMigrationWorkflowRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartMigrationWorkflowRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5346,7 +5328,6 @@ impl std::fmt::Debug for GetMigrationSubtaskRequest {
         let mut debug_struct = f.debug_struct("GetMigrationSubtaskRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5628,7 +5609,6 @@ impl std::fmt::Debug for ListMigrationSubtasksRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5819,7 +5799,6 @@ impl std::fmt::Debug for ListMigrationSubtasksResponse {
         let mut debug_struct = f.debug_struct("ListMigrationSubtasksResponse");
         debug_struct.field("migration_subtasks", &self.migration_subtasks);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6321,7 +6300,6 @@ impl std::fmt::Debug for TranslationConfigDetails {
         debug_struct.field("source_location", &self.source_location);
         debug_struct.field("target_location", &self.target_location);
         debug_struct.field("output_name_mapping", &self.output_name_mapping);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7437,7 +7415,6 @@ impl std::fmt::Debug for Dialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Dialect");
         debug_struct.field("dialect_value", &self.dialect_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7597,7 +7574,6 @@ impl serde::ser::Serialize for BigQueryDialect {
 impl std::fmt::Debug for BigQueryDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7711,7 +7687,6 @@ impl serde::ser::Serialize for HiveQLDialect {
 impl std::fmt::Debug for HiveQLDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HiveQLDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7825,7 +7800,6 @@ impl serde::ser::Serialize for RedshiftDialect {
 impl std::fmt::Debug for RedshiftDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RedshiftDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7968,7 +7942,6 @@ impl std::fmt::Debug for TeradataDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TeradataDialect");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8220,7 +8193,6 @@ impl serde::ser::Serialize for OracleDialect {
 impl std::fmt::Debug for OracleDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OracleDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8334,7 +8306,6 @@ impl serde::ser::Serialize for SparkSQLDialect {
 impl std::fmt::Debug for SparkSQLDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SparkSQLDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8448,7 +8419,6 @@ impl serde::ser::Serialize for SnowflakeDialect {
 impl std::fmt::Debug for SnowflakeDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SnowflakeDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8562,7 +8532,6 @@ impl serde::ser::Serialize for NetezzaDialect {
 impl std::fmt::Debug for NetezzaDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetezzaDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8676,7 +8645,6 @@ impl serde::ser::Serialize for AzureSynapseDialect {
 impl std::fmt::Debug for AzureSynapseDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureSynapseDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8790,7 +8758,6 @@ impl serde::ser::Serialize for VerticaDialect {
 impl std::fmt::Debug for VerticaDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerticaDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8904,7 +8871,6 @@ impl serde::ser::Serialize for SQLServerDialect {
 impl std::fmt::Debug for SQLServerDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SQLServerDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9018,7 +8984,6 @@ impl serde::ser::Serialize for PostgresqlDialect {
 impl std::fmt::Debug for PostgresqlDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PostgresqlDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9132,7 +9097,6 @@ impl serde::ser::Serialize for PrestoDialect {
 impl std::fmt::Debug for PrestoDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrestoDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9246,7 +9210,6 @@ impl serde::ser::Serialize for MySQLDialect {
 impl std::fmt::Debug for MySQLDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MySQLDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9360,7 +9323,6 @@ impl serde::ser::Serialize for DB2Dialect {
 impl std::fmt::Debug for DB2Dialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DB2Dialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9474,7 +9436,6 @@ impl serde::ser::Serialize for SQLiteDialect {
 impl std::fmt::Debug for SQLiteDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SQLiteDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9588,7 +9549,6 @@ impl serde::ser::Serialize for GreenplumDialect {
 impl std::fmt::Debug for GreenplumDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GreenplumDialect");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9739,7 +9699,6 @@ impl std::fmt::Debug for ObjectNameMappingList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ObjectNameMappingList");
         debug_struct.field("name_map", &self.name_map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9931,7 +9890,6 @@ impl std::fmt::Debug for ObjectNameMapping {
         let mut debug_struct = f.debug_struct("ObjectNameMapping");
         debug_struct.field("source", &self.source);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10178,7 +10136,6 @@ impl std::fmt::Debug for NameMappingKey {
         debug_struct.field("schema", &self.schema);
         debug_struct.field("relation", &self.relation);
         debug_struct.field("attribute", &self.attribute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10572,7 +10529,6 @@ impl std::fmt::Debug for NameMappingValue {
         debug_struct.field("schema", &self.schema);
         debug_struct.field("relation", &self.relation);
         debug_struct.field("attribute", &self.attribute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10783,7 +10739,6 @@ impl std::fmt::Debug for SourceEnv {
         debug_struct.field("default_database", &self.default_database);
         debug_struct.field("schema_search_path", &self.schema_search_path);
         debug_struct.field("metadata_store_dataset", &self.metadata_store_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11061,7 +11016,6 @@ impl std::fmt::Debug for TranslationDetails {
         debug_struct.field("source_environment", &self.source_environment);
         debug_struct.field("target_return_literals", &self.target_return_literals);
         debug_struct.field("target_types", &self.target_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11252,7 +11206,6 @@ impl std::fmt::Debug for SourceTargetMapping {
         let mut debug_struct = f.debug_struct("SourceTargetMapping");
         debug_struct.field("source_spec", &self.source_spec);
         debug_struct.field("target_spec", &self.target_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11509,7 +11462,6 @@ impl std::fmt::Debug for SourceSpec {
         let mut debug_struct = f.debug_struct("SourceSpec");
         debug_struct.field("encoding", &self.encoding);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11670,7 +11622,6 @@ impl std::fmt::Debug for TargetSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TargetSpec");
         debug_struct.field("relative_path", &self.relative_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11942,7 +11893,6 @@ impl std::fmt::Debug for Literal {
         let mut debug_struct = f.debug_struct("Literal");
         debug_struct.field("relative_path", &self.relative_path);
         debug_struct.field("literal_data", &self.literal_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12169,7 +12119,6 @@ impl std::fmt::Debug for SourceEnvironment {
         debug_struct.field("default_database", &self.default_database);
         debug_struct.field("schema_search_path", &self.schema_search_path);
         debug_struct.field("metadata_store_dataset", &self.metadata_store_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12459,7 +12408,6 @@ impl std::fmt::Debug for TranslationReportRecord {
         debug_struct.field("script_column", &self.script_column);
         debug_struct.field("category", &self.category);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13042,7 +12990,6 @@ impl std::fmt::Debug for GcsReportLogMessage {
         debug_struct.field("action", &self.action);
         debug_struct.field("effect", &self.effect);
         debug_struct.field("object_name", &self.object_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -620,7 +620,6 @@ impl std::fmt::Debug for Reservation {
         debug_struct.field("secondary_location", &self.secondary_location);
         debug_struct.field("original_primary_location", &self.original_primary_location);
         debug_struct.field("replication_status", &self.replication_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -839,7 +838,6 @@ pub mod reservation {
             let mut debug_struct = f.debug_struct("Autoscale");
             debug_struct.field("current_slots", &self.current_slots);
             debug_struct.field("max_slots", &self.max_slots);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1074,7 +1072,6 @@ pub mod reservation {
             debug_struct.field("error", &self.error);
             debug_struct.field("last_error_time", &self.last_error_time);
             debug_struct.field("last_replication_time", &self.last_replication_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1569,7 +1566,6 @@ impl std::fmt::Debug for CapacityCommitment {
         debug_struct.field("multi_region_auxiliary", &self.multi_region_auxiliary);
         debug_struct.field("edition", &self.edition);
         debug_struct.field("is_flat_rate", &self.is_flat_rate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2133,7 +2129,6 @@ impl std::fmt::Debug for CreateReservationRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("reservation_id", &self.reservation_id);
         debug_struct.field("reservation", &self.reservation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2349,7 +2344,6 @@ impl std::fmt::Debug for ListReservationsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2538,7 +2532,6 @@ impl std::fmt::Debug for ListReservationsResponse {
         let mut debug_struct = f.debug_struct("ListReservationsResponse");
         debug_struct.field("reservations", &self.reservations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2684,7 +2677,6 @@ impl std::fmt::Debug for GetReservationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReservationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2830,7 +2822,6 @@ impl std::fmt::Debug for DeleteReservationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteReservationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3023,7 +3014,6 @@ impl std::fmt::Debug for UpdateReservationRequest {
         let mut debug_struct = f.debug_struct("UpdateReservationRequest");
         debug_struct.field("reservation", &self.reservation);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3166,7 +3156,6 @@ impl std::fmt::Debug for FailoverReservationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FailoverReservationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3422,7 +3411,6 @@ impl std::fmt::Debug for CreateCapacityCommitmentRequest {
             &self.enforce_single_admin_project_per_org,
         );
         debug_struct.field("capacity_commitment_id", &self.capacity_commitment_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3638,7 +3626,6 @@ impl std::fmt::Debug for ListCapacityCommitmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3832,7 +3819,6 @@ impl std::fmt::Debug for ListCapacityCommitmentsResponse {
         let mut debug_struct = f.debug_struct("ListCapacityCommitmentsResponse");
         debug_struct.field("capacity_commitments", &self.capacity_commitments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3978,7 +3964,6 @@ impl std::fmt::Debug for GetCapacityCommitmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCapacityCommitmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4151,7 +4136,6 @@ impl std::fmt::Debug for DeleteCapacityCommitmentRequest {
         let mut debug_struct = f.debug_struct("DeleteCapacityCommitmentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4345,7 +4329,6 @@ impl std::fmt::Debug for UpdateCapacityCommitmentRequest {
         let mut debug_struct = f.debug_struct("UpdateCapacityCommitmentRequest");
         debug_struct.field("capacity_commitment", &self.capacity_commitment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4535,7 +4518,6 @@ impl std::fmt::Debug for SplitCapacityCommitmentRequest {
         let mut debug_struct = f.debug_struct("SplitCapacityCommitmentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("slot_count", &self.slot_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4727,7 +4709,6 @@ impl std::fmt::Debug for SplitCapacityCommitmentResponse {
         let mut debug_struct = f.debug_struct("SplitCapacityCommitmentResponse");
         debug_struct.field("first", &self.first);
         debug_struct.field("second", &self.second);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4906,7 +4887,6 @@ impl std::fmt::Debug for MergeCapacityCommitmentsRequest {
         let mut debug_struct = f.debug_struct("MergeCapacityCommitmentsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("capacity_commitment_ids", &self.capacity_commitment_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5169,7 +5149,6 @@ impl std::fmt::Debug for Assignment {
         debug_struct.field("job_type", &self.job_type);
         debug_struct.field("state", &self.state);
         debug_struct.field("enable_gemini_in_bigquery", &self.enable_gemini_in_bigquery);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5679,7 +5658,6 @@ impl std::fmt::Debug for CreateAssignmentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("assignment", &self.assignment);
         debug_struct.field("assignment_id", &self.assignment_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5900,7 +5878,6 @@ impl std::fmt::Debug for ListAssignmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6089,7 +6066,6 @@ impl std::fmt::Debug for ListAssignmentsResponse {
         let mut debug_struct = f.debug_struct("ListAssignmentsResponse");
         debug_struct.field("assignments", &self.assignments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6237,7 +6213,6 @@ impl std::fmt::Debug for DeleteAssignmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAssignmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6487,7 +6462,6 @@ impl std::fmt::Debug for SearchAssignmentsRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6737,7 +6711,6 @@ impl std::fmt::Debug for SearchAllAssignmentsRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6926,7 +6899,6 @@ impl std::fmt::Debug for SearchAssignmentsResponse {
         let mut debug_struct = f.debug_struct("SearchAssignmentsResponse");
         debug_struct.field("assignments", &self.assignments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7115,7 +7087,6 @@ impl std::fmt::Debug for SearchAllAssignmentsResponse {
         let mut debug_struct = f.debug_struct("SearchAllAssignmentsResponse");
         debug_struct.field("assignments", &self.assignments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7326,7 +7297,6 @@ impl std::fmt::Debug for MoveAssignmentRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("destination_id", &self.destination_id);
         debug_struct.field("assignment_id", &self.assignment_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7519,7 +7489,6 @@ impl std::fmt::Debug for UpdateAssignmentRequest {
         let mut debug_struct = f.debug_struct("UpdateAssignmentRequest");
         debug_struct.field("assignment", &self.assignment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7715,7 +7684,6 @@ impl std::fmt::Debug for TableReference {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7972,7 +7940,6 @@ impl std::fmt::Debug for BiReservation {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("size", &self.size);
         debug_struct.field("preferred_tables", &self.preferred_tables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8115,7 +8082,6 @@ impl std::fmt::Debug for GetBiReservationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBiReservationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8306,7 +8272,6 @@ impl std::fmt::Debug for UpdateBiReservationRequest {
         let mut debug_struct = f.debug_struct("UpdateBiReservationRequest");
         debug_struct.field("bi_reservation", &self.bi_reservation);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -264,7 +264,6 @@ impl std::fmt::Debug for BigLakeConfiguration {
         debug_struct.field("storage_uri", &self.storage_uri);
         debug_struct.field("file_format", &self.file_format);
         debug_struct.field("table_format", &self.table_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -672,7 +671,6 @@ impl std::fmt::Debug for Clustering {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Clustering");
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -815,7 +813,6 @@ impl std::fmt::Debug for DataFormatOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataFormatOptions");
         debug_struct.field("use_int64_timestamp", &self.use_int64_timestamp);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1010,7 +1007,6 @@ impl std::fmt::Debug for DatasetAccessEntry {
         let mut debug_struct = f.debug_struct("DatasetAccessEntry");
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("target_types", &self.target_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1603,7 +1599,6 @@ impl std::fmt::Debug for Access {
         debug_struct.field("routine", &self.routine);
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2962,7 +2957,6 @@ impl std::fmt::Debug for Dataset {
         debug_struct.field("storage_billing_model", &self.storage_billing_model);
         debug_struct.field("restrictions", &self.restrictions);
         debug_struct.field("resource_tags", &self.resource_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3271,7 +3265,6 @@ impl std::fmt::Debug for GcpTag {
         let mut debug_struct = f.debug_struct("GcpTag");
         debug_struct.field("tag_key", &self.tag_key);
         debug_struct.field("tag_value", &self.tag_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3426,7 +3419,6 @@ impl std::fmt::Debug for LinkedDatasetSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LinkedDatasetSource");
         debug_struct.field("source_dataset", &self.source_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3577,7 +3569,6 @@ impl std::fmt::Debug for LinkedDatasetMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LinkedDatasetMetadata");
         debug_struct.field("link_state", &self.link_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3990,7 +3981,6 @@ impl std::fmt::Debug for GetDatasetRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("dataset_view", &self.dataset_view);
         debug_struct.field("access_policy_version", &self.access_policy_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4381,7 +4371,6 @@ impl std::fmt::Debug for InsertDatasetRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("access_policy_version", &self.access_policy_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4688,7 +4677,6 @@ impl std::fmt::Debug for UpdateOrPatchDatasetRequest {
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("update_mode", &self.update_mode);
         debug_struct.field("access_policy_version", &self.access_policy_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5033,7 +5021,6 @@ impl std::fmt::Debug for DeleteDatasetRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("delete_contents", &self.delete_contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5317,7 +5304,6 @@ impl std::fmt::Debug for ListDatasetsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("all", &self.all);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5671,7 +5657,6 @@ impl std::fmt::Debug for ListFormatDataset {
             "external_dataset_reference",
             &self.external_dataset_reference,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5933,7 +5918,6 @@ impl std::fmt::Debug for DatasetList {
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("datasets", &self.datasets);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6141,7 +6125,6 @@ impl std::fmt::Debug for UndeleteDatasetRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("deletion_time", &self.deletion_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6312,7 +6295,6 @@ impl std::fmt::Debug for DatasetReference {
         let mut debug_struct = f.debug_struct("DatasetReference");
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6468,7 +6450,6 @@ impl std::fmt::Debug for EncryptionConfiguration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptionConfiguration");
         debug_struct.field("kms_key_name", &self.kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6687,7 +6668,6 @@ impl std::fmt::Debug for ErrorProto {
         debug_struct.field("location", &self.location);
         debug_struct.field("debug_info", &self.debug_info);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6884,7 +6864,6 @@ impl std::fmt::Debug for ExternalCatalogDatasetOptions {
             "default_storage_location_uri",
             &self.default_storage_location_uri,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7110,7 +7089,6 @@ impl std::fmt::Debug for ExternalCatalogTableOptions {
         debug_struct.field("parameters", &self.parameters);
         debug_struct.field("storage_descriptor", &self.storage_descriptor);
         debug_struct.field("connection_id", &self.connection_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7350,7 +7328,6 @@ impl std::fmt::Debug for StorageDescriptor {
         debug_struct.field("input_format", &self.input_format);
         debug_struct.field("output_format", &self.output_format);
         debug_struct.field("serde_info", &self.serde_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7563,7 +7540,6 @@ impl std::fmt::Debug for SerDeInfo {
         debug_struct.field("name", &self.name);
         debug_struct.field("serialization_library", &self.serialization_library);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7719,7 +7695,6 @@ impl std::fmt::Debug for AvroOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AvroOptions");
         debug_struct.field("use_avro_logical_types", &self.use_avro_logical_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7941,7 +7916,6 @@ impl std::fmt::Debug for ParquetOptions {
         debug_struct.field("enum_as_string", &self.enum_as_string);
         debug_struct.field("enable_list_inference", &self.enable_list_inference);
         debug_struct.field("map_target_type", &self.map_target_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8487,7 +8461,6 @@ impl std::fmt::Debug for CsvOptions {
         debug_struct.field("null_marker", &self.null_marker);
         debug_struct.field("null_markers", &self.null_markers);
         debug_struct.field("source_column_match", &self.source_column_match);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8631,7 +8604,6 @@ impl std::fmt::Debug for JsonOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("JsonOptions");
         debug_struct.field("encoding", &self.encoding);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8990,7 +8962,6 @@ impl std::fmt::Debug for BigtableColumn {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("encoding", &self.encoding);
         debug_struct.field("only_read_latest", &self.only_read_latest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9281,7 +9252,6 @@ impl std::fmt::Debug for BigtableColumnFamily {
         debug_struct.field("encoding", &self.encoding);
         debug_struct.field("columns", &self.columns);
         debug_struct.field("only_read_latest", &self.only_read_latest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9585,7 +9555,6 @@ impl std::fmt::Debug for BigtableOptions {
             "output_column_families_as_json",
             &self.output_column_families_as_json,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9799,7 +9768,6 @@ impl std::fmt::Debug for GoogleSheetsOptions {
         let mut debug_struct = f.debug_struct("GoogleSheetsOptions");
         debug_struct.field("skip_leading_rows", &self.skip_leading_rows);
         debug_struct.field("range", &self.range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10936,7 +10904,6 @@ impl std::fmt::Debug for ExternalDataConfiguration {
         debug_struct.field("datetime_format", &self.datetime_format);
         debug_struct.field("time_format", &self.time_format);
         debug_struct.field("timestamp_format", &self.timestamp_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11382,7 +11349,6 @@ impl std::fmt::Debug for ExternalDatasetReference {
         let mut debug_struct = f.debug_struct("ExternalDatasetReference");
         debug_struct.field("external_source", &self.external_source);
         debug_struct.field("connection", &self.connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11668,7 +11634,6 @@ impl std::fmt::Debug for HivePartitioningOptions {
         debug_struct.field("source_uri_prefix", &self.source_uri_prefix);
         debug_struct.field("require_partition_filter", &self.require_partition_filter);
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12126,7 +12091,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("status", &self.status);
         debug_struct.field("principal_subject", &self.principal_subject);
         debug_struct.field("job_creation_reason", &self.job_creation_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12328,7 +12292,6 @@ impl std::fmt::Debug for CancelJobRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12506,7 +12469,6 @@ impl std::fmt::Debug for JobCancelResponse {
         let mut debug_struct = f.debug_struct("JobCancelResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12710,7 +12672,6 @@ impl std::fmt::Debug for GetJobRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12889,7 +12850,6 @@ impl std::fmt::Debug for InsertJobRequest {
         let mut debug_struct = f.debug_struct("InsertJobRequest");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13090,7 +13050,6 @@ impl std::fmt::Debug for DeleteJobRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13540,7 +13499,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("projection", &self.projection);
         debug_struct.field("state_filter", &self.state_filter);
         debug_struct.field("parent_job_id", &self.parent_job_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14241,7 +14199,6 @@ impl std::fmt::Debug for ListFormatJob {
         debug_struct.field("status", &self.status);
         debug_struct.field("user_email", &self.user_email);
         debug_struct.field("principal_subject", &self.principal_subject);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14492,7 +14449,6 @@ impl std::fmt::Debug for JobList {
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14948,7 +14904,6 @@ impl std::fmt::Debug for GetQueryResultsRequest {
         debug_struct.field("timeout_ms", &self.timeout_ms);
         debug_struct.field("location", &self.location);
         debug_struct.field("format_options", &self.format_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15542,7 +15497,6 @@ impl std::fmt::Debug for GetQueryResultsResponse {
         debug_struct.field("errors", &self.errors);
         debug_struct.field("cache_hit", &self.cache_hit);
         debug_struct.field("num_dml_affected_rows", &self.num_dml_affected_rows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15722,7 +15676,6 @@ impl std::fmt::Debug for PostQueryRequest {
         let mut debug_struct = f.debug_struct("PostQueryRequest");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("query_request", &self.query_request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16752,7 +16705,6 @@ impl std::fmt::Debug for QueryRequest {
         debug_struct.field("job_creation_mode", &self.job_creation_mode);
         debug_struct.field("reservation", &self.reservation);
         debug_struct.field("write_incremental_results", &self.write_incremental_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17933,7 +17885,6 @@ impl std::fmt::Debug for QueryResponse {
         debug_struct.field("creation_time", &self.creation_time);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18166,7 +18117,6 @@ impl std::fmt::Debug for DestinationTableProperties {
         debug_struct.field("friendly_name", &self.friendly_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18362,7 +18312,6 @@ impl std::fmt::Debug for ConnectionProperty {
         let mut debug_struct = f.debug_struct("ConnectionProperty");
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19505,7 +19454,6 @@ impl std::fmt::Debug for JobConfigurationQuery {
         debug_struct.field("create_session", &self.create_session);
         debug_struct.field("continuous", &self.continuous);
         debug_struct.field("write_incremental_results", &self.write_incremental_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19774,7 +19722,6 @@ impl std::fmt::Debug for ScriptOptions {
         debug_struct.field("statement_timeout_ms", &self.statement_timeout_ms);
         debug_struct.field("statement_byte_budget", &self.statement_byte_budget);
         debug_struct.field("key_result_statement", &self.key_result_statement);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21777,7 +21724,6 @@ impl std::fmt::Debug for JobConfigurationLoad {
         debug_struct.field("time_format", &self.time_format);
         debug_struct.field("timestamp_format", &self.timestamp_format);
         debug_struct.field("source_column_match", &self.source_column_match);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22502,7 +22448,6 @@ impl std::fmt::Debug for JobConfigurationTableCopy {
             "destination_expiration_time",
             &self.destination_expiration_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23144,7 +23089,6 @@ impl std::fmt::Debug for JobConfigurationExtract {
         debug_struct.field("use_avro_logical_types", &self.use_avro_logical_types);
         debug_struct.field("model_extract_options", &self.model_extract_options);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23331,7 +23275,6 @@ pub mod job_configuration_extract {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ModelExtractOptions");
             debug_struct.field("trial_id", &self.trial_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23813,7 +23756,6 @@ impl std::fmt::Debug for JobConfiguration {
         debug_struct.field("job_timeout_ms", &self.job_timeout_ms);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("reservation", &self.reservation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23962,7 +23904,6 @@ impl std::fmt::Debug for JobCreationReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("JobCreationReason");
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24328,7 +24269,6 @@ impl std::fmt::Debug for JobReference {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24498,7 +24438,6 @@ impl std::fmt::Debug for ExplainQueryStep {
         let mut debug_struct = f.debug_struct("ExplainQueryStep");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("substeps", &self.substeps);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26283,7 +26222,6 @@ impl std::fmt::Debug for ExplainQueryStage {
         debug_struct.field("steps", &self.steps);
         debug_struct.field("slot_ms", &self.slot_ms);
         debug_struct.field("compute_mode", &self.compute_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26957,7 +26895,6 @@ impl std::fmt::Debug for QueryTimelineSample {
         debug_struct.field("active_units", &self.active_units);
         debug_struct.field("shuffle_ram_usage_ratio", &self.shuffle_ram_usage_ratio);
         debug_struct.field("estimated_runnable_units", &self.estimated_runnable_units);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27334,7 +27271,6 @@ impl std::fmt::Debug for ExternalServiceCost {
         debug_struct.field("bytes_billed", &self.bytes_billed);
         debug_struct.field("slot_ms", &self.slot_ms);
         debug_struct.field("reserved_slot_count", &self.reserved_slot_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27570,7 +27506,6 @@ impl std::fmt::Debug for ExportDataStatistics {
         let mut debug_struct = f.debug_struct("ExportDataStatistics");
         debug_struct.field("file_count", &self.file_count);
         debug_struct.field("row_count", &self.row_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27740,7 +27675,6 @@ impl std::fmt::Debug for BiEngineReason {
         let mut debug_struct = f.debug_struct("BiEngineReason");
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28129,7 +28063,6 @@ impl std::fmt::Debug for BiEngineStatistics {
         debug_struct.field("bi_engine_mode", &self.bi_engine_mode);
         debug_struct.field("acceleration_mode", &self.acceleration_mode);
         debug_struct.field("bi_engine_reasons", &self.bi_engine_reasons);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28700,7 +28633,6 @@ impl std::fmt::Debug for IndexUnusedReason {
         debug_struct.field("message", &self.message);
         debug_struct.field("base_table", &self.base_table);
         debug_struct.field("index_name", &self.index_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29245,7 +29177,6 @@ impl std::fmt::Debug for StoredColumnsUsage {
             "stored_columns_unused_reasons",
             &self.stored_columns_unused_reasons,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29480,7 +29411,6 @@ pub mod stored_columns_usage {
             debug_struct.field("code", &self.code);
             debug_struct.field("message", &self.message);
             debug_struct.field("uncovered_columns", &self.uncovered_columns);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29842,7 +29772,6 @@ impl std::fmt::Debug for SearchStatistics {
         let mut debug_struct = f.debug_struct("SearchStatistics");
         debug_struct.field("index_usage_mode", &self.index_usage_mode);
         debug_struct.field("index_unused_reasons", &self.index_unused_reasons);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30212,7 +30141,6 @@ impl std::fmt::Debug for VectorSearchStatistics {
         debug_struct.field("index_usage_mode", &self.index_usage_mode);
         debug_struct.field("index_unused_reasons", &self.index_unused_reasons);
         debug_struct.field("stored_columns_usages", &self.stored_columns_usages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30517,7 +30445,6 @@ impl std::fmt::Debug for QueryInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryInfo");
         debug_struct.field("optimization_details", &self.optimization_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30931,7 +30858,6 @@ impl std::fmt::Debug for LoadQueryStatistics {
         debug_struct.field("output_rows", &self.output_rows);
         debug_struct.field("output_bytes", &self.output_bytes);
         debug_struct.field("bad_records", &self.bad_records);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32903,7 +32829,6 @@ impl std::fmt::Debug for JobStatistics2 {
             &self.materialized_view_statistics,
         );
         debug_struct.field("metadata_cache_statistics", &self.metadata_cache_statistics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33348,7 +33273,6 @@ impl std::fmt::Debug for JobStatistics3 {
         debug_struct.field("output_bytes", &self.output_bytes);
         debug_struct.field("bad_records", &self.bad_records);
         debug_struct.field("timeline", &self.timeline);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33625,7 +33549,6 @@ impl std::fmt::Debug for JobStatistics4 {
         );
         debug_struct.field("input_bytes", &self.input_bytes);
         debug_struct.field("timeline", &self.timeline);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33858,7 +33781,6 @@ impl std::fmt::Debug for CopyJobStatistics {
         let mut debug_struct = f.debug_struct("CopyJobStatistics");
         debug_struct.field("copied_rows", &self.copied_rows);
         debug_struct.field("copied_logical_bytes", &self.copied_logical_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34151,7 +34073,6 @@ impl std::fmt::Debug for MlStatistics {
         debug_struct.field("model_type", &self.model_type);
         debug_struct.field("training_type", &self.training_type);
         debug_struct.field("hparam_trials", &self.hparam_trials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34477,7 +34398,6 @@ impl std::fmt::Debug for ScriptStatistics {
         let mut debug_struct = f.debug_struct("ScriptStatistics");
         debug_struct.field("evaluation_kind", &self.evaluation_kind);
         debug_struct.field("stack_frames", &self.stack_frames);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34850,7 +34770,6 @@ pub mod script_statistics {
             debug_struct.field("end_column", &self.end_column);
             debug_struct.field("procedure_id", &self.procedure_id);
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35133,7 +35052,6 @@ impl std::fmt::Debug for RowLevelSecurityStatistics {
             "row_level_security_applied",
             &self.row_level_security_applied,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35276,7 +35194,6 @@ impl std::fmt::Debug for DataMaskingStatistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataMaskingStatistics");
         debug_struct.field("data_masking_applied", &self.data_masking_applied);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36273,7 +36190,6 @@ impl std::fmt::Debug for JobStatistics {
             &self.final_execution_duration_ms,
         );
         debug_struct.field("edition", &self.edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36427,7 +36343,6 @@ pub mod job_statistics {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TransactionInfo");
             debug_struct.field("transaction_id", &self.transaction_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36722,7 +36637,6 @@ impl std::fmt::Debug for DmlStats {
         debug_struct.field("inserted_row_count", &self.inserted_row_count);
         debug_struct.field("deleted_row_count", &self.deleted_row_count);
         debug_struct.field("updated_row_count", &self.updated_row_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36981,7 +36895,6 @@ impl std::fmt::Debug for PerformanceInsights {
             "stage_performance_change_insights",
             &self.stage_performance_change_insights,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37181,7 +37094,6 @@ impl std::fmt::Debug for StagePerformanceChangeInsight {
         let mut debug_struct = f.debug_struct("StagePerformanceChangeInsight");
         debug_struct.field("stage_id", &self.stage_id);
         debug_struct.field("input_data_change", &self.input_data_change);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37353,7 +37265,6 @@ impl std::fmt::Debug for InputDataChange {
             "records_read_diff_percentage",
             &self.records_read_diff_percentage,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37699,7 +37610,6 @@ impl std::fmt::Debug for StagePerformanceStandaloneInsight {
         debug_struct.field("bi_engine_reasons", &self.bi_engine_reasons);
         debug_struct.field("high_cardinality_joins", &self.high_cardinality_joins);
         debug_struct.field("partition_skew", &self.partition_skew);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37992,7 +37902,6 @@ impl std::fmt::Debug for HighCardinalityJoin {
         debug_struct.field("right_rows", &self.right_rows);
         debug_struct.field("output_rows", &self.output_rows);
         debug_struct.field("step_index", &self.step_index);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38142,7 +38051,6 @@ impl std::fmt::Debug for PartitionSkew {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PartitionSkew");
         debug_struct.field("skew_sources", &self.skew_sources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38311,7 +38219,6 @@ pub mod partition_skew {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SkewSource");
             debug_struct.field("stage_id", &self.stage_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38679,7 +38586,6 @@ impl std::fmt::Debug for SparkStatistics {
         debug_struct.field("logging_info", &self.logging_info);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("gcs_staging_bucket", &self.gcs_staging_bucket);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38859,7 +38765,6 @@ pub mod spark_statistics {
             let mut debug_struct = f.debug_struct("LoggingInfo");
             debug_struct.field("resource_type", &self.resource_type);
             debug_struct.field("project_id", &self.project_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39014,7 +38919,6 @@ impl std::fmt::Debug for MaterializedViewStatistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaterializedViewStatistics");
         debug_struct.field("materialized_view", &self.materialized_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39307,7 +39211,6 @@ impl std::fmt::Debug for MaterializedView {
         debug_struct.field("chosen", &self.chosen);
         debug_struct.field("estimated_bytes_saved", &self.estimated_bytes_saved);
         debug_struct.field("rejected_reason", &self.rejected_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39833,7 +39736,6 @@ impl std::fmt::Debug for TableMetadataCacheUsage {
         debug_struct.field("explanation", &self.explanation);
         debug_struct.field("staleness", &self.staleness);
         debug_struct.field("table_type", &self.table_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40139,7 +40041,6 @@ impl std::fmt::Debug for MetadataCacheStatistics {
             "table_metadata_cache_usage",
             &self.table_metadata_cache_usage,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40350,7 +40251,6 @@ impl std::fmt::Debug for JobStatus {
         debug_struct.field("error_result", &self.error_result);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40499,7 +40399,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("legacy_location_id", &self.legacy_location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40879,7 +40778,6 @@ impl std::fmt::Debug for RemoteModelInfo {
         debug_struct.field("remote_model_version", &self.remote_model_version);
         debug_struct.field("speech_recognizer", &self.speech_recognizer);
         debug_struct.field("remote_service", &self.remote_service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41255,7 +41153,6 @@ impl std::fmt::Debug for TransformColumn {
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("transform_sql", &self.transform_sql);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42122,7 +42019,6 @@ impl std::fmt::Debug for Model {
         debug_struct.field("hparam_trials", &self.hparam_trials);
         debug_struct.field("optimal_trial_ids", &self.optimal_trial_ids);
         debug_struct.field("remote_model_info", &self.remote_model_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42244,7 +42140,6 @@ pub mod model {
     impl std::fmt::Debug for SeasonalPeriod {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SeasonalPeriod");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42532,7 +42427,6 @@ pub mod model {
     impl std::fmt::Debug for KmeansEnums {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("KmeansEnums");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42803,7 +42697,6 @@ pub mod model {
     impl std::fmt::Debug for BoostedTreeOptionEnums {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BoostedTreeOptionEnums");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43350,7 +43243,6 @@ pub mod model {
     impl std::fmt::Debug for HparamTuningEnums {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("HparamTuningEnums");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44030,7 +43922,6 @@ pub mod model {
             debug_struct.field("mean_squared_log_error", &self.mean_squared_log_error);
             debug_struct.field("median_absolute_error", &self.median_absolute_error);
             debug_struct.field("r_squared", &self.r_squared);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44566,7 +44457,6 @@ pub mod model {
             debug_struct.field("f1_score", &self.f1_score);
             debug_struct.field("log_loss", &self.log_loss);
             debug_struct.field("roc_auc", &self.roc_auc);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44840,7 +44730,6 @@ pub mod model {
             );
             debug_struct.field("positive_label", &self.positive_label);
             debug_struct.field("negative_label", &self.negative_label);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45542,7 +45431,6 @@ pub mod model {
                 debug_struct.field("recall", &self.recall);
                 debug_struct.field("f1_score", &self.f1_score);
                 debug_struct.field("accuracy", &self.accuracy);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -45748,7 +45636,6 @@ pub mod model {
                 &self.aggregate_classification_metrics,
             );
             debug_struct.field("confusion_matrix_list", &self.confusion_matrix_list);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45975,7 +45862,6 @@ pub mod model {
                 let mut debug_struct = f.debug_struct("ConfusionMatrix");
                 debug_struct.field("confidence_threshold", &self.confidence_threshold);
                 debug_struct.field("rows", &self.rows);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -46211,7 +46097,6 @@ pub mod model {
                     let mut debug_struct = f.debug_struct("Entry");
                     debug_struct.field("predicted_label", &self.predicted_label);
                     debug_struct.field("item_count", &self.item_count);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -46403,7 +46288,6 @@ pub mod model {
                     let mut debug_struct = f.debug_struct("Row");
                     debug_struct.field("actual_label", &self.actual_label);
                     debug_struct.field("entries", &self.entries);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -46676,7 +46560,6 @@ pub mod model {
             debug_struct.field("davies_bouldin_index", &self.davies_bouldin_index);
             debug_struct.field("mean_squared_distance", &self.mean_squared_distance);
             debug_struct.field("clusters", &self.clusters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46948,7 +46831,6 @@ pub mod model {
                 debug_struct.field("centroid_id", &self.centroid_id);
                 debug_struct.field("feature_values", &self.feature_values);
                 debug_struct.field("count", &self.count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -47273,7 +47155,6 @@ pub mod model {
                     let mut debug_struct = f.debug_struct("FeatureValue");
                     debug_struct.field("feature_column", &self.feature_column);
                     debug_struct.field("value", &self.value);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -47444,7 +47325,6 @@ pub mod model {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                         let mut debug_struct = f.debug_struct("CategoricalValue");
                         debug_struct.field("category_counts", &self.category_counts);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -47679,7 +47559,6 @@ pub mod model {
                             let mut debug_struct = f.debug_struct("CategoryCount");
                             debug_struct.field("category", &self.category);
                             debug_struct.field("count", &self.count);
-
                             if !self._unknown_fields.is_empty() {
                                 debug_struct.field("_unknown_fields", &self._unknown_fields);
                             }
@@ -48075,7 +47954,6 @@ pub mod model {
                 &self.normalized_discounted_cumulative_gain,
             );
             debug_struct.field("average_rank", &self.average_rank);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -48239,7 +48117,6 @@ pub mod model {
                 "arima_single_model_forecasting_metrics",
                 &self.arima_single_model_forecasting_metrics,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -48717,7 +48594,6 @@ pub mod model {
                 debug_struct.field("has_holiday_effect", &self.has_holiday_effect);
                 debug_struct.field("has_spikes_and_dips", &self.has_spikes_and_dips);
                 debug_struct.field("has_step_changes", &self.has_step_changes);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -48911,7 +48787,6 @@ pub mod model {
                 "total_explained_variance_ratio",
                 &self.total_explained_variance_ratio,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49467,7 +49342,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EvaluationMetrics");
             debug_struct.field("metrics", &self.metrics);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49733,7 +49607,6 @@ pub mod model {
             debug_struct.field("training_table", &self.training_table);
             debug_struct.field("evaluation_table", &self.evaluation_table);
             debug_struct.field("test_table", &self.test_table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50024,7 +49897,6 @@ pub mod model {
             debug_struct.field("p", &self.p);
             debug_struct.field("d", &self.d);
             debug_struct.field("q", &self.q);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50316,7 +50188,6 @@ pub mod model {
             debug_struct.field("log_likelihood", &self.log_likelihood);
             debug_struct.field("aic", &self.aic);
             debug_struct.field("variance", &self.variance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50500,7 +50371,6 @@ pub mod model {
             let mut debug_struct = f.debug_struct("GlobalExplanation");
             debug_struct.field("explanations", &self.explanations);
             debug_struct.field("class_label", &self.class_label);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50723,7 +50593,6 @@ pub mod model {
                 let mut debug_struct = f.debug_struct("Explanation");
                 debug_struct.field("feature_name", &self.feature_name);
                 debug_struct.field("attribution", &self.attribution);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -50841,7 +50710,6 @@ pub mod model {
     impl std::fmt::Debug for CategoryEncodingMethod {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CategoryEncodingMethod");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51106,7 +50974,6 @@ pub mod model {
     impl std::fmt::Debug for PcaSolverOptionEnums {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PcaSolverOptionEnums");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51371,7 +51238,6 @@ pub mod model {
     impl std::fmt::Debug for ModelRegistryOptionEnums {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ModelRegistryOptionEnums");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51974,7 +51840,6 @@ pub mod model {
             );
             debug_struct.field("vertex_ai_model_id", &self.vertex_ai_model_id);
             debug_struct.field("vertex_ai_model_version", &self.vertex_ai_model_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -56392,7 +56257,6 @@ pub mod model {
                 debug_struct.field("contribution_metric", &self.contribution_metric);
                 debug_struct.field("is_test_column", &self.is_test_column);
                 debug_struct.field("min_apriori_support", &self.min_apriori_support);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -56935,7 +56799,6 @@ pub mod model {
                 debug_struct.field("cluster_infos", &self.cluster_infos);
                 debug_struct.field("arima_result", &self.arima_result);
                 debug_struct.field("principal_component_infos", &self.principal_component_infos);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -57261,7 +57124,6 @@ pub mod model {
                     debug_struct.field("centroid_id", &self.centroid_id);
                     debug_struct.field("cluster_radius", &self.cluster_radius);
                     debug_struct.field("cluster_size", &self.cluster_size);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -57456,7 +57318,6 @@ pub mod model {
                     let mut debug_struct = f.debug_struct("ArimaResult");
                     debug_struct.field("arima_model_info", &self.arima_model_info);
                     debug_struct.field("seasonal_periods", &self.seasonal_periods);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -57823,7 +57684,6 @@ pub mod model {
                             &self.moving_average_coefficients,
                         );
                         debug_struct.field("intercept_coefficient", &self.intercept_coefficient);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -58389,7 +58249,6 @@ pub mod model {
                         debug_struct.field("has_holiday_effect", &self.has_holiday_effect);
                         debug_struct.field("has_spikes_and_dips", &self.has_spikes_and_dips);
                         debug_struct.field("has_step_changes", &self.has_step_changes);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -58841,7 +58700,6 @@ pub mod model {
                         "cumulative_explained_variance_ratio",
                         &self.cumulative_explained_variance_ratio,
                     );
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -59104,7 +58962,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DoubleHparamSearchSpace");
             debug_struct.field("search_space", &self.search_space);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -59352,7 +59209,6 @@ pub mod model {
                 let mut debug_struct = f.debug_struct("DoubleRange");
                 debug_struct.field("min", &self.min);
                 debug_struct.field("max", &self.max);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -59540,7 +59396,6 @@ pub mod model {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("DoubleCandidates");
                 debug_struct.field("candidates", &self.candidates);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -59810,7 +59665,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IntHparamSearchSpace");
             debug_struct.field("search_space", &self.search_space);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60058,7 +59912,6 @@ pub mod model {
                 let mut debug_struct = f.debug_struct("IntRange");
                 debug_struct.field("min", &self.min);
                 debug_struct.field("max", &self.max);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -60246,7 +60099,6 @@ pub mod model {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("IntCandidates");
                 debug_struct.field("candidates", &self.candidates);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -60407,7 +60259,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StringHparamSearchSpace");
             debug_struct.field("candidates", &self.candidates);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60555,7 +60406,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IntArrayHparamSearchSpace");
             debug_struct.field("candidates", &self.candidates);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60746,7 +60596,6 @@ pub mod model {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("IntArray");
                 debug_struct.field("elements", &self.elements);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -61711,7 +61560,6 @@ pub mod model {
             debug_struct.field("colsample_bynode", &self.colsample_bynode);
             debug_struct.field("activation_fn", &self.activation_fn);
             debug_struct.field("optimizer", &self.optimizer);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -62272,7 +62120,6 @@ pub mod model {
                 "hparam_tuning_evaluation_metrics",
                 &self.hparam_tuning_evaluation_metrics,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -64675,7 +64522,6 @@ impl std::fmt::Debug for GetModelRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("model_id", &self.model_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64907,7 +64753,6 @@ impl std::fmt::Debug for PatchModelRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("model_id", &self.model_id);
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65102,7 +64947,6 @@ impl std::fmt::Debug for DeleteModelRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("model_id", &self.model_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65357,7 +65201,6 @@ impl std::fmt::Debug for ListModelsRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65530,7 +65373,6 @@ impl std::fmt::Debug for ListModelsResponse {
         let mut debug_struct = f.debug_struct("ListModelsResponse");
         debug_struct.field("models", &self.models);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65727,7 +65569,6 @@ impl std::fmt::Debug for ModelReference {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("model_id", &self.model_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65889,7 +65730,6 @@ impl std::fmt::Debug for PartitioningDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PartitioningDefinition");
         debug_struct.field("partitioned_column", &self.partitioned_column);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66042,7 +65882,6 @@ impl std::fmt::Debug for PartitionedColumn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PartitionedColumn");
         debug_struct.field("field", &self.field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66251,7 +66090,6 @@ impl std::fmt::Debug for AggregationThresholdPolicy {
         let mut debug_struct = f.debug_struct("AggregationThresholdPolicy");
         debug_struct.field("threshold", &self.threshold);
         debug_struct.field("privacy_unit_columns", &self.privacy_unit_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66862,7 +66700,6 @@ impl std::fmt::Debug for DifferentialPrivacyPolicy {
         debug_struct.field("delta_budget", &self.delta_budget);
         debug_struct.field("epsilon_budget_remaining", &self.epsilon_budget_remaining);
         debug_struct.field("delta_budget_remaining", &self.delta_budget_remaining);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67051,7 +66888,6 @@ impl std::fmt::Debug for JoinRestrictionPolicy {
         let mut debug_struct = f.debug_struct("JoinRestrictionPolicy");
         debug_struct.field("join_condition", &self.join_condition);
         debug_struct.field("join_allowed_columns", &self.join_allowed_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67499,7 +67335,6 @@ impl std::fmt::Debug for PrivacyPolicy {
         let mut debug_struct = f.debug_struct("PrivacyPolicy");
         debug_struct.field("join_restriction_policy", &self.join_restriction_policy);
         debug_struct.field("privacy_policy", &self.privacy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67659,7 +67494,6 @@ impl std::fmt::Debug for GetServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceAccountRequest");
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67826,7 +67660,6 @@ impl std::fmt::Debug for GetServiceAccountResponse {
         let mut debug_struct = f.debug_struct("GetServiceAccountResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68030,7 +67863,6 @@ impl std::fmt::Debug for QueryParameterStructType {
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68282,7 +68114,6 @@ impl std::fmt::Debug for QueryParameterType {
         debug_struct.field("array_type", &self.array_type);
         debug_struct.field("struct_types", &self.struct_types);
         debug_struct.field("range_element_type", &self.range_element_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68475,7 +68306,6 @@ impl std::fmt::Debug for RangeValue {
         let mut debug_struct = f.debug_struct("RangeValue");
         debug_struct.field("start", &self.start);
         debug_struct.field("end", &self.end);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68767,7 +68597,6 @@ impl std::fmt::Debug for QueryParameterValue {
         debug_struct.field("struct_values", &self.struct_values);
         debug_struct.field("range_value", &self.range_value);
         debug_struct.field("alt_struct_values", &self.alt_struct_values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68984,7 +68813,6 @@ impl std::fmt::Debug for QueryParameter {
         debug_struct.field("name", &self.name);
         debug_struct.field("parameter_type", &self.parameter_type);
         debug_struct.field("parameter_value", &self.parameter_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69162,7 +68990,6 @@ impl std::fmt::Debug for RangePartitioning {
         let mut debug_struct = f.debug_struct("RangePartitioning");
         debug_struct.field("field", &self.field);
         debug_struct.field("range", &self.range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69365,7 +69192,6 @@ pub mod range_partitioning {
             debug_struct.field("start", &self.start);
             debug_struct.field("end", &self.end);
             debug_struct.field("interval", &self.interval);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -69512,7 +69338,6 @@ impl std::fmt::Debug for RestrictionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestrictionConfig");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70502,7 +70327,6 @@ impl std::fmt::Debug for Routine {
         debug_struct.field("data_governance_type", &self.data_governance_type);
         debug_struct.field("python_options", &self.python_options);
         debug_struct.field("external_runtime_options", &self.external_runtime_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70791,7 +70615,6 @@ pub mod routine {
             debug_struct.field("mode", &self.mode);
             debug_struct.field("data_type", &self.data_type);
             debug_struct.field("is_aggregate", &self.is_aggregate);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -71337,7 +71160,6 @@ pub mod routine {
             debug_struct.field("connection", &self.connection);
             debug_struct.field("user_defined_context", &self.user_defined_context);
             debug_struct.field("max_batching_rows", &self.max_batching_rows);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -72214,7 +72036,6 @@ impl std::fmt::Debug for PythonOptions {
         let mut debug_struct = f.debug_struct("PythonOptions");
         debug_struct.field("entry_point", &self.entry_point);
         debug_struct.field("packages", &self.packages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72512,7 +72333,6 @@ impl std::fmt::Debug for ExternalRuntimeOptions {
         debug_struct.field("runtime_connection", &self.runtime_connection);
         debug_struct.field("max_batching_rows", &self.max_batching_rows);
         debug_struct.field("runtime_version", &self.runtime_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72929,7 +72749,6 @@ impl std::fmt::Debug for SparkOptions {
         debug_struct.field("file_uris", &self.file_uris);
         debug_struct.field("archive_uris", &self.archive_uris);
         debug_struct.field("main_class", &self.main_class);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73124,7 +72943,6 @@ impl std::fmt::Debug for GetRoutineRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("routine_id", &self.routine_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73329,7 +73147,6 @@ impl std::fmt::Debug for InsertRoutineRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("routine", &self.routine);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73560,7 +73377,6 @@ impl std::fmt::Debug for UpdateRoutineRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("routine_id", &self.routine_id);
         debug_struct.field("routine", &self.routine);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73831,7 +73647,6 @@ impl std::fmt::Debug for PatchRoutineRequest {
         debug_struct.field("routine_id", &self.routine_id);
         debug_struct.field("routine", &self.routine);
         debug_struct.field("field_mask", &self.field_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74026,7 +73841,6 @@ impl std::fmt::Debug for DeleteRoutineRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("routine_id", &self.routine_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74308,7 +74122,6 @@ impl std::fmt::Debug for ListRoutinesRequest {
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74482,7 +74295,6 @@ impl std::fmt::Debug for ListRoutinesResponse {
         let mut debug_struct = f.debug_struct("ListRoutinesResponse");
         debug_struct.field("routines", &self.routines);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74679,7 +74491,6 @@ impl std::fmt::Debug for RoutineReference {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("routine_id", &self.routine_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74946,7 +74757,6 @@ impl std::fmt::Debug for ListRowAccessPoliciesRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75136,7 +74946,6 @@ impl std::fmt::Debug for ListRowAccessPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListRowAccessPoliciesResponse");
         debug_struct.field("row_access_policies", &self.row_access_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75357,7 +75166,6 @@ impl std::fmt::Debug for GetRowAccessPolicyRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("policy_id", &self.policy_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75590,7 +75398,6 @@ impl std::fmt::Debug for CreateRowAccessPolicyRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("row_access_policy", &self.row_access_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75849,7 +75656,6 @@ impl std::fmt::Debug for UpdateRowAccessPolicyRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("policy_id", &self.policy_id);
         debug_struct.field("row_access_policy", &self.row_access_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76107,7 +75913,6 @@ impl std::fmt::Debug for DeleteRowAccessPolicyRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("policy_id", &self.policy_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76368,7 +76173,6 @@ impl std::fmt::Debug for BatchDeleteRowAccessPoliciesRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("policy_ids", &self.policy_ids);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76724,7 +76528,6 @@ impl std::fmt::Debug for RowAccessPolicy {
         debug_struct.field("creation_time", &self.creation_time);
         debug_struct.field("last_modified_time", &self.last_modified_time);
         debug_struct.field("grantees", &self.grantees);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76947,7 +76750,6 @@ impl std::fmt::Debug for RowAccessPolicyReference {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("policy_id", &self.policy_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77090,7 +76892,6 @@ impl std::fmt::Debug for SessionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SessionInfo");
         debug_struct.field("session_id", &self.session_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77473,7 +77274,6 @@ impl std::fmt::Debug for StandardSqlDataType {
         let mut debug_struct = f.debug_struct("StandardSqlDataType");
         debug_struct.field("type_kind", &self.type_kind);
         debug_struct.field("sub_type", &self.sub_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77912,7 +77712,6 @@ impl std::fmt::Debug for StandardSqlField {
         let mut debug_struct = f.debug_struct("StandardSqlField");
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78061,7 +77860,6 @@ impl std::fmt::Debug for StandardSqlStructType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StandardSqlStructType");
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78210,7 +78008,6 @@ impl std::fmt::Debug for StandardSqlTableType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StandardSqlTableType");
         debug_struct.field("columns", &self.columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78398,7 +78195,6 @@ impl std::fmt::Debug for SystemVariables {
         let mut debug_struct = f.debug_struct("SystemVariables");
         debug_struct.field("types", &self.types);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78735,7 +78531,6 @@ impl std::fmt::Debug for TableReplicationInfo {
         );
         debug_struct.field("replication_status", &self.replication_status);
         debug_struct.field("replication_error", &self.replication_error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79218,7 +79013,6 @@ impl std::fmt::Debug for ViewDefinition {
         debug_struct.field("use_explicit_column_names", &self.use_explicit_column_names);
         debug_struct.field("privacy_policy", &self.privacy_policy);
         debug_struct.field("foreign_definitions", &self.foreign_definitions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79386,7 +79180,6 @@ impl std::fmt::Debug for ForeignViewDefinition {
         let mut debug_struct = f.debug_struct("ForeignViewDefinition");
         debug_struct.field("query", &self.query);
         debug_struct.field("dialect", &self.dialect);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79725,7 +79518,6 @@ impl std::fmt::Debug for MaterializedViewDefinition {
             "allow_non_incremental_definition",
             &self.allow_non_incremental_definition,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79920,7 +79712,6 @@ impl std::fmt::Debug for MaterializedViewStatus {
         let mut debug_struct = f.debug_struct("MaterializedViewStatus");
         debug_struct.field("refresh_watermark", &self.refresh_watermark);
         debug_struct.field("last_refresh_status", &self.last_refresh_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80113,7 +79904,6 @@ impl std::fmt::Debug for SnapshotDefinition {
         let mut debug_struct = f.debug_struct("SnapshotDefinition");
         debug_struct.field("base_table_reference", &self.base_table_reference);
         debug_struct.field("snapshot_time", &self.snapshot_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80306,7 +80096,6 @@ impl std::fmt::Debug for CloneDefinition {
         let mut debug_struct = f.debug_struct("CloneDefinition");
         debug_struct.field("base_table_reference", &self.base_table_reference);
         debug_struct.field("clone_time", &self.clone_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80561,7 +80350,6 @@ impl std::fmt::Debug for Streamingbuffer {
         debug_struct.field("estimated_bytes", &self.estimated_bytes);
         debug_struct.field("estimated_rows", &self.estimated_rows);
         debug_struct.field("oldest_entry_time", &self.oldest_entry_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82952,7 +82740,6 @@ impl std::fmt::Debug for Table {
             "external_catalog_table_options",
             &self.external_catalog_table_options,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83210,7 +82997,6 @@ impl std::fmt::Debug for GetTableRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("selected_fields", &self.selected_fields);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83567,7 +83353,6 @@ impl std::fmt::Debug for InsertTableRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table", &self.table);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83823,7 +83608,6 @@ impl std::fmt::Debug for UpdateOrPatchTableRequest {
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("table", &self.table);
         debug_struct.field("autodetect_schema", &self.autodetect_schema);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84018,7 +83802,6 @@ impl std::fmt::Debug for DeleteTableRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84273,7 +84056,6 @@ impl std::fmt::Debug for ListTablesRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84465,7 +84247,6 @@ impl std::fmt::Debug for ListFormatView {
         let mut debug_struct = f.debug_struct("ListFormatView");
         debug_struct.field("use_legacy_sql", &self.use_legacy_sql);
         debug_struct.field("privacy_policy", &self.privacy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85050,7 +84831,6 @@ impl std::fmt::Debug for ListFormatTable {
         debug_struct.field("creation_time", &self.creation_time);
         debug_struct.field("expiration_time", &self.expiration_time);
         debug_struct.field("require_partition_filter", &self.require_partition_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85333,7 +85113,6 @@ impl std::fmt::Debug for TableList {
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("tables", &self.tables);
         debug_struct.field("total_items", &self.total_items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85478,7 +85257,6 @@ impl std::fmt::Debug for PrimaryKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrimaryKey");
         debug_struct.field("columns", &self.columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85654,7 +85432,6 @@ impl std::fmt::Debug for ColumnReference {
         let mut debug_struct = f.debug_struct("ColumnReference");
         debug_struct.field("referencing_column", &self.referencing_column);
         debug_struct.field("referenced_column", &self.referenced_column);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85868,7 +85645,6 @@ impl std::fmt::Debug for ForeignKey {
         debug_struct.field("name", &self.name);
         debug_struct.field("referenced_table", &self.referenced_table);
         debug_struct.field("column_references", &self.column_references);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86054,7 +85830,6 @@ impl std::fmt::Debug for TableConstraints {
         let mut debug_struct = f.debug_struct("TableConstraints");
         debug_struct.field("primary_key", &self.primary_key);
         debug_struct.field("foreign_keys", &self.foreign_keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86254,7 +86029,6 @@ impl std::fmt::Debug for TableReference {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86445,7 +86219,6 @@ impl std::fmt::Debug for TableSchema {
         let mut debug_struct = f.debug_struct("TableSchema");
         debug_struct.field("fields", &self.fields);
         debug_struct.field("foreign_type_info", &self.foreign_type_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86594,7 +86367,6 @@ impl std::fmt::Debug for ForeignTypeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ForeignTypeInfo");
         debug_struct.field("type_system", &self.type_system);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86881,7 +86653,6 @@ impl std::fmt::Debug for DataPolicyOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataPolicyOption");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -87597,7 +87368,6 @@ impl std::fmt::Debug for TableFieldSchema {
         debug_struct.field("default_value_expression", &self.default_value_expression);
         debug_struct.field("range_element_type", &self.range_element_type);
         debug_struct.field("foreign_type_definition", &self.foreign_type_definition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -87751,7 +87521,6 @@ pub mod table_field_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PolicyTagList");
             debug_struct.field("names", &self.names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -87899,7 +87668,6 @@ pub mod table_field_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FieldElementType");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -88289,7 +88057,6 @@ impl std::fmt::Debug for TimePartitioning {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("expiration_ms", &self.expiration_ms);
         debug_struct.field("field", &self.field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88489,7 +88256,6 @@ impl std::fmt::Debug for UserDefinedFunctionResource {
         let mut debug_struct = f.debug_struct("UserDefinedFunctionResource");
         debug_struct.field("resource_uri", &self.resource_uri);
         debug_struct.field("inline_code", &self.inline_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -326,7 +326,6 @@ impl std::fmt::Debug for BillingAccount {
         debug_struct.field("master_billing_account", &self.master_billing_account);
         debug_struct.field("parent", &self.parent);
         debug_struct.field("currency_code", &self.currency_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -560,7 +559,6 @@ impl std::fmt::Debug for ProjectBillingInfo {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("billing_account_name", &self.billing_account_name);
         debug_struct.field("billing_enabled", &self.billing_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -703,7 +701,6 @@ impl std::fmt::Debug for GetBillingAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBillingAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -955,7 +952,6 @@ impl std::fmt::Debug for ListBillingAccountsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1147,7 +1143,6 @@ impl std::fmt::Debug for ListBillingAccountsResponse {
         let mut debug_struct = f.debug_struct("ListBillingAccountsResponse");
         debug_struct.field("billing_accounts", &self.billing_accounts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1334,7 +1329,6 @@ impl std::fmt::Debug for CreateBillingAccountRequest {
         let mut debug_struct = f.debug_struct("CreateBillingAccountRequest");
         debug_struct.field("billing_account", &self.billing_account);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1552,7 +1546,6 @@ impl std::fmt::Debug for UpdateBillingAccountRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("account", &self.account);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1769,7 +1762,6 @@ impl std::fmt::Debug for ListProjectBillingInfoRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1962,7 +1954,6 @@ impl std::fmt::Debug for ListProjectBillingInfoResponse {
         let mut debug_struct = f.debug_struct("ListProjectBillingInfoResponse");
         debug_struct.field("project_billing_info", &self.project_billing_info);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2105,7 +2096,6 @@ impl std::fmt::Debug for GetProjectBillingInfoRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProjectBillingInfoRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2288,7 +2278,6 @@ impl std::fmt::Debug for UpdateProjectBillingInfoRequest {
         let mut debug_struct = f.debug_struct("UpdateProjectBillingInfoRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("project_billing_info", &self.project_billing_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2464,7 +2453,6 @@ impl std::fmt::Debug for MoveBillingAccountRequest {
         let mut debug_struct = f.debug_struct("MoveBillingAccountRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination_parent", &self.destination_parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2690,7 +2678,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("business_entity_name", &self.business_entity_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3049,7 +3036,6 @@ impl std::fmt::Debug for Sku {
         debug_struct.field("pricing_info", &self.pricing_info);
         debug_struct.field("service_provider_name", &self.service_provider_name);
         debug_struct.field("geo_taxonomy", &self.geo_taxonomy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3276,7 +3262,6 @@ impl std::fmt::Debug for Category {
         debug_struct.field("resource_family", &self.resource_family);
         debug_struct.field("resource_group", &self.resource_group);
         debug_struct.field("usage_type", &self.usage_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3592,7 +3577,6 @@ impl std::fmt::Debug for PricingInfo {
         debug_struct.field("pricing_expression", &self.pricing_expression);
         debug_struct.field("aggregation_info", &self.aggregation_info);
         debug_struct.field("currency_conversion_rate", &self.currency_conversion_rate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3978,7 +3962,6 @@ impl std::fmt::Debug for PricingExpression {
             "base_unit_conversion_factor",
             &self.base_unit_conversion_factor,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4188,7 +4171,6 @@ pub mod pricing_expression {
             let mut debug_struct = f.debug_struct("TierRate");
             debug_struct.field("start_usage_amount", &self.start_usage_amount);
             debug_struct.field("unit_price", &self.unit_price);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4417,7 +4399,6 @@ impl std::fmt::Debug for AggregationInfo {
         debug_struct.field("aggregation_level", &self.aggregation_level);
         debug_struct.field("aggregation_interval", &self.aggregation_interval);
         debug_struct.field("aggregation_count", &self.aggregation_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4857,7 +4838,6 @@ impl std::fmt::Debug for GeoTaxonomy {
         let mut debug_struct = f.debug_struct("GeoTaxonomy");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("regions", &self.regions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5193,7 +5173,6 @@ impl std::fmt::Debug for ListServicesRequest {
         let mut debug_struct = f.debug_struct("ListServicesRequest");
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5380,7 +5359,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5707,7 +5685,6 @@ impl std::fmt::Debug for ListSkusRequest {
         debug_struct.field("currency_code", &self.currency_code);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5894,7 +5871,6 @@ impl std::fmt::Debug for ListSkusResponse {
         let mut debug_struct = f.debug_struct("ListSkusResponse");
         debug_struct.field("skus", &self.skus);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -559,7 +559,6 @@ impl std::fmt::Debug for Policy {
         );
         debug_struct.field("default_admission_rule", &self.default_admission_rule);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -850,7 +849,6 @@ impl std::fmt::Debug for AdmissionWhitelistPattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdmissionWhitelistPattern");
         debug_struct.field("name_pattern", &self.name_pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1079,7 +1077,6 @@ impl std::fmt::Debug for AdmissionRule {
         debug_struct.field("evaluation_mode", &self.evaluation_mode);
         debug_struct.field("require_attestations_by", &self.require_attestations_by);
         debug_struct.field("enforcement_mode", &self.enforcement_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1646,7 +1643,6 @@ impl std::fmt::Debug for Attestor {
         debug_struct.field("description", &self.description);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("attestor_type", &self.attestor_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1900,7 +1896,6 @@ impl std::fmt::Debug for UserOwnedGrafeasNote {
             "delegation_service_account_email",
             &self.delegation_service_account_email,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2084,7 +2079,6 @@ impl std::fmt::Debug for PkixPublicKey {
         let mut debug_struct = f.debug_struct("PkixPublicKey");
         debug_struct.field("public_key_pem", &self.public_key_pem);
         debug_struct.field("signature_algorithm", &self.signature_algorithm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2622,7 +2616,6 @@ impl std::fmt::Debug for AttestorPublicKey {
         debug_struct.field("comment", &self.comment);
         debug_struct.field("id", &self.id);
         debug_struct.field("public_key", &self.public_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2794,7 +2787,6 @@ impl std::fmt::Debug for GetPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2952,7 +2944,6 @@ impl std::fmt::Debug for UpdatePolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdatePolicyRequest");
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3165,7 +3156,6 @@ impl std::fmt::Debug for CreateAttestorRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("attestor_id", &self.attestor_id);
         debug_struct.field("attestor", &self.attestor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3310,7 +3300,6 @@ impl std::fmt::Debug for GetAttestorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAttestorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3468,7 +3457,6 @@ impl std::fmt::Debug for UpdateAttestorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateAttestorRequest");
         debug_struct.field("attestor", &self.attestor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3688,7 +3676,6 @@ impl std::fmt::Debug for ListAttestorsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3879,7 +3866,6 @@ impl std::fmt::Debug for ListAttestorsResponse {
         let mut debug_struct = f.debug_struct("ListAttestorsResponse");
         debug_struct.field("attestors", &self.attestors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4024,7 +4010,6 @@ impl std::fmt::Debug for DeleteAttestorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAttestorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4167,7 +4152,6 @@ impl std::fmt::Debug for GetSystemPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSystemPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4414,7 +4398,6 @@ impl std::fmt::Debug for ValidateAttestationOccurrenceRequest {
         debug_struct.field("attestation", &self.attestation);
         debug_struct.field("occurrence_note", &self.occurrence_note);
         debug_struct.field("occurrence_resource_uri", &self.occurrence_resource_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4593,7 +4576,6 @@ impl std::fmt::Debug for ValidateAttestationOccurrenceResponse {
         let mut debug_struct = f.debug_struct("ValidateAttestationOccurrenceResponse");
         debug_struct.field("result", &self.result);
         debug_struct.field("denial_reason", &self.denial_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -295,7 +295,6 @@ impl std::fmt::Debug for ListCertificateIssuanceConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -526,7 +525,6 @@ impl std::fmt::Debug for ListCertificateIssuanceConfigsResponse {
         );
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -669,7 +667,6 @@ impl std::fmt::Debug for GetCertificateIssuanceConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateIssuanceConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -899,7 +896,6 @@ impl std::fmt::Debug for CreateCertificateIssuanceConfigRequest {
             "certificate_issuance_config",
             &self.certificate_issuance_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1043,7 +1039,6 @@ impl std::fmt::Debug for DeleteCertificateIssuanceConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCertificateIssuanceConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1501,7 +1496,6 @@ impl std::fmt::Debug for CertificateIssuanceConfig {
             &self.rotation_window_percentage,
         );
         debug_struct.field("key_algorithm", &self.key_algorithm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1696,7 +1690,6 @@ pub mod certificate_issuance_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CertificateAuthorityConfig");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1855,7 +1848,6 @@ pub mod certificate_issuance_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CertificateAuthorityServiceConfig");
                 debug_struct.field("ca_pool", &self.ca_pool);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2264,7 +2256,6 @@ impl std::fmt::Debug for ListCertificatesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2479,7 +2470,6 @@ impl std::fmt::Debug for ListCertificatesResponse {
         debug_struct.field("certificates", &self.certificates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2622,7 +2612,6 @@ impl std::fmt::Debug for GetCertificateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2827,7 +2816,6 @@ impl std::fmt::Debug for CreateCertificateRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("certificate_id", &self.certificate_id);
         debug_struct.field("certificate", &self.certificate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3019,7 +3007,6 @@ impl std::fmt::Debug for UpdateCertificateRequest {
         let mut debug_struct = f.debug_struct("UpdateCertificateRequest");
         debug_struct.field("certificate", &self.certificate);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3162,7 +3149,6 @@ impl std::fmt::Debug for DeleteCertificateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCertificateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3430,7 +3416,6 @@ impl std::fmt::Debug for ListCertificateMapsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3650,7 +3635,6 @@ impl std::fmt::Debug for ListCertificateMapsResponse {
         debug_struct.field("certificate_maps", &self.certificate_maps);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3793,7 +3777,6 @@ impl std::fmt::Debug for GetCertificateMapRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateMapRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4003,7 +3986,6 @@ impl std::fmt::Debug for CreateCertificateMapRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("certificate_map_id", &self.certificate_map_id);
         debug_struct.field("certificate_map", &self.certificate_map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4197,7 +4179,6 @@ impl std::fmt::Debug for UpdateCertificateMapRequest {
         let mut debug_struct = f.debug_struct("UpdateCertificateMapRequest");
         debug_struct.field("certificate_map", &self.certificate_map);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4340,7 +4321,6 @@ impl std::fmt::Debug for DeleteCertificateMapRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCertificateMapRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4613,7 +4593,6 @@ impl std::fmt::Debug for ListCertificateMapEntriesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4833,7 +4812,6 @@ impl std::fmt::Debug for ListCertificateMapEntriesResponse {
         debug_struct.field("certificate_map_entries", &self.certificate_map_entries);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4976,7 +4954,6 @@ impl std::fmt::Debug for GetCertificateMapEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateMapEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5187,7 +5164,6 @@ impl std::fmt::Debug for CreateCertificateMapEntryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("certificate_map_entry_id", &self.certificate_map_entry_id);
         debug_struct.field("certificate_map_entry", &self.certificate_map_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5380,7 +5356,6 @@ impl std::fmt::Debug for UpdateCertificateMapEntryRequest {
         let mut debug_struct = f.debug_struct("UpdateCertificateMapEntryRequest");
         debug_struct.field("certificate_map_entry", &self.certificate_map_entry);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5523,7 +5498,6 @@ impl std::fmt::Debug for DeleteCertificateMapEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCertificateMapEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5791,7 +5765,6 @@ impl std::fmt::Debug for ListDnsAuthorizationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6011,7 +5984,6 @@ impl std::fmt::Debug for ListDnsAuthorizationsResponse {
         debug_struct.field("dns_authorizations", &self.dns_authorizations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6154,7 +6126,6 @@ impl std::fmt::Debug for GetDnsAuthorizationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDnsAuthorizationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6364,7 +6335,6 @@ impl std::fmt::Debug for CreateDnsAuthorizationRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("dns_authorization_id", &self.dns_authorization_id);
         debug_struct.field("dns_authorization", &self.dns_authorization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6558,7 +6528,6 @@ impl std::fmt::Debug for UpdateDnsAuthorizationRequest {
         let mut debug_struct = f.debug_struct("UpdateDnsAuthorizationRequest");
         debug_struct.field("dns_authorization", &self.dns_authorization);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6701,7 +6670,6 @@ impl std::fmt::Debug for DeleteDnsAuthorizationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDnsAuthorizationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7026,7 +6994,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7553,7 +7520,6 @@ impl std::fmt::Debug for Certificate {
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("scope", &self.scope);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7739,7 +7705,6 @@ pub mod certificate {
             let mut debug_struct = f.debug_struct("SelfManagedCertificate");
             debug_struct.field("pem_certificate", &self.pem_certificate);
             debug_struct.field("pem_private_key", &self.pem_private_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8076,7 +8041,6 @@ pub mod certificate {
                 "authorization_attempt_info",
                 &self.authorization_attempt_info,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8263,7 +8227,6 @@ pub mod certificate {
                 let mut debug_struct = f.debug_struct("ProvisioningIssue");
                 debug_struct.field("reason", &self.reason);
                 debug_struct.field("details", &self.details);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8638,7 +8601,6 @@ pub mod certificate {
                 debug_struct.field("state", &self.state);
                 debug_struct.field("failure_reason", &self.failure_reason);
                 debug_struct.field("details", &self.details);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9543,7 +9505,6 @@ impl std::fmt::Debug for CertificateMap {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("gclb_targets", &self.gclb_targets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9827,7 +9788,6 @@ pub mod certificate_map {
             let mut debug_struct = f.debug_struct("GclbTarget");
             debug_struct.field("ip_configs", &self.ip_configs);
             debug_struct.field("target_proxy", &self.target_proxy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10047,7 +10007,6 @@ pub mod certificate_map {
                 let mut debug_struct = f.debug_struct("IpConfig");
                 debug_struct.field("ip_address", &self.ip_address);
                 debug_struct.field("ports", &self.ports);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -10511,7 +10470,6 @@ impl std::fmt::Debug for CertificateMapEntry {
         debug_struct.field("certificates", &self.certificates);
         debug_struct.field("state", &self.state);
         debug_struct.field("r#match", &self.r#match);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11032,7 +10990,6 @@ impl std::fmt::Debug for DnsAuthorization {
         debug_struct.field("domain", &self.domain);
         debug_struct.field("dns_resource_record", &self.dns_resource_record);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11236,7 +11193,6 @@ pub mod dns_authorization {
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("data", &self.data);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11639,7 +11595,6 @@ impl std::fmt::Debug for ListTrustConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11855,7 +11810,6 @@ impl std::fmt::Debug for ListTrustConfigsResponse {
         debug_struct.field("trust_configs", &self.trust_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11998,7 +11952,6 @@ impl std::fmt::Debug for GetTrustConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTrustConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12205,7 +12158,6 @@ impl std::fmt::Debug for CreateTrustConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("trust_config_id", &self.trust_config_id);
         debug_struct.field("trust_config", &self.trust_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12398,7 +12350,6 @@ impl std::fmt::Debug for UpdateTrustConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateTrustConfigRequest");
         debug_struct.field("trust_config", &self.trust_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12568,7 +12519,6 @@ impl std::fmt::Debug for DeleteTrustConfigRequest {
         let mut debug_struct = f.debug_struct("DeleteTrustConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12912,7 +12862,6 @@ impl std::fmt::Debug for TrustConfig {
         debug_struct.field("description", &self.description);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("trust_stores", &self.trust_stores);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13107,7 +13056,6 @@ pub mod trust_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TrustAnchor");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13312,7 +13260,6 @@ pub mod trust_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IntermediateCA");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13519,7 +13466,6 @@ pub mod trust_config {
             let mut debug_struct = f.debug_struct("TrustStore");
             debug_struct.field("trust_anchors", &self.trust_anchors);
             debug_struct.field("intermediate_cas", &self.intermediate_cas);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/chronicle/v1/src/model.rs
+++ b/src/generated/cloud/chronicle/v1/src/model.rs
@@ -238,7 +238,6 @@ impl std::fmt::Debug for CreateDataAccessLabelRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("data_access_label", &self.data_access_label);
         debug_struct.field("data_access_label_id", &self.data_access_label_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -382,7 +381,6 @@ impl std::fmt::Debug for GetDataAccessLabelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataAccessLabelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -628,7 +626,6 @@ impl std::fmt::Debug for ListDataAccessLabelsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -819,7 +816,6 @@ impl std::fmt::Debug for ListDataAccessLabelsResponse {
         let mut debug_struct = f.debug_struct("ListDataAccessLabelsResponse");
         debug_struct.field("data_access_labels", &self.data_access_labels);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1018,7 +1014,6 @@ impl std::fmt::Debug for UpdateDataAccessLabelRequest {
         let mut debug_struct = f.debug_struct("UpdateDataAccessLabelRequest");
         debug_struct.field("data_access_label", &self.data_access_label);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1162,7 +1157,6 @@ impl std::fmt::Debug for DeleteDataAccessLabelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDataAccessLabelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1374,7 +1368,6 @@ impl std::fmt::Debug for CreateDataAccessScopeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("data_access_scope", &self.data_access_scope);
         debug_struct.field("data_access_scope_id", &self.data_access_scope_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1518,7 +1511,6 @@ impl std::fmt::Debug for GetDataAccessScopeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataAccessScopeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1764,7 +1756,6 @@ impl std::fmt::Debug for ListDataAccessScopesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2005,7 +1996,6 @@ impl std::fmt::Debug for ListDataAccessScopesResponse {
             &self.global_data_access_scope_granted,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2205,7 +2195,6 @@ impl std::fmt::Debug for UpdateDataAccessScopeRequest {
         let mut debug_struct = f.debug_struct("UpdateDataAccessScopeRequest");
         debug_struct.field("data_access_scope", &self.data_access_scope);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2349,7 +2338,6 @@ impl std::fmt::Debug for DeleteDataAccessScopeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDataAccessScopeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2737,7 +2725,6 @@ impl std::fmt::Debug for DataAccessLabel {
         debug_struct.field("last_editor", &self.last_editor);
         debug_struct.field("description", &self.description);
         debug_struct.field("definition", &self.definition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3192,7 +3179,6 @@ impl std::fmt::Debug for DataAccessScope {
         debug_struct.field("last_editor", &self.last_editor);
         debug_struct.field("description", &self.description);
         debug_struct.field("allow_all", &self.allow_all);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3565,7 +3551,6 @@ impl std::fmt::Debug for DataAccessLabelReference {
         let mut debug_struct = f.debug_struct("DataAccessLabelReference");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("label", &self.label);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3763,7 +3748,6 @@ impl std::fmt::Debug for IngestionLabel {
         let mut debug_struct = f.debug_struct("IngestionLabel");
         debug_struct.field("ingestion_label_key", &self.ingestion_label_key);
         debug_struct.field("ingestion_label_value", &self.ingestion_label_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4213,7 +4197,6 @@ impl std::fmt::Debug for Watchlist {
             "watchlist_user_preferences",
             &self.watchlist_user_preferences,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4420,7 +4403,6 @@ pub mod watchlist {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EntityPopulationMechanism");
             debug_struct.field("mechanism", &self.mechanism);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4545,7 +4527,6 @@ pub mod watchlist {
         impl std::fmt::Debug for Manual {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Manual");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4761,7 +4742,6 @@ pub mod watchlist {
             let mut debug_struct = f.debug_struct("EntityCount");
             debug_struct.field("user", &self.user);
             debug_struct.field("asset", &self.asset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4904,7 +4884,6 @@ impl std::fmt::Debug for WatchlistUserPreferences {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WatchlistUserPreferences");
         debug_struct.field("pinned", &self.pinned);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5049,7 +5028,6 @@ impl std::fmt::Debug for GetWatchlistRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWatchlistRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5300,7 +5278,6 @@ impl std::fmt::Debug for ListWatchlistsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5486,7 +5463,6 @@ impl std::fmt::Debug for ListWatchlistsResponse {
         let mut debug_struct = f.debug_struct("ListWatchlistsResponse");
         debug_struct.field("watchlists", &self.watchlists);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5695,7 +5671,6 @@ impl std::fmt::Debug for CreateWatchlistRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("watchlist_id", &self.watchlist_id);
         debug_struct.field("watchlist", &self.watchlist);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5889,7 +5864,6 @@ impl std::fmt::Debug for UpdateWatchlistRequest {
         let mut debug_struct = f.debug_struct("UpdateWatchlistRequest");
         debug_struct.field("watchlist", &self.watchlist);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6060,7 +6034,6 @@ impl std::fmt::Debug for DeleteWatchlistRequest {
         let mut debug_struct = f.debug_struct("DeleteWatchlistRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6203,7 +6176,6 @@ impl std::fmt::Debug for Instance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Instance");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6347,7 +6319,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6502,7 +6473,6 @@ impl std::fmt::Debug for ScopeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScopeInfo");
         debug_struct.field("reference_list_scope", &self.reference_list_scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6650,7 +6620,6 @@ impl std::fmt::Debug for ReferenceListScope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReferenceListScope");
         debug_struct.field("scope_names", &self.scope_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6824,7 +6793,6 @@ impl std::fmt::Debug for GetReferenceListRequest {
         let mut debug_struct = f.debug_struct("GetReferenceListRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7074,7 +7042,6 @@ impl std::fmt::Debug for ListReferenceListsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7262,7 +7229,6 @@ impl std::fmt::Debug for ListReferenceListsResponse {
         let mut debug_struct = f.debug_struct("ListReferenceListsResponse");
         debug_struct.field("reference_lists", &self.reference_lists);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7477,7 +7443,6 @@ impl std::fmt::Debug for CreateReferenceListRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("reference_list", &self.reference_list);
         debug_struct.field("reference_list_id", &self.reference_list_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7675,7 +7640,6 @@ impl std::fmt::Debug for UpdateReferenceListRequest {
         let mut debug_struct = f.debug_struct("UpdateReferenceListRequest");
         debug_struct.field("reference_list", &self.reference_list);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8091,7 +8055,6 @@ impl std::fmt::Debug for ReferenceList {
         debug_struct.field("syntax_type", &self.syntax_type);
         debug_struct.field("rule_associations_count", &self.rule_associations_count);
         debug_struct.field("scope_info", &self.scope_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8233,7 +8196,6 @@ impl std::fmt::Debug for ReferenceListEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReferenceListEntry");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8924,7 +8886,6 @@ impl std::fmt::Debug for Rule {
             &self.near_real_time_live_rule_eligible,
         );
         debug_struct.field("inputs_used", &self.inputs_used);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9509,7 +9470,6 @@ impl std::fmt::Debug for RuleDeployment {
             "last_alert_status_change_time",
             &self.last_alert_status_change_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9952,7 +9912,6 @@ impl std::fmt::Debug for Retrohunt {
         debug_struct.field("execution_interval", &self.execution_interval);
         debug_struct.field("state", &self.state);
         debug_struct.field("progress_percentage", &self.progress_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10283,7 +10242,6 @@ impl std::fmt::Debug for CreateRuleRequest {
         let mut debug_struct = f.debug_struct("CreateRuleRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10453,7 +10411,6 @@ impl std::fmt::Debug for GetRuleRequest {
         let mut debug_struct = f.debug_struct("GetRuleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10727,7 +10684,6 @@ impl std::fmt::Debug for ListRulesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10913,7 +10869,6 @@ impl std::fmt::Debug for ListRulesResponse {
         let mut debug_struct = f.debug_struct("ListRulesResponse");
         debug_struct.field("rules", &self.rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11108,7 +11063,6 @@ impl std::fmt::Debug for UpdateRuleRequest {
         let mut debug_struct = f.debug_struct("UpdateRuleRequest");
         debug_struct.field("rule", &self.rule);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11283,7 +11237,6 @@ impl std::fmt::Debug for DeleteRuleRequest {
         let mut debug_struct = f.debug_struct("DeleteRuleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11530,7 +11483,6 @@ impl std::fmt::Debug for ListRuleRevisionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11716,7 +11668,6 @@ impl std::fmt::Debug for ListRuleRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListRuleRevisionsResponse");
         debug_struct.field("rules", &self.rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11896,7 +11847,6 @@ impl std::fmt::Debug for CreateRetrohuntRequest {
         let mut debug_struct = f.debug_struct("CreateRetrohuntRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("retrohunt", &self.retrohunt);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12040,7 +11990,6 @@ impl std::fmt::Debug for GetRetrohuntRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRetrohuntRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12288,7 +12237,6 @@ impl std::fmt::Debug for ListRetrohuntsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12474,7 +12422,6 @@ impl std::fmt::Debug for ListRetrohuntsResponse {
         let mut debug_struct = f.debug_struct("ListRetrohuntsResponse");
         debug_struct.field("retrohunts", &self.retrohunts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12618,7 +12565,6 @@ impl std::fmt::Debug for GetRuleDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRuleDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12867,7 +12813,6 @@ impl std::fmt::Debug for ListRuleDeploymentsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13058,7 +13003,6 @@ impl std::fmt::Debug for ListRuleDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListRuleDeploymentsResponse");
         debug_struct.field("rule_deployments", &self.rule_deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13254,7 +13198,6 @@ impl std::fmt::Debug for UpdateRuleDeploymentRequest {
         let mut debug_struct = f.debug_struct("UpdateRuleDeploymentRequest");
         debug_struct.field("rule_deployment", &self.rule_deployment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13548,7 +13491,6 @@ impl std::fmt::Debug for CompilationPosition {
         debug_struct.field("start_column", &self.start_column);
         debug_struct.field("end_line", &self.end_line);
         debug_struct.field("end_column", &self.end_column);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13786,7 +13728,6 @@ impl std::fmt::Debug for CompilationDiagnostic {
         debug_struct.field("position", &self.position);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14068,7 +14009,6 @@ impl std::fmt::Debug for Severity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Severity");
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14295,7 +14235,6 @@ impl std::fmt::Debug for RetrohuntMetadata {
         debug_struct.field("retrohunt", &self.retrohunt);
         debug_struct.field("execution_interval", &self.execution_interval);
         debug_struct.field("progress_percentage", &self.progress_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14492,7 +14431,6 @@ impl std::fmt::Debug for InputsUsed {
         debug_struct.field("uses_udm", &self.uses_udm);
         debug_struct.field("uses_entity", &self.uses_entity);
         debug_struct.field("uses_detection", &self.uses_detection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -282,7 +282,6 @@ impl std::fmt::Debug for AccessApprovalRequest {
         debug_struct.field("request_time", &self.request_time);
         debug_struct.field("requested_reason", &self.requested_reason);
         debug_struct.field("requested_expiration_time", &self.requested_expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -551,7 +550,6 @@ impl std::fmt::Debug for ListAccessApprovalRequestsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -772,7 +770,6 @@ impl std::fmt::Debug for ListAccessApprovalRequestsResponse {
         debug_struct.field("access_approval_requests", &self.access_approval_requests);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -940,7 +937,6 @@ impl std::fmt::Debug for AccessReason {
         let mut debug_struct = f.debug_struct("AccessReason");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1455,7 +1451,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1858,7 +1853,6 @@ impl std::fmt::Debug for Workload {
         debug_struct.field("key_management_project_id", &self.key_management_project_id);
         debug_struct.field("location", &self.location);
         debug_struct.field("partner", &self.partner);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2304,7 +2298,6 @@ impl std::fmt::Debug for ListWorkloadsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2518,7 +2511,6 @@ impl std::fmt::Debug for ListWorkloadsResponse {
         debug_struct.field("workloads", &self.workloads);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2661,7 +2653,6 @@ impl std::fmt::Debug for GetWorkloadRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkloadRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2811,7 +2802,6 @@ impl std::fmt::Debug for WorkloadOnboardingState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WorkloadOnboardingState");
         debug_struct.field("onboarding_steps", &self.onboarding_steps);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3061,7 +3051,6 @@ impl std::fmt::Debug for WorkloadOnboardingStep {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("completion_time", &self.completion_time);
         debug_struct.field("completion_state", &self.completion_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3467,7 +3456,6 @@ impl std::fmt::Debug for Customer {
         debug_struct.field("customer_onboarding_state", &self.customer_onboarding_state);
         debug_struct.field("is_onboarded", &self.is_onboarded);
         debug_struct.field("organization_domain", &self.organization_domain);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3733,7 +3721,6 @@ impl std::fmt::Debug for ListCustomersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3947,7 +3934,6 @@ impl std::fmt::Debug for ListCustomersResponse {
         debug_struct.field("customers", &self.customers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4154,7 +4140,6 @@ impl std::fmt::Debug for CreateCustomerRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("customer", &self.customer);
         debug_struct.field("customer_id", &self.customer_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4297,7 +4282,6 @@ impl std::fmt::Debug for GetCustomerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCustomerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4447,7 +4431,6 @@ impl std::fmt::Debug for CustomerOnboardingState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomerOnboardingState");
         debug_struct.field("onboarding_steps", &self.onboarding_steps);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4697,7 +4680,6 @@ impl std::fmt::Debug for CustomerOnboardingStep {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("completion_time", &self.completion_time);
         debug_struct.field("completion_state", &self.completion_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5027,7 +5009,6 @@ impl std::fmt::Debug for UpdateCustomerRequest {
         let mut debug_struct = f.debug_struct("UpdateCustomerRequest");
         debug_struct.field("customer", &self.customer);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5170,7 +5151,6 @@ impl std::fmt::Debug for DeleteCustomerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCustomerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5342,7 +5322,6 @@ impl std::fmt::Debug for EkmConnections {
         let mut debug_struct = f.debug_struct("EkmConnections");
         debug_struct.field("name", &self.name);
         debug_struct.field("ekm_connections", &self.ekm_connections);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5485,7 +5464,6 @@ impl std::fmt::Debug for GetEkmConnectionsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEkmConnectionsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5700,7 +5678,6 @@ impl std::fmt::Debug for EkmConnection {
         debug_struct.field("connection_name", &self.connection_name);
         debug_struct.field("connection_state", &self.connection_state);
         debug_struct.field("connection_error", &self.connection_error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5884,7 +5861,6 @@ pub mod ekm_connection {
             let mut debug_struct = f.debug_struct("ConnectionError");
             debug_struct.field("error_domain", &self.error_domain);
             debug_struct.field("error_message", &self.error_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6207,7 +6183,6 @@ impl std::fmt::Debug for PartnerPermissions {
         let mut debug_struct = f.debug_struct("PartnerPermissions");
         debug_struct.field("name", &self.name);
         debug_struct.field("partner_permissions", &self.partner_permissions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6524,7 +6499,6 @@ impl std::fmt::Debug for GetPartnerPermissionsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPartnerPermissionsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6860,7 +6834,6 @@ impl std::fmt::Debug for Partner {
         debug_struct.field("partner_project_id", &self.partner_project_id);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7003,7 +6976,6 @@ impl std::fmt::Debug for GetPartnerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPartnerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7175,7 +7147,6 @@ impl std::fmt::Debug for Sku {
         let mut debug_struct = f.debug_struct("Sku");
         debug_struct.field("id", &self.id);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7349,7 +7320,6 @@ impl std::fmt::Debug for EkmMetadata {
         let mut debug_struct = f.debug_struct("EkmMetadata");
         debug_struct.field("ekm_solution", &self.ekm_solution);
         debug_struct.field("ekm_endpoint_uri", &self.ekm_endpoint_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7955,7 +7925,6 @@ impl std::fmt::Debug for Violation {
         debug_struct.field("non_compliant_org_policy", &self.non_compliant_org_policy);
         debug_struct.field("folder_id", &self.folder_id);
         debug_struct.field("remediation", &self.remediation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8183,7 +8152,6 @@ pub mod violation {
             debug_struct.field("instructions", &self.instructions);
             debug_struct.field("compliant_values", &self.compliant_values);
             debug_struct.field("remediation_type", &self.remediation_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8399,7 +8367,6 @@ pub mod violation {
                 let mut debug_struct = f.debug_struct("Instructions");
                 debug_struct.field("gcloud_instructions", &self.gcloud_instructions);
                 debug_struct.field("console_instructions", &self.console_instructions);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8637,7 +8604,6 @@ pub mod violation {
                     debug_struct.field("gcloud_commands", &self.gcloud_commands);
                     debug_struct.field("steps", &self.steps);
                     debug_struct.field("additional_links", &self.additional_links);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8870,7 +8836,6 @@ pub mod violation {
                     debug_struct.field("console_uris", &self.console_uris);
                     debug_struct.field("steps", &self.steps);
                     debug_struct.field("additional_links", &self.additional_links);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -9514,7 +9479,6 @@ impl std::fmt::Debug for ListViolationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("interval", &self.interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9729,7 +9693,6 @@ impl std::fmt::Debug for ListViolationsResponse {
         debug_struct.field("violations", &self.violations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9872,7 +9835,6 @@ impl std::fmt::Debug for GetViolationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetViolationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -306,7 +306,6 @@ impl std::fmt::Debug for ListMigrationJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -521,7 +520,6 @@ impl std::fmt::Debug for ListMigrationJobsResponse {
         debug_struct.field("migration_jobs", &self.migration_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -663,7 +661,6 @@ impl std::fmt::Debug for GetMigrationJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMigrationJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -906,7 +903,6 @@ impl std::fmt::Debug for CreateMigrationJobRequest {
         debug_struct.field("migration_job_id", &self.migration_job_id);
         debug_struct.field("migration_job", &self.migration_job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1130,7 +1126,6 @@ impl std::fmt::Debug for UpdateMigrationJobRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("migration_job", &self.migration_job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1331,7 +1326,6 @@ impl std::fmt::Debug for DeleteMigrationJobRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1500,7 +1494,6 @@ impl std::fmt::Debug for StartMigrationJobRequest {
         let mut debug_struct = f.debug_struct("StartMigrationJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("skip_validation", &self.skip_validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1642,7 +1635,6 @@ impl std::fmt::Debug for StopMigrationJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopMigrationJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1784,7 +1776,6 @@ impl std::fmt::Debug for ResumeMigrationJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeMigrationJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1926,7 +1917,6 @@ impl std::fmt::Debug for PromoteMigrationJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PromoteMigrationJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2144,7 +2134,6 @@ impl std::fmt::Debug for VerifyMigrationJobRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("migration_job", &self.migration_job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2313,7 +2302,6 @@ impl std::fmt::Debug for RestartMigrationJobRequest {
         let mut debug_struct = f.debug_struct("RestartMigrationJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("skip_validation", &self.skip_validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2655,7 +2643,6 @@ impl std::fmt::Debug for GenerateSshScriptRequest {
         debug_struct.field("vm", &self.vm);
         debug_struct.field("vm_port", &self.vm_port);
         debug_struct.field("vm_config", &self.vm_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2865,7 +2852,6 @@ impl std::fmt::Debug for VmCreationConfig {
         debug_struct.field("vm_machine_type", &self.vm_machine_type);
         debug_struct.field("vm_zone", &self.vm_zone);
         debug_struct.field("subnet", &self.subnet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3008,7 +2994,6 @@ impl std::fmt::Debug for VmSelectionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VmSelectionConfig");
         debug_struct.field("vm_zone", &self.vm_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3150,7 +3135,6 @@ impl std::fmt::Debug for SshScript {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SshScript");
         debug_struct.field("script", &self.script);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3403,7 +3387,6 @@ impl std::fmt::Debug for GenerateTcpProxyScriptRequest {
         debug_struct.field("vm_machine_type", &self.vm_machine_type);
         debug_struct.field("vm_zone", &self.vm_zone);
         debug_struct.field("vm_subnet", &self.vm_subnet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3545,7 +3528,6 @@ impl std::fmt::Debug for TcpProxyScript {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TcpProxyScript");
         debug_struct.field("script", &self.script);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3823,7 +3805,6 @@ impl std::fmt::Debug for ListConnectionProfilesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4042,7 +4023,6 @@ impl std::fmt::Debug for ListConnectionProfilesResponse {
         debug_struct.field("connection_profiles", &self.connection_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4184,7 +4164,6 @@ impl std::fmt::Debug for GetConnectionProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4481,7 +4460,6 @@ impl std::fmt::Debug for CreateConnectionProfileRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("skip_validation", &self.skip_validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4762,7 +4740,6 @@ impl std::fmt::Debug for UpdateConnectionProfileRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("skip_validation", &self.skip_validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4962,7 +4939,6 @@ impl std::fmt::Debug for DeleteConnectionProfileRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5230,7 +5206,6 @@ impl std::fmt::Debug for CreatePrivateConnectionRequest {
         debug_struct.field("private_connection", &self.private_connection);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("skip_validation", &self.skip_validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5506,7 +5481,6 @@ impl std::fmt::Debug for ListPrivateConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5725,7 +5699,6 @@ impl std::fmt::Debug for ListPrivateConnectionsResponse {
         debug_struct.field("private_connections", &self.private_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5899,7 +5872,6 @@ impl std::fmt::Debug for DeletePrivateConnectionRequest {
         let mut debug_struct = f.debug_struct("DeletePrivateConnectionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6041,7 +6013,6 @@ impl std::fmt::Debug for GetPrivateConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPrivateConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6368,7 +6339,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6618,7 +6588,6 @@ impl std::fmt::Debug for ListConversionWorkspacesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6837,7 +6806,6 @@ impl std::fmt::Debug for ListConversionWorkspacesResponse {
         debug_struct.field("conversion_workspaces", &self.conversion_workspaces);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6979,7 +6947,6 @@ impl std::fmt::Debug for GetConversionWorkspaceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConversionWorkspaceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7220,7 +7187,6 @@ impl std::fmt::Debug for CreateConversionWorkspaceRequest {
         debug_struct.field("conversion_workspace_id", &self.conversion_workspace_id);
         debug_struct.field("conversion_workspace", &self.conversion_workspace);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7444,7 +7410,6 @@ impl std::fmt::Debug for UpdateConversionWorkspaceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("conversion_workspace", &self.conversion_workspace);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7644,7 +7609,6 @@ impl std::fmt::Debug for DeleteConversionWorkspaceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7812,7 +7776,6 @@ impl std::fmt::Debug for CommitConversionWorkspaceRequest {
         let mut debug_struct = f.debug_struct("CommitConversionWorkspaceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("commit_name", &self.commit_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7954,7 +7917,6 @@ impl std::fmt::Debug for RollbackConversionWorkspaceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RollbackConversionWorkspaceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8253,7 +8215,6 @@ impl std::fmt::Debug for ApplyConversionWorkspaceRequest {
         debug_struct.field("dry_run", &self.dry_run);
         debug_struct.field("auto_commit", &self.auto_commit);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8487,7 +8448,6 @@ impl std::fmt::Debug for ListMappingRulesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8674,7 +8634,6 @@ impl std::fmt::Debug for ListMappingRulesResponse {
         let mut debug_struct = f.debug_struct("ListMappingRulesResponse");
         debug_struct.field("mapping_rules", &self.mapping_rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8822,7 +8781,6 @@ impl std::fmt::Debug for GetMappingRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMappingRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9127,7 +9085,6 @@ impl std::fmt::Debug for SeedConversionWorkspaceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("auto_commit", &self.auto_commit);
         debug_struct.field("seed_from", &self.seed_from);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9370,7 +9327,6 @@ impl std::fmt::Debug for ConvertConversionWorkspaceRequest {
         debug_struct.field("auto_commit", &self.auto_commit);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("convert_full_path", &self.convert_full_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9603,7 +9559,6 @@ impl std::fmt::Debug for ImportMappingRulesRequest {
         debug_struct.field("rules_format", &self.rules_format);
         debug_struct.field("rules_files", &self.rules_files);
         debug_struct.field("auto_commit", &self.auto_commit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9788,7 +9743,6 @@ pub mod import_mapping_rules_request {
             let mut debug_struct = f.debug_struct("RulesFile");
             debug_struct.field("rules_source_filename", &self.rules_source_filename);
             debug_struct.field("rules_content", &self.rules_content);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10150,7 +10104,6 @@ impl std::fmt::Debug for DescribeDatabaseEntitiesRequest {
         debug_struct.field("commit_id", &self.commit_id);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10486,7 +10439,6 @@ impl std::fmt::Debug for DescribeDatabaseEntitiesResponse {
         let mut debug_struct = f.debug_struct("DescribeDatabaseEntitiesResponse");
         debug_struct.field("database_entities", &self.database_entities);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10758,7 +10710,6 @@ impl std::fmt::Debug for SearchBackgroundJobsRequest {
         );
         debug_struct.field("max_size", &self.max_size);
         debug_struct.field("completed_until_time", &self.completed_until_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10907,7 +10858,6 @@ impl std::fmt::Debug for SearchBackgroundJobsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SearchBackgroundJobsResponse");
         debug_struct.field("jobs", &self.jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11083,7 +11033,6 @@ impl std::fmt::Debug for DescribeConversionWorkspaceRevisionsRequest {
         let mut debug_struct = f.debug_struct("DescribeConversionWorkspaceRevisionsRequest");
         debug_struct.field("conversion_workspace", &self.conversion_workspace);
         debug_struct.field("commit_id", &self.commit_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11234,7 +11183,6 @@ impl std::fmt::Debug for DescribeConversionWorkspaceRevisionsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DescribeConversionWorkspaceRevisionsResponse");
         debug_struct.field("revisions", &self.revisions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11473,7 +11421,6 @@ impl std::fmt::Debug for CreateMappingRuleRequest {
         debug_struct.field("mapping_rule_id", &self.mapping_rule_id);
         debug_struct.field("mapping_rule", &self.mapping_rule);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11647,7 +11594,6 @@ impl std::fmt::Debug for DeleteMappingRuleRequest {
         let mut debug_struct = f.debug_struct("DeleteMappingRuleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11860,7 +11806,6 @@ impl std::fmt::Debug for FetchStaticIpsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12033,7 +11978,6 @@ impl std::fmt::Debug for FetchStaticIpsResponse {
         let mut debug_struct = f.debug_struct("FetchStaticIpsResponse");
         debug_struct.field("static_ips", &self.static_ips);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12264,7 +12208,6 @@ impl std::fmt::Debug for SslConfig {
         debug_struct.field("client_key", &self.client_key);
         debug_struct.field("client_certificate", &self.client_certificate);
         debug_struct.field("ca_certificate", &self.ca_certificate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12732,7 +12675,6 @@ impl std::fmt::Debug for MySqlConnectionProfile {
         debug_struct.field("password_set", &self.password_set);
         debug_struct.field("ssl", &self.ssl);
         debug_struct.field("cloud_sql_id", &self.cloud_sql_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13228,7 +13170,6 @@ impl std::fmt::Debug for PostgreSqlConnectionProfile {
         debug_struct.field("cloud_sql_id", &self.cloud_sql_id);
         debug_struct.field("network_architecture", &self.network_architecture);
         debug_struct.field("connectivity", &self.connectivity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13774,7 +13715,6 @@ impl std::fmt::Debug for OracleConnectionProfile {
         debug_struct.field("database_service", &self.database_service);
         debug_struct.field("ssl", &self.ssl);
         debug_struct.field("connectivity", &self.connectivity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14057,7 +13997,6 @@ impl std::fmt::Debug for CloudSqlConnectionProfile {
         debug_struct.field("private_ip", &self.private_ip);
         debug_struct.field("public_ip", &self.public_ip);
         debug_struct.field("additional_public_ip", &self.additional_public_ip);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14239,7 +14178,6 @@ impl std::fmt::Debug for AlloyDbConnectionProfile {
         let mut debug_struct = f.debug_struct("AlloyDbConnectionProfile");
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("settings", &self.settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14517,7 +14455,6 @@ impl std::fmt::Debug for SqlAclEntry {
         debug_struct.field("value", &self.value);
         debug_struct.field("label", &self.label);
         debug_struct.field("expiration", &self.expiration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14821,7 +14758,6 @@ impl std::fmt::Debug for SqlIpConfig {
         debug_struct.field("allocated_ip_range", &self.allocated_ip_range);
         debug_struct.field("require_ssl", &self.require_ssl);
         debug_struct.field("authorized_networks", &self.authorized_networks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15606,7 +15542,6 @@ impl std::fmt::Debug for CloudSqlSettings {
         debug_struct.field("cmek_key_name", &self.cmek_key_name);
         debug_struct.field("availability_type", &self.availability_type);
         debug_struct.field("edition", &self.edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16637,7 +16572,6 @@ impl std::fmt::Debug for AlloyDbSettings {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("primary_instance_settings", &self.primary_instance_settings);
         debug_struct.field("encryption_config", &self.encryption_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16839,7 +16773,6 @@ pub mod alloy_db_settings {
             debug_struct.field("user", &self.user);
             debug_struct.field("password", &self.password);
             debug_struct.field("password_set", &self.password_set);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17132,7 +17065,6 @@ pub mod alloy_db_settings {
             debug_struct.field("database_flags", &self.database_flags);
             debug_struct.field("labels", &self.labels);
             debug_struct.field("private_ip", &self.private_ip);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17310,7 +17242,6 @@ pub mod alloy_db_settings {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("MachineConfig");
                 debug_struct.field("cpu_count", &self.cpu_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17463,7 +17394,6 @@ pub mod alloy_db_settings {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EncryptionConfig");
             debug_struct.field("kms_key_name", &self.kms_key_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17581,7 +17511,6 @@ impl serde::ser::Serialize for StaticIpConnectivity {
 impl std::fmt::Debug for StaticIpConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StaticIpConnectivity");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17730,7 +17659,6 @@ impl std::fmt::Debug for PrivateServiceConnectConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrivateServiceConnectConnectivity");
         debug_struct.field("service_attachment", &self.service_attachment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17975,7 +17903,6 @@ impl std::fmt::Debug for ReverseSshConnectivity {
         debug_struct.field("vm_port", &self.vm_port);
         debug_struct.field("vm", &self.vm);
         debug_struct.field("vpc", &self.vpc);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18119,7 +18046,6 @@ impl std::fmt::Debug for VpcPeeringConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VpcPeeringConnectivity");
         debug_struct.field("vpc", &self.vpc);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18448,7 +18374,6 @@ impl std::fmt::Debug for ForwardSshTunnelConnectivity {
         debug_struct.field("username", &self.username);
         debug_struct.field("port", &self.port);
         debug_struct.field("authentication_method", &self.authentication_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18577,7 +18502,6 @@ impl serde::ser::Serialize for StaticServiceIpConnectivity {
 impl std::fmt::Debug for StaticServiceIpConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StaticServiceIpConnectivity");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18723,7 +18647,6 @@ impl std::fmt::Debug for PrivateConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrivateConnectivity");
         debug_struct.field("private_connection", &self.private_connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18894,7 +18817,6 @@ impl std::fmt::Debug for DatabaseType {
         let mut debug_struct = f.debug_struct("DatabaseType");
         debug_struct.field("provider", &self.provider);
         debug_struct.field("engine", &self.engine);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19899,7 +19821,6 @@ impl std::fmt::Debug for MigrationJob {
         debug_struct.field("cmek_key_name", &self.cmek_key_name);
         debug_struct.field("performance_config", &self.performance_config);
         debug_struct.field("connectivity", &self.connectivity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20074,7 +19995,6 @@ pub mod migration_job {
             let mut debug_struct = f.debug_struct("DumpFlag");
             debug_struct.field("name", &self.name);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20227,7 +20147,6 @@ pub mod migration_job {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DumpFlags");
             debug_struct.field("dump_flags", &self.dump_flags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20376,7 +20295,6 @@ pub mod migration_job {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PerformanceConfig");
             debug_struct.field("dump_parallel_level", &self.dump_parallel_level);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21218,7 +21136,6 @@ impl std::fmt::Debug for ConversionWorkspaceInfo {
         let mut debug_struct = f.debug_struct("ConversionWorkspaceInfo");
         debug_struct.field("name", &self.name);
         debug_struct.field("commit_id", &self.commit_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21902,7 +21819,6 @@ impl std::fmt::Debug for ConnectionProfile {
         debug_struct.field("error", &self.error);
         debug_struct.field("provider", &self.provider);
         debug_struct.field("connection_profile", &self.connection_profile);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22297,7 +22213,6 @@ impl std::fmt::Debug for MigrationJobVerificationError {
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("error_message", &self.error_message);
         debug_struct.field("error_detail_message", &self.error_detail_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23076,7 +22991,6 @@ impl std::fmt::Debug for PrivateConnection {
         debug_struct.field("state", &self.state);
         debug_struct.field("error", &self.error);
         debug_struct.field("connectivity", &self.connectivity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23418,7 +23332,6 @@ impl std::fmt::Debug for VpcPeeringConfig {
         let mut debug_struct = f.debug_struct("VpcPeeringConfig");
         debug_struct.field("vpc_name", &self.vpc_name);
         debug_struct.field("subnet", &self.subnet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23585,7 +23498,6 @@ impl std::fmt::Debug for DatabaseEngineInfo {
         let mut debug_struct = f.debug_struct("DatabaseEngineInfo");
         debug_struct.field("engine", &self.engine);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24034,7 +23946,6 @@ impl std::fmt::Debug for ConversionWorkspace {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24633,7 +24544,6 @@ impl std::fmt::Debug for BackgroundJobLogEntry {
         debug_struct.field("completion_comment", &self.completion_comment);
         debug_struct.field("request_autocommit", &self.request_autocommit);
         debug_struct.field("job_details", &self.job_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24787,7 +24697,6 @@ pub mod background_job_log_entry {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SeedJobDetails");
             debug_struct.field("connection_profile", &self.connection_profile);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24962,7 +24871,6 @@ pub mod background_job_log_entry {
             let mut debug_struct = f.debug_struct("ImportRulesJobDetails");
             debug_struct.field("files", &self.files);
             debug_struct.field("file_format", &self.file_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25107,7 +25015,6 @@ pub mod background_job_log_entry {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConvertJobDetails");
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25281,7 +25188,6 @@ pub mod background_job_log_entry {
             let mut debug_struct = f.debug_struct("ApplyJobDetails");
             debug_struct.field("connection_profile", &self.connection_profile);
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25701,7 +25607,6 @@ impl std::fmt::Debug for MappingRuleFilter {
         debug_struct.field("entity_name_suffix", &self.entity_name_suffix);
         debug_struct.field("entity_name_contains", &self.entity_name_contains);
         debug_struct.field("entities", &self.entities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26727,7 +26632,6 @@ impl std::fmt::Debug for MappingRule {
         debug_struct.field("revision_id", &self.revision_id);
         debug_struct.field("revision_create_time", &self.revision_create_time);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27057,7 +26961,6 @@ impl std::fmt::Debug for SingleEntityRename {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SingleEntityRename");
         debug_struct.field("new_name", &self.new_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27252,7 +27155,6 @@ impl std::fmt::Debug for MultiEntityRename {
             "source_name_transformation",
             &self.source_name_transformation,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27401,7 +27303,6 @@ impl std::fmt::Debug for EntityMove {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EntityMove");
         debug_struct.field("new_schema", &self.new_schema);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28025,7 +27926,6 @@ impl std::fmt::Debug for SingleColumnChange {
         debug_struct.field("custom_features", &self.custom_features);
         debug_struct.field("set_values", &self.set_values);
         debug_struct.field("comment", &self.comment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28575,7 +28475,6 @@ impl std::fmt::Debug for MultiColumnDatatypeChange {
         );
         debug_struct.field("custom_features", &self.custom_features);
         debug_struct.field("source_filter", &self.source_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28811,7 +28710,6 @@ impl std::fmt::Debug for SourceTextFilter {
         let mut debug_struct = f.debug_struct("SourceTextFilter");
         debug_struct.field("source_min_length_filter", &self.source_min_length_filter);
         debug_struct.field("source_max_length_filter", &self.source_max_length_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29166,7 +29064,6 @@ impl std::fmt::Debug for SourceNumericFilter {
             &self.source_max_precision_filter,
         );
         debug_struct.field("numeric_filter_option", &self.numeric_filter_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29492,7 +29389,6 @@ impl std::fmt::Debug for ConditionalColumnSetValue {
         debug_struct.field("value_transformation", &self.value_transformation);
         debug_struct.field("custom_features", &self.custom_features);
         debug_struct.field("source_filter", &self.source_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30197,7 +30093,6 @@ impl std::fmt::Debug for ValueTransformation {
         let mut debug_struct = f.debug_struct("ValueTransformation");
         debug_struct.field("filter", &self.filter);
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30391,7 +30286,6 @@ impl std::fmt::Debug for ConvertRowIdToColumn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConvertRowIdToColumn");
         debug_struct.field("only_if_no_primary_key", &self.only_if_no_primary_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30569,7 +30463,6 @@ impl std::fmt::Debug for SetTablePrimaryKey {
         let mut debug_struct = f.debug_struct("SetTablePrimaryKey");
         debug_struct.field("primary_key_columns", &self.primary_key_columns);
         debug_struct.field("primary_key", &self.primary_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30746,7 +30639,6 @@ impl std::fmt::Debug for SinglePackageChange {
         let mut debug_struct = f.debug_struct("SinglePackageChange");
         debug_struct.field("package_description", &self.package_description);
         debug_struct.field("package_body", &self.package_body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30894,7 +30786,6 @@ impl std::fmt::Debug for SourceSqlChange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceSqlChange");
         debug_struct.field("sql_code", &self.sql_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31077,7 +30968,6 @@ impl std::fmt::Debug for FilterTableColumns {
         let mut debug_struct = f.debug_struct("FilterTableColumns");
         debug_struct.field("include_columns", &self.include_columns);
         debug_struct.field("exclude_columns", &self.exclude_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31277,7 +31167,6 @@ impl std::fmt::Debug for ValueListFilter {
         debug_struct.field("value_present_list", &self.value_present_list);
         debug_struct.field("values", &self.values);
         debug_struct.field("ignore_case", &self.ignore_case);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31467,7 +31356,6 @@ impl std::fmt::Debug for IntComparisonFilter {
         let mut debug_struct = f.debug_struct("IntComparisonFilter");
         debug_struct.field("value_comparison", &self.value_comparison);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31657,7 +31545,6 @@ impl std::fmt::Debug for DoubleComparisonFilter {
         let mut debug_struct = f.debug_struct("DoubleComparisonFilter");
         debug_struct.field("value_comparison", &self.value_comparison);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31799,7 +31686,6 @@ impl std::fmt::Debug for AssignSpecificValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AssignSpecificValue");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31984,7 +31870,6 @@ impl std::fmt::Debug for ApplyHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApplyHash");
         debug_struct.field("hash_function", &self.hash_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32159,7 +32044,6 @@ impl std::fmt::Debug for RoundToScale {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RoundToScale");
         debug_struct.field("scale", &self.scale);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33081,7 +32965,6 @@ impl std::fmt::Debug for DatabaseEntity {
         debug_struct.field("entity_ddl", &self.entity_ddl);
         debug_struct.field("issues", &self.issues);
         debug_struct.field("entity_body", &self.entity_body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33408,7 +33291,6 @@ impl std::fmt::Debug for DatabaseInstanceEntity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseInstanceEntity");
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33566,7 +33448,6 @@ impl std::fmt::Debug for SchemaEntity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SchemaEntity");
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33861,7 +33742,6 @@ impl std::fmt::Debug for TableEntity {
         debug_struct.field("triggers", &self.triggers);
         debug_struct.field("custom_features", &self.custom_features);
         debug_struct.field("comment", &self.comment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34572,7 +34452,6 @@ impl std::fmt::Debug for ColumnEntity {
         debug_struct.field("comment", &self.comment);
         debug_struct.field("ordinal_position", &self.ordinal_position);
         debug_struct.field("default_value", &self.default_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34896,7 +34775,6 @@ impl std::fmt::Debug for ConstraintEntity {
         debug_struct.field("reference_columns", &self.reference_columns);
         debug_struct.field("reference_table", &self.reference_table);
         debug_struct.field("table_name", &self.table_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35156,7 +35034,6 @@ impl std::fmt::Debug for IndexEntity {
         debug_struct.field("table_columns", &self.table_columns);
         debug_struct.field("unique", &self.unique);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35419,7 +35296,6 @@ impl std::fmt::Debug for TriggerEntity {
         debug_struct.field("trigger_type", &self.trigger_type);
         debug_struct.field("sql_code", &self.sql_code);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35631,7 +35507,6 @@ impl std::fmt::Debug for ViewEntity {
         debug_struct.field("sql_code", &self.sql_code);
         debug_struct.field("custom_features", &self.custom_features);
         debug_struct.field("constraints", &self.constraints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36031,7 +35906,6 @@ impl std::fmt::Debug for SequenceEntity {
         debug_struct.field("cycle", &self.cycle);
         debug_struct.field("cache", &self.cache);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36211,7 +36085,6 @@ impl std::fmt::Debug for StoredProcedureEntity {
         let mut debug_struct = f.debug_struct("StoredProcedureEntity");
         debug_struct.field("sql_code", &self.sql_code);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36391,7 +36264,6 @@ impl std::fmt::Debug for FunctionEntity {
         let mut debug_struct = f.debug_struct("FunctionEntity");
         debug_struct.field("sql_code", &self.sql_code);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36571,7 +36443,6 @@ impl std::fmt::Debug for MaterializedViewEntity {
         let mut debug_struct = f.debug_struct("MaterializedViewEntity");
         debug_struct.field("sql_code", &self.sql_code);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36779,7 +36650,6 @@ impl std::fmt::Debug for SynonymEntity {
         debug_struct.field("source_entity", &self.source_entity);
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36989,7 +36859,6 @@ impl std::fmt::Debug for PackageEntity {
         debug_struct.field("package_sql_code", &self.package_sql_code);
         debug_struct.field("package_body", &self.package_body);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37195,7 +37064,6 @@ impl std::fmt::Debug for UDTEntity {
         debug_struct.field("udt_sql_code", &self.udt_sql_code);
         debug_struct.field("udt_body", &self.udt_body);
         debug_struct.field("custom_features", &self.custom_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37459,7 +37327,6 @@ impl std::fmt::Debug for EntityMapping {
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("draft_type", &self.draft_type);
         debug_struct.field("mapping_log", &self.mapping_log);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37657,7 +37524,6 @@ impl std::fmt::Debug for EntityMappingLogEntry {
         debug_struct.field("rule_id", &self.rule_id);
         debug_struct.field("rule_revision_id", &self.rule_revision_id);
         debug_struct.field("mapping_comment", &self.mapping_comment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37906,7 +37772,6 @@ impl std::fmt::Debug for EntityDdl {
         debug_struct.field("ddl", &self.ddl);
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("issue_id", &self.issue_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38249,7 +38114,6 @@ impl std::fmt::Debug for EntityIssue {
         debug_struct.field("ddl", &self.ddl);
         debug_struct.field("position", &self.position);
         debug_struct.field("entity_type", &self.entity_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38546,7 +38410,6 @@ pub mod entity_issue {
             debug_struct.field("column", &self.column);
             debug_struct.field("offset", &self.offset);
             debug_struct.field("length", &self.length);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -274,7 +274,6 @@ impl std::fmt::Debug for AssignmentProtocol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AssignmentProtocol");
         debug_struct.field("assignment_type", &self.assignment_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -396,7 +395,6 @@ pub mod assignment_protocol {
     impl std::fmt::Debug for ManualAssignmentType {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ManualAssignmentType");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -555,7 +553,6 @@ pub mod assignment_protocol {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AutoAssignmentType");
             debug_struct.field("inactive_license_ttl", &self.inactive_license_ttl);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -851,7 +848,6 @@ impl std::fmt::Debug for LicensePool {
         );
         debug_struct.field("available_license_count", &self.available_license_count);
         debug_struct.field("total_license_count", &self.total_license_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -994,7 +990,6 @@ impl std::fmt::Debug for GetLicensePoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLicensePoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1189,7 +1184,6 @@ impl std::fmt::Debug for UpdateLicensePoolRequest {
         let mut debug_struct = f.debug_struct("UpdateLicensePoolRequest");
         debug_struct.field("license_pool", &self.license_pool);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1363,7 +1357,6 @@ impl std::fmt::Debug for AssignRequest {
         let mut debug_struct = f.debug_struct("AssignRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("usernames", &self.usernames);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1480,7 +1473,6 @@ impl serde::ser::Serialize for AssignResponse {
 impl std::fmt::Debug for AssignResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AssignResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1654,7 +1646,6 @@ impl std::fmt::Debug for UnassignRequest {
         let mut debug_struct = f.debug_struct("UnassignRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("usernames", &self.usernames);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1771,7 +1762,6 @@ impl serde::ser::Serialize for UnassignResponse {
 impl std::fmt::Debug for UnassignResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UnassignResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1988,7 +1978,6 @@ impl std::fmt::Debug for EnumerateLicensedUsersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2207,7 +2196,6 @@ impl std::fmt::Debug for LicensedUser {
         debug_struct.field("username", &self.username);
         debug_struct.field("assign_time", &self.assign_time);
         debug_struct.field("recent_usage_time", &self.recent_usage_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2397,7 +2385,6 @@ impl std::fmt::Debug for EnumerateLicensedUsersResponse {
         let mut debug_struct = f.debug_struct("EnumerateLicensedUsersResponse");
         debug_struct.field("licensed_users", &self.licensed_users);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2733,7 +2720,6 @@ impl std::fmt::Debug for Order {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2990,7 +2976,6 @@ impl std::fmt::Debug for LineItem {
         debug_struct.field("line_item_info", &self.line_item_info);
         debug_struct.field("pending_change", &self.pending_change);
         debug_struct.field("change_history", &self.change_history);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3443,7 +3428,6 @@ impl std::fmt::Debug for LineItemChange {
         debug_struct.field("change_effective_time", &self.change_effective_time);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3651,7 +3635,6 @@ impl std::fmt::Debug for LineItemInfo {
         debug_struct.field("offer", &self.offer);
         debug_struct.field("parameters", &self.parameters);
         debug_struct.field("subscription", &self.subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3830,7 +3813,6 @@ impl std::fmt::Debug for Parameter {
         let mut debug_struct = f.debug_struct("Parameter");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4159,7 +4141,6 @@ pub mod parameter {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Value");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4397,7 +4378,6 @@ impl std::fmt::Debug for Subscription {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("auto_renewal_enabled", &self.auto_renewal_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4630,7 +4610,6 @@ impl std::fmt::Debug for PlaceOrderRequest {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("line_item_info", &self.line_item_info);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4747,7 +4726,6 @@ impl serde::ser::Serialize for PlaceOrderMetadata {
 impl std::fmt::Debug for PlaceOrderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PlaceOrderMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4892,7 +4870,6 @@ impl std::fmt::Debug for GetOrderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrderRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5149,7 +5126,6 @@ impl std::fmt::Debug for ListOrdersRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5337,7 +5313,6 @@ impl std::fmt::Debug for ListOrdersResponse {
         let mut debug_struct = f.debug_struct("ListOrdersResponse");
         debug_struct.field("orders", &self.orders);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5570,7 +5545,6 @@ impl std::fmt::Debug for ModifyOrderRequest {
         debug_struct.field("modifications", &self.modifications);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5827,7 +5801,6 @@ pub mod modify_order_request {
             debug_struct.field("change_type", &self.change_type);
             debug_struct.field("new_line_item_info", &self.new_line_item_info);
             debug_struct.field("auto_renewal_behavior", &self.auto_renewal_behavior);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5945,7 +5918,6 @@ impl serde::ser::Serialize for ModifyOrderMetadata {
 impl std::fmt::Debug for ModifyOrderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ModifyOrderMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6150,7 +6122,6 @@ impl std::fmt::Debug for CancelOrderRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("cancellation_policy", &self.cancellation_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6414,7 +6385,6 @@ impl serde::ser::Serialize for CancelOrderMetadata {
 impl std::fmt::Debug for CancelOrderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelOrderMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/common/src/model.rs
+++ b/src/generated/cloud/common/src/model.rs
@@ -338,7 +338,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("cancel_requested", &self.cancel_requested);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -293,7 +293,6 @@ impl std::fmt::Debug for Challenge {
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("used", &self.used);
         debug_struct.field("tpm_nonce", &self.tpm_nonce);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -473,7 +472,6 @@ impl std::fmt::Debug for CreateChallengeRequest {
         let mut debug_struct = f.debug_struct("CreateChallengeRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("challenge", &self.challenge);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -930,7 +928,6 @@ impl std::fmt::Debug for VerifyAttestationRequest {
         debug_struct.field("token_options", &self.token_options);
         debug_struct.field("attester", &self.attester);
         debug_struct.field("tee_attestation", &self.tee_attestation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1245,7 +1242,6 @@ impl std::fmt::Debug for TdxCcelAttestation {
         debug_struct.field("ccel_data", &self.ccel_data);
         debug_struct.field("canonical_event_log", &self.canonical_event_log);
         debug_struct.field("td_quote", &self.td_quote);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1457,7 +1453,6 @@ impl std::fmt::Debug for SevSnpAttestation {
         let mut debug_struct = f.debug_struct("SevSnpAttestation");
         debug_struct.field("report", &self.report);
         debug_struct.field("aux_blob", &self.aux_blob);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1634,7 +1629,6 @@ impl std::fmt::Debug for VerifyAttestationResponse {
         let mut debug_struct = f.debug_struct("VerifyAttestationResponse");
         debug_struct.field("oidc_claims_token", &self.oidc_claims_token);
         debug_struct.field("partial_errors", &self.partial_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1783,7 +1777,6 @@ impl std::fmt::Debug for GcpCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcpCredentials");
         debug_struct.field("service_account_id_tokens", &self.service_account_id_tokens);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2060,7 +2053,6 @@ impl std::fmt::Debug for TokenOptions {
         debug_struct.field("nonce", &self.nonce);
         debug_struct.field("token_type", &self.token_type);
         debug_struct.field("token_type_options", &self.token_type_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2230,7 +2222,6 @@ pub mod token_options {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AwsPrincipalTagsOptions");
             debug_struct.field("allowed_principal_tags", &self.allowed_principal_tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2407,7 +2398,6 @@ pub mod token_options {
                     "container_image_signatures",
                     &self.container_image_signatures,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2579,7 +2569,6 @@ pub mod token_options {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("ContainerImageSignatures");
                     debug_struct.field("key_ids", &self.key_ids);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -2938,7 +2927,6 @@ impl std::fmt::Debug for TpmAttestation {
         debug_struct.field("canonical_event_log", &self.canonical_event_log);
         debug_struct.field("ak_cert", &self.ak_cert);
         debug_struct.field("cert_chain", &self.cert_chain);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3279,7 +3267,6 @@ pub mod tpm_attestation {
             debug_struct.field("pcr_values", &self.pcr_values);
             debug_struct.field("raw_quote", &self.raw_quote);
             debug_struct.field("raw_signature", &self.raw_signature);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3428,7 +3415,6 @@ impl std::fmt::Debug for ConfidentialSpaceInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConfidentialSpaceInfo");
         debug_struct.field("signed_entities", &self.signed_entities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3587,7 +3573,6 @@ impl std::fmt::Debug for SignedEntity {
             "container_image_signatures",
             &self.container_image_signatures,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3874,7 +3859,6 @@ impl std::fmt::Debug for ContainerImageSignature {
         debug_struct.field("signature", &self.signature);
         debug_struct.field("public_key", &self.public_key);
         debug_struct.field("sig_alg", &self.sig_alg);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -955,7 +955,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("quota_validation", &self.quota_validation);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("blueprint", &self.blueprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1739,7 +1738,6 @@ impl std::fmt::Debug for TerraformBlueprint {
         let mut debug_struct = f.debug_struct("TerraformBlueprint");
         debug_struct.field("input_values", &self.input_values);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1915,7 +1913,6 @@ impl std::fmt::Debug for TerraformVariable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TerraformVariable");
         debug_struct.field("input_value", &self.input_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2120,7 +2117,6 @@ impl std::fmt::Debug for ApplyResults {
         debug_struct.field("content", &self.content);
         debug_struct.field("artifacts", &self.artifacts);
         debug_struct.field("outputs", &self.outputs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2300,7 +2296,6 @@ impl std::fmt::Debug for TerraformOutput {
         let mut debug_struct = f.debug_struct("TerraformOutput");
         debug_struct.field("sensitive", &self.sensitive);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2589,7 +2584,6 @@ impl std::fmt::Debug for ListDeploymentsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2804,7 +2798,6 @@ impl std::fmt::Debug for ListDeploymentsResponse {
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2946,7 +2939,6 @@ impl std::fmt::Debug for GetDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3236,7 +3228,6 @@ impl std::fmt::Debug for ListRevisionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3453,7 +3444,6 @@ impl std::fmt::Debug for ListRevisionsResponse {
         debug_struct.field("revisions", &self.revisions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3596,7 +3586,6 @@ impl std::fmt::Debug for GetRevisionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRevisionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3841,7 +3830,6 @@ impl std::fmt::Debug for CreateDeploymentRequest {
         debug_struct.field("deployment_id", &self.deployment_id);
         debug_struct.field("deployment", &self.deployment);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4079,7 +4067,6 @@ impl std::fmt::Debug for UpdateDeploymentRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("deployment", &self.deployment);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4321,7 +4308,6 @@ impl std::fmt::Debug for DeleteDeploymentRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
         debug_struct.field("delete_policy", &self.delete_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4917,7 +4903,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("resource_metadata", &self.resource_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5702,7 +5687,6 @@ impl std::fmt::Debug for Revision {
         debug_struct.field("quota_validation_results", &self.quota_validation_results);
         debug_struct.field("quota_validation", &self.quota_validation);
         debug_struct.field("blueprint", &self.blueprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6406,7 +6390,6 @@ impl std::fmt::Debug for TerraformError {
         debug_struct.field("http_response_code", &self.http_response_code);
         debug_struct.field("error_description", &self.error_description);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6633,7 +6616,6 @@ impl std::fmt::Debug for GitSource {
         debug_struct.field("repo", &self.repo);
         debug_struct.field("directory", &self.directory);
         debug_struct.field("r#ref", &self.r#ref);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6870,7 +6852,6 @@ impl std::fmt::Debug for DeploymentOperationMetadata {
         debug_struct.field("apply_results", &self.apply_results);
         debug_struct.field("build", &self.build);
         debug_struct.field("logs", &self.logs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7359,7 +7340,6 @@ impl std::fmt::Debug for Resource {
         debug_struct.field("cai_assets", &self.cai_assets);
         debug_struct.field("intent", &self.intent);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7857,7 +7837,6 @@ impl std::fmt::Debug for ResourceTerraformInfo {
         debug_struct.field("address", &self.address);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8004,7 +7983,6 @@ impl std::fmt::Debug for ResourceCAIInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceCAIInfo");
         debug_struct.field("full_resource_name", &self.full_resource_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8147,7 +8125,6 @@ impl std::fmt::Debug for GetResourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetResourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8428,7 +8405,6 @@ impl std::fmt::Debug for ListResourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8645,7 +8621,6 @@ impl std::fmt::Debug for ListResourcesResponse {
         debug_struct.field("resources", &self.resources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8789,7 +8764,6 @@ impl std::fmt::Debug for Statefile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Statefile");
         debug_struct.field("signed_uri", &self.signed_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8961,7 +8935,6 @@ impl std::fmt::Debug for ExportDeploymentStatefileRequest {
         let mut debug_struct = f.debug_struct("ExportDeploymentStatefileRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("draft", &self.draft);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9106,7 +9079,6 @@ impl std::fmt::Debug for ExportRevisionStatefileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportRevisionStatefileRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9321,7 +9293,6 @@ impl std::fmt::Debug for ImportStatefileRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("lock_id", &self.lock_id);
         debug_struct.field("skip_draft", &self.skip_draft);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9509,7 +9480,6 @@ impl std::fmt::Debug for DeleteStatefileRequest {
         let mut debug_struct = f.debug_struct("DeleteStatefileRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("lock_id", &self.lock_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9652,7 +9622,6 @@ impl std::fmt::Debug for LockDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LockDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9839,7 +9808,6 @@ impl std::fmt::Debug for UnlockDeploymentRequest {
         let mut debug_struct = f.debug_struct("UnlockDeploymentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("lock_id", &self.lock_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9982,7 +9950,6 @@ impl std::fmt::Debug for ExportLockInfoRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportLockInfoRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10280,7 +10247,6 @@ impl std::fmt::Debug for LockInfo {
         debug_struct.field("who", &self.who);
         debug_struct.field("version", &self.version);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11088,7 +11054,6 @@ impl std::fmt::Debug for Preview {
         debug_struct.field("tf_version_constraint", &self.tf_version_constraint);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("blueprint", &self.blueprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11810,7 +11775,6 @@ impl std::fmt::Debug for PreviewOperationMetadata {
         debug_struct.field("preview_artifacts", &self.preview_artifacts);
         debug_struct.field("logs", &self.logs);
         debug_struct.field("build", &self.build);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12176,7 +12140,6 @@ impl std::fmt::Debug for PreviewArtifacts {
         let mut debug_struct = f.debug_struct("PreviewArtifacts");
         debug_struct.field("content", &self.content);
         debug_struct.field("artifacts", &self.artifacts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12421,7 +12384,6 @@ impl std::fmt::Debug for CreatePreviewRequest {
         debug_struct.field("preview_id", &self.preview_id);
         debug_struct.field("preview", &self.preview);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12564,7 +12526,6 @@ impl std::fmt::Debug for GetPreviewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPreviewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12854,7 +12815,6 @@ impl std::fmt::Debug for ListPreviewsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13070,7 +13030,6 @@ impl std::fmt::Debug for ListPreviewsResponse {
         debug_struct.field("previews", &self.previews);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13251,7 +13210,6 @@ impl std::fmt::Debug for DeletePreviewRequest {
         let mut debug_struct = f.debug_struct("DeletePreviewRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13395,7 +13353,6 @@ impl std::fmt::Debug for ExportPreviewResultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportPreviewResultRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13548,7 +13505,6 @@ impl std::fmt::Debug for ExportPreviewResultResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportPreviewResultResponse");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13720,7 +13676,6 @@ impl std::fmt::Debug for PreviewResult {
         let mut debug_struct = f.debug_struct("PreviewResult");
         debug_struct.field("binary_signed_uri", &self.binary_signed_uri);
         debug_struct.field("json_signed_uri", &self.json_signed_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13863,7 +13818,6 @@ impl std::fmt::Debug for GetTerraformVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTerraformVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14139,7 +14093,6 @@ impl std::fmt::Debug for ListTerraformVersionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14360,7 +14313,6 @@ impl std::fmt::Debug for ListTerraformVersionsResponse {
         debug_struct.field("terraform_versions", &self.terraform_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14641,7 +14593,6 @@ impl std::fmt::Debug for TerraformVersion {
         debug_struct.field("support_time", &self.support_time);
         debug_struct.field("deprecate_time", &self.deprecate_time);
         debug_struct.field("obsolete_time", &self.obsolete_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15032,7 +14983,6 @@ impl std::fmt::Debug for ResourceChangeTerraformInfo {
         debug_struct.field("resource_name", &self.resource_name);
         debug_struct.field("provider", &self.provider);
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15272,7 +15222,6 @@ impl std::fmt::Debug for ResourceChange {
         debug_struct.field("terraform_info", &self.terraform_info);
         debug_struct.field("intent", &self.intent);
         debug_struct.field("property_changes", &self.property_changes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15707,7 +15656,6 @@ impl std::fmt::Debug for PropertyChange {
         debug_struct.field("before", &self.before);
         debug_struct.field("after_sensitive_paths", &self.after_sensitive_paths);
         debug_struct.field("after", &self.after);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15990,7 +15938,6 @@ impl std::fmt::Debug for ListResourceChangesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16211,7 +16158,6 @@ impl std::fmt::Debug for ListResourceChangesResponse {
         debug_struct.field("resource_changes", &self.resource_changes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16355,7 +16301,6 @@ impl std::fmt::Debug for GetResourceChangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetResourceChangeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16573,7 +16518,6 @@ impl std::fmt::Debug for ResourceDriftTerraformInfo {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("resource_name", &self.resource_name);
         debug_struct.field("provider", &self.provider);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16783,7 +16727,6 @@ impl std::fmt::Debug for ResourceDrift {
         debug_struct.field("name", &self.name);
         debug_struct.field("terraform_info", &self.terraform_info);
         debug_struct.field("property_drifts", &self.property_drifts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17059,7 +17002,6 @@ impl std::fmt::Debug for PropertyDrift {
         debug_struct.field("before", &self.before);
         debug_struct.field("after_sensitive_paths", &self.after_sensitive_paths);
         debug_struct.field("after", &self.after);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17342,7 +17284,6 @@ impl std::fmt::Debug for ListResourceDriftsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17558,7 +17499,6 @@ impl std::fmt::Debug for ListResourceDriftsResponse {
         debug_struct.field("resource_drifts", &self.resource_drifts);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17702,7 +17642,6 @@ impl std::fmt::Debug for GetResourceDriftRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetResourceDriftRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/configdelivery/v1/src/model.rs
+++ b/src/generated/cloud/configdelivery/v1/src/model.rs
@@ -304,7 +304,6 @@ impl std::fmt::Debug for ResourceBundle {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -568,7 +567,6 @@ impl std::fmt::Debug for ListResourceBundlesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -786,7 +784,6 @@ impl std::fmt::Debug for ListResourceBundlesResponse {
         debug_struct.field("resource_bundles", &self.resource_bundles);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -928,7 +925,6 @@ impl std::fmt::Debug for GetResourceBundleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetResourceBundleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1177,7 +1173,6 @@ impl std::fmt::Debug for CreateResourceBundleRequest {
         debug_struct.field("resource_bundle_id", &self.resource_bundle_id);
         debug_struct.field("resource_bundle", &self.resource_bundle);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1411,7 +1406,6 @@ impl std::fmt::Debug for UpdateResourceBundleRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("resource_bundle", &self.resource_bundle);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1618,7 +1612,6 @@ impl std::fmt::Debug for DeleteResourceBundleRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2149,7 +2142,6 @@ impl std::fmt::Debug for FleetPackage {
             &self.deletion_propagation_policy,
         );
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2414,7 +2406,6 @@ pub mod fleet_package {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ResourceBundleSelector");
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2606,7 +2597,6 @@ pub mod fleet_package {
             let mut debug_struct = f.debug_struct("ResourceBundleTag");
             debug_struct.field("name", &self.name);
             debug_struct.field("tag", &self.tag);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2913,7 +2903,6 @@ pub mod fleet_package {
             debug_struct.field("tag", &self.tag);
             debug_struct.field("service_account", &self.service_account);
             debug_struct.field("variants", &self.variants);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3120,7 +3109,6 @@ pub mod fleet_package {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Target");
             debug_struct.field("target", &self.target);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3328,7 +3316,6 @@ pub mod fleet_package {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("VariantSelector");
             debug_struct.field("strategy", &self.strategy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3722,7 +3709,6 @@ impl std::fmt::Debug for FleetPackageInfo {
         debug_struct.field("last_completed_rollout", &self.last_completed_rollout);
         debug_struct.field("state", &self.state);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4018,7 +4004,6 @@ impl std::fmt::Debug for FleetPackageError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FleetPackageError");
         debug_struct.field("error_message", &self.error_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4397,7 +4382,6 @@ impl std::fmt::Debug for ClusterInfo {
         debug_struct.field("messages", &self.messages);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4841,7 +4825,6 @@ impl std::fmt::Debug for ResourceBundleDeploymentInfo {
         debug_struct.field("variant", &self.variant);
         debug_struct.field("sync_state", &self.sync_state);
         debug_struct.field("messages", &self.messages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5201,7 +5184,6 @@ impl std::fmt::Debug for Fleet {
         let mut debug_struct = f.debug_struct("Fleet");
         debug_struct.field("project", &self.project);
         debug_struct.field("selector", &self.selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5366,7 +5348,6 @@ pub mod fleet {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LabelSelector");
             debug_struct.field("match_labels", &self.match_labels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5481,7 +5462,6 @@ impl serde::ser::Serialize for AllAtOnceStrategy {
 impl std::fmt::Debug for AllAtOnceStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AllAtOnceStrategy");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5645,7 +5625,6 @@ impl std::fmt::Debug for RollingStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RollingStrategy");
         debug_struct.field("max_concurrent", &self.max_concurrent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5888,7 +5867,6 @@ impl std::fmt::Debug for RolloutStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RolloutStrategy");
         debug_struct.field("strategy", &self.strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6158,7 +6136,6 @@ impl std::fmt::Debug for RolloutStrategyInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RolloutStrategyInfo");
         debug_struct.field("strategy", &self.strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6323,7 +6300,6 @@ impl std::fmt::Debug for AllAtOnceStrategyInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AllAtOnceStrategyInfo");
         debug_struct.field("clusters", &self.clusters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6470,7 +6446,6 @@ impl std::fmt::Debug for RollingStrategyInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RollingStrategyInfo");
         debug_struct.field("clusters", &self.clusters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6734,7 +6709,6 @@ impl std::fmt::Debug for ListFleetPackagesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6948,7 +6922,6 @@ impl std::fmt::Debug for ListFleetPackagesResponse {
         debug_struct.field("fleet_packages", &self.fleet_packages);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7090,7 +7063,6 @@ impl std::fmt::Debug for GetFleetPackageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFleetPackageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7338,7 +7310,6 @@ impl std::fmt::Debug for CreateFleetPackageRequest {
         debug_struct.field("fleet_package_id", &self.fleet_package_id);
         debug_struct.field("fleet_package", &self.fleet_package);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7571,7 +7542,6 @@ impl std::fmt::Debug for UpdateFleetPackageRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("fleet_package", &self.fleet_package);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7805,7 +7775,6 @@ impl std::fmt::Debug for DeleteFleetPackageRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8132,7 +8101,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8510,7 +8478,6 @@ impl std::fmt::Debug for Release {
         debug_struct.field("version", &self.version);
         debug_struct.field("publish_time", &self.publish_time);
         debug_struct.field("info", &self.info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8932,7 +8899,6 @@ impl std::fmt::Debug for Variant {
         debug_struct.field("name", &self.name);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9196,7 +9162,6 @@ impl std::fmt::Debug for ListVariantsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9409,7 +9374,6 @@ impl std::fmt::Debug for ListVariantsResponse {
         debug_struct.field("variants", &self.variants);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9551,7 +9515,6 @@ impl std::fmt::Debug for GetVariantRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVariantRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9793,7 +9756,6 @@ impl std::fmt::Debug for CreateVariantRequest {
         debug_struct.field("variant_id", &self.variant_id);
         debug_struct.field("variant", &self.variant);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10025,7 +9987,6 @@ impl std::fmt::Debug for UpdateVariantRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("variant", &self.variant);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10205,7 +10166,6 @@ impl std::fmt::Debug for DeleteVariantRequest {
         let mut debug_struct = f.debug_struct("DeleteVariantRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10389,7 +10349,6 @@ impl std::fmt::Debug for ReleaseInfo {
         let mut debug_struct = f.debug_struct("ReleaseInfo");
         debug_struct.field("oci_image_path", &self.oci_image_path);
         debug_struct.field("variant_oci_image_paths", &self.variant_oci_image_paths);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10653,7 +10612,6 @@ impl std::fmt::Debug for ListReleasesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10866,7 +10824,6 @@ impl std::fmt::Debug for ListReleasesResponse {
         debug_struct.field("releases", &self.releases);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11008,7 +10965,6 @@ impl std::fmt::Debug for GetReleaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReleaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11252,7 +11208,6 @@ impl std::fmt::Debug for CreateReleaseRequest {
         debug_struct.field("release_id", &self.release_id);
         debug_struct.field("release", &self.release);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11484,7 +11439,6 @@ impl std::fmt::Debug for UpdateReleaseRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("release", &self.release);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11691,7 +11645,6 @@ impl std::fmt::Debug for DeleteReleaseRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11955,7 +11908,6 @@ impl std::fmt::Debug for ListRolloutsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12168,7 +12120,6 @@ impl std::fmt::Debug for ListRolloutsResponse {
         debug_struct.field("rollouts", &self.rollouts);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12310,7 +12261,6 @@ impl std::fmt::Debug for GetRolloutRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRolloutRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12592,7 +12542,6 @@ impl std::fmt::Debug for RolloutInfo {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("message", &self.message);
         debug_struct.field("rollout_strategy_info", &self.rollout_strategy_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13123,7 +13072,6 @@ impl std::fmt::Debug for Rollout {
         );
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13290,7 +13238,6 @@ impl std::fmt::Debug for SuspendRolloutRequest {
         let mut debug_struct = f.debug_struct("SuspendRolloutRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13457,7 +13404,6 @@ impl std::fmt::Debug for ResumeRolloutRequest {
         let mut debug_struct = f.debug_struct("ResumeRolloutRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13624,7 +13570,6 @@ impl std::fmt::Debug for AbortRolloutRequest {
         let mut debug_struct = f.debug_struct("AbortRolloutRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -448,7 +448,6 @@ impl std::fmt::Debug for AuthConfig {
         debug_struct.field("auth_type", &self.auth_type);
         debug_struct.field("additional_variables", &self.additional_variables);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -634,7 +633,6 @@ pub mod auth_config {
             let mut debug_struct = f.debug_struct("UserPassword");
             debug_struct.field("username", &self.username);
             debug_struct.field("password", &self.password);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -835,7 +833,6 @@ pub mod auth_config {
             let mut debug_struct = f.debug_struct("Oauth2JwtBearer");
             debug_struct.field("client_key", &self.client_key);
             debug_struct.field("jwt_claims", &self.jwt_claims);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1045,7 +1042,6 @@ pub mod auth_config {
                 debug_struct.field("issuer", &self.issuer);
                 debug_struct.field("subject", &self.subject);
                 debug_struct.field("audience", &self.audience);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1230,7 +1226,6 @@ pub mod auth_config {
             let mut debug_struct = f.debug_struct("Oauth2ClientCredentials");
             debug_struct.field("client_id", &self.client_id);
             debug_struct.field("client_secret", &self.client_secret);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1475,7 +1470,6 @@ pub mod auth_config {
             debug_struct.field("ssh_client_cert", &self.ssh_client_cert);
             debug_struct.field("cert_type", &self.cert_type);
             debug_struct.field("ssh_client_cert_pass", &self.ssh_client_cert_pass);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1723,7 +1717,6 @@ impl std::fmt::Debug for AuthConfigTemplate {
         debug_struct.field("config_variable_templates", &self.config_variable_templates);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2048,7 +2041,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2492,7 +2484,6 @@ impl std::fmt::Debug for ConfigVariableTemplate {
         debug_struct.field("authorization_code_link", &self.authorization_code_link);
         debug_struct.field("state", &self.state);
         debug_struct.field("is_advanced", &self.is_advanced);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2934,7 +2925,6 @@ impl std::fmt::Debug for Secret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Secret");
         debug_struct.field("secret_version", &self.secret_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3102,7 +3092,6 @@ impl std::fmt::Debug for EnumOption {
         let mut debug_struct = f.debug_struct("EnumOption");
         debug_struct.field("id", &self.id);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3472,7 +3461,6 @@ impl std::fmt::Debug for ConfigVariable {
         let mut debug_struct = f.debug_struct("ConfigVariable");
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3732,7 +3720,6 @@ impl std::fmt::Debug for RoleGrant {
         debug_struct.field("roles", &self.roles);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("helper_text_template", &self.helper_text_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3918,7 +3905,6 @@ pub mod role_grant {
             let mut debug_struct = f.debug_struct("Resource");
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("path_template", &self.path_template);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4431,7 +4417,6 @@ impl std::fmt::Debug for AuthorizationCodeLink {
         debug_struct.field("scopes", &self.scopes);
         debug_struct.field("client_id", &self.client_id);
         debug_struct.field("enable_pkce", &self.enable_pkce);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5138,7 +5123,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("suspended", &self.suspended);
         debug_struct.field("node_config", &self.node_config);
         debug_struct.field("ssl_config", &self.ssl_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5345,7 +5329,6 @@ impl std::fmt::Debug for NodeConfig {
         let mut debug_struct = f.debug_struct("NodeConfig");
         debug_struct.field("min_node_count", &self.min_node_count);
         debug_struct.field("max_node_count", &self.max_node_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5652,7 +5635,6 @@ impl std::fmt::Debug for ConnectionSchemaMetadata {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("refresh_time", &self.refresh_time);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5964,7 +5946,6 @@ impl std::fmt::Debug for RuntimeEntitySchema {
         let mut debug_struct = f.debug_struct("RuntimeEntitySchema");
         debug_struct.field("entity", &self.entity);
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6322,7 +6303,6 @@ pub mod runtime_entity_schema {
             debug_struct.field("nullable", &self.nullable);
             debug_struct.field("default_value", &self.default_value);
             debug_struct.field("additional_details", &self.additional_details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6535,7 +6515,6 @@ impl std::fmt::Debug for RuntimeActionSchema {
         debug_struct.field("action", &self.action);
         debug_struct.field("input_parameters", &self.input_parameters);
         debug_struct.field("result_metadata", &self.result_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6803,7 +6782,6 @@ pub mod runtime_action_schema {
             debug_struct.field("data_type", &self.data_type);
             debug_struct.field("nullable", &self.nullable);
             debug_struct.field("default_value", &self.default_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7002,7 +6980,6 @@ pub mod runtime_action_schema {
             debug_struct.field("field", &self.field);
             debug_struct.field("description", &self.description);
             debug_struct.field("data_type", &self.data_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7171,7 +7148,6 @@ impl std::fmt::Debug for LockConfig {
         let mut debug_struct = f.debug_struct("LockConfig");
         debug_struct.field("locked", &self.locked);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7461,7 +7437,6 @@ impl std::fmt::Debug for ListConnectionsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7674,7 +7649,6 @@ impl std::fmt::Debug for ListConnectionsResponse {
         debug_struct.field("connections", &self.connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7843,7 +7817,6 @@ impl std::fmt::Debug for GetConnectionRequest {
         let mut debug_struct = f.debug_struct("GetConnectionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8049,7 +8022,6 @@ impl std::fmt::Debug for CreateConnectionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("connection_id", &self.connection_id);
         debug_struct.field("connection", &self.connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8257,7 +8229,6 @@ impl std::fmt::Debug for UpdateConnectionRequest {
         let mut debug_struct = f.debug_struct("UpdateConnectionRequest");
         debug_struct.field("connection", &self.connection);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8400,7 +8371,6 @@ impl std::fmt::Debug for DeleteConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8544,7 +8514,6 @@ impl std::fmt::Debug for GetConnectionSchemaMetadataRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionSchemaMetadataRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8689,7 +8658,6 @@ impl std::fmt::Debug for RefreshConnectionSchemaMetadataRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RefreshConnectionSchemaMetadataRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8936,7 +8904,6 @@ impl std::fmt::Debug for ListRuntimeEntitySchemasRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9126,7 +9093,6 @@ impl std::fmt::Debug for ListRuntimeEntitySchemasResponse {
         let mut debug_struct = f.debug_struct("ListRuntimeEntitySchemasResponse");
         debug_struct.field("runtime_entity_schemas", &self.runtime_entity_schemas);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9373,7 +9339,6 @@ impl std::fmt::Debug for ListRuntimeActionSchemasRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9563,7 +9528,6 @@ impl std::fmt::Debug for ListRuntimeActionSchemasResponse {
         let mut debug_struct = f.debug_struct("ListRuntimeActionSchemasResponse");
         debug_struct.field("runtime_action_schemas", &self.runtime_action_schemas);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9756,7 +9720,6 @@ impl std::fmt::Debug for ConnectionStatus {
         debug_struct.field("state", &self.state);
         debug_struct.field("description", &self.description);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10351,7 +10314,6 @@ impl std::fmt::Debug for Connector {
         debug_struct.field("web_assets_location", &self.web_assets_location);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("launch_stage", &self.launch_stage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10495,7 +10457,6 @@ impl std::fmt::Debug for GetConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10709,7 +10670,6 @@ impl std::fmt::Debug for ListConnectorsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10922,7 +10882,6 @@ impl std::fmt::Debug for ListConnectorsResponse {
         debug_struct.field("connectors", &self.connectors);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11517,7 +11476,6 @@ impl std::fmt::Debug for ConnectorVersion {
         debug_struct.field("role_grants", &self.role_grants);
         debug_struct.field("role_grant", &self.role_grant);
         debug_struct.field("ssl_config_template", &self.ssl_config_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11688,7 +11646,6 @@ impl std::fmt::Debug for GetConnectorVersionRequest {
         let mut debug_struct = f.debug_struct("GetConnectorVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11929,7 +11886,6 @@ impl std::fmt::Debug for ListConnectorVersionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12147,7 +12103,6 @@ impl std::fmt::Debug for ListConnectorVersionsResponse {
         debug_struct.field("connector_versions", &self.connector_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12345,7 +12300,6 @@ impl std::fmt::Debug for SupportedRuntimeFeatures {
         debug_struct.field("entity_apis", &self.entity_apis);
         debug_struct.field("action_apis", &self.action_apis);
         debug_struct.field("sql_query", &self.sql_query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12589,7 +12543,6 @@ impl std::fmt::Debug for EgressControlConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EgressControlConfig");
         debug_struct.field("oneof_backends", &self.oneof_backends);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12758,7 +12711,6 @@ impl std::fmt::Debug for ExtractionRules {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExtractionRules");
         debug_struct.field("extraction_rule", &self.extraction_rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12941,7 +12893,6 @@ impl std::fmt::Debug for ExtractionRule {
         let mut debug_struct = f.debug_struct("ExtractionRule");
         debug_struct.field("source", &self.source);
         debug_struct.field("extraction_regex", &self.extraction_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13123,7 +13074,6 @@ pub mod extraction_rule {
             let mut debug_struct = f.debug_struct("Source");
             debug_struct.field("source_type", &self.source_type);
             debug_struct.field("field_id", &self.field_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13419,7 +13369,6 @@ impl std::fmt::Debug for DestinationConfig {
         let mut debug_struct = f.debug_struct("DestinationConfig");
         debug_struct.field("key", &self.key);
         debug_struct.field("destinations", &self.destinations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13692,7 +13641,6 @@ impl std::fmt::Debug for Destination {
         let mut debug_struct = f.debug_struct("Destination");
         debug_struct.field("port", &self.port);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14128,7 +14076,6 @@ impl std::fmt::Debug for Provider {
         debug_struct.field("web_assets_location", &self.web_assets_location);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("launch_stage", &self.launch_stage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14272,7 +14219,6 @@ impl std::fmt::Debug for GetProviderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProviderRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14486,7 +14432,6 @@ impl std::fmt::Debug for ListProvidersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14699,7 +14644,6 @@ impl std::fmt::Debug for ListProvidersResponse {
         debug_struct.field("providers", &self.providers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14842,7 +14786,6 @@ impl std::fmt::Debug for GetRuntimeConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRuntimeConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15253,7 +15196,6 @@ impl std::fmt::Debug for RuntimeConfig {
         debug_struct.field("schema_gcs_bucket", &self.schema_gcs_bucket);
         debug_struct.field("service_directory", &self.service_directory);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15563,7 +15505,6 @@ impl std::fmt::Debug for GetGlobalSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGlobalSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15756,7 +15697,6 @@ impl std::fmt::Debug for Settings {
         debug_struct.field("name", &self.name);
         debug_struct.field("vpcsc", &self.vpcsc);
         debug_struct.field("payg", &self.payg);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16016,7 +15956,6 @@ impl std::fmt::Debug for SslConfigTemplate {
         debug_struct.field("server_cert_type", &self.server_cert_type);
         debug_struct.field("client_cert_type", &self.client_cert_type);
         debug_struct.field("additional_variables", &self.additional_variables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16458,7 +16397,6 @@ impl std::fmt::Debug for SslConfig {
         debug_struct.field("client_cert_type", &self.client_cert_type);
         debug_struct.field("use_ssl", &self.use_ssl);
         debug_struct.field("additional_variables", &self.additional_variables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -194,7 +194,6 @@ impl std::fmt::Debug for CalculateStatsRequest {
         let mut debug_struct = f.debug_struct("CalculateStatsRequest");
         debug_struct.field("location", &self.location);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -749,7 +748,6 @@ impl std::fmt::Debug for CalculateStatsResponse {
             "conversation_count_time_series",
             &self.conversation_count_time_series,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -941,7 +939,6 @@ pub mod calculate_stats_response {
             let mut debug_struct = f.debug_struct("TimeSeries");
             debug_struct.field("interval_duration", &self.interval_duration);
             debug_struct.field("points", &self.points);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1159,7 +1156,6 @@ pub mod calculate_stats_response {
                 let mut debug_struct = f.debug_struct("Interval");
                 debug_struct.field("start_time", &self.start_time);
                 debug_struct.field("conversation_count", &self.conversation_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1415,7 +1411,6 @@ impl std::fmt::Debug for CreateAnalysisOperationMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("annotator_selector", &self.annotator_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1624,7 +1619,6 @@ impl std::fmt::Debug for CreateConversationRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("conversation_id", &self.conversation_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1910,7 +1904,6 @@ impl std::fmt::Debug for UploadConversationRequest {
         debug_struct.field("conversation_id", &self.conversation_id);
         debug_struct.field("redaction_config", &self.redaction_config);
         debug_struct.field("speech_config", &self.speech_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2207,7 +2200,6 @@ impl std::fmt::Debug for UploadConversationMetadata {
         debug_struct.field("request", &self.request);
         debug_struct.field("analysis_operation", &self.analysis_operation);
         debug_struct.field("applied_redaction_config", &self.applied_redaction_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2516,7 +2508,6 @@ impl std::fmt::Debug for ListConversationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2703,7 +2694,6 @@ impl std::fmt::Debug for ListConversationsResponse {
         let mut debug_struct = f.debug_struct("ListConversationsResponse");
         debug_struct.field("conversations", &self.conversations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2871,7 +2861,6 @@ impl std::fmt::Debug for GetConversationRequest {
         let mut debug_struct = f.debug_struct("GetConversationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3074,7 +3063,6 @@ impl std::fmt::Debug for UpdateConversationRequest {
         let mut debug_struct = f.debug_struct("UpdateConversationRequest");
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3243,7 +3231,6 @@ impl std::fmt::Debug for DeleteConversationRequest {
         let mut debug_struct = f.debug_struct("DeleteConversationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3726,7 +3713,6 @@ impl std::fmt::Debug for IngestConversationsRequest {
         debug_struct.field("sample_size", &self.sample_size);
         debug_struct.field("source", &self.source);
         debug_struct.field("object_config", &self.object_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3984,7 +3970,6 @@ pub mod ingest_conversations_request {
             debug_struct.field("bucket_object_type", &self.bucket_object_type);
             debug_struct.field("metadata_bucket_uri", &self.metadata_bucket_uri);
             debug_struct.field("custom_metadata_keys", &self.custom_metadata_keys);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4271,7 +4256,6 @@ pub mod ingest_conversations_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TranscriptObjectConfig");
             debug_struct.field("medium", &self.medium);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4514,7 +4498,6 @@ pub mod ingest_conversations_request {
             debug_struct.field("agent_id", &self.agent_id);
             debug_struct.field("agent_channel", &self.agent_channel);
             debug_struct.field("customer_channel", &self.customer_channel);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4841,7 +4824,6 @@ impl std::fmt::Debug for IngestConversationsMetadata {
             "ingest_conversations_stats",
             &self.ingest_conversations_stats,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5168,7 +5150,6 @@ pub mod ingest_conversations_metadata {
             debug_struct.field("duplicates_skipped_count", &self.duplicates_skipped_count);
             debug_struct.field("successful_ingest_count", &self.successful_ingest_count);
             debug_struct.field("failed_ingest_count", &self.failed_ingest_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5283,7 +5264,6 @@ impl serde::ser::Serialize for IngestConversationsResponse {
 impl std::fmt::Debug for IngestConversationsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IngestConversationsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5461,7 +5441,6 @@ impl std::fmt::Debug for CreateAnalysisRequest {
         let mut debug_struct = f.debug_struct("CreateAnalysisRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("analysis", &self.analysis);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5704,7 +5683,6 @@ impl std::fmt::Debug for ListAnalysesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5890,7 +5868,6 @@ impl std::fmt::Debug for ListAnalysesResponse {
         let mut debug_struct = f.debug_struct("ListAnalysesResponse");
         debug_struct.field("analyses", &self.analyses);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6032,7 +6009,6 @@ impl std::fmt::Debug for GetAnalysisRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAnalysisRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6174,7 +6150,6 @@ impl std::fmt::Debug for DeleteAnalysisRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAnalysisRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6426,7 +6401,6 @@ impl std::fmt::Debug for BulkAnalyzeConversationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("analysis_percentage", &self.analysis_percentage);
         debug_struct.field("annotator_selector", &self.annotator_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6835,7 +6809,6 @@ impl std::fmt::Debug for BulkAnalyzeConversationsMetadata {
             &self.total_requested_analyses_count,
         );
         debug_struct.field("partial_errors", &self.partial_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7049,7 +7022,6 @@ impl std::fmt::Debug for BulkAnalyzeConversationsResponse {
         let mut debug_struct = f.debug_struct("BulkAnalyzeConversationsResponse");
         debug_struct.field("successful_analysis_count", &self.successful_analysis_count);
         debug_struct.field("failed_analysis_count", &self.failed_analysis_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7290,7 +7262,6 @@ impl std::fmt::Debug for BulkDeleteConversationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("max_delete_count", &self.max_delete_count);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7549,7 +7520,6 @@ impl std::fmt::Debug for BulkDeleteConversationsMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
         debug_struct.field("partial_errors", &self.partial_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7663,7 +7633,6 @@ impl serde::ser::Serialize for BulkDeleteConversationsResponse {
 impl std::fmt::Debug for BulkDeleteConversationsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BulkDeleteConversationsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7971,7 +7940,6 @@ impl std::fmt::Debug for ExportInsightsDataRequest {
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("write_disposition", &self.write_disposition);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8178,7 +8146,6 @@ pub mod export_insights_data_request {
             debug_struct.field("project_id", &self.project_id);
             debug_struct.field("dataset", &self.dataset);
             debug_struct.field("table", &self.table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8579,7 +8546,6 @@ impl std::fmt::Debug for ExportInsightsDataMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
         debug_struct.field("partial_errors", &self.partial_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8693,7 +8659,6 @@ impl serde::ser::Serialize for ExportInsightsDataResponse {
 impl std::fmt::Debug for ExportInsightsDataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportInsightsDataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8872,7 +8837,6 @@ impl std::fmt::Debug for CreateIssueModelRequest {
         let mut debug_struct = f.debug_struct("CreateIssueModelRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("issue_model", &self.issue_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9099,7 +9063,6 @@ impl std::fmt::Debug for CreateIssueModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9290,7 +9253,6 @@ impl std::fmt::Debug for UpdateIssueModelRequest {
         let mut debug_struct = f.debug_struct("UpdateIssueModelRequest");
         debug_struct.field("issue_model", &self.issue_model);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9432,7 +9394,6 @@ impl std::fmt::Debug for ListIssueModelsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListIssueModelsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9578,7 +9539,6 @@ impl std::fmt::Debug for ListIssueModelsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListIssueModelsResponse");
         debug_struct.field("issue_models", &self.issue_models);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9720,7 +9680,6 @@ impl std::fmt::Debug for GetIssueModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetIssueModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9862,7 +9821,6 @@ impl std::fmt::Debug for DeleteIssueModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIssueModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10089,7 +10047,6 @@ impl std::fmt::Debug for DeleteIssueModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10231,7 +10188,6 @@ impl std::fmt::Debug for DeployIssueModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployIssueModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10345,7 +10301,6 @@ impl serde::ser::Serialize for DeployIssueModelResponse {
 impl std::fmt::Debug for DeployIssueModelResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployIssueModelResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10572,7 +10527,6 @@ impl std::fmt::Debug for DeployIssueModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10714,7 +10668,6 @@ impl std::fmt::Debug for UndeployIssueModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployIssueModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10828,7 +10781,6 @@ impl serde::ser::Serialize for UndeployIssueModelResponse {
 impl std::fmt::Debug for UndeployIssueModelResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployIssueModelResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11055,7 +11007,6 @@ impl std::fmt::Debug for UndeployIssueModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11275,7 +11226,6 @@ impl std::fmt::Debug for ExportIssueModelRequest {
         let mut debug_struct = f.debug_struct("ExportIssueModelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11426,7 +11376,6 @@ pub mod export_issue_model_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GcsDestination");
             debug_struct.field("object_uri", &self.object_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11548,7 +11497,6 @@ impl serde::ser::Serialize for ExportIssueModelResponse {
 impl std::fmt::Debug for ExportIssueModelResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportIssueModelResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11775,7 +11723,6 @@ impl std::fmt::Debug for ExportIssueModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12023,7 +11970,6 @@ impl std::fmt::Debug for ImportIssueModelRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("create_new_model", &self.create_new_model);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12174,7 +12120,6 @@ pub mod import_issue_model_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GcsSource");
             debug_struct.field("object_uri", &self.object_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12296,7 +12241,6 @@ impl serde::ser::Serialize for ImportIssueModelResponse {
 impl std::fmt::Debug for ImportIssueModelResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportIssueModelResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12523,7 +12467,6 @@ impl std::fmt::Debug for ImportIssueModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12665,7 +12608,6 @@ impl std::fmt::Debug for GetIssueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetIssueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12807,7 +12749,6 @@ impl std::fmt::Debug for ListIssuesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListIssuesRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12952,7 +12893,6 @@ impl std::fmt::Debug for ListIssuesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListIssuesResponse");
         debug_struct.field("issues", &self.issues);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13142,7 +13082,6 @@ impl std::fmt::Debug for UpdateIssueRequest {
         let mut debug_struct = f.debug_struct("UpdateIssueRequest");
         debug_struct.field("issue", &self.issue);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13284,7 +13223,6 @@ impl std::fmt::Debug for DeleteIssueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIssueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13427,7 +13365,6 @@ impl std::fmt::Debug for CalculateIssueModelStatsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CalculateIssueModelStatsRequest");
         debug_struct.field("issue_model", &self.issue_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13582,7 +13519,6 @@ impl std::fmt::Debug for CalculateIssueModelStatsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CalculateIssueModelStatsResponse");
         debug_struct.field("current_stats", &self.current_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13764,7 +13700,6 @@ impl std::fmt::Debug for CreatePhraseMatcherRequest {
         let mut debug_struct = f.debug_struct("CreatePhraseMatcherRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("phrase_matcher", &self.phrase_matcher);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14007,7 +13942,6 @@ impl std::fmt::Debug for ListPhraseMatchersRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14194,7 +14128,6 @@ impl std::fmt::Debug for ListPhraseMatchersResponse {
         let mut debug_struct = f.debug_struct("ListPhraseMatchersResponse");
         debug_struct.field("phrase_matchers", &self.phrase_matchers);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14336,7 +14269,6 @@ impl std::fmt::Debug for GetPhraseMatcherRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPhraseMatcherRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14478,7 +14410,6 @@ impl std::fmt::Debug for DeletePhraseMatcherRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeletePhraseMatcherRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14669,7 +14600,6 @@ impl std::fmt::Debug for UpdatePhraseMatcherRequest {
         let mut debug_struct = f.debug_struct("UpdatePhraseMatcherRequest");
         debug_struct.field("phrase_matcher", &self.phrase_matcher);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14811,7 +14741,6 @@ impl std::fmt::Debug for GetSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15001,7 +14930,6 @@ impl std::fmt::Debug for UpdateSettingsRequest {
         let mut debug_struct = f.debug_struct("UpdateSettingsRequest");
         debug_struct.field("settings", &self.settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15184,7 +15112,6 @@ impl std::fmt::Debug for CreateAnalysisRuleRequest {
         let mut debug_struct = f.debug_struct("CreateAnalysisRuleRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("analysis_rule", &self.analysis_rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15326,7 +15253,6 @@ impl std::fmt::Debug for GetAnalysisRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAnalysisRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15519,7 +15445,6 @@ impl std::fmt::Debug for UpdateAnalysisRuleRequest {
         let mut debug_struct = f.debug_struct("UpdateAnalysisRuleRequest");
         debug_struct.field("analysis_rule", &self.analysis_rule);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15661,7 +15586,6 @@ impl std::fmt::Debug for DeleteAnalysisRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAnalysisRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15878,7 +15802,6 @@ impl std::fmt::Debug for ListAnalysisRulesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16065,7 +15988,6 @@ impl std::fmt::Debug for ListAnalysisRulesResponse {
         let mut debug_struct = f.debug_struct("ListAnalysisRulesResponse");
         debug_struct.field("analysis_rules", &self.analysis_rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16207,7 +16129,6 @@ impl std::fmt::Debug for GetEncryptionSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEncryptionSpecRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16365,7 +16286,6 @@ impl std::fmt::Debug for InitializeEncryptionSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeEncryptionSpecRequest");
         debug_struct.field("encryption_spec", &self.encryption_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16479,7 +16399,6 @@ impl serde::ser::Serialize for InitializeEncryptionSpecResponse {
 impl std::fmt::Debug for InitializeEncryptionSpecResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeEncryptionSpecResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16737,7 +16656,6 @@ impl std::fmt::Debug for InitializeEncryptionSpecMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("request", &self.request);
         debug_struct.field("partial_errors", &self.partial_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16918,7 +16836,6 @@ impl std::fmt::Debug for CreateViewRequest {
         let mut debug_struct = f.debug_struct("CreateViewRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17060,7 +16977,6 @@ impl std::fmt::Debug for GetViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17277,7 +17193,6 @@ impl std::fmt::Debug for ListViewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17463,7 +17378,6 @@ impl std::fmt::Debug for ListViewsResponse {
         let mut debug_struct = f.debug_struct("ListViewsResponse");
         debug_struct.field("views", &self.views);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17653,7 +17567,6 @@ impl std::fmt::Debug for UpdateViewRequest {
         let mut debug_struct = f.debug_struct("UpdateViewRequest");
         debug_struct.field("view", &self.view);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17795,7 +17708,6 @@ impl std::fmt::Debug for DeleteViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18207,7 +18119,6 @@ impl std::fmt::Debug for Dimension {
         let mut debug_struct = f.debug_struct("Dimension");
         debug_struct.field("dimension_key", &self.dimension_key);
         debug_struct.field("dimension_metadata", &self.dimension_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18416,7 +18327,6 @@ pub mod dimension {
             debug_struct.field("issue_id", &self.issue_id);
             debug_struct.field("issue_display_name", &self.issue_display_name);
             debug_struct.field("issue_model_id", &self.issue_model_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18617,7 +18527,6 @@ pub mod dimension {
             debug_struct.field("agent_id", &self.agent_id);
             debug_struct.field("agent_display_name", &self.agent_display_name);
             debug_struct.field("agent_team", &self.agent_team);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18824,7 +18733,6 @@ pub mod dimension {
             debug_struct.field("qa_scorecard_id", &self.qa_scorecard_id);
             debug_struct.field("qa_question_id", &self.qa_question_id);
             debug_struct.field("question_body", &self.question_body);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19063,7 +18971,6 @@ pub mod dimension {
             debug_struct.field("qa_question_id", &self.qa_question_id);
             debug_struct.field("question_body", &self.question_body);
             debug_struct.field("answer_value", &self.answer_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19531,7 +19438,6 @@ impl std::fmt::Debug for QueryMetricsRequest {
         debug_struct.field("time_granularity", &self.time_granularity);
         debug_struct.field("dimensions", &self.dimensions);
         debug_struct.field("measure_mask", &self.measure_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19961,7 +19867,6 @@ impl std::fmt::Debug for QueryMetricsResponse {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("slices", &self.slices);
         debug_struct.field("macro_average_slice", &self.macro_average_slice);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20201,7 +20106,6 @@ pub mod query_metrics_response {
             debug_struct.field("dimensions", &self.dimensions);
             debug_struct.field("total", &self.total);
             debug_struct.field("time_series", &self.time_series);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20457,7 +20361,6 @@ pub mod query_metrics_response {
                 let mut debug_struct = f.debug_struct("DataPoint");
                 debug_struct.field("interval", &self.interval);
                 debug_struct.field("measure", &self.measure);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -21320,7 +21223,6 @@ pub mod query_metrics_response {
                         "average_qa_question_normalized_score",
                         &self.average_qa_question_normalized_score,
                     );
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -21556,7 +21458,6 @@ pub mod query_metrics_response {
                             "average_tag_normalized_score",
                             &self.average_tag_normalized_score,
                         );
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -21720,7 +21621,6 @@ pub mod query_metrics_response {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("TimeSeries");
                 debug_struct.field("data_points", &self.data_points);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -21836,7 +21736,6 @@ impl serde::ser::Serialize for QueryMetricsMetadata {
 impl std::fmt::Debug for QueryMetricsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryMetricsMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22046,7 +21945,6 @@ impl std::fmt::Debug for CreateQaQuestionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("qa_question", &self.qa_question);
         debug_struct.field("qa_question_id", &self.qa_question_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22188,7 +22086,6 @@ impl std::fmt::Debug for GetQaQuestionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQaQuestionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22405,7 +22302,6 @@ impl std::fmt::Debug for ListQaQuestionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22592,7 +22488,6 @@ impl std::fmt::Debug for ListQaQuestionsResponse {
         let mut debug_struct = f.debug_struct("ListQaQuestionsResponse");
         debug_struct.field("qa_questions", &self.qa_questions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22792,7 +22687,6 @@ impl std::fmt::Debug for UpdateQaQuestionRequest {
         let mut debug_struct = f.debug_struct("UpdateQaQuestionRequest");
         debug_struct.field("qa_question", &self.qa_question);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22934,7 +22828,6 @@ impl std::fmt::Debug for DeleteQaQuestionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteQaQuestionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23144,7 +23037,6 @@ impl std::fmt::Debug for CreateQaScorecardRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("qa_scorecard", &self.qa_scorecard);
         debug_struct.field("qa_scorecard_id", &self.qa_scorecard_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23286,7 +23178,6 @@ impl std::fmt::Debug for GetQaScorecardRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQaScorecardRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23482,7 +23373,6 @@ impl std::fmt::Debug for UpdateQaScorecardRequest {
         let mut debug_struct = f.debug_struct("UpdateQaScorecardRequest");
         debug_struct.field("qa_scorecard", &self.qa_scorecard);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23650,7 +23540,6 @@ impl std::fmt::Debug for DeleteQaScorecardRequest {
         let mut debug_struct = f.debug_struct("DeleteQaScorecardRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23865,7 +23754,6 @@ impl std::fmt::Debug for CreateQaScorecardRevisionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("qa_scorecard_revision", &self.qa_scorecard_revision);
         debug_struct.field("qa_scorecard_revision_id", &self.qa_scorecard_revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24007,7 +23895,6 @@ impl std::fmt::Debug for GetQaScorecardRevisionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQaScorecardRevisionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24207,7 +24094,6 @@ impl std::fmt::Debug for TuneQaScorecardRevisionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24321,7 +24207,6 @@ impl serde::ser::Serialize for TuneQaScorecardRevisionResponse {
 impl std::fmt::Debug for TuneQaScorecardRevisionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TuneQaScorecardRevisionResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24686,7 +24571,6 @@ impl std::fmt::Debug for TuneQaScorecardRevisionMetadata {
             &self.qa_question_dataset_tuning_metrics,
         );
         debug_struct.field("tuning_completion_ratio", &self.tuning_completion_ratio);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24937,7 +24821,6 @@ pub mod tune_qa_scorecard_revision_metadata {
                 "valid_feedback_labels_count",
                 &self.valid_feedback_labels_count,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25119,7 +25002,6 @@ pub mod tune_qa_scorecard_revision_metadata {
             let mut debug_struct = f.debug_struct("QaQuestionDatasetTuningMetrics");
             debug_struct.field("question", &self.question);
             debug_struct.field("metrics", &self.metrics);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25297,7 +25179,6 @@ pub mod tune_qa_scorecard_revision_metadata {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Metrics");
                 debug_struct.field("accuracy", &self.accuracy);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25441,7 +25322,6 @@ impl std::fmt::Debug for DeployQaScorecardRevisionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployQaScorecardRevisionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25583,7 +25463,6 @@ impl std::fmt::Debug for UndeployQaScorecardRevisionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployQaScorecardRevisionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25752,7 +25631,6 @@ impl std::fmt::Debug for DeleteQaScorecardRevisionRequest {
         let mut debug_struct = f.debug_struct("DeleteQaScorecardRevisionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25969,7 +25847,6 @@ impl std::fmt::Debug for ListQaScorecardsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26156,7 +26033,6 @@ impl std::fmt::Debug for ListQaScorecardsResponse {
         let mut debug_struct = f.debug_struct("ListQaScorecardsResponse");
         debug_struct.field("qa_scorecards", &self.qa_scorecards);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26402,7 +26278,6 @@ impl std::fmt::Debug for ListQaScorecardRevisionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26593,7 +26468,6 @@ impl std::fmt::Debug for ListQaScorecardRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListQaScorecardRevisionsResponse");
         debug_struct.field("qa_scorecard_revisions", &self.qa_scorecard_revisions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26802,7 +26676,6 @@ impl std::fmt::Debug for CreateFeedbackLabelRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("feedback_label_id", &self.feedback_label_id);
         debug_struct.field("feedback_label", &self.feedback_label);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27058,7 +26931,6 @@ impl std::fmt::Debug for ListFeedbackLabelsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27244,7 +27116,6 @@ impl std::fmt::Debug for ListFeedbackLabelsResponse {
         let mut debug_struct = f.debug_struct("ListFeedbackLabelsResponse");
         debug_struct.field("feedback_labels", &self.feedback_labels);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27386,7 +27257,6 @@ impl std::fmt::Debug for GetFeedbackLabelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFeedbackLabelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27577,7 +27447,6 @@ impl std::fmt::Debug for UpdateFeedbackLabelRequest {
         let mut debug_struct = f.debug_struct("UpdateFeedbackLabelRequest");
         debug_struct.field("feedback_label", &self.feedback_label);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27719,7 +27588,6 @@ impl std::fmt::Debug for DeleteFeedbackLabelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFeedbackLabelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27973,7 +27841,6 @@ impl std::fmt::Debug for ListAllFeedbackLabelsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28160,7 +28027,6 @@ impl std::fmt::Debug for ListAllFeedbackLabelsResponse {
         let mut debug_struct = f.debug_struct("ListAllFeedbackLabelsResponse");
         debug_struct.field("feedback_labels", &self.feedback_labels);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28410,7 +28276,6 @@ impl std::fmt::Debug for BulkUploadFeedbackLabelsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28592,7 +28457,6 @@ pub mod bulk_upload_feedback_labels_request {
             let mut debug_struct = f.debug_struct("GcsSource");
             debug_struct.field("format", &self.format);
             debug_struct.field("object_uri", &self.object_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28856,7 +28720,6 @@ impl serde::ser::Serialize for BulkUploadFeedbackLabelsResponse {
 impl std::fmt::Debug for BulkUploadFeedbackLabelsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BulkUploadFeedbackLabelsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29153,7 +29016,6 @@ impl std::fmt::Debug for BulkUploadFeedbackLabelsMetadata {
         debug_struct.field("request", &self.request);
         debug_struct.field("partial_errors", &self.partial_errors);
         debug_struct.field("upload_stats", &self.upload_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29432,7 +29294,6 @@ pub mod bulk_upload_feedback_labels_metadata {
             debug_struct.field("processed_object_count", &self.processed_object_count);
             debug_struct.field("failed_validation_count", &self.failed_validation_count);
             debug_struct.field("successful_upload_count", &self.successful_upload_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29840,7 +29701,6 @@ impl std::fmt::Debug for BulkDownloadFeedbackLabelsRequest {
         debug_struct.field("conversation_filter", &self.conversation_filter);
         debug_struct.field("template_qa_scorecard_id", &self.template_qa_scorecard_id);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30135,7 +29995,6 @@ pub mod bulk_download_feedback_labels_request {
             debug_struct.field("add_whitespace", &self.add_whitespace);
             debug_struct.field("always_print_empty_fields", &self.always_print_empty_fields);
             debug_struct.field("records_per_file_count", &self.records_per_file_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30537,7 +30396,6 @@ impl serde::ser::Serialize for BulkDownloadFeedbackLabelsResponse {
 impl std::fmt::Debug for BulkDownloadFeedbackLabelsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BulkDownloadFeedbackLabelsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30834,7 +30692,6 @@ impl std::fmt::Debug for BulkDownloadFeedbackLabelsMetadata {
         debug_struct.field("request", &self.request);
         debug_struct.field("partial_errors", &self.partial_errors);
         debug_struct.field("download_stats", &self.download_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31137,7 +30994,6 @@ pub mod bulk_download_feedback_labels_metadata {
             debug_struct.field("successful_download_count", &self.successful_download_count);
             debug_struct.field("total_files_written", &self.total_files_written);
             debug_struct.field("file_names", &self.file_names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32094,7 +31950,6 @@ impl std::fmt::Debug for Conversation {
         debug_struct.field("obfuscated_user_id", &self.obfuscated_user_id);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("expiration", &self.expiration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32309,7 +32164,6 @@ pub mod conversation {
             let mut debug_struct = f.debug_struct("CallMetadata");
             debug_struct.field("customer_channel", &self.customer_channel);
             debug_struct.field("agent_channel", &self.agent_channel);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32585,7 +32439,6 @@ pub mod conversation {
             debug_struct.field("wait_duration", &self.wait_duration);
             debug_struct.field("menu_path", &self.menu_path);
             debug_struct.field("agent_info", &self.agent_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32867,7 +32720,6 @@ pub mod conversation {
                 debug_struct.field("team", &self.team);
                 debug_struct.field("disposition_code", &self.disposition_code);
                 debug_struct.field("agent_type", &self.agent_type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -33018,7 +32870,6 @@ pub mod conversation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Transcript");
             debug_struct.field("transcript_segments", &self.transcript_segments);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33503,7 +33354,6 @@ pub mod conversation {
                     &self.dialogflow_segment_metadata,
                 );
                 debug_struct.field("sentiment", &self.sentiment);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -33803,7 +33653,6 @@ pub mod conversation {
                     debug_struct.field("end_offset", &self.end_offset);
                     debug_struct.field("word", &self.word);
                     debug_struct.field("confidence", &self.confidence);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -33977,7 +33826,6 @@ pub mod conversation {
                         "smart_reply_allowlist_covered",
                         &self.smart_reply_allowlist_covered,
                     );
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -34432,7 +34280,6 @@ impl std::fmt::Debug for Analysis {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("analysis_result", &self.analysis_result);
         debug_struct.field("annotator_selector", &self.annotator_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34679,7 +34526,6 @@ impl std::fmt::Debug for ConversationDataSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConversationDataSource");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34866,7 +34712,6 @@ impl std::fmt::Debug for GcsSource {
         let mut debug_struct = f.debug_struct("GcsSource");
         debug_struct.field("audio_uri", &self.audio_uri);
         debug_struct.field("transcript_uri", &self.transcript_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35041,7 +34886,6 @@ impl std::fmt::Debug for DialogflowSource {
         let mut debug_struct = f.debug_struct("DialogflowSource");
         debug_struct.field("dialogflow_conversation", &self.dialogflow_conversation);
         debug_struct.field("audio_uri", &self.audio_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35274,7 +35118,6 @@ impl std::fmt::Debug for AnalysisResult {
         let mut debug_struct = f.debug_struct("AnalysisResult");
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35679,7 +35522,6 @@ pub mod analysis_result {
             debug_struct.field("phrase_matchers", &self.phrase_matchers);
             debug_struct.field("issue_model_result", &self.issue_model_result);
             debug_struct.field("qa_scorecard_results", &self.qa_scorecard_results);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35864,7 +35706,6 @@ impl std::fmt::Debug for IssueModelResult {
         let mut debug_struct = f.debug_struct("IssueModelResult");
         debug_struct.field("issue_model", &self.issue_model);
         debug_struct.field("issues", &self.issues);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36232,7 +36073,6 @@ impl std::fmt::Debug for FeedbackLabel {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("label_type", &self.label_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36446,7 +36286,6 @@ impl std::fmt::Debug for ConversationLevelSentiment {
         let mut debug_struct = f.debug_struct("ConversationLevelSentiment");
         debug_struct.field("channel_tag", &self.channel_tag);
         debug_struct.field("sentiment_data", &self.sentiment_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36645,7 +36484,6 @@ impl std::fmt::Debug for ConversationLevelSilence {
         let mut debug_struct = f.debug_struct("ConversationLevelSilence");
         debug_struct.field("silence_duration", &self.silence_duration);
         debug_struct.field("silence_percentage", &self.silence_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36858,7 +36696,6 @@ impl std::fmt::Debug for IssueAssignment {
         debug_struct.field("issue", &self.issue);
         debug_struct.field("score", &self.score);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37557,7 +37394,6 @@ impl std::fmt::Debug for CallAnnotation {
         debug_struct.field("annotation_start_boundary", &self.annotation_start_boundary);
         debug_struct.field("annotation_end_boundary", &self.annotation_end_boundary);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37836,7 +37672,6 @@ impl std::fmt::Debug for AnnotationBoundary {
         let mut debug_struct = f.debug_struct("AnnotationBoundary");
         debug_struct.field("transcript_index", &self.transcript_index);
         debug_struct.field("detailed_boundary", &self.detailed_boundary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38145,7 +37980,6 @@ impl std::fmt::Debug for Entity {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("salience", &self.salience);
         debug_struct.field("sentiment", &self.sentiment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38559,7 +38393,6 @@ impl std::fmt::Debug for Intent {
         let mut debug_struct = f.debug_struct("Intent");
         debug_struct.field("id", &self.id);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38729,7 +38562,6 @@ impl std::fmt::Debug for PhraseMatchData {
         let mut debug_struct = f.debug_struct("PhraseMatchData");
         debug_struct.field("phrase_matcher", &self.phrase_matcher);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38873,7 +38705,6 @@ impl std::fmt::Debug for DialogflowIntent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DialogflowIntent");
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38987,7 +38818,6 @@ impl serde::ser::Serialize for InterruptionData {
 impl std::fmt::Debug for InterruptionData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InterruptionData");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39101,7 +38931,6 @@ impl serde::ser::Serialize for SilenceData {
 impl std::fmt::Debug for SilenceData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SilenceData");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39215,7 +39044,6 @@ impl serde::ser::Serialize for HoldData {
 impl std::fmt::Debug for HoldData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HoldData");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39429,7 +39257,6 @@ impl std::fmt::Debug for EntityMentionData {
         debug_struct.field("entity_unique_id", &self.entity_unique_id);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("sentiment", &self.sentiment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39717,7 +39544,6 @@ impl std::fmt::Debug for IntentMatchData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IntentMatchData");
         debug_struct.field("intent_unique_id", &self.intent_unique_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39921,7 +39747,6 @@ impl std::fmt::Debug for SentimentData {
         let mut debug_struct = f.debug_struct("SentimentData");
         debug_struct.field("magnitude", &self.magnitude);
         debug_struct.field("score", &self.score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40076,7 +39901,6 @@ impl std::fmt::Debug for IssueMatchData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IssueMatchData");
         debug_struct.field("issue_assignment", &self.issue_assignment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40518,7 +40342,6 @@ impl std::fmt::Debug for IssueModel {
         debug_struct.field("training_stats", &self.training_stats);
         debug_struct.field("model_type", &self.model_type);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40757,7 +40580,6 @@ pub mod issue_model {
                 &self.training_conversations_count,
             );
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -41347,7 +41169,6 @@ impl std::fmt::Debug for Issue {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("sample_utterances", &self.sample_utterances);
         debug_struct.field("display_description", &self.display_description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41618,7 +41439,6 @@ impl std::fmt::Debug for IssueModelLabelStats {
             &self.unclassified_conversations_count,
         );
         debug_struct.field("issue_stats", &self.issue_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41854,7 +41674,6 @@ pub mod issue_model_label_stats {
                 &self.labeled_conversations_count,
             );
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42317,7 +42136,6 @@ impl std::fmt::Debug for PhraseMatcher {
         debug_struct.field("activation_update_time", &self.activation_update_time);
         debug_struct.field("role_match", &self.role_match);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42638,7 +42456,6 @@ impl std::fmt::Debug for PhraseMatchRuleGroup {
         let mut debug_struct = f.debug_struct("PhraseMatchRuleGroup");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("phrase_match_rules", &self.phrase_match_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42983,7 +42800,6 @@ impl std::fmt::Debug for PhraseMatchRule {
         debug_struct.field("query", &self.query);
         debug_struct.field("negated", &self.negated);
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43176,7 +42992,6 @@ impl std::fmt::Debug for PhraseMatchRuleConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PhraseMatchRuleConfig");
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43333,7 +43148,6 @@ impl std::fmt::Debug for ExactMatchConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExactMatchConfig");
         debug_struct.field("case_sensitive", &self.case_sensitive);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43809,7 +43623,6 @@ impl std::fmt::Debug for Settings {
         debug_struct.field("analysis_config", &self.analysis_config);
         debug_struct.field("redaction_config", &self.redaction_config);
         debug_struct.field("speech_config", &self.speech_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44094,7 +43907,6 @@ pub mod settings {
                 &self.upload_conversation_analysis_percentage,
             );
             debug_struct.field("annotator_selector", &self.annotator_selector);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44499,7 +44311,6 @@ impl std::fmt::Debug for AnalysisRule {
         debug_struct.field("annotator_selector", &self.annotator_selector);
         debug_struct.field("analysis_percentage", &self.analysis_percentage);
         debug_struct.field("active", &self.active);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44674,7 +44485,6 @@ impl std::fmt::Debug for EncryptionSpec {
         let mut debug_struct = f.debug_struct("EncryptionSpec");
         debug_struct.field("name", &self.name);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44859,7 +44669,6 @@ impl std::fmt::Debug for RedactionConfig {
         let mut debug_struct = f.debug_struct("RedactionConfig");
         debug_struct.field("deidentify_template", &self.deidentify_template);
         debug_struct.field("inspect_template", &self.inspect_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45011,7 +44820,6 @@ impl std::fmt::Debug for SpeechConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SpeechConfig");
         debug_struct.field("speech_recognizer", &self.speech_recognizer);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45702,7 +45510,6 @@ impl std::fmt::Debug for RuntimeAnnotation {
         debug_struct.field("answer_feedback", &self.answer_feedback);
         debug_struct.field("user_input", &self.user_input);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45916,7 +45723,6 @@ pub mod runtime_annotation {
             debug_struct.field("query", &self.query);
             debug_struct.field("generator_name", &self.generator_name);
             debug_struct.field("query_source", &self.query_source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46280,7 +46086,6 @@ impl std::fmt::Debug for AnswerFeedback {
         debug_struct.field("correctness_level", &self.correctness_level);
         debug_struct.field("clicked", &self.clicked);
         debug_struct.field("displayed", &self.displayed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46731,7 +46536,6 @@ impl std::fmt::Debug for ArticleSuggestionData {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("query_record", &self.query_record);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47037,7 +46841,6 @@ impl std::fmt::Debug for FaqAnswerData {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("query_record", &self.query_record);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47291,7 +47094,6 @@ impl std::fmt::Debug for SmartReplyData {
         debug_struct.field("confidence_score", &self.confidence_score);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("query_record", &self.query_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47545,7 +47347,6 @@ impl std::fmt::Debug for SmartComposeSuggestionData {
         debug_struct.field("confidence_score", &self.confidence_score);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("query_record", &self.query_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47736,7 +47537,6 @@ impl std::fmt::Debug for DialogflowInteractionData {
         let mut debug_struct = f.debug_struct("DialogflowInteractionData");
         debug_struct.field("dialogflow_intent_id", &self.dialogflow_intent_id);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48057,7 +47857,6 @@ impl std::fmt::Debug for ConversationSummarizationSuggestionData {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("answer_record", &self.answer_record);
         debug_struct.field("conversation_model", &self.conversation_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48401,7 +48200,6 @@ impl std::fmt::Debug for ConversationParticipant {
         );
         debug_struct.field("role", &self.role);
         debug_struct.field("participant", &self.participant);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48832,7 +48630,6 @@ impl std::fmt::Debug for View {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49355,7 +49152,6 @@ impl std::fmt::Debug for AnnotatorSelector {
         debug_struct.field("summarization_config", &self.summarization_config);
         debug_struct.field("run_qa_annotator", &self.run_qa_annotator);
         debug_struct.field("qa_config", &self.qa_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49615,7 +49411,6 @@ pub mod annotator_selector {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SummarizationConfig");
             debug_struct.field("model_source", &self.model_source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49976,7 +49771,6 @@ pub mod annotator_selector {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QaConfig");
             debug_struct.field("scorecard_source", &self.scorecard_source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50139,7 +49933,6 @@ pub mod annotator_selector {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ScorecardList");
                 debug_struct.field("qa_scorecard_revisions", &self.qa_scorecard_revisions);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -50633,7 +50426,6 @@ impl std::fmt::Debug for QaQuestion {
         debug_struct.field("order", &self.order);
         debug_struct.field("metrics", &self.metrics);
         debug_struct.field("tuning_metadata", &self.tuning_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51077,7 +50869,6 @@ pub mod qa_question {
             debug_struct.field("key", &self.key);
             debug_struct.field("score", &self.score);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51264,7 +51055,6 @@ pub mod qa_question {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Metrics");
             debug_struct.field("accuracy", &self.accuracy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51510,7 +51300,6 @@ pub mod qa_question {
                 &self.dataset_validation_warnings,
             );
             debug_struct.field("tuning_error", &self.tuning_error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51781,7 +51570,6 @@ impl std::fmt::Debug for QaScorecard {
         debug_struct.field("description", &self.description);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52060,7 +51848,6 @@ impl std::fmt::Debug for QaScorecardRevision {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("alternate_ids", &self.alternate_ids);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52520,7 +52307,6 @@ impl std::fmt::Debug for QaAnswer {
         debug_struct.field("answer_value", &self.answer_value);
         debug_struct.field("tags", &self.tags);
         debug_struct.field("answer_sources", &self.answer_sources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53085,7 +52871,6 @@ pub mod qa_answer {
             debug_struct.field("potential_score", &self.potential_score);
             debug_struct.field("normalized_score", &self.normalized_score);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -53297,7 +53082,6 @@ pub mod qa_answer {
             let mut debug_struct = f.debug_struct("AnswerSource");
             debug_struct.field("source_type", &self.source_type);
             debug_struct.field("answer_value", &self.answer_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -53972,7 +53756,6 @@ impl std::fmt::Debug for QaScorecardResult {
         debug_struct.field("normalized_score", &self.normalized_score);
         debug_struct.field("qa_tag_results", &self.qa_tag_results);
         debug_struct.field("score_sources", &self.score_sources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54295,7 +54078,6 @@ pub mod qa_scorecard_result {
             debug_struct.field("score", &self.score);
             debug_struct.field("potential_score", &self.potential_score);
             debug_struct.field("normalized_score", &self.normalized_score);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -54659,7 +54441,6 @@ pub mod qa_scorecard_result {
             debug_struct.field("potential_score", &self.potential_score);
             debug_struct.field("normalized_score", &self.normalized_score);
             debug_struct.field("qa_tag_results", &self.qa_tag_results);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -271,7 +271,6 @@ impl std::fmt::Debug for Process {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("origin", &self.origin);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -581,7 +580,6 @@ impl std::fmt::Debug for Run {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -988,7 +986,6 @@ impl std::fmt::Debug for LineageEvent {
         debug_struct.field("links", &self.links);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1179,7 +1176,6 @@ impl std::fmt::Debug for EventLink {
         let mut debug_struct = f.debug_struct("EventLink");
         debug_struct.field("source", &self.source);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1327,7 +1323,6 @@ impl std::fmt::Debug for EntityReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EntityReference");
         debug_struct.field("fully_qualified_name", &self.fully_qualified_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1625,7 +1620,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("resource_uuid", &self.resource_uuid);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2119,7 +2113,6 @@ impl std::fmt::Debug for ProcessOpenLineageRunEventRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("open_lineage", &self.open_lineage);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2321,7 +2314,6 @@ impl std::fmt::Debug for ProcessOpenLineageRunEventResponse {
         debug_struct.field("process", &self.process);
         debug_struct.field("run", &self.run);
         debug_struct.field("lineage_events", &self.lineage_events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2529,7 +2521,6 @@ impl std::fmt::Debug for CreateProcessRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("process", &self.process);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2749,7 +2740,6 @@ impl std::fmt::Debug for UpdateProcessRequest {
         debug_struct.field("process", &self.process);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2892,7 +2882,6 @@ impl std::fmt::Debug for GetProcessRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProcessRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3113,7 +3102,6 @@ impl std::fmt::Debug for ListProcessesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3300,7 +3288,6 @@ impl std::fmt::Debug for ListProcessesResponse {
         let mut debug_struct = f.debug_struct("ListProcessesResponse");
         debug_struct.field("processes", &self.processes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3470,7 +3457,6 @@ impl std::fmt::Debug for DeleteProcessRequest {
         let mut debug_struct = f.debug_struct("DeleteProcessRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3677,7 +3663,6 @@ impl std::fmt::Debug for CreateRunRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("run", &self.run);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3900,7 +3885,6 @@ impl std::fmt::Debug for UpdateRunRequest {
         debug_struct.field("run", &self.run);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4043,7 +4027,6 @@ impl std::fmt::Debug for GetRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4263,7 +4246,6 @@ impl std::fmt::Debug for ListRunsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4450,7 +4432,6 @@ impl std::fmt::Debug for ListRunsResponse {
         let mut debug_struct = f.debug_struct("ListRunsResponse");
         debug_struct.field("runs", &self.runs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4620,7 +4601,6 @@ impl std::fmt::Debug for DeleteRunRequest {
         let mut debug_struct = f.debug_struct("DeleteRunRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4828,7 +4808,6 @@ impl std::fmt::Debug for CreateLineageEventRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("lineage_event", &self.lineage_event);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4971,7 +4950,6 @@ impl std::fmt::Debug for GetLineageEventRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLineageEventRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5193,7 +5171,6 @@ impl std::fmt::Debug for ListLineageEventsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5381,7 +5358,6 @@ impl std::fmt::Debug for ListLineageEventsResponse {
         let mut debug_struct = f.debug_struct("ListLineageEventsResponse");
         debug_struct.field("lineage_events", &self.lineage_events);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5551,7 +5527,6 @@ impl std::fmt::Debug for DeleteLineageEventRequest {
         let mut debug_struct = f.debug_struct("DeleteLineageEventRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5895,7 +5870,6 @@ impl std::fmt::Debug for SearchLinksRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("criteria", &self.criteria);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6103,7 +6077,6 @@ impl std::fmt::Debug for SearchLinksResponse {
         let mut debug_struct = f.debug_struct("SearchLinksResponse");
         debug_struct.field("links", &self.links);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6398,7 +6371,6 @@ impl std::fmt::Debug for Link {
         debug_struct.field("target", &self.target);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6653,7 +6625,6 @@ impl std::fmt::Debug for BatchSearchLinkProcessesRequest {
         debug_struct.field("links", &self.links);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6843,7 +6814,6 @@ impl std::fmt::Debug for BatchSearchLinkProcessesResponse {
         let mut debug_struct = f.debug_struct("BatchSearchLinkProcessesResponse");
         debug_struct.field("process_links", &self.process_links);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7023,7 +6993,6 @@ impl std::fmt::Debug for ProcessLinks {
         let mut debug_struct = f.debug_struct("ProcessLinks");
         debug_struct.field("process", &self.process);
         debug_struct.field("links", &self.links);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7240,7 +7209,6 @@ impl std::fmt::Debug for ProcessLinkInfo {
         debug_struct.field("link", &self.link);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7421,7 +7389,6 @@ impl std::fmt::Debug for Origin {
         let mut debug_struct = f.debug_struct("Origin");
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -283,7 +283,6 @@ impl std::fmt::Debug for BigQueryConnectionSpec {
         debug_struct.field("connection_type", &self.connection_type);
         debug_struct.field("has_credential", &self.has_credential);
         debug_struct.field("connection_spec", &self.connection_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -621,7 +620,6 @@ impl std::fmt::Debug for CloudSqlBigQueryConnectionSpec {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("database", &self.database);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -905,7 +903,6 @@ impl std::fmt::Debug for BigQueryRoutineSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryRoutineSpec");
         debug_struct.field("imported_libraries", &self.imported_libraries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1084,7 +1081,6 @@ impl std::fmt::Debug for PersonalDetails {
         let mut debug_struct = f.debug_struct("PersonalDetails");
         debug_struct.field("starred", &self.starred);
         debug_struct.field("star_time", &self.star_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1355,7 +1351,6 @@ impl std::fmt::Debug for DataSource {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("source_entry", &self.source_entry);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1691,7 +1686,6 @@ impl std::fmt::Debug for StorageProperties {
         let mut debug_struct = f.debug_struct("StorageProperties");
         debug_struct.field("file_pattern", &self.file_pattern);
         debug_struct.field("file_type", &self.file_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2044,7 +2038,6 @@ impl std::fmt::Debug for SearchCatalogRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("admin_search", &self.admin_search);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2385,7 +2378,6 @@ pub mod search_catalog_request {
                 "include_public_tag_templates",
                 &self.include_public_tag_templates,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2656,7 +2648,6 @@ impl std::fmt::Debug for SearchCatalogResponse {
         debug_struct.field("total_size", &self.total_size);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2872,7 +2863,6 @@ impl std::fmt::Debug for CreateEntryGroupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entry_group_id", &self.entry_group_id);
         debug_struct.field("entry_group", &self.entry_group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3070,7 +3060,6 @@ impl std::fmt::Debug for UpdateEntryGroupRequest {
         let mut debug_struct = f.debug_struct("UpdateEntryGroupRequest");
         debug_struct.field("entry_group", &self.entry_group);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3252,7 +3241,6 @@ impl std::fmt::Debug for GetEntryGroupRequest {
         let mut debug_struct = f.debug_struct("GetEntryGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3422,7 +3410,6 @@ impl std::fmt::Debug for DeleteEntryGroupRequest {
         let mut debug_struct = f.debug_struct("DeleteEntryGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3643,7 +3630,6 @@ impl std::fmt::Debug for ListEntryGroupsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3833,7 +3819,6 @@ impl std::fmt::Debug for ListEntryGroupsResponse {
         let mut debug_struct = f.debug_struct("ListEntryGroupsResponse");
         debug_struct.field("entry_groups", &self.entry_groups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4047,7 +4032,6 @@ impl std::fmt::Debug for CreateEntryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entry_id", &self.entry_id);
         debug_struct.field("entry", &self.entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4268,7 +4252,6 @@ impl std::fmt::Debug for UpdateEntryRequest {
         let mut debug_struct = f.debug_struct("UpdateEntryRequest");
         debug_struct.field("entry", &self.entry);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4413,7 +4396,6 @@ impl std::fmt::Debug for DeleteEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4558,7 +4540,6 @@ impl std::fmt::Debug for GetEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4901,7 +4882,6 @@ impl std::fmt::Debug for LookupEntryRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("location", &self.location);
         debug_struct.field("target_name", &self.target_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6570,7 +6550,6 @@ impl std::fmt::Debug for Entry {
         debug_struct.field("system_spec", &self.system_spec);
         debug_struct.field("type_spec", &self.type_spec);
         debug_struct.field("spec", &self.spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6912,7 +6891,6 @@ impl std::fmt::Debug for DatabaseTableSpec {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("dataplex_table", &self.dataplex_table);
         debug_struct.field("database_view_spec", &self.database_view_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7186,7 +7164,6 @@ pub mod database_table_spec {
             let mut debug_struct = f.debug_struct("DatabaseViewSpec");
             debug_struct.field("view_type", &self.view_type);
             debug_struct.field("source_definition", &self.source_definition);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7626,7 +7603,6 @@ impl std::fmt::Debug for FilesetSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FilesetSpec");
         debug_struct.field("dataplex_fileset", &self.dataplex_fileset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7785,7 +7761,6 @@ impl std::fmt::Debug for DataSourceConnectionSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataSourceConnectionSpec");
         debug_struct.field("bigquery_connection_spec", &self.bigquery_connection_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8121,7 +8096,6 @@ impl std::fmt::Debug for RoutineSpec {
         debug_struct.field("return_type", &self.return_type);
         debug_struct.field("definition_body", &self.definition_body);
         debug_struct.field("system_spec", &self.system_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8328,7 +8302,6 @@ pub mod routine_spec {
             debug_struct.field("name", &self.name);
             debug_struct.field("mode", &self.mode);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8811,7 +8784,6 @@ impl std::fmt::Debug for DatasetSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatasetSpec");
         debug_struct.field("system_spec", &self.system_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9040,7 +9012,6 @@ impl std::fmt::Debug for SqlDatabaseSystemSpec {
         debug_struct.field("sql_engine", &self.sql_engine);
         debug_struct.field("database_version", &self.database_version);
         debug_struct.field("instance_host", &self.instance_host);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9342,7 +9313,6 @@ impl std::fmt::Debug for LookerSystemSpec {
         debug_struct.field("parent_model_display_name", &self.parent_model_display_name);
         debug_struct.field("parent_view_id", &self.parent_view_id);
         debug_struct.field("parent_view_display_name", &self.parent_view_display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9491,7 +9461,6 @@ impl std::fmt::Debug for CloudBigtableSystemSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudBigtableSystemSpec");
         debug_struct.field("instance_display_name", &self.instance_display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9650,7 +9619,6 @@ impl std::fmt::Debug for CloudBigtableInstanceSpec {
             "cloud_bigtable_cluster_specs",
             &self.cloud_bigtable_cluster_specs,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9883,7 +9851,6 @@ pub mod cloud_bigtable_instance_spec {
             debug_struct.field("location", &self.location);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("linked_resource", &self.linked_resource);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10082,7 +10049,6 @@ impl std::fmt::Debug for ServiceSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceSpec");
         debug_struct.field("system_spec", &self.system_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10276,7 +10242,6 @@ impl std::fmt::Debug for VertexModelSourceInfo {
         let mut debug_struct = f.debug_struct("VertexModelSourceInfo");
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("copy", &self.copy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10720,7 +10685,6 @@ impl std::fmt::Debug for VertexModelSpec {
         debug_struct.field("version_description", &self.version_description);
         debug_struct.field("vertex_model_source_info", &self.vertex_model_source_info);
         debug_struct.field("container_image_uri", &self.container_image_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10914,7 +10878,6 @@ impl std::fmt::Debug for VertexDatasetSpec {
         let mut debug_struct = f.debug_struct("VertexDatasetSpec");
         debug_struct.field("data_item_count", &self.data_item_count);
         debug_struct.field("data_type", &self.data_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11322,7 +11285,6 @@ impl std::fmt::Debug for ModelSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ModelSpec");
         debug_struct.field("system_spec", &self.system_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11487,7 +11449,6 @@ impl std::fmt::Debug for FeatureOnlineStoreSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FeatureOnlineStoreSpec");
         debug_struct.field("storage_type", &self.storage_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11815,7 +11776,6 @@ impl std::fmt::Debug for BusinessContext {
         let mut debug_struct = f.debug_struct("BusinessContext");
         debug_struct.field("entry_overview", &self.entry_overview);
         debug_struct.field("contacts", &self.contacts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11963,7 +11923,6 @@ impl std::fmt::Debug for EntryOverview {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EntryOverview");
         debug_struct.field("overview", &self.overview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12112,7 +12071,6 @@ impl std::fmt::Debug for Contacts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Contacts");
         debug_struct.field("people", &self.people);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12288,7 +12246,6 @@ pub mod contacts {
             let mut debug_struct = f.debug_struct("Person");
             debug_struct.field("designation", &self.designation);
             debug_struct.field("email", &self.email);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12561,7 +12518,6 @@ impl std::fmt::Debug for EntryGroup {
         debug_struct.field("description", &self.description);
         debug_struct.field("data_catalog_timestamps", &self.data_catalog_timestamps);
         debug_struct.field("transferred_to_dataplex", &self.transferred_to_dataplex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12774,7 +12730,6 @@ impl std::fmt::Debug for CreateTagTemplateRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tag_template_id", &self.tag_template_id);
         debug_struct.field("tag_template", &self.tag_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12919,7 +12874,6 @@ impl std::fmt::Debug for GetTagTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTagTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13121,7 +13075,6 @@ impl std::fmt::Debug for UpdateTagTemplateRequest {
         let mut debug_struct = f.debug_struct("UpdateTagTemplateRequest");
         debug_struct.field("tag_template", &self.tag_template);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13293,7 +13246,6 @@ impl std::fmt::Debug for DeleteTagTemplateRequest {
         let mut debug_struct = f.debug_struct("DeleteTagTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13480,7 +13432,6 @@ impl std::fmt::Debug for CreateTagRequest {
         let mut debug_struct = f.debug_struct("CreateTagRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tag", &self.tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13678,7 +13629,6 @@ impl std::fmt::Debug for UpdateTagRequest {
         let mut debug_struct = f.debug_struct("UpdateTagRequest");
         debug_struct.field("tag", &self.tag);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13823,7 +13773,6 @@ impl std::fmt::Debug for DeleteTagRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14043,7 +13992,6 @@ impl std::fmt::Debug for CreateTagTemplateFieldRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tag_template_field_id", &self.tag_template_field_id);
         debug_struct.field("tag_template_field", &self.tag_template_field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14278,7 +14226,6 @@ impl std::fmt::Debug for UpdateTagTemplateFieldRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("tag_template_field", &self.tag_template_field);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14455,7 +14402,6 @@ impl std::fmt::Debug for RenameTagTemplateFieldRequest {
         let mut debug_struct = f.debug_struct("RenameTagTemplateFieldRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("new_tag_template_field_id", &self.new_tag_template_field_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14638,7 +14584,6 @@ impl std::fmt::Debug for RenameTagTemplateFieldEnumValueRequest {
             "new_enum_value_display_name",
             &self.new_enum_value_display_name,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14810,7 +14755,6 @@ impl std::fmt::Debug for DeleteTagTemplateFieldRequest {
         let mut debug_struct = f.debug_struct("DeleteTagTemplateFieldRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15033,7 +14977,6 @@ impl std::fmt::Debug for ListTagsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15224,7 +15167,6 @@ impl std::fmt::Debug for ListTagsResponse {
         let mut debug_struct = f.debug_struct("ListTagsResponse");
         debug_struct.field("tags", &self.tags);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15456,7 +15398,6 @@ impl std::fmt::Debug for ReconcileTagsRequest {
         debug_struct.field("tag_template", &self.tag_template);
         debug_struct.field("force_delete_missing", &self.force_delete_missing);
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15713,7 +15654,6 @@ impl std::fmt::Debug for ReconcileTagsResponse {
         debug_struct.field("created_tags_count", &self.created_tags_count);
         debug_struct.field("updated_tags_count", &self.updated_tags_count);
         debug_struct.field("deleted_tags_count", &self.deleted_tags_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15906,7 +15846,6 @@ impl std::fmt::Debug for ReconcileTagsMetadata {
         let mut debug_struct = f.debug_struct("ReconcileTagsMetadata");
         debug_struct.field("state", &self.state);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16313,7 +16252,6 @@ impl std::fmt::Debug for ListEntriesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16502,7 +16440,6 @@ impl std::fmt::Debug for ListEntriesResponse {
         let mut debug_struct = f.debug_struct("ListEntriesResponse");
         debug_struct.field("entries", &self.entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16647,7 +16584,6 @@ impl std::fmt::Debug for StarEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StarEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16765,7 +16701,6 @@ impl serde::ser::Serialize for StarEntryResponse {
 impl std::fmt::Debug for StarEntryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StarEntryResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16910,7 +16845,6 @@ impl std::fmt::Debug for UnstarEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UnstarEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17028,7 +16962,6 @@ impl serde::ser::Serialize for UnstarEntryResponse {
 impl std::fmt::Debug for UnstarEntryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UnstarEntryResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17268,7 +17201,6 @@ impl std::fmt::Debug for ImportEntriesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17524,7 +17456,6 @@ impl std::fmt::Debug for ImportEntriesResponse {
         let mut debug_struct = f.debug_struct("ImportEntriesResponse");
         debug_struct.field("upserted_entries_count", &self.upserted_entries_count);
         debug_struct.field("deleted_entries_count", &self.deleted_entries_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17707,7 +17638,6 @@ impl std::fmt::Debug for ImportEntriesMetadata {
         let mut debug_struct = f.debug_struct("ImportEntriesMetadata");
         debug_struct.field("state", &self.state);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18041,7 +17971,6 @@ impl std::fmt::Debug for ModifyEntryOverviewRequest {
         let mut debug_struct = f.debug_struct("ModifyEntryOverviewRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("entry_overview", &self.entry_overview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18222,7 +18151,6 @@ impl std::fmt::Debug for ModifyEntryContactsRequest {
         let mut debug_struct = f.debug_struct("ModifyEntryContactsRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("contacts", &self.contacts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18489,7 +18417,6 @@ impl std::fmt::Debug for SetConfigRequest {
         let mut debug_struct = f.debug_struct("SetConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("configuration", &self.configuration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18650,7 +18577,6 @@ impl std::fmt::Debug for RetrieveConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18795,7 +18721,6 @@ impl std::fmt::Debug for RetrieveEffectiveConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveEffectiveConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18955,7 +18880,6 @@ impl std::fmt::Debug for OrganizationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OrganizationConfig");
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19184,7 +19108,6 @@ impl std::fmt::Debug for MigrationConfig {
             "template_migration_enabled_time",
             &self.template_migration_enabled_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19423,7 +19346,6 @@ impl std::fmt::Debug for DataplexSpec {
         debug_struct.field("data_format", &self.data_format);
         debug_struct.field("compression_format", &self.compression_format);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19577,7 +19499,6 @@ impl std::fmt::Debug for DataplexFilesetSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataplexFilesetSpec");
         debug_struct.field("dataplex_spec", &self.dataplex_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19793,7 +19714,6 @@ impl std::fmt::Debug for DataplexTableSpec {
         debug_struct.field("external_tables", &self.external_tables);
         debug_struct.field("dataplex_spec", &self.dataplex_spec);
         debug_struct.field("user_managed", &self.user_managed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20032,7 +19952,6 @@ impl std::fmt::Debug for DataplexExternalTable {
         debug_struct.field("fully_qualified_name", &self.fully_qualified_name);
         debug_struct.field("google_cloud_resource", &self.google_cloud_resource);
         debug_struct.field("data_catalog_entry", &self.data_catalog_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20280,7 +20199,6 @@ impl std::fmt::Debug for TaggedEntry {
         debug_struct.field("present_tags", &self.present_tags);
         debug_struct.field("absent_tags", &self.absent_tags);
         debug_struct.field("entry", &self.entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20476,7 +20394,6 @@ impl std::fmt::Debug for DumpItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DumpItem");
         debug_struct.field("item", &self.item);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20693,7 +20610,6 @@ impl std::fmt::Debug for GcsFilesetSpec {
         let mut debug_struct = f.debug_struct("GcsFilesetSpec");
         debug_struct.field("file_patterns", &self.file_patterns);
         debug_struct.field("sample_gcs_file_specs", &self.sample_gcs_file_specs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20919,7 +20835,6 @@ impl std::fmt::Debug for GcsFileSpec {
         debug_struct.field("file_path", &self.file_path);
         debug_struct.field("gcs_timestamps", &self.gcs_timestamps);
         debug_struct.field("size_bytes", &self.size_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21384,7 +21299,6 @@ impl std::fmt::Debug for PhysicalSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PhysicalSchema");
         debug_struct.field("schema", &self.schema);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21534,7 +21448,6 @@ pub mod physical_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AvroSchema");
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21679,7 +21592,6 @@ pub mod physical_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ThriftSchema");
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21824,7 +21736,6 @@ pub mod physical_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ProtobufSchema");
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21941,7 +21852,6 @@ pub mod physical_schema {
     impl std::fmt::Debug for ParquetSchema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ParquetSchema");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22058,7 +21968,6 @@ pub mod physical_schema {
     impl std::fmt::Debug for OrcSchema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("OrcSchema");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22175,7 +22084,6 @@ pub mod physical_schema {
     impl std::fmt::Debug for CsvSchema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CsvSchema");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22577,7 +22485,6 @@ impl std::fmt::Debug for Taxonomy {
         debug_struct.field("taxonomy_timestamps", &self.taxonomy_timestamps);
         debug_struct.field("activated_policy_types", &self.activated_policy_types);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22753,7 +22660,6 @@ pub mod taxonomy {
             let mut debug_struct = f.debug_struct("Service");
             debug_struct.field("name", &self.name);
             debug_struct.field("identity", &self.identity);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23159,7 +23065,6 @@ impl std::fmt::Debug for PolicyTag {
         debug_struct.field("description", &self.description);
         debug_struct.field("parent_policy_tag", &self.parent_policy_tag);
         debug_struct.field("child_policy_tags", &self.child_policy_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23340,7 +23245,6 @@ impl std::fmt::Debug for CreateTaxonomyRequest {
         let mut debug_struct = f.debug_struct("CreateTaxonomyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("taxonomy", &self.taxonomy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23487,7 +23391,6 @@ impl std::fmt::Debug for DeleteTaxonomyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTaxonomyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23685,7 +23588,6 @@ impl std::fmt::Debug for UpdateTaxonomyRequest {
         let mut debug_struct = f.debug_struct("UpdateTaxonomyRequest");
         debug_struct.field("taxonomy", &self.taxonomy);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23930,7 +23832,6 @@ impl std::fmt::Debug for ListTaxonomiesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24119,7 +24020,6 @@ impl std::fmt::Debug for ListTaxonomiesResponse {
         let mut debug_struct = f.debug_struct("ListTaxonomiesResponse");
         debug_struct.field("taxonomies", &self.taxonomies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24264,7 +24164,6 @@ impl std::fmt::Debug for GetTaxonomyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTaxonomyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24446,7 +24345,6 @@ impl std::fmt::Debug for CreatePolicyTagRequest {
         let mut debug_struct = f.debug_struct("CreatePolicyTagRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("policy_tag", &self.policy_tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24593,7 +24491,6 @@ impl std::fmt::Debug for DeletePolicyTagRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeletePolicyTagRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24793,7 +24690,6 @@ impl std::fmt::Debug for UpdatePolicyTagRequest {
         let mut debug_struct = f.debug_struct("UpdatePolicyTagRequest");
         debug_struct.field("policy_tag", &self.policy_tag);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25013,7 +24909,6 @@ impl std::fmt::Debug for ListPolicyTagsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25203,7 +25098,6 @@ impl std::fmt::Debug for ListPolicyTagsResponse {
         let mut debug_struct = f.debug_struct("ListPolicyTagsResponse");
         debug_struct.field("policy_tags", &self.policy_tags);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25348,7 +25242,6 @@ impl std::fmt::Debug for GetPolicyTagRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyTagRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25586,7 +25479,6 @@ impl std::fmt::Debug for SerializedTaxonomy {
         debug_struct.field("description", &self.description);
         debug_struct.field("policy_tags", &self.policy_tags);
         debug_struct.field("activated_policy_types", &self.activated_policy_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25819,7 +25711,6 @@ impl std::fmt::Debug for SerializedPolicyTag {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("child_policy_tags", &self.child_policy_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26001,7 +25892,6 @@ impl std::fmt::Debug for ReplaceTaxonomyRequest {
         let mut debug_struct = f.debug_struct("ReplaceTaxonomyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("serialized_taxonomy", &self.serialized_taxonomy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26276,7 +26166,6 @@ impl std::fmt::Debug for ImportTaxonomiesRequest {
         let mut debug_struct = f.debug_struct("ImportTaxonomiesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26441,7 +26330,6 @@ impl std::fmt::Debug for InlineSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InlineSource");
         debug_struct.field("taxonomies", &self.taxonomies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26584,7 +26472,6 @@ impl std::fmt::Debug for CrossRegionalSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CrossRegionalSource");
         debug_struct.field("taxonomy", &self.taxonomy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26732,7 +26619,6 @@ impl std::fmt::Debug for ImportTaxonomiesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportTaxonomiesResponse");
         debug_struct.field("taxonomies", &self.taxonomies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26974,7 +26860,6 @@ impl std::fmt::Debug for ExportTaxonomiesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("taxonomies", &self.taxonomies);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27141,7 +27026,6 @@ impl std::fmt::Debug for ExportTaxonomiesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportTaxonomiesResponse");
         debug_struct.field("taxonomies", &self.taxonomies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27289,7 +27173,6 @@ impl std::fmt::Debug for Schema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Schema");
         debug_struct.field("columns", &self.columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27797,7 +27680,6 @@ impl std::fmt::Debug for ColumnSchema {
         debug_struct.field("range_element_type", &self.range_element_type);
         debug_struct.field("gc_rule", &self.gc_rule);
         debug_struct.field("system_spec", &self.system_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27950,7 +27832,6 @@ pub mod column_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LookerColumnSpec");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28262,7 +28143,6 @@ pub mod column_schema {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FieldElementType");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28925,7 +28805,6 @@ impl std::fmt::Debug for SearchCatalogResult {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("system", &self.system);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29215,7 +29094,6 @@ impl std::fmt::Debug for BigQueryTableSpec {
         let mut debug_struct = f.debug_struct("BigQueryTableSpec");
         debug_struct.field("table_source_type", &self.table_source_type);
         debug_struct.field("type_spec", &self.type_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29376,7 +29254,6 @@ impl std::fmt::Debug for ViewSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ViewSpec");
         debug_struct.field("view_query", &self.view_query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29525,7 +29402,6 @@ impl std::fmt::Debug for TableSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TableSpec");
         debug_struct.field("grouped_entry", &self.grouped_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29777,7 +29653,6 @@ impl std::fmt::Debug for BigQueryDateShardedSpec {
         debug_struct.field("table_prefix", &self.table_prefix);
         debug_struct.field("shard_count", &self.shard_count);
         debug_struct.field("latest_shard_resource", &self.latest_shard_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30126,7 +30001,6 @@ impl std::fmt::Debug for Tag {
         debug_struct.field("fields", &self.fields);
         debug_struct.field("dataplex_transfer_status", &self.dataplex_transfer_status);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30665,7 +30539,6 @@ impl std::fmt::Debug for TagField {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("order", &self.order);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30819,7 +30692,6 @@ pub mod tag_field {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EnumValue");
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31143,7 +31015,6 @@ impl std::fmt::Debug for TagTemplate {
         debug_struct.field("is_publicly_readable", &self.is_publicly_readable);
         debug_struct.field("fields", &self.fields);
         debug_struct.field("dataplex_transfer_status", &self.dataplex_transfer_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31606,7 +31477,6 @@ impl std::fmt::Debug for TagTemplateField {
         debug_struct.field("is_required", &self.is_required);
         debug_struct.field("description", &self.description);
         debug_struct.field("order", &self.order);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31846,7 +31716,6 @@ impl std::fmt::Debug for FieldType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FieldType");
         debug_struct.field("type_decl", &self.type_decl);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32013,7 +31882,6 @@ pub mod field_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EnumType");
             debug_struct.field("allowed_values", &self.allowed_values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32176,7 +32044,6 @@ pub mod field_type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("EnumValue");
                 debug_struct.field("display_name", &self.display_name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -32576,7 +32443,6 @@ impl std::fmt::Debug for SystemTimestamps {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32897,7 +32763,6 @@ impl std::fmt::Debug for UsageStats {
             "total_execution_time_for_completions_millis",
             &self.total_execution_time_for_completions_millis,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33074,7 +32939,6 @@ impl std::fmt::Debug for CommonUsageStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CommonUsageStats");
         debug_struct.field("view_count", &self.view_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33381,7 +33245,6 @@ impl std::fmt::Debug for UsageSignal {
             &self.common_usage_within_time_range,
         );
         debug_struct.field("favorite_count", &self.favorite_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/dataform/v1/src/model.rs
+++ b/src/generated/cloud/dataform/v1/src/model.rs
@@ -173,7 +173,6 @@ impl std::fmt::Debug for DataEncryptionState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataEncryptionState");
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -725,7 +724,6 @@ impl std::fmt::Debug for Repository {
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("data_encryption_state", &self.data_encryption_state);
         debug_struct.field("internal_metadata", &self.internal_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1035,7 +1033,6 @@ pub mod repository {
             );
             debug_struct.field("ssh_authentication_config", &self.ssh_authentication_config);
             debug_struct.field("token_status", &self.token_status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1241,7 +1238,6 @@ pub mod repository {
                     &self.user_private_key_secret_version,
                 );
                 debug_struct.field("host_public_key", &self.host_public_key);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1593,7 +1589,6 @@ pub mod repository {
             debug_struct.field("default_database", &self.default_database);
             debug_struct.field("schema_suffix", &self.schema_suffix);
             debug_struct.field("table_prefix", &self.table_prefix);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1867,7 +1862,6 @@ impl std::fmt::Debug for ListRepositoriesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2081,7 +2075,6 @@ impl std::fmt::Debug for ListRepositoriesResponse {
         debug_struct.field("repositories", &self.repositories);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2223,7 +2216,6 @@ impl std::fmt::Debug for GetRepositoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRepositoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2429,7 +2421,6 @@ impl std::fmt::Debug for CreateRepositoryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("repository", &self.repository);
         debug_struct.field("repository_id", &self.repository_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2620,7 +2611,6 @@ impl std::fmt::Debug for UpdateRepositoryRequest {
         let mut debug_struct = f.debug_struct("UpdateRepositoryRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("repository", &self.repository);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2789,7 +2779,6 @@ impl std::fmt::Debug for DeleteRepositoryRequest {
         let mut debug_struct = f.debug_struct("DeleteRepositoryRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3036,7 +3025,6 @@ impl std::fmt::Debug for CommitRepositoryChangesRequest {
         debug_struct.field("commit_metadata", &self.commit_metadata);
         debug_struct.field("required_head_commit_sha", &self.required_head_commit_sha);
         debug_struct.field("file_operations", &self.file_operations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3311,7 +3299,6 @@ pub mod commit_repository_changes_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FileOperation");
             debug_struct.field("operation", &self.operation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3495,7 +3482,6 @@ pub mod commit_repository_changes_request {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("WriteFile");
                 debug_struct.field("contents", &self.contents);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3615,7 +3601,6 @@ pub mod commit_repository_changes_request {
         impl std::fmt::Debug for DeleteFile {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("DeleteFile");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3778,7 +3763,6 @@ impl std::fmt::Debug for CommitRepositoryChangesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CommitRepositoryChangesResponse");
         debug_struct.field("commit_sha", &self.commit_sha);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3972,7 +3956,6 @@ impl std::fmt::Debug for ReadRepositoryFileRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("commit_sha", &self.commit_sha);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4132,7 +4115,6 @@ impl std::fmt::Debug for ReadRepositoryFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReadRepositoryFileResponse");
         debug_struct.field("contents", &self.contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4406,7 +4388,6 @@ impl std::fmt::Debug for QueryRepositoryDirectoryContentsRequest {
         debug_struct.field("path", &self.path);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4598,7 +4579,6 @@ impl std::fmt::Debug for QueryRepositoryDirectoryContentsResponse {
         let mut debug_struct = f.debug_struct("QueryRepositoryDirectoryContentsResponse");
         debug_struct.field("directory_entries", &self.directory_entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4817,7 +4797,6 @@ impl std::fmt::Debug for FetchRepositoryHistoryRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5007,7 +4986,6 @@ impl std::fmt::Debug for FetchRepositoryHistoryResponse {
         let mut debug_struct = f.debug_struct("FetchRepositoryHistoryResponse");
         debug_struct.field("commits", &self.commits);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5249,7 +5227,6 @@ impl std::fmt::Debug for CommitLogEntry {
         debug_struct.field("commit_sha", &self.commit_sha);
         debug_struct.field("author", &self.author);
         debug_struct.field("commit_message", &self.commit_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5428,7 +5405,6 @@ impl std::fmt::Debug for CommitMetadata {
         let mut debug_struct = f.debug_struct("CommitMetadata");
         debug_struct.field("author", &self.author);
         debug_struct.field("commit_message", &self.commit_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5571,7 +5547,6 @@ impl std::fmt::Debug for ComputeRepositoryAccessTokenStatusRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ComputeRepositoryAccessTokenStatusRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5721,7 +5696,6 @@ impl std::fmt::Debug for ComputeRepositoryAccessTokenStatusResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ComputeRepositoryAccessTokenStatusResponse");
         debug_struct.field("token_status", &self.token_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6009,7 +5983,6 @@ impl std::fmt::Debug for FetchRemoteBranchesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchRemoteBranchesRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6154,7 +6127,6 @@ impl std::fmt::Debug for FetchRemoteBranchesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchRemoteBranchesResponse");
         debug_struct.field("branches", &self.branches);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6410,7 +6382,6 @@ impl std::fmt::Debug for Workspace {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("data_encryption_state", &self.data_encryption_state);
         debug_struct.field("internal_metadata", &self.internal_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6683,7 +6654,6 @@ impl std::fmt::Debug for ListWorkspacesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6897,7 +6867,6 @@ impl std::fmt::Debug for ListWorkspacesResponse {
         debug_struct.field("workspaces", &self.workspaces);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7039,7 +7008,6 @@ impl std::fmt::Debug for GetWorkspaceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkspaceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7245,7 +7213,6 @@ impl std::fmt::Debug for CreateWorkspaceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("workspace_id", &self.workspace_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7387,7 +7354,6 @@ impl std::fmt::Debug for DeleteWorkspaceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteWorkspaceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7555,7 +7521,6 @@ impl std::fmt::Debug for CommitAuthor {
         let mut debug_struct = f.debug_struct("CommitAuthor");
         debug_struct.field("name", &self.name);
         debug_struct.field("email_address", &self.email_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7761,7 +7726,6 @@ impl std::fmt::Debug for PullGitCommitsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("remote_branch", &self.remote_branch);
         debug_struct.field("author", &self.author);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7875,7 +7839,6 @@ impl serde::ser::Serialize for PullGitCommitsResponse {
 impl std::fmt::Debug for PullGitCommitsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PullGitCommitsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8045,7 +8008,6 @@ impl std::fmt::Debug for PushGitCommitsRequest {
         let mut debug_struct = f.debug_struct("PushGitCommitsRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("remote_branch", &self.remote_branch);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8159,7 +8121,6 @@ impl serde::ser::Serialize for PushGitCommitsResponse {
 impl std::fmt::Debug for PushGitCommitsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PushGitCommitsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8301,7 +8262,6 @@ impl std::fmt::Debug for FetchFileGitStatusesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchFileGitStatusesRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8453,7 +8413,6 @@ impl std::fmt::Debug for FetchFileGitStatusesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchFileGitStatusesResponse");
         debug_struct.field("uncommitted_file_changes", &self.uncommitted_file_changes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8633,7 +8592,6 @@ pub mod fetch_file_git_statuses_response {
             let mut debug_struct = f.debug_struct("UncommittedFileChange");
             debug_struct.field("path", &self.path);
             debug_struct.field("state", &self.state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8958,7 +8916,6 @@ impl std::fmt::Debug for FetchGitAheadBehindRequest {
         let mut debug_struct = f.debug_struct("FetchGitAheadBehindRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("remote_branch", &self.remote_branch);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9165,7 +9122,6 @@ impl std::fmt::Debug for FetchGitAheadBehindResponse {
         let mut debug_struct = f.debug_struct("FetchGitAheadBehindResponse");
         debug_struct.field("commits_ahead", &self.commits_ahead);
         debug_struct.field("commits_behind", &self.commits_behind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9398,7 +9354,6 @@ impl std::fmt::Debug for CommitWorkspaceChangesRequest {
         debug_struct.field("author", &self.author);
         debug_struct.field("commit_message", &self.commit_message);
         debug_struct.field("paths", &self.paths);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9512,7 +9467,6 @@ impl serde::ser::Serialize for CommitWorkspaceChangesResponse {
 impl std::fmt::Debug for CommitWorkspaceChangesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CommitWorkspaceChangesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9708,7 +9662,6 @@ impl std::fmt::Debug for ResetWorkspaceChangesRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("paths", &self.paths);
         debug_struct.field("clean", &self.clean);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9822,7 +9775,6 @@ impl serde::ser::Serialize for ResetWorkspaceChangesResponse {
 impl std::fmt::Debug for ResetWorkspaceChangesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetWorkspaceChangesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9990,7 +9942,6 @@ impl std::fmt::Debug for FetchFileDiffRequest {
         let mut debug_struct = f.debug_struct("FetchFileDiffRequest");
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10133,7 +10084,6 @@ impl std::fmt::Debug for FetchFileDiffResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchFileDiffResponse");
         debug_struct.field("formatted_diff", &self.formatted_diff);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10378,7 +10328,6 @@ impl std::fmt::Debug for QueryDirectoryContentsRequest {
         debug_struct.field("path", &self.path);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10569,7 +10518,6 @@ impl std::fmt::Debug for QueryDirectoryContentsResponse {
         let mut debug_struct = f.debug_struct("QueryDirectoryContentsResponse");
         debug_struct.field("directory_entries", &self.directory_entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10794,7 +10742,6 @@ impl std::fmt::Debug for DirectoryEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DirectoryEntry");
         debug_struct.field("entry", &self.entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11056,7 +11003,6 @@ impl std::fmt::Debug for SearchFilesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11243,7 +11189,6 @@ impl std::fmt::Debug for SearchFilesResponse {
         let mut debug_struct = f.debug_struct("SearchFilesResponse");
         debug_struct.field("search_results", &self.search_results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11481,7 +11426,6 @@ impl std::fmt::Debug for SearchResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SearchResult");
         debug_struct.field("entry", &self.entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11639,7 +11583,6 @@ impl std::fmt::Debug for FileSearchResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileSearchResult");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11781,7 +11724,6 @@ impl std::fmt::Debug for DirectorySearchResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DirectorySearchResult");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11949,7 +11891,6 @@ impl std::fmt::Debug for MakeDirectoryRequest {
         let mut debug_struct = f.debug_struct("MakeDirectoryRequest");
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12063,7 +12004,6 @@ impl serde::ser::Serialize for MakeDirectoryResponse {
 impl std::fmt::Debug for MakeDirectoryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MakeDirectoryResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12231,7 +12171,6 @@ impl std::fmt::Debug for RemoveDirectoryRequest {
         let mut debug_struct = f.debug_struct("RemoveDirectoryRequest");
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12345,7 +12284,6 @@ impl serde::ser::Serialize for RemoveDirectoryResponse {
 impl std::fmt::Debug for RemoveDirectoryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveDirectoryResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12540,7 +12478,6 @@ impl std::fmt::Debug for MoveDirectoryRequest {
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
         debug_struct.field("new_path", &self.new_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12654,7 +12591,6 @@ impl serde::ser::Serialize for MoveDirectoryResponse {
 impl std::fmt::Debug for MoveDirectoryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MoveDirectoryResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12848,7 +12784,6 @@ impl std::fmt::Debug for ReadFileRequest {
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13010,7 +12945,6 @@ impl std::fmt::Debug for ReadFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReadFileResponse");
         debug_struct.field("file_contents", &self.file_contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13178,7 +13112,6 @@ impl std::fmt::Debug for RemoveFileRequest {
         let mut debug_struct = f.debug_struct("RemoveFileRequest");
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13292,7 +13225,6 @@ impl serde::ser::Serialize for RemoveFileResponse {
 impl std::fmt::Debug for RemoveFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveFileResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13487,7 +13419,6 @@ impl std::fmt::Debug for MoveFileRequest {
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
         debug_struct.field("new_path", &self.new_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13601,7 +13532,6 @@ impl serde::ser::Serialize for MoveFileResponse {
 impl std::fmt::Debug for MoveFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MoveFileResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13811,7 +13741,6 @@ impl std::fmt::Debug for WriteFileRequest {
         debug_struct.field("workspace", &self.workspace);
         debug_struct.field("path", &self.path);
         debug_struct.field("contents", &self.contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13925,7 +13854,6 @@ impl serde::ser::Serialize for WriteFileResponse {
 impl std::fmt::Debug for WriteFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WriteFileResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14067,7 +13995,6 @@ impl std::fmt::Debug for InstallNpmPackagesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstallNpmPackagesRequest");
         debug_struct.field("workspace", &self.workspace);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14181,7 +14108,6 @@ impl serde::ser::Serialize for InstallNpmPackagesResponse {
 impl std::fmt::Debug for InstallNpmPackagesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstallNpmPackagesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14602,7 +14528,6 @@ impl std::fmt::Debug for ReleaseConfig {
         );
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("internal_metadata", &self.internal_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14892,7 +14817,6 @@ pub mod release_config {
             let mut debug_struct = f.debug_struct("ScheduledReleaseRecord");
             debug_struct.field("release_time", &self.release_time);
             debug_struct.field("result", &self.result);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15132,7 +15056,6 @@ impl std::fmt::Debug for ListReleaseConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15347,7 +15270,6 @@ impl std::fmt::Debug for ListReleaseConfigsResponse {
         debug_struct.field("release_configs", &self.release_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15489,7 +15411,6 @@ impl std::fmt::Debug for GetReleaseConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReleaseConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15699,7 +15620,6 @@ impl std::fmt::Debug for CreateReleaseConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("release_config", &self.release_config);
         debug_struct.field("release_config_id", &self.release_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15891,7 +15811,6 @@ impl std::fmt::Debug for UpdateReleaseConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateReleaseConfigRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("release_config", &self.release_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16033,7 +15952,6 @@ impl std::fmt::Debug for DeleteReleaseConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteReleaseConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16582,7 +16500,6 @@ impl std::fmt::Debug for CompilationResult {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("internal_metadata", &self.internal_metadata);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16821,7 +16738,6 @@ pub mod compilation_result {
             debug_struct.field("stack", &self.stack);
             debug_struct.field("path", &self.path);
             debug_struct.field("action_target", &self.action_target);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17279,7 +17195,6 @@ impl std::fmt::Debug for CodeCompilationConfig {
             "default_notebook_runtime_options",
             &self.default_notebook_runtime_options,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17509,7 +17424,6 @@ impl std::fmt::Debug for NotebookRuntimeOptions {
             &self.ai_platform_notebook_runtime_template,
         );
         debug_struct.field("execution_sink", &self.execution_sink);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17797,7 +17711,6 @@ impl std::fmt::Debug for ListCompilationResultsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18016,7 +17929,6 @@ impl std::fmt::Debug for ListCompilationResultsResponse {
         debug_struct.field("compilation_results", &self.compilation_results);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18158,7 +18070,6 @@ impl std::fmt::Debug for GetCompilationResultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCompilationResultRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18339,7 +18250,6 @@ impl std::fmt::Debug for CreateCompilationResultRequest {
         let mut debug_struct = f.debug_struct("CreateCompilationResultRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("compilation_result", &self.compilation_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18532,7 +18442,6 @@ impl std::fmt::Debug for Target {
         debug_struct.field("database", &self.database);
         debug_struct.field("schema", &self.schema);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18745,7 +18654,6 @@ impl std::fmt::Debug for RelationDescriptor {
         debug_struct.field("description", &self.description);
         debug_struct.field("columns", &self.columns);
         debug_struct.field("bigquery_labels", &self.bigquery_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18953,7 +18861,6 @@ pub mod relation_descriptor {
             debug_struct.field("path", &self.path);
             debug_struct.field("description", &self.description);
             debug_struct.field("bigquery_policy_tags", &self.bigquery_policy_tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19586,7 +19493,6 @@ impl std::fmt::Debug for CompilationResultAction {
         debug_struct.field("file_path", &self.file_path);
         debug_struct.field("internal_metadata", &self.internal_metadata);
         debug_struct.field("compiled_object", &self.compiled_object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20175,7 +20081,6 @@ pub mod compilation_result_action {
             debug_struct.field("partition_expiration_days", &self.partition_expiration_days);
             debug_struct.field("require_partition_filter", &self.require_partition_filter);
             debug_struct.field("additional_options", &self.additional_options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20526,7 +20431,6 @@ pub mod compilation_result_action {
                     "incremental_post_operations",
                     &self.incremental_post_operations,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -20971,7 +20875,6 @@ pub mod compilation_result_action {
             debug_struct.field("relation_descriptor", &self.relation_descriptor);
             debug_struct.field("queries", &self.queries);
             debug_struct.field("has_output", &self.has_output);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21280,7 +21183,6 @@ pub mod compilation_result_action {
             debug_struct.field("tags", &self.tags);
             debug_struct.field("select_query", &self.select_query);
             debug_struct.field("relation_descriptor", &self.relation_descriptor);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21439,7 +21341,6 @@ pub mod compilation_result_action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Declaration");
             debug_struct.field("relation_descriptor", &self.relation_descriptor);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21666,7 +21567,6 @@ pub mod compilation_result_action {
             debug_struct.field("disabled", &self.disabled);
             debug_struct.field("contents", &self.contents);
             debug_struct.field("tags", &self.tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22006,7 +21906,6 @@ pub mod compilation_result_action {
             debug_struct.field("disabled", &self.disabled);
             debug_struct.field("tags", &self.tags);
             debug_struct.field("definition", &self.definition);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22242,7 +22141,6 @@ pub mod compilation_result_action {
                 debug_struct.field("query", &self.query);
                 debug_struct.field("error_table", &self.error_table);
                 debug_struct.field("load", &self.load);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -22454,7 +22352,6 @@ pub mod compilation_result_action {
                 let mut debug_struct = f.debug_struct("ErrorTable");
                 debug_struct.field("target", &self.target);
                 debug_struct.field("retention_days", &self.retention_days);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -22842,7 +22739,6 @@ pub mod compilation_result_action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LoadConfig");
             debug_struct.field("mode", &self.mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22981,7 +22877,6 @@ pub mod compilation_result_action {
     impl std::fmt::Debug for SimpleLoadMode {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SimpleLoadMode");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23126,7 +23021,6 @@ pub mod compilation_result_action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IncrementalLoadMode");
             debug_struct.field("column", &self.column);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23391,7 +23285,6 @@ impl std::fmt::Debug for QueryCompilationResultActionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23590,7 +23483,6 @@ impl std::fmt::Debug for QueryCompilationResultActionsResponse {
             &self.compilation_result_actions,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24040,7 +23932,6 @@ impl std::fmt::Debug for WorkflowConfig {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("internal_metadata", &self.internal_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24330,7 +24221,6 @@ pub mod workflow_config {
             let mut debug_struct = f.debug_struct("ScheduledExecutionRecord");
             debug_struct.field("execution_time", &self.execution_time);
             debug_struct.field("result", &self.result);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24671,7 +24561,6 @@ impl std::fmt::Debug for InvocationConfig {
             &self.fully_refresh_incremental_tables_enabled,
         );
         debug_struct.field("service_account", &self.service_account);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24891,7 +24780,6 @@ impl std::fmt::Debug for ListWorkflowConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25110,7 +24998,6 @@ impl std::fmt::Debug for ListWorkflowConfigsResponse {
         debug_struct.field("workflow_configs", &self.workflow_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25252,7 +25139,6 @@ impl std::fmt::Debug for GetWorkflowConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkflowConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25463,7 +25349,6 @@ impl std::fmt::Debug for CreateWorkflowConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("workflow_config", &self.workflow_config);
         debug_struct.field("workflow_config_id", &self.workflow_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25656,7 +25541,6 @@ impl std::fmt::Debug for UpdateWorkflowConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateWorkflowConfigRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("workflow_config", &self.workflow_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25798,7 +25682,6 @@ impl std::fmt::Debug for DeleteWorkflowConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteWorkflowConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26278,7 +26161,6 @@ impl std::fmt::Debug for WorkflowInvocation {
         debug_struct.field("data_encryption_state", &self.data_encryption_state);
         debug_struct.field("internal_metadata", &self.internal_metadata);
         debug_struct.field("compilation_source", &self.compilation_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26724,7 +26606,6 @@ impl std::fmt::Debug for ListWorkflowInvocationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26943,7 +26824,6 @@ impl std::fmt::Debug for ListWorkflowInvocationsResponse {
         debug_struct.field("workflow_invocations", &self.workflow_invocations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27085,7 +26965,6 @@ impl std::fmt::Debug for GetWorkflowInvocationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkflowInvocationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27265,7 +27144,6 @@ impl std::fmt::Debug for CreateWorkflowInvocationRequest {
         let mut debug_struct = f.debug_struct("CreateWorkflowInvocationRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("workflow_invocation", &self.workflow_invocation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27407,7 +27285,6 @@ impl std::fmt::Debug for DeleteWorkflowInvocationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteWorkflowInvocationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27549,7 +27426,6 @@ impl std::fmt::Debug for CancelWorkflowInvocationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelWorkflowInvocationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27663,7 +27539,6 @@ impl serde::ser::Serialize for CancelWorkflowInvocationResponse {
 impl std::fmt::Debug for CancelWorkflowInvocationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelWorkflowInvocationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28187,7 +28062,6 @@ impl std::fmt::Debug for WorkflowInvocationAction {
         debug_struct.field("invocation_timing", &self.invocation_timing);
         debug_struct.field("internal_metadata", &self.internal_metadata);
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28365,7 +28239,6 @@ pub mod workflow_invocation_action {
             let mut debug_struct = f.debug_struct("BigQueryAction");
             debug_struct.field("sql_script", &self.sql_script);
             debug_struct.field("job_id", &self.job_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28538,7 +28411,6 @@ pub mod workflow_invocation_action {
             let mut debug_struct = f.debug_struct("NotebookAction");
             debug_struct.field("contents", &self.contents);
             debug_struct.field("job_id", &self.job_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28830,7 +28702,6 @@ pub mod workflow_invocation_action {
             debug_struct.field("generated_sql", &self.generated_sql);
             debug_struct.field("job_id", &self.job_id);
             debug_struct.field("definition", &self.definition);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29062,7 +28933,6 @@ pub mod workflow_invocation_action {
                 debug_struct.field("query", &self.query);
                 debug_struct.field("error_table", &self.error_table);
                 debug_struct.field("load_config", &self.load_config);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29274,7 +29144,6 @@ pub mod workflow_invocation_action {
                 let mut debug_struct = f.debug_struct("ActionErrorTable");
                 debug_struct.field("target", &self.target);
                 debug_struct.field("retention_days", &self.retention_days);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29612,7 +29481,6 @@ pub mod workflow_invocation_action {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ActionLoadConfig");
                 debug_struct.field("mode", &self.mode);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29754,7 +29622,6 @@ pub mod workflow_invocation_action {
         impl std::fmt::Debug for ActionSimpleLoadMode {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ActionSimpleLoadMode");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29902,7 +29769,6 @@ pub mod workflow_invocation_action {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ActionIncrementalLoadMode");
                 debug_struct.field("column", &self.column);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -30313,7 +30179,6 @@ impl std::fmt::Debug for QueryWorkflowInvocationActionsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30515,7 +30380,6 @@ impl std::fmt::Debug for QueryWorkflowInvocationActionsResponse {
             &self.workflow_invocation_actions,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30687,7 +30551,6 @@ impl std::fmt::Debug for Config {
         let mut debug_struct = f.debug_struct("Config");
         debug_struct.field("name", &self.name);
         debug_struct.field("default_kms_key_name", &self.default_kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30829,7 +30692,6 @@ impl std::fmt::Debug for GetConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31019,7 +30881,6 @@ impl std::fmt::Debug for UpdateConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateConfigRequest");
         debug_struct.field("config", &self.config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -202,7 +202,6 @@ impl std::fmt::Debug for NetworkConfig {
         let mut debug_struct = f.debug_struct("NetworkConfig");
         debug_struct.field("network", &self.network);
         debug_struct.field("ip_allocation", &self.ip_allocation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -426,7 +425,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("default_version", &self.default_version);
         debug_struct.field("available_features", &self.available_features);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -736,7 +734,6 @@ impl std::fmt::Debug for Accelerator {
         let mut debug_struct = f.debug_struct("Accelerator");
         debug_struct.field("accelerator_type", &self.accelerator_type);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1171,7 +1168,6 @@ impl std::fmt::Debug for CryptoKeyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CryptoKeyConfig");
         debug_struct.field("key_reference", &self.key_reference);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2135,7 +2131,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("enable_rbac", &self.enable_rbac);
         debug_struct.field("crypto_key_config", &self.crypto_key_config);
         debug_struct.field("disabled_reason", &self.disabled_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2870,7 +2865,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3084,7 +3078,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3326,7 +3319,6 @@ impl std::fmt::Debug for ListAvailableVersionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("latest_patch_only", &self.latest_patch_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3513,7 +3505,6 @@ impl std::fmt::Debug for ListAvailableVersionsResponse {
         let mut debug_struct = f.debug_struct("ListAvailableVersionsResponse");
         debug_struct.field("available_versions", &self.available_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3656,7 +3647,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3861,7 +3851,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4004,7 +3993,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4203,7 +4191,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("UpdateInstanceRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4346,7 +4333,6 @@ impl std::fmt::Debug for RestartInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestartInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4710,7 +4696,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("additional_status", &self.additional_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -532,7 +532,6 @@ impl std::fmt::Debug for Environment {
         debug_struct.field("session_spec", &self.session_spec);
         debug_struct.field("session_status", &self.session_status);
         debug_struct.field("endpoints", &self.endpoints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -817,7 +816,6 @@ pub mod environment {
             let mut debug_struct = f.debug_struct("InfrastructureSpec");
             debug_struct.field("resources", &self.resources);
             debug_struct.field("runtime", &self.runtime);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1097,7 +1095,6 @@ pub mod environment {
                 debug_struct.field("disk_size_gb", &self.disk_size_gb);
                 debug_struct.field("node_count", &self.node_count);
                 debug_struct.field("max_node_count", &self.max_node_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1358,7 +1355,6 @@ pub mod environment {
                 debug_struct.field("java_libraries", &self.java_libraries);
                 debug_struct.field("python_packages", &self.python_packages);
                 debug_struct.field("properties", &self.properties);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1568,7 +1564,6 @@ pub mod environment {
             let mut debug_struct = f.debug_struct("SessionSpec");
             debug_struct.field("max_idle_duration", &self.max_idle_duration);
             debug_struct.field("enable_fast_startup", &self.enable_fast_startup);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1714,7 +1709,6 @@ pub mod environment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SessionStatus");
             debug_struct.field("active", &self.active);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1884,7 +1878,6 @@ pub mod environment {
             let mut debug_struct = f.debug_struct("Endpoints");
             debug_struct.field("notebooks", &self.notebooks);
             debug_struct.field("sql", &self.sql);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2402,7 +2395,6 @@ impl std::fmt::Debug for Content {
         debug_struct.field("description", &self.description);
         debug_struct.field("data", &self.data);
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2557,7 +2549,6 @@ pub mod content {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SqlScript");
             debug_struct.field("engine", &self.engine);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2844,7 +2835,6 @@ pub mod content {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Notebook");
             debug_struct.field("kernel_type", &self.kernel_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3228,7 +3218,6 @@ impl std::fmt::Debug for Session {
         debug_struct.field("user_id", &self.user_id);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3691,7 +3680,6 @@ impl std::fmt::Debug for AspectType {
         debug_struct.field("authorization", &self.authorization);
         debug_struct.field("metadata_template", &self.metadata_template);
         debug_struct.field("transfer_status", &self.transfer_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3851,7 +3839,6 @@ pub mod aspect_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Authorization");
             debug_struct.field("alternate_use_permission", &self.alternate_use_permission);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4374,7 +4361,6 @@ pub mod aspect_type {
             debug_struct.field("type_ref", &self.type_ref);
             debug_struct.field("constraints", &self.constraints);
             debug_struct.field("annotations", &self.annotations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4606,7 +4592,6 @@ pub mod aspect_type {
                 debug_struct.field("index", &self.index);
                 debug_struct.field("name", &self.name);
                 debug_struct.field("deprecated", &self.deprecated);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4756,7 +4741,6 @@ pub mod aspect_type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Constraints");
                 debug_struct.field("required", &self.required);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5090,7 +5074,6 @@ pub mod aspect_type {
                 debug_struct.field("display_order", &self.display_order);
                 debug_struct.field("string_type", &self.string_type);
                 debug_struct.field("string_values", &self.string_values);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5480,7 +5463,6 @@ impl std::fmt::Debug for EntryGroup {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("transfer_status", &self.transfer_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5988,7 +5970,6 @@ impl std::fmt::Debug for EntryType {
         debug_struct.field("system", &self.system);
         debug_struct.field("required_aspects", &self.required_aspects);
         debug_struct.field("authorization", &self.authorization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6137,7 +6118,6 @@ pub mod entry_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AspectInfo");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6292,7 +6272,6 @@ pub mod entry_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Authorization");
             debug_struct.field("alternate_use_permission", &self.alternate_use_permission);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6608,7 +6587,6 @@ impl std::fmt::Debug for Aspect {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("data", &self.data);
         debug_struct.field("aspect_source", &self.aspect_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6827,7 +6805,6 @@ impl std::fmt::Debug for AspectSource {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("data_version", &self.data_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7213,7 +7190,6 @@ impl std::fmt::Debug for Entry {
         debug_struct.field("parent_entry", &self.parent_entry);
         debug_struct.field("fully_qualified_name", &self.fully_qualified_name);
         debug_struct.field("entry_source", &self.entry_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7637,7 +7613,6 @@ impl std::fmt::Debug for EntrySource {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7813,7 +7788,6 @@ pub mod entry_source {
             let mut debug_struct = f.debug_struct("Ancestor");
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8048,7 +8022,6 @@ impl std::fmt::Debug for CreateEntryGroupRequest {
         debug_struct.field("entry_group_id", &self.entry_group_id);
         debug_struct.field("entry_group", &self.entry_group);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8266,7 +8239,6 @@ impl std::fmt::Debug for UpdateEntryGroupRequest {
         debug_struct.field("entry_group", &self.entry_group);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8436,7 +8408,6 @@ impl std::fmt::Debug for DeleteEntryGroupRequest {
         let mut debug_struct = f.debug_struct("DeleteEntryGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8707,7 +8678,6 @@ impl std::fmt::Debug for ListEntryGroupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8923,7 +8893,6 @@ impl std::fmt::Debug for ListEntryGroupsResponse {
         debug_struct.field("entry_groups", &self.entry_groups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9066,7 +9035,6 @@ impl std::fmt::Debug for GetEntryGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEntryGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9300,7 +9268,6 @@ impl std::fmt::Debug for CreateEntryTypeRequest {
         debug_struct.field("entry_type_id", &self.entry_type_id);
         debug_struct.field("entry_type", &self.entry_type);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9518,7 +9485,6 @@ impl std::fmt::Debug for UpdateEntryTypeRequest {
         debug_struct.field("entry_type", &self.entry_type);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9687,7 +9653,6 @@ impl std::fmt::Debug for DeleteEntryTypeRequest {
         let mut debug_struct = f.debug_struct("DeleteEntryTypeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9966,7 +9931,6 @@ impl std::fmt::Debug for ListEntryTypesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10182,7 +10146,6 @@ impl std::fmt::Debug for ListEntryTypesResponse {
         debug_struct.field("entry_types", &self.entry_types);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10325,7 +10288,6 @@ impl std::fmt::Debug for GetEntryTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEntryTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10559,7 +10521,6 @@ impl std::fmt::Debug for CreateAspectTypeRequest {
         debug_struct.field("aspect_type_id", &self.aspect_type_id);
         debug_struct.field("aspect_type", &self.aspect_type);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10777,7 +10738,6 @@ impl std::fmt::Debug for UpdateAspectTypeRequest {
         debug_struct.field("aspect_type", &self.aspect_type);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10947,7 +10907,6 @@ impl std::fmt::Debug for DeleteAspectTypeRequest {
         let mut debug_struct = f.debug_struct("DeleteAspectTypeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11226,7 +11185,6 @@ impl std::fmt::Debug for ListAspectTypesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11442,7 +11400,6 @@ impl std::fmt::Debug for ListAspectTypesResponse {
         debug_struct.field("aspect_types", &self.aspect_types);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11585,7 +11542,6 @@ impl std::fmt::Debug for GetAspectTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAspectTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11809,7 +11765,6 @@ impl std::fmt::Debug for CreateEntryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entry_id", &self.entry_id);
         debug_struct.field("entry", &self.entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12104,7 +12059,6 @@ impl std::fmt::Debug for UpdateEntryRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("delete_missing_aspects", &self.delete_missing_aspects);
         debug_struct.field("aspect_keys", &self.aspect_keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12247,7 +12201,6 @@ impl std::fmt::Debug for DeleteEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12509,7 +12462,6 @@ impl std::fmt::Debug for ListEntriesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12695,7 +12647,6 @@ impl std::fmt::Debug for ListEntriesResponse {
         let mut debug_struct = f.debug_struct("ListEntriesResponse");
         debug_struct.field("entries", &self.entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12923,7 +12874,6 @@ impl std::fmt::Debug for GetEntryRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("aspect_types", &self.aspect_types);
         debug_struct.field("paths", &self.paths);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13177,7 +13127,6 @@ impl std::fmt::Debug for LookupEntryRequest {
         debug_struct.field("aspect_types", &self.aspect_types);
         debug_struct.field("paths", &self.paths);
         debug_struct.field("entry", &self.entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13505,7 +13454,6 @@ impl std::fmt::Debug for SearchEntriesRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("scope", &self.scope);
         debug_struct.field("semantic_search", &self.semantic_search);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13726,7 +13674,6 @@ impl std::fmt::Debug for SearchEntriesResult {
         debug_struct.field("linked_resource", &self.linked_resource);
         debug_struct.field("dataplex_entry", &self.dataplex_entry);
         debug_struct.field("snippets", &self.snippets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13893,7 +13840,6 @@ pub mod search_entries_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Snippets");
             debug_struct.field("dataplex_entry", &self.dataplex_entry);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14157,7 +14103,6 @@ impl std::fmt::Debug for SearchEntriesResponse {
         debug_struct.field("total_size", &self.total_size);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14421,7 +14366,6 @@ impl std::fmt::Debug for ImportItem {
         debug_struct.field("entry", &self.entry);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("aspect_keys", &self.aspect_keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14655,7 +14599,6 @@ impl std::fmt::Debug for CreateMetadataJobRequest {
         debug_struct.field("metadata_job", &self.metadata_job);
         debug_struct.field("metadata_job_id", &self.metadata_job_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14798,7 +14741,6 @@ impl std::fmt::Debug for GetMetadataJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMetadataJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15076,7 +15018,6 @@ impl std::fmt::Debug for ListMetadataJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15292,7 +15233,6 @@ impl std::fmt::Debug for ListMetadataJobsResponse {
         debug_struct.field("metadata_jobs", &self.metadata_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15435,7 +15375,6 @@ impl std::fmt::Debug for CancelMetadataJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelMetadataJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16036,7 +15975,6 @@ impl std::fmt::Debug for MetadataJob {
         debug_struct.field("status", &self.status);
         debug_struct.field("spec", &self.spec);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16423,7 +16361,6 @@ pub mod metadata_job {
             debug_struct.field("unchanged_entries", &self.unchanged_entries);
             debug_struct.field("recreated_entries", &self.recreated_entries);
             debug_struct.field("update_time", &self.update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16619,7 +16556,6 @@ pub mod metadata_job {
             let mut debug_struct = f.debug_struct("ExportJobResult");
             debug_struct.field("exported_entries", &self.exported_entries);
             debug_struct.field("error_message", &self.error_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16977,7 +16913,6 @@ pub mod metadata_job {
             debug_struct.field("entry_sync_mode", &self.entry_sync_mode);
             debug_struct.field("aspect_sync_mode", &self.aspect_sync_mode);
             debug_struct.field("log_level", &self.log_level);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17228,7 +17163,6 @@ pub mod metadata_job {
                 debug_struct.field("entry_groups", &self.entry_groups);
                 debug_struct.field("entry_types", &self.entry_types);
                 debug_struct.field("aspect_types", &self.aspect_types);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17723,7 +17657,6 @@ pub mod metadata_job {
             let mut debug_struct = f.debug_struct("ExportJobSpec");
             debug_struct.field("scope", &self.scope);
             debug_struct.field("output_path", &self.output_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18038,7 +17971,6 @@ pub mod metadata_job {
                 debug_struct.field("entry_groups", &self.entry_groups);
                 debug_struct.field("entry_types", &self.entry_types);
                 debug_struct.field("aspect_types", &self.aspect_types);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -18296,7 +18228,6 @@ pub mod metadata_job {
             debug_struct.field("message", &self.message);
             debug_struct.field("completion_percent", &self.completion_percent);
             debug_struct.field("update_time", &self.update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18966,7 +18897,6 @@ impl std::fmt::Debug for EncryptionConfig {
         debug_struct.field("encryption_state", &self.encryption_state);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("failure_details", &self.failure_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19154,7 +19084,6 @@ pub mod encryption_config {
             let mut debug_struct = f.debug_struct("FailureDetails");
             debug_struct.field("error_code", &self.error_code);
             debug_struct.field("error_message", &self.error_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19653,7 +19582,6 @@ impl std::fmt::Debug for CreateEncryptionConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("encryption_config_id", &self.encryption_config_id);
         debug_struct.field("encryption_config", &self.encryption_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19795,7 +19723,6 @@ impl std::fmt::Debug for GetEncryptionConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEncryptionConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19989,7 +19916,6 @@ impl std::fmt::Debug for UpdateEncryptionConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateEncryptionConfigRequest");
         debug_struct.field("encryption_config", &self.encryption_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20156,7 +20082,6 @@ impl std::fmt::Debug for DeleteEncryptionConfigRequest {
         let mut debug_struct = f.debug_struct("DeleteEncryptionConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20440,7 +20365,6 @@ impl std::fmt::Debug for ListEncryptionConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20660,7 +20584,6 @@ impl std::fmt::Debug for ListEncryptionConfigsResponse {
         debug_struct.field("encryption_configs", &self.encryption_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20866,7 +20789,6 @@ impl std::fmt::Debug for CreateContentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("content", &self.content);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21084,7 +21006,6 @@ impl std::fmt::Debug for UpdateContentRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("content", &self.content);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21227,7 +21148,6 @@ impl std::fmt::Debug for DeleteContentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteContentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21478,7 +21398,6 @@ impl std::fmt::Debug for ListContentRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21664,7 +21583,6 @@ impl std::fmt::Debug for ListContentResponse {
         let mut debug_struct = f.debug_struct("ListContentResponse");
         debug_struct.field("content", &self.content);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21837,7 +21755,6 @@ impl std::fmt::Debug for GetContentRequest {
         let mut debug_struct = f.debug_struct("GetContentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22220,7 +22137,6 @@ impl std::fmt::Debug for DataDiscoverySpec {
             &self.bigquery_publishing_config,
         );
         debug_struct.field("resource_config", &self.resource_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22450,7 +22366,6 @@ pub mod data_discovery_spec {
             debug_struct.field("table_type", &self.table_type);
             debug_struct.field("connection", &self.connection);
             debug_struct.field("location", &self.location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22859,7 +22774,6 @@ pub mod data_discovery_spec {
             debug_struct.field("exclude_patterns", &self.exclude_patterns);
             debug_struct.field("csv_options", &self.csv_options);
             debug_struct.field("json_options", &self.json_options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23163,7 +23077,6 @@ pub mod data_discovery_spec {
                 debug_struct.field("encoding", &self.encoding);
                 debug_struct.field("type_inference_disabled", &self.type_inference_disabled);
                 debug_struct.field("quote", &self.quote);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -23354,7 +23267,6 @@ pub mod data_discovery_spec {
                 let mut debug_struct = f.debug_struct("JsonOptions");
                 debug_struct.field("encoding", &self.encoding);
                 debug_struct.field("type_inference_disabled", &self.type_inference_disabled);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -23558,7 +23470,6 @@ impl std::fmt::Debug for DataDiscoveryResult {
         let mut debug_struct = f.debug_struct("DataDiscoveryResult");
         debug_struct.field("bigquery_publishing", &self.bigquery_publishing);
         debug_struct.field("scan_statistics", &self.scan_statistics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23733,7 +23644,6 @@ pub mod data_discovery_result {
             let mut debug_struct = f.debug_struct("BigQueryPublishing");
             debug_struct.field("dataset", &self.dataset);
             debug_struct.field("location", &self.location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24258,7 +24168,6 @@ pub mod data_discovery_result {
             debug_struct.field("filesets_created", &self.filesets_created);
             debug_struct.field("filesets_deleted", &self.filesets_deleted);
             debug_struct.field("filesets_updated", &self.filesets_updated);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24578,7 +24487,6 @@ impl std::fmt::Debug for DataProfileSpec {
         debug_struct.field("post_scan_actions", &self.post_scan_actions);
         debug_struct.field("include_fields", &self.include_fields);
         debug_struct.field("exclude_fields", &self.exclude_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24746,7 +24654,6 @@ pub mod data_profile_spec {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PostScanActions");
             debug_struct.field("bigquery_export", &self.bigquery_export);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24909,7 +24816,6 @@ pub mod data_profile_spec {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("BigQueryExport");
                 debug_struct.field("results_table", &self.results_table);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25065,7 +24971,6 @@ pub mod data_profile_spec {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SelectedFields");
             debug_struct.field("field_names", &self.field_names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25343,7 +25248,6 @@ impl std::fmt::Debug for DataProfileResult {
         debug_struct.field("profile", &self.profile);
         debug_struct.field("scanned_data", &self.scanned_data);
         debug_struct.field("post_scan_actions_result", &self.post_scan_actions_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25502,7 +25406,6 @@ pub mod data_profile_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Profile");
             debug_struct.field("fields", &self.fields);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25756,7 +25659,6 @@ pub mod data_profile_result {
                 debug_struct.field("r#type", &self.r#type);
                 debug_struct.field("mode", &self.mode);
                 debug_struct.field("profile", &self.profile);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -26212,7 +26114,6 @@ pub mod data_profile_result {
                     debug_struct.field("distinct_ratio", &self.distinct_ratio);
                     debug_struct.field("top_n_values", &self.top_n_values);
                     debug_struct.field("field_info", &self.field_info);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -26520,7 +26421,6 @@ pub mod data_profile_result {
                         debug_struct.field("min_length", &self.min_length);
                         debug_struct.field("max_length", &self.max_length);
                         debug_struct.field("average_length", &self.average_length);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -26964,7 +26864,6 @@ pub mod data_profile_result {
                         debug_struct.field("min", &self.min);
                         debug_struct.field("quartiles", &self.quartiles);
                         debug_struct.field("max", &self.max);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -27407,7 +27306,6 @@ pub mod data_profile_result {
                         debug_struct.field("min", &self.min);
                         debug_struct.field("quartiles", &self.quartiles);
                         debug_struct.field("max", &self.max);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -27679,7 +27577,6 @@ pub mod data_profile_result {
                         debug_struct.field("value", &self.value);
                         debug_struct.field("count", &self.count);
                         debug_struct.field("ratio", &self.ratio);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -27854,7 +27751,6 @@ pub mod data_profile_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PostScanActionsResult");
             debug_struct.field("bigquery_export_result", &self.bigquery_export_result);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28033,7 +27929,6 @@ pub mod data_profile_result {
                 let mut debug_struct = f.debug_struct("BigQueryExportResult");
                 debug_struct.field("state", &self.state);
                 debug_struct.field("message", &self.message);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -28453,7 +28348,6 @@ impl std::fmt::Debug for DataQualitySpec {
         debug_struct.field("sampling_percent", &self.sampling_percent);
         debug_struct.field("row_filter", &self.row_filter);
         debug_struct.field("post_scan_actions", &self.post_scan_actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28665,7 +28559,6 @@ pub mod data_quality_spec {
             let mut debug_struct = f.debug_struct("PostScanActions");
             debug_struct.field("bigquery_export", &self.bigquery_export);
             debug_struct.field("notification_report", &self.notification_report);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28828,7 +28721,6 @@ pub mod data_quality_spec {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("BigQueryExport");
                 debug_struct.field("results_table", &self.results_table);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -28981,7 +28873,6 @@ pub mod data_quality_spec {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Recipients");
                 debug_struct.field("emails", &self.emails);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29155,7 +29046,6 @@ pub mod data_quality_spec {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ScoreThresholdTrigger");
                 debug_struct.field("score_threshold", &self.score_threshold);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29276,7 +29166,6 @@ pub mod data_quality_spec {
         impl std::fmt::Debug for JobFailureTrigger {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("JobFailureTrigger");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29397,7 +29286,6 @@ pub mod data_quality_spec {
         impl std::fmt::Debug for JobEndTrigger {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("JobEndTrigger");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29706,7 +29594,6 @@ pub mod data_quality_spec {
                 debug_struct.field("score_threshold_trigger", &self.score_threshold_trigger);
                 debug_struct.field("job_failure_trigger", &self.job_failure_trigger);
                 debug_struct.field("job_end_trigger", &self.job_end_trigger);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -30134,7 +30021,6 @@ impl std::fmt::Debug for DataQualityResult {
         debug_struct.field("row_count", &self.row_count);
         debug_struct.field("scanned_data", &self.scanned_data);
         debug_struct.field("post_scan_actions_result", &self.post_scan_actions_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30298,7 +30184,6 @@ pub mod data_quality_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PostScanActionsResult");
             debug_struct.field("bigquery_export_result", &self.bigquery_export_result);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30477,7 +30362,6 @@ pub mod data_quality_result {
                 let mut debug_struct = f.debug_struct("BigQueryExportResult");
                 debug_struct.field("state", &self.state);
                 debug_struct.field("message", &self.message);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -31079,7 +30963,6 @@ impl std::fmt::Debug for DataQualityRuleResult {
         debug_struct.field("pass_ratio", &self.pass_ratio);
         debug_struct.field("failing_rows_query", &self.failing_rows_query);
         debug_struct.field("assertion_row_count", &self.assertion_row_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31319,7 +31202,6 @@ impl std::fmt::Debug for DataQualityDimensionResult {
         debug_struct.field("dimension", &self.dimension);
         debug_struct.field("passed", &self.passed);
         debug_struct.field("score", &self.score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31463,7 +31345,6 @@ impl std::fmt::Debug for DataQualityDimension {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataQualityDimension");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32372,7 +32253,6 @@ impl std::fmt::Debug for DataQualityRule {
         debug_struct.field("description", &self.description);
         debug_struct.field("suspended", &self.suspended);
         debug_struct.field("rule_type", &self.rule_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32611,7 +32491,6 @@ pub mod data_quality_rule {
             debug_struct.field("max_value", &self.max_value);
             debug_struct.field("strict_min_enabled", &self.strict_min_enabled);
             debug_struct.field("strict_max_enabled", &self.strict_max_enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32728,7 +32607,6 @@ pub mod data_quality_rule {
     impl std::fmt::Debug for NonNullExpectation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NonNullExpectation");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32876,7 +32754,6 @@ pub mod data_quality_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SetExpectation");
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33021,7 +32898,6 @@ pub mod data_quality_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RegexExpectation");
             debug_struct.field("regex", &self.regex);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33138,7 +33014,6 @@ pub mod data_quality_rule {
     impl std::fmt::Debug for UniquenessExpectation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UniquenessExpectation");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33406,7 +33281,6 @@ pub mod data_quality_rule {
             debug_struct.field("max_value", &self.max_value);
             debug_struct.field("strict_min_enabled", &self.strict_min_enabled);
             debug_struct.field("strict_max_enabled", &self.strict_max_enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33708,7 +33582,6 @@ pub mod data_quality_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RowConditionExpectation");
             debug_struct.field("sql_expression", &self.sql_expression);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33863,7 +33736,6 @@ pub mod data_quality_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TableConditionExpectation");
             debug_struct.field("sql_expression", &self.sql_expression);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34025,7 +33897,6 @@ pub mod data_quality_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SqlAssertion");
             debug_struct.field("sql_statement", &self.sql_statement);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34269,7 +34140,6 @@ impl std::fmt::Debug for DataQualityColumnResult {
         let mut debug_struct = f.debug_struct("DataQualityColumnResult");
         debug_struct.field("column", &self.column);
         debug_struct.field("score", &self.score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34719,7 +34589,6 @@ impl std::fmt::Debug for DataTaxonomy {
         debug_struct.field("attribute_count", &self.attribute_count);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("class_count", &self.class_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35239,7 +35108,6 @@ impl std::fmt::Debug for DataAttribute {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("resource_access_spec", &self.resource_access_spec);
         debug_struct.field("data_access_spec", &self.data_access_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35735,7 +35603,6 @@ impl std::fmt::Debug for DataAttributeBinding {
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("paths", &self.paths);
         debug_struct.field("resource_reference", &self.resource_reference);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35918,7 +35785,6 @@ pub mod data_attribute_binding {
             let mut debug_struct = f.debug_struct("Path");
             debug_struct.field("name", &self.name);
             debug_struct.field("attributes", &self.attributes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36173,7 +36039,6 @@ impl std::fmt::Debug for CreateDataTaxonomyRequest {
         debug_struct.field("data_taxonomy_id", &self.data_taxonomy_id);
         debug_struct.field("data_taxonomy", &self.data_taxonomy);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36392,7 +36257,6 @@ impl std::fmt::Debug for UpdateDataTaxonomyRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("data_taxonomy", &self.data_taxonomy);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36534,7 +36398,6 @@ impl std::fmt::Debug for GetDataTaxonomyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataTaxonomyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36805,7 +36668,6 @@ impl std::fmt::Debug for ListDataTaxonomiesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37021,7 +36883,6 @@ impl std::fmt::Debug for ListDataTaxonomiesResponse {
         debug_struct.field("data_taxonomies", &self.data_taxonomies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37191,7 +37052,6 @@ impl std::fmt::Debug for DeleteDataTaxonomyRequest {
         let mut debug_struct = f.debug_struct("DeleteDataTaxonomyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37433,7 +37293,6 @@ impl std::fmt::Debug for CreateDataAttributeRequest {
         debug_struct.field("data_attribute_id", &self.data_attribute_id);
         debug_struct.field("data_attribute", &self.data_attribute);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37651,7 +37510,6 @@ impl std::fmt::Debug for UpdateDataAttributeRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("data_attribute", &self.data_attribute);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37794,7 +37652,6 @@ impl std::fmt::Debug for GetDataAttributeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataAttributeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38064,7 +37921,6 @@ impl std::fmt::Debug for ListDataAttributesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38280,7 +38136,6 @@ impl std::fmt::Debug for ListDataAttributesResponse {
         debug_struct.field("data_attributes", &self.data_attributes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38449,7 +38304,6 @@ impl std::fmt::Debug for DeleteDataAttributeRequest {
         let mut debug_struct = f.debug_struct("DeleteDataAttributeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38693,7 +38547,6 @@ impl std::fmt::Debug for CreateDataAttributeBindingRequest {
         debug_struct.field("data_attribute_binding_id", &self.data_attribute_binding_id);
         debug_struct.field("data_attribute_binding", &self.data_attribute_binding);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38911,7 +38764,6 @@ impl std::fmt::Debug for UpdateDataAttributeBindingRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("data_attribute_binding", &self.data_attribute_binding);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39054,7 +38906,6 @@ impl std::fmt::Debug for GetDataAttributeBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDataAttributeBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39328,7 +39179,6 @@ impl std::fmt::Debug for ListDataAttributeBindingsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39548,7 +39398,6 @@ impl std::fmt::Debug for ListDataAttributeBindingsResponse {
         debug_struct.field("data_attribute_bindings", &self.data_attribute_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39719,7 +39568,6 @@ impl std::fmt::Debug for DeleteDataAttributeBindingRequest {
         let mut debug_struct = f.debug_struct("DeleteDataAttributeBindingRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39960,7 +39808,6 @@ impl std::fmt::Debug for CreateDataScanRequest {
         debug_struct.field("data_scan", &self.data_scan);
         debug_struct.field("data_scan_id", &self.data_scan_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40180,7 +40027,6 @@ impl std::fmt::Debug for UpdateDataScanRequest {
         debug_struct.field("data_scan", &self.data_scan);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40352,7 +40198,6 @@ impl std::fmt::Debug for DeleteDataScanRequest {
         let mut debug_struct = f.debug_struct("DeleteDataScanRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40527,7 +40372,6 @@ impl std::fmt::Debug for GetDataScanRequest {
         let mut debug_struct = f.debug_struct("GetDataScanRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40937,7 +40781,6 @@ impl std::fmt::Debug for ListDataScansRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41152,7 +40995,6 @@ impl std::fmt::Debug for ListDataScansResponse {
         debug_struct.field("data_scans", &self.data_scans);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41299,7 +41141,6 @@ impl std::fmt::Debug for RunDataScanRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunDataScanRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41452,7 +41293,6 @@ impl std::fmt::Debug for RunDataScanResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunDataScanResponse");
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41629,7 +41469,6 @@ impl std::fmt::Debug for GetDataScanJobRequest {
         let mut debug_struct = f.debug_struct("GetDataScanJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42029,7 +41868,6 @@ impl std::fmt::Debug for ListDataScanJobsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42216,7 +42054,6 @@ impl std::fmt::Debug for ListDataScanJobsResponse {
         let mut debug_struct = f.debug_struct("ListDataScanJobsResponse");
         debug_struct.field("data_scan_jobs", &self.data_scan_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42363,7 +42200,6 @@ impl std::fmt::Debug for GenerateDataQualityRulesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateDataQualityRulesRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42513,7 +42349,6 @@ impl std::fmt::Debug for GenerateDataQualityRulesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateDataQualityRulesResponse");
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43394,7 +43229,6 @@ impl std::fmt::Debug for DataScan {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("spec", &self.spec);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43631,7 +43465,6 @@ pub mod data_scan {
             let mut debug_struct = f.debug_struct("ExecutionSpec");
             debug_struct.field("trigger", &self.trigger);
             debug_struct.field("incremental", &self.incremental);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43885,7 +43718,6 @@ pub mod data_scan {
             debug_struct.field("latest_job_start_time", &self.latest_job_start_time);
             debug_struct.field("latest_job_end_time", &self.latest_job_end_time);
             debug_struct.field("latest_job_create_time", &self.latest_job_create_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44647,7 +44479,6 @@ impl std::fmt::Debug for DataScanJob {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("spec", &self.spec);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45434,7 +45265,6 @@ impl std::fmt::Debug for DiscoveryEvent {
         debug_struct.field("datascan_id", &self.datascan_id);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45598,7 +45428,6 @@ pub mod discovery_event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConfigDetails");
             debug_struct.field("parameters", &self.parameters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45774,7 +45603,6 @@ pub mod discovery_event {
             let mut debug_struct = f.debug_struct("EntityDetails");
             debug_struct.field("entity", &self.entity);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45949,7 +45777,6 @@ pub mod discovery_event {
             let mut debug_struct = f.debug_struct("TableDetails");
             debug_struct.field("table", &self.table);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46183,7 +46010,6 @@ pub mod discovery_event {
             debug_struct.field("entity", &self.entity);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("sampled_data_locations", &self.sampled_data_locations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46354,7 +46180,6 @@ pub mod discovery_event {
             let mut debug_struct = f.debug_struct("ActionDetails");
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("issue", &self.issue);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -47258,7 +47083,6 @@ impl std::fmt::Debug for JobEvent {
         debug_struct.field("service", &self.service);
         debug_struct.field("service_job", &self.service_job);
         debug_struct.field("execution_trigger", &self.execution_trigger);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48184,7 +48008,6 @@ impl std::fmt::Debug for SessionEvent {
         debug_struct.field("fast_startup_enabled", &self.fast_startup_enabled);
         debug_struct.field("unassigned_duration", &self.unassigned_duration);
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48519,7 +48342,6 @@ pub mod session_event {
             debug_struct.field("duration", &self.duration);
             debug_struct.field("result_size_bytes", &self.result_size_bytes);
             debug_struct.field("data_processed_bytes", &self.data_processed_bytes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49022,7 +48844,6 @@ impl std::fmt::Debug for GovernanceEvent {
         debug_struct.field("message", &self.message);
         debug_struct.field("event_type", &self.event_type);
         debug_struct.field("entity", &self.entity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49207,7 +49028,6 @@ pub mod governance_event {
             let mut debug_struct = f.debug_struct("Entity");
             debug_struct.field("entity", &self.entity);
             debug_struct.field("entity_type", &self.entity_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50349,7 +50169,6 @@ impl std::fmt::Debug for DataScanEvent {
         debug_struct.field("post_scan_actions_result", &self.post_scan_actions_result);
         debug_struct.field("result", &self.result);
         debug_struct.field("applied_configs", &self.applied_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50519,7 +50338,6 @@ pub mod data_scan_event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DataProfileResult");
             debug_struct.field("row_count", &self.row_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50936,7 +50754,6 @@ pub mod data_scan_event {
             debug_struct.field("score", &self.score);
             debug_struct.field("dimension_score", &self.dimension_score);
             debug_struct.field("column_score", &self.column_score);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51157,7 +50974,6 @@ pub mod data_scan_event {
             debug_struct.field("sampling_percent", &self.sampling_percent);
             debug_struct.field("row_filter_applied", &self.row_filter_applied);
             debug_struct.field("column_filter_applied", &self.column_filter_applied);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51351,7 +51167,6 @@ pub mod data_scan_event {
             let mut debug_struct = f.debug_struct("DataQualityAppliedConfigs");
             debug_struct.field("sampling_percent", &self.sampling_percent);
             debug_struct.field("row_filter_applied", &self.row_filter_applied);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51516,7 +51331,6 @@ pub mod data_scan_event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PostScanActionsResult");
             debug_struct.field("bigquery_export_result", &self.bigquery_export_result);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51695,7 +51509,6 @@ pub mod data_scan_event {
                 let mut debug_struct = f.debug_struct("BigQueryExportResult");
                 debug_struct.field("state", &self.state);
                 debug_struct.field("message", &self.message);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -52998,7 +52811,6 @@ impl std::fmt::Debug for DataQualityScanRuleResult {
         debug_struct.field("passed_row_count", &self.passed_row_count);
         debug_struct.field("null_row_count", &self.null_row_count);
         debug_struct.field("assertion_row_count", &self.assertion_row_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53682,7 +53494,6 @@ impl std::fmt::Debug for BusinessGlossaryEvent {
         debug_struct.field("message", &self.message);
         debug_struct.field("event_type", &self.event_type);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54069,7 +53880,6 @@ impl std::fmt::Debug for EntryLinkEvent {
         debug_struct.field("message", &self.message);
         debug_struct.field("event_type", &self.event_type);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54413,7 +54223,6 @@ impl std::fmt::Debug for CreateEntityRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entity", &self.entity);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54596,7 +54405,6 @@ impl std::fmt::Debug for UpdateEntityRequest {
         let mut debug_struct = f.debug_struct("UpdateEntityRequest");
         debug_struct.field("entity", &self.entity);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54765,7 +54573,6 @@ impl std::fmt::Debug for DeleteEntityRequest {
         let mut debug_struct = f.debug_struct("DeleteEntityRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55046,7 +54853,6 @@ impl std::fmt::Debug for ListEntitiesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55371,7 +55177,6 @@ impl std::fmt::Debug for ListEntitiesResponse {
         let mut debug_struct = f.debug_struct("ListEntitiesResponse");
         debug_struct.field("entities", &self.entities);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55545,7 +55350,6 @@ impl std::fmt::Debug for GetEntityRequest {
         let mut debug_struct = f.debug_struct("GetEntityRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55952,7 +55756,6 @@ impl std::fmt::Debug for ListPartitionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56158,7 +55961,6 @@ impl std::fmt::Debug for CreatePartitionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("partition", &self.partition);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56331,7 +56133,6 @@ impl std::fmt::Debug for DeletePartitionRequest {
         let mut debug_struct = f.debug_struct("DeletePartitionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56517,7 +56318,6 @@ impl std::fmt::Debug for ListPartitionsResponse {
         let mut debug_struct = f.debug_struct("ListPartitionsResponse");
         debug_struct.field("partitions", &self.partitions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56662,7 +56462,6 @@ impl std::fmt::Debug for GetPartitionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPartitionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57324,7 +57123,6 @@ impl std::fmt::Debug for Entity {
         debug_struct.field("access", &self.access);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("schema", &self.schema);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57526,7 +57324,6 @@ pub mod entity {
             let mut debug_struct = f.debug_struct("CompatibilityStatus");
             debug_struct.field("hive_metastore", &self.hive_metastore);
             debug_struct.field("bigquery", &self.bigquery);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -57708,7 +57505,6 @@ pub mod entity {
                 let mut debug_struct = f.debug_struct("Compatibility");
                 debug_struct.field("compatible", &self.compatible);
                 debug_struct.field("reason", &self.reason);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -58071,7 +57867,6 @@ impl std::fmt::Debug for Partition {
         debug_struct.field("values", &self.values);
         debug_struct.field("location", &self.location);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58322,7 +58117,6 @@ impl std::fmt::Debug for Schema {
         debug_struct.field("fields", &self.fields);
         debug_struct.field("partition_fields", &self.partition_fields);
         debug_struct.field("partition_style", &self.partition_style);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58584,7 +58378,6 @@ pub mod schema {
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("mode", &self.mode);
             debug_struct.field("fields", &self.fields);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -58760,7 +58553,6 @@ pub mod schema {
             let mut debug_struct = f.debug_struct("PartitionField");
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -59653,7 +59445,6 @@ impl std::fmt::Debug for StorageFormat {
         debug_struct.field("compression_format", &self.compression_format);
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59902,7 +59693,6 @@ pub mod storage_format {
             debug_struct.field("header_rows", &self.header_rows);
             debug_struct.field("delimiter", &self.delimiter);
             debug_struct.field("quote", &self.quote);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60048,7 +59838,6 @@ pub mod storage_format {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("JsonOptions");
             debug_struct.field("encoding", &self.encoding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60198,7 +59987,6 @@ pub mod storage_format {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IcebergOptions");
             debug_struct.field("metadata_location", &self.metadata_location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60689,7 +60477,6 @@ impl std::fmt::Debug for StorageAccess {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StorageAccess");
         debug_struct.field("read", &self.read);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61065,7 +60852,6 @@ impl std::fmt::Debug for Trigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Trigger");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61187,7 +60973,6 @@ pub mod trigger {
     impl std::fmt::Debug for OnDemand {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("OnDemand");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -61343,7 +61128,6 @@ pub mod trigger {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Schedule");
             debug_struct.field("cron", &self.cron);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -61582,7 +61366,6 @@ impl std::fmt::Debug for DataSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataSource");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61799,7 +61582,6 @@ impl std::fmt::Debug for ScannedData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScannedData");
         debug_struct.field("data_range", &self.data_range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62000,7 +61782,6 @@ pub mod scanned_data {
             debug_struct.field("field", &self.field);
             debug_struct.field("start", &self.start);
             debug_struct.field("end", &self.end);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -62511,7 +62292,6 @@ impl std::fmt::Debug for Lake {
         debug_struct.field("metastore", &self.metastore);
         debug_struct.field("asset_status", &self.asset_status);
         debug_struct.field("metastore_status", &self.metastore_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62664,7 +62444,6 @@ pub mod lake {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Metastore");
             debug_struct.field("service", &self.service);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -62901,7 +62680,6 @@ pub mod lake {
             debug_struct.field("message", &self.message);
             debug_struct.field("update_time", &self.update_time);
             debug_struct.field("endpoint", &self.endpoint);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -63312,7 +63090,6 @@ impl std::fmt::Debug for AssetStatus {
             "security_policy_applying_assets",
             &self.security_policy_applying_assets,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63808,7 +63585,6 @@ impl std::fmt::Debug for Zone {
         debug_struct.field("discovery_spec", &self.discovery_spec);
         debug_struct.field("resource_spec", &self.resource_spec);
         debug_struct.field("asset_status", &self.asset_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63967,7 +63743,6 @@ pub mod zone {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ResourceSpec");
             debug_struct.field("location_type", &self.location_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -64461,7 +64236,6 @@ pub mod zone {
             debug_struct.field("csv_options", &self.csv_options);
             debug_struct.field("json_options", &self.json_options);
             debug_struct.field("trigger", &self.trigger);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -64734,7 +64508,6 @@ pub mod zone {
                 debug_struct.field("delimiter", &self.delimiter);
                 debug_struct.field("encoding", &self.encoding);
                 debug_struct.field("disable_type_inference", &self.disable_type_inference);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -64921,7 +64694,6 @@ pub mod zone {
                 let mut debug_struct = f.debug_struct("JsonOptions");
                 debug_struct.field("encoding", &self.encoding);
                 debug_struct.field("disable_type_inference", &self.disable_type_inference);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -65909,7 +65681,6 @@ impl std::fmt::Debug for Action {
         debug_struct.field("asset", &self.asset);
         debug_struct.field("data_locations", &self.data_locations);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66031,7 +65802,6 @@ pub mod action {
     impl std::fmt::Debug for MissingResource {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MissingResource");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -66150,7 +65920,6 @@ pub mod action {
     impl std::fmt::Debug for UnauthorizedResource {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UnauthorizedResource");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -66299,7 +66068,6 @@ pub mod action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FailedSecurityPolicyApply");
             debug_struct.field("asset", &self.asset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -66506,7 +66274,6 @@ pub mod action {
             debug_struct.field("sampled_data_locations", &self.sampled_data_locations);
             debug_struct.field("expected_format", &self.expected_format);
             debug_struct.field("new_format", &self.new_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -66769,7 +66536,6 @@ pub mod action {
             debug_struct.field("new_schema", &self.new_schema);
             debug_struct.field("sampled_data_locations", &self.sampled_data_locations);
             debug_struct.field("schema_change", &self.schema_change);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -67060,7 +66826,6 @@ pub mod action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InvalidDataPartition");
             debug_struct.field("expected_structure", &self.expected_structure);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -67320,7 +67085,6 @@ pub mod action {
     impl std::fmt::Debug for MissingData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MissingData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -67437,7 +67201,6 @@ pub mod action {
     impl std::fmt::Debug for InvalidDataOrganization {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InvalidDataOrganization");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -68147,7 +67910,6 @@ impl std::fmt::Debug for Asset {
         debug_struct.field("security_status", &self.security_status);
         debug_struct.field("discovery_spec", &self.discovery_spec);
         debug_struct.field("discovery_status", &self.discovery_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68366,7 +68128,6 @@ pub mod asset {
             debug_struct.field("state", &self.state);
             debug_struct.field("message", &self.message);
             debug_struct.field("update_time", &self.update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -68869,7 +68630,6 @@ pub mod asset {
             debug_struct.field("csv_options", &self.csv_options);
             debug_struct.field("json_options", &self.json_options);
             debug_struct.field("trigger", &self.trigger);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -69142,7 +68902,6 @@ pub mod asset {
                 debug_struct.field("delimiter", &self.delimiter);
                 debug_struct.field("encoding", &self.encoding);
                 debug_struct.field("disable_type_inference", &self.disable_type_inference);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -69329,7 +69088,6 @@ pub mod asset {
                 let mut debug_struct = f.debug_struct("JsonOptions");
                 debug_struct.field("encoding", &self.encoding);
                 debug_struct.field("disable_type_inference", &self.disable_type_inference);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -69559,7 +69317,6 @@ pub mod asset {
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("read_access_mode", &self.read_access_mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -70081,7 +69838,6 @@ pub mod asset {
             debug_struct.field("message", &self.message);
             debug_struct.field("update_time", &self.update_time);
             debug_struct.field("managed_access_identity", &self.managed_access_identity);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -70545,7 +70301,6 @@ pub mod asset {
             debug_struct.field("last_run_time", &self.last_run_time);
             debug_struct.field("stats", &self.stats);
             debug_struct.field("last_run_duration", &self.last_run_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -70869,7 +70624,6 @@ pub mod asset {
                 debug_struct.field("data_size", &self.data_size);
                 debug_struct.field("tables", &self.tables);
                 debug_struct.field("filesets", &self.filesets);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -71226,7 +70980,6 @@ impl std::fmt::Debug for ResourceAccessSpec {
         debug_struct.field("readers", &self.readers);
         debug_struct.field("writers", &self.writers);
         debug_struct.field("owners", &self.owners);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71378,7 +71131,6 @@ impl std::fmt::Debug for DataAccessSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataAccessSpec");
         debug_struct.field("readers", &self.readers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71619,7 +71371,6 @@ impl std::fmt::Debug for CreateLakeRequest {
         debug_struct.field("lake_id", &self.lake_id);
         debug_struct.field("lake", &self.lake);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71837,7 +71588,6 @@ impl std::fmt::Debug for UpdateLakeRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("lake", &self.lake);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71980,7 +71730,6 @@ impl std::fmt::Debug for DeleteLakeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteLakeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72249,7 +71998,6 @@ impl std::fmt::Debug for ListLakesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72464,7 +72212,6 @@ impl std::fmt::Debug for ListLakesResponse {
         debug_struct.field("lakes", &self.lakes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72682,7 +72429,6 @@ impl std::fmt::Debug for ListLakeActionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72868,7 +72614,6 @@ impl std::fmt::Debug for ListActionsResponse {
         let mut debug_struct = f.debug_struct("ListActionsResponse");
         debug_struct.field("actions", &self.actions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73011,7 +72756,6 @@ impl std::fmt::Debug for GetLakeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLakeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73252,7 +72996,6 @@ impl std::fmt::Debug for CreateZoneRequest {
         debug_struct.field("zone_id", &self.zone_id);
         debug_struct.field("zone", &self.zone);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73470,7 +73213,6 @@ impl std::fmt::Debug for UpdateZoneRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("zone", &self.zone);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73613,7 +73355,6 @@ impl std::fmt::Debug for DeleteZoneRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteZoneRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73881,7 +73622,6 @@ impl std::fmt::Debug for ListZonesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74067,7 +73807,6 @@ impl std::fmt::Debug for ListZonesResponse {
         let mut debug_struct = f.debug_struct("ListZonesResponse");
         debug_struct.field("zones", &self.zones);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74285,7 +74024,6 @@ impl std::fmt::Debug for ListZoneActionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74428,7 +74166,6 @@ impl std::fmt::Debug for GetZoneRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetZoneRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74668,7 +74405,6 @@ impl std::fmt::Debug for CreateAssetRequest {
         debug_struct.field("asset_id", &self.asset_id);
         debug_struct.field("asset", &self.asset);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74886,7 +74622,6 @@ impl std::fmt::Debug for UpdateAssetRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("asset", &self.asset);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75029,7 +74764,6 @@ impl std::fmt::Debug for DeleteAssetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAssetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75298,7 +75032,6 @@ impl std::fmt::Debug for ListAssetsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75484,7 +75217,6 @@ impl std::fmt::Debug for ListAssetsResponse {
         let mut debug_struct = f.debug_struct("ListAssetsResponse");
         debug_struct.field("assets", &self.assets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75702,7 +75434,6 @@ impl std::fmt::Debug for ListAssetActionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75845,7 +75576,6 @@ impl std::fmt::Debug for GetAssetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAssetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76170,7 +75900,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76402,7 +76131,6 @@ impl std::fmt::Debug for CreateTaskRequest {
         debug_struct.field("task_id", &self.task_id);
         debug_struct.field("task", &self.task);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76620,7 +76348,6 @@ impl std::fmt::Debug for UpdateTaskRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("task", &self.task);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76763,7 +76490,6 @@ impl std::fmt::Debug for DeleteTaskRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTaskRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77031,7 +76757,6 @@ impl std::fmt::Debug for ListTasksRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77246,7 +76971,6 @@ impl std::fmt::Debug for ListTasksResponse {
         debug_struct.field("tasks", &self.tasks);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable_locations", &self.unreachable_locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77389,7 +77113,6 @@ impl std::fmt::Debug for GetTaskRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTaskRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77532,7 +77255,6 @@ impl std::fmt::Debug for GetJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77758,7 +77480,6 @@ impl std::fmt::Debug for RunTaskRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("args", &self.args);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77910,7 +77631,6 @@ impl std::fmt::Debug for RunTaskResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunTaskResponse");
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78128,7 +77848,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78314,7 +78033,6 @@ impl std::fmt::Debug for ListJobsResponse {
         let mut debug_struct = f.debug_struct("ListJobsResponse");
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78457,7 +78175,6 @@ impl std::fmt::Debug for CancelJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78695,7 +78412,6 @@ impl std::fmt::Debug for CreateEnvironmentRequest {
         debug_struct.field("environment_id", &self.environment_id);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78913,7 +78629,6 @@ impl std::fmt::Debug for UpdateEnvironmentRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79056,7 +78771,6 @@ impl std::fmt::Debug for DeleteEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79326,7 +79040,6 @@ impl std::fmt::Debug for ListEnvironmentsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79512,7 +79225,6 @@ impl std::fmt::Debug for ListEnvironmentsResponse {
         let mut debug_struct = f.debug_struct("ListEnvironmentsResponse");
         debug_struct.field("environments", &self.environments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79655,7 +79367,6 @@ impl std::fmt::Debug for GetEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79906,7 +79617,6 @@ impl std::fmt::Debug for ListSessionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80092,7 +79802,6 @@ impl std::fmt::Debug for ListSessionsResponse {
         let mut debug_struct = f.debug_struct("ListSessionsResponse");
         debug_struct.field("sessions", &self.sessions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80680,7 +80389,6 @@ impl std::fmt::Debug for Task {
         debug_struct.field("execution_spec", &self.execution_spec);
         debug_struct.field("execution_status", &self.execution_status);
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81046,7 +80754,6 @@ pub mod task {
             debug_struct.field("resources", &self.resources);
             debug_struct.field("runtime", &self.runtime);
             debug_struct.field("network", &self.network);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -81278,7 +80985,6 @@ pub mod task {
                 let mut debug_struct = f.debug_struct("BatchComputeResources");
                 debug_struct.field("executors_count", &self.executors_count);
                 debug_struct.field("max_executors_count", &self.max_executors_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -81534,7 +81240,6 @@ pub mod task {
                 debug_struct.field("java_jars", &self.java_jars);
                 debug_struct.field("python_packages", &self.python_packages);
                 debug_struct.field("properties", &self.properties);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -81820,7 +81525,6 @@ pub mod task {
                 let mut debug_struct = f.debug_struct("VpcNetwork");
                 debug_struct.field("network_tags", &self.network_tags);
                 debug_struct.field("network_name", &self.network_name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -82189,7 +81893,6 @@ pub mod task {
             debug_struct.field("disabled", &self.disabled);
             debug_struct.field("max_retries", &self.max_retries);
             debug_struct.field("trigger", &self.trigger);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -82648,7 +82351,6 @@ pub mod task {
                 &self.max_job_execution_lifetime,
             );
             debug_struct.field("kms_key", &self.kms_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -83145,7 +82847,6 @@ pub mod task {
             debug_struct.field("archive_uris", &self.archive_uris);
             debug_struct.field("infrastructure_spec", &self.infrastructure_spec);
             debug_struct.field("driver", &self.driver);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -83427,7 +83128,6 @@ pub mod task {
             debug_struct.field("infrastructure_spec", &self.infrastructure_spec);
             debug_struct.field("file_uris", &self.file_uris);
             debug_struct.field("archive_uris", &self.archive_uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -83621,7 +83321,6 @@ pub mod task {
             let mut debug_struct = f.debug_struct("ExecutionStatus");
             debug_struct.field("update_time", &self.update_time);
             debug_struct.field("latest_job", &self.latest_job);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -84119,7 +83818,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("trigger", &self.trigger);
         debug_struct.field("execution_spec", &self.execution_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -402,7 +402,6 @@ impl std::fmt::Debug for AutoscalingPolicy {
         debug_struct.field("secondary_worker_config", &self.secondary_worker_config);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("algorithm", &self.algorithm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -647,7 +646,6 @@ impl std::fmt::Debug for BasicAutoscalingAlgorithm {
         let mut debug_struct = f.debug_struct("BasicAutoscalingAlgorithm");
         debug_struct.field("cooldown_period", &self.cooldown_period);
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1062,7 +1060,6 @@ impl std::fmt::Debug for BasicYarnAutoscalingConfig {
             "scale_down_min_worker_fraction",
             &self.scale_down_min_worker_fraction,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1338,7 +1335,6 @@ impl std::fmt::Debug for InstanceGroupAutoscalingPolicyConfig {
         debug_struct.field("min_instances", &self.min_instances);
         debug_struct.field("max_instances", &self.max_instances);
         debug_struct.field("weight", &self.weight);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1527,7 +1523,6 @@ impl std::fmt::Debug for CreateAutoscalingPolicyRequest {
         let mut debug_struct = f.debug_struct("CreateAutoscalingPolicyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1679,7 +1674,6 @@ impl std::fmt::Debug for GetAutoscalingPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAutoscalingPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1833,7 +1827,6 @@ impl std::fmt::Debug for UpdateAutoscalingPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateAutoscalingPolicyRequest");
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1987,7 +1980,6 @@ impl std::fmt::Debug for DeleteAutoscalingPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAutoscalingPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2211,7 +2203,6 @@ impl std::fmt::Debug for ListAutoscalingPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2401,7 +2392,6 @@ impl std::fmt::Debug for ListAutoscalingPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListAutoscalingPoliciesResponse");
         debug_struct.field("policies", &self.policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2645,7 +2635,6 @@ impl std::fmt::Debug for CreateBatchRequest {
         debug_struct.field("batch", &self.batch);
         debug_struct.field("batch_id", &self.batch_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2789,7 +2778,6 @@ impl std::fmt::Debug for GetBatchRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBatchRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3071,7 +3059,6 @@ impl std::fmt::Debug for ListBatchesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3287,7 +3274,6 @@ impl std::fmt::Debug for ListBatchesResponse {
         debug_struct.field("batches", &self.batches);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3431,7 +3417,6 @@ impl std::fmt::Debug for DeleteBatchRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBatchRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4192,7 +4177,6 @@ impl std::fmt::Debug for Batch {
         debug_struct.field("operation", &self.operation);
         debug_struct.field("state_history", &self.state_history);
         debug_struct.field("batch_config", &self.batch_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4412,7 +4396,6 @@ pub mod batch {
             debug_struct.field("state", &self.state);
             debug_struct.field("state_message", &self.state_message);
             debug_struct.field("state_start_time", &self.state_start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4888,7 +4871,6 @@ impl std::fmt::Debug for PySparkBatch {
         debug_struct.field("jar_file_uris", &self.jar_file_uris);
         debug_struct.field("file_uris", &self.file_uris);
         debug_struct.field("archive_uris", &self.archive_uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5244,7 +5226,6 @@ impl std::fmt::Debug for SparkBatch {
         debug_struct.field("file_uris", &self.file_uris);
         debug_struct.field("archive_uris", &self.archive_uris);
         debug_struct.field("driver", &self.driver);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5502,7 +5483,6 @@ impl std::fmt::Debug for SparkRBatch {
         debug_struct.field("args", &self.args);
         debug_struct.field("file_uris", &self.file_uris);
         debug_struct.field("archive_uris", &self.archive_uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5715,7 +5695,6 @@ impl std::fmt::Debug for SparkSqlBatch {
         debug_struct.field("query_file_uri", &self.query_file_uri);
         debug_struct.field("query_variables", &self.query_variables);
         debug_struct.field("jar_file_uris", &self.jar_file_uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6150,7 +6129,6 @@ impl std::fmt::Debug for Cluster {
         debug_struct.field("status_history", &self.status_history);
         debug_struct.field("cluster_uuid", &self.cluster_uuid);
         debug_struct.field("metrics", &self.metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6903,7 +6881,6 @@ impl std::fmt::Debug for ClusterConfig {
         debug_struct.field("metastore_config", &self.metastore_config);
         debug_struct.field("dataproc_metric_config", &self.dataproc_metric_config);
         debug_struct.field("auxiliary_node_groups", &self.auxiliary_node_groups);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7318,7 +7295,6 @@ impl std::fmt::Debug for VirtualClusterConfig {
         debug_struct.field("staging_bucket", &self.staging_bucket);
         debug_struct.field("auxiliary_services_config", &self.auxiliary_services_config);
         debug_struct.field("infrastructure_config", &self.infrastructure_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7534,7 +7510,6 @@ impl std::fmt::Debug for AuxiliaryServicesConfig {
             "spark_history_server_config",
             &self.spark_history_server_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7716,7 +7691,6 @@ impl std::fmt::Debug for EndpointConfig {
         let mut debug_struct = f.debug_struct("EndpointConfig");
         debug_struct.field("http_ports", &self.http_ports);
         debug_struct.field("enable_http_port_access", &self.enable_http_port_access);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7867,7 +7841,6 @@ impl std::fmt::Debug for AutoscalingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutoscalingConfig");
         debug_struct.field("policy_uri", &self.policy_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8068,7 +8041,6 @@ impl std::fmt::Debug for EncryptionConfig {
         let mut debug_struct = f.debug_struct("EncryptionConfig");
         debug_struct.field("gce_pd_kms_key_name", &self.gce_pd_kms_key_name);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8691,7 +8663,6 @@ impl std::fmt::Debug for GceClusterConfig {
             "confidential_instance_config",
             &self.confidential_instance_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9008,7 +8979,6 @@ impl std::fmt::Debug for NodeGroupAffinity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodeGroupAffinity");
         debug_struct.field("node_group_uri", &self.node_group_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9246,7 +9216,6 @@ impl std::fmt::Debug for ShieldedInstanceConfig {
             "enable_integrity_monitoring",
             &self.enable_integrity_monitoring,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9401,7 +9370,6 @@ impl std::fmt::Debug for ConfidentialInstanceConfig {
             "enable_confidential_compute",
             &self.enable_confidential_compute,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10065,7 +10033,6 @@ impl std::fmt::Debug for InstanceGroupConfig {
             &self.instance_flexibility_policy,
         );
         debug_struct.field("startup_config", &self.startup_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10420,7 +10387,6 @@ impl std::fmt::Debug for StartupConfig {
             "required_registration_fraction",
             &self.required_registration_fraction,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10644,7 +10610,6 @@ impl std::fmt::Debug for InstanceReference {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("public_key", &self.public_key);
         debug_struct.field("public_ecies_key", &self.public_ecies_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10867,7 +10832,6 @@ impl std::fmt::Debug for ManagedGroupConfig {
             "instance_group_manager_uri",
             &self.instance_group_manager_uri,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11093,7 +11057,6 @@ impl std::fmt::Debug for InstanceFlexibilityPolicy {
             "instance_selection_results",
             &self.instance_selection_results,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11368,7 +11331,6 @@ pub mod instance_flexibility_policy {
                 "standard_capacity_percent_above_base",
                 &self.standard_capacity_percent_above_base,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11564,7 +11526,6 @@ pub mod instance_flexibility_policy {
             let mut debug_struct = f.debug_struct("InstanceSelection");
             debug_struct.field("machine_types", &self.machine_types);
             debug_struct.field("rank", &self.rank);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11780,7 +11741,6 @@ pub mod instance_flexibility_policy {
             let mut debug_struct = f.debug_struct("InstanceSelectionResult");
             debug_struct.field("machine_type", &self.machine_type);
             debug_struct.field("vm_count", &self.vm_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11989,7 +11949,6 @@ impl std::fmt::Debug for AcceleratorConfig {
         let mut debug_struct = f.debug_struct("AcceleratorConfig");
         debug_struct.field("accelerator_type_uri", &self.accelerator_type_uri);
         debug_struct.field("accelerator_count", &self.accelerator_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12411,7 +12370,6 @@ impl std::fmt::Debug for DiskConfig {
             "boot_disk_provisioned_throughput",
             &self.boot_disk_provisioned_throughput,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12595,7 +12553,6 @@ impl std::fmt::Debug for AuxiliaryNodeGroup {
         let mut debug_struct = f.debug_struct("AuxiliaryNodeGroup");
         debug_struct.field("node_group", &self.node_group);
         debug_struct.field("node_group_id", &self.node_group_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12854,7 +12811,6 @@ impl std::fmt::Debug for NodeGroup {
         debug_struct.field("roles", &self.roles);
         debug_struct.field("node_group_config", &self.node_group_config);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13172,7 +13128,6 @@ impl std::fmt::Debug for NodeInitializationAction {
         let mut debug_struct = f.debug_struct("NodeInitializationAction");
         debug_struct.field("executable_file", &self.executable_file);
         debug_struct.field("execution_timeout", &self.execution_timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13405,7 +13360,6 @@ impl std::fmt::Debug for ClusterStatus {
         debug_struct.field("detail", &self.detail);
         debug_struct.field("state_start_time", &self.state_start_time);
         debug_struct.field("substate", &self.substate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13937,7 +13891,6 @@ impl std::fmt::Debug for SecurityConfig {
         let mut debug_struct = f.debug_struct("SecurityConfig");
         debug_struct.field("kerberos_config", &self.kerberos_config);
         debug_struct.field("identity_config", &self.identity_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14538,7 +14491,6 @@ impl std::fmt::Debug for KerberosConfig {
         debug_struct.field("kdc_db_key_uri", &self.kdc_db_key_uri);
         debug_struct.field("tgt_lifetime_hours", &self.tgt_lifetime_hours);
         debug_struct.field("realm", &self.realm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14705,7 +14657,6 @@ impl std::fmt::Debug for IdentityConfig {
             "user_service_account_mapping",
             &self.user_service_account_mapping,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14936,7 +14887,6 @@ impl std::fmt::Debug for SoftwareConfig {
         debug_struct.field("image_version", &self.image_version);
         debug_struct.field("properties", &self.properties);
         debug_struct.field("optional_components", &self.optional_components);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15250,7 +15200,6 @@ impl std::fmt::Debug for LifecycleConfig {
         debug_struct.field("idle_delete_ttl", &self.idle_delete_ttl);
         debug_struct.field("idle_start_time", &self.idle_start_time);
         debug_struct.field("ttl", &self.ttl);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15429,7 +15378,6 @@ impl std::fmt::Debug for MetastoreConfig {
             "dataproc_metastore_service",
             &self.dataproc_metastore_service,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15673,7 +15621,6 @@ impl std::fmt::Debug for ClusterMetrics {
         let mut debug_struct = f.debug_struct("ClusterMetrics");
         debug_struct.field("hdfs_metrics", &self.hdfs_metrics);
         debug_struct.field("yarn_metrics", &self.yarn_metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15822,7 +15769,6 @@ impl std::fmt::Debug for DataprocMetricConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataprocMetricConfig");
         debug_struct.field("metrics", &self.metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16040,7 +15986,6 @@ pub mod dataproc_metric_config {
             let mut debug_struct = f.debug_struct("Metric");
             debug_struct.field("metric_source", &self.metric_source);
             debug_struct.field("metric_overrides", &self.metric_overrides);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16507,7 +16452,6 @@ impl std::fmt::Debug for CreateClusterRequest {
             "action_on_failed_primary_workers",
             &self.action_on_failed_primary_workers,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16903,7 +16847,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         );
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17164,7 +17107,6 @@ impl std::fmt::Debug for StopClusterRequest {
         debug_struct.field("cluster_name", &self.cluster_name);
         debug_struct.field("cluster_uuid", &self.cluster_uuid);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17425,7 +17367,6 @@ impl std::fmt::Debug for StartClusterRequest {
         debug_struct.field("cluster_name", &self.cluster_name);
         debug_struct.field("cluster_uuid", &self.cluster_uuid);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17686,7 +17627,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         debug_struct.field("cluster_name", &self.cluster_name);
         debug_struct.field("cluster_uuid", &self.cluster_uuid);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17881,7 +17821,6 @@ impl std::fmt::Debug for GetClusterRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("region", &self.region);
         debug_struct.field("cluster_name", &self.cluster_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18163,7 +18102,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18350,7 +18288,6 @@ impl std::fmt::Debug for ListClustersResponse {
         let mut debug_struct = f.debug_struct("ListClustersResponse");
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18704,7 +18641,6 @@ impl std::fmt::Debug for DiagnoseClusterRequest {
         debug_struct.field("diagnosis_interval", &self.diagnosis_interval);
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("yarn_application_ids", &self.yarn_application_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18991,7 +18927,6 @@ impl std::fmt::Debug for DiagnoseClusterResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiagnoseClusterResults");
         debug_struct.field("output_uri", &self.output_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19192,7 +19127,6 @@ impl std::fmt::Debug for ReservationAffinity {
         debug_struct.field("consume_reservation_type", &self.consume_reservation_type);
         debug_struct.field("key", &self.key);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19498,7 +19432,6 @@ impl std::fmt::Debug for LoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingConfig");
         debug_struct.field("driver_log_levels", &self.driver_log_levels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20116,7 +20049,6 @@ impl std::fmt::Debug for HadoopJob {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("driver", &self.driver);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20576,7 +20508,6 @@ impl std::fmt::Debug for SparkJob {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("driver", &self.driver);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20979,7 +20910,6 @@ impl std::fmt::Debug for PySparkJob {
         debug_struct.field("archive_uris", &self.archive_uris);
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21139,7 +21069,6 @@ impl std::fmt::Debug for QueryList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryList");
         debug_struct.field("queries", &self.queries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21509,7 +21438,6 @@ impl std::fmt::Debug for HiveJob {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("jar_file_uris", &self.jar_file_uris);
         debug_struct.field("queries", &self.queries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21902,7 +21830,6 @@ impl std::fmt::Debug for SparkSqlJob {
         debug_struct.field("jar_file_uris", &self.jar_file_uris);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("queries", &self.queries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22325,7 +22252,6 @@ impl std::fmt::Debug for PigJob {
         debug_struct.field("jar_file_uris", &self.jar_file_uris);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("queries", &self.queries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22655,7 +22581,6 @@ impl std::fmt::Debug for SparkRJob {
         debug_struct.field("archive_uris", &self.archive_uris);
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23051,7 +22976,6 @@ impl std::fmt::Debug for PrestoJob {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("queries", &self.queries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23464,7 +23388,6 @@ impl std::fmt::Debug for TrinoJob {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("queries", &self.queries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23882,7 +23805,6 @@ impl std::fmt::Debug for FlinkJob {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("driver", &self.driver);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24118,7 +24040,6 @@ impl std::fmt::Debug for JobPlacement {
         debug_struct.field("cluster_name", &self.cluster_name);
         debug_struct.field("cluster_uuid", &self.cluster_uuid);
         debug_struct.field("cluster_labels", &self.cluster_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24354,7 +24275,6 @@ impl std::fmt::Debug for JobStatus {
         debug_struct.field("details", &self.details);
         debug_struct.field("state_start_time", &self.state_start_time);
         debug_struct.field("substate", &self.substate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24870,7 +24790,6 @@ impl std::fmt::Debug for JobReference {
         let mut debug_struct = f.debug_struct("JobReference");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("job_id", &self.job_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25114,7 +25033,6 @@ impl std::fmt::Debug for YarnApplication {
         debug_struct.field("state", &self.state);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("tracking_url", &self.tracking_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26347,7 +26265,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("done", &self.done);
         debug_struct.field("driver_scheduling_config", &self.driver_scheduling_config);
         debug_struct.field("type_job", &self.type_job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26583,7 +26500,6 @@ impl std::fmt::Debug for DriverSchedulingConfig {
         let mut debug_struct = f.debug_struct("DriverSchedulingConfig");
         debug_struct.field("memory_mb", &self.memory_mb);
         debug_struct.field("vcores", &self.vcores);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26810,7 +26726,6 @@ impl std::fmt::Debug for JobScheduling {
         let mut debug_struct = f.debug_struct("JobScheduling");
         debug_struct.field("max_failures_per_hour", &self.max_failures_per_hour);
         debug_struct.field("max_failures_total", &self.max_failures_total);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27054,7 +26969,6 @@ impl std::fmt::Debug for SubmitJobRequest {
         debug_struct.field("region", &self.region);
         debug_struct.field("job", &self.job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27296,7 +27210,6 @@ impl std::fmt::Debug for JobMetadata {
         debug_struct.field("status", &self.status);
         debug_struct.field("operation_type", &self.operation_type);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27491,7 +27404,6 @@ impl std::fmt::Debug for GetJobRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("region", &self.region);
         debug_struct.field("job_id", &self.job_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27832,7 +27744,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("cluster_name", &self.cluster_name);
         debug_struct.field("job_state_matcher", &self.job_state_matcher);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28244,7 +28155,6 @@ impl std::fmt::Debug for UpdateJobRequest {
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("job", &self.job);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28464,7 +28374,6 @@ impl std::fmt::Debug for ListJobsResponse {
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28659,7 +28568,6 @@ impl std::fmt::Debug for CancelJobRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("region", &self.region);
         debug_struct.field("job_id", &self.job_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28854,7 +28762,6 @@ impl std::fmt::Debug for DeleteJobRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("region", &self.region);
         debug_struct.field("job_id", &self.job_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29103,7 +29010,6 @@ impl std::fmt::Debug for CreateNodeGroupRequest {
         debug_struct.field("node_group", &self.node_group);
         debug_struct.field("node_group_id", &self.node_group_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29392,7 +29298,6 @@ impl std::fmt::Debug for ResizeNodeGroupRequest {
             "graceful_decommission_timeout",
             &self.graceful_decommission_timeout,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29536,7 +29441,6 @@ impl std::fmt::Debug for GetNodeGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNodeGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29900,7 +29804,6 @@ impl std::fmt::Debug for BatchOperationMetadata {
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("warnings", &self.warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30395,7 +30298,6 @@ impl std::fmt::Debug for SessionOperationMetadata {
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("warnings", &self.warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30777,7 +30679,6 @@ impl std::fmt::Debug for ClusterOperationStatus {
         debug_struct.field("inner_state", &self.inner_state);
         debug_struct.field("details", &self.details);
         debug_struct.field("state_start_time", &self.state_start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31304,7 +31205,6 @@ impl std::fmt::Debug for ClusterOperationMetadata {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("warnings", &self.warnings);
         debug_struct.field("child_operation_ids", &self.child_operation_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31660,7 +31560,6 @@ impl std::fmt::Debug for NodeGroupOperationMetadata {
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("warnings", &self.warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31994,7 +31893,6 @@ impl std::fmt::Debug for CreateSessionTemplateRequest {
         let mut debug_struct = f.debug_struct("CreateSessionTemplateRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("session_template", &self.session_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32149,7 +32047,6 @@ impl std::fmt::Debug for UpdateSessionTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateSessionTemplateRequest");
         debug_struct.field("session_template", &self.session_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32291,7 +32188,6 @@ impl std::fmt::Debug for GetSessionTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSessionTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32533,7 +32429,6 @@ impl std::fmt::Debug for ListSessionTemplatesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32724,7 +32619,6 @@ impl std::fmt::Debug for ListSessionTemplatesResponse {
         let mut debug_struct = f.debug_struct("ListSessionTemplatesResponse");
         debug_struct.field("session_templates", &self.session_templates);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32866,7 +32760,6 @@ impl std::fmt::Debug for DeleteSessionTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSessionTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33409,7 +33302,6 @@ impl std::fmt::Debug for SessionTemplate {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("uuid", &self.uuid);
         debug_struct.field("session_config", &self.session_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33672,7 +33564,6 @@ impl std::fmt::Debug for CreateSessionRequest {
         debug_struct.field("session", &self.session);
         debug_struct.field("session_id", &self.session_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33814,7 +33705,6 @@ impl std::fmt::Debug for GetSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34067,7 +33957,6 @@ impl std::fmt::Debug for ListSessionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34253,7 +34142,6 @@ impl std::fmt::Debug for ListSessionsResponse {
         let mut debug_struct = f.debug_struct("ListSessionsResponse");
         debug_struct.field("sessions", &self.sessions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34430,7 +34318,6 @@ impl std::fmt::Debug for TerminateSessionRequest {
         let mut debug_struct = f.debug_struct("TerminateSessionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34607,7 +34494,6 @@ impl std::fmt::Debug for DeleteSessionRequest {
         let mut debug_struct = f.debug_struct("DeleteSessionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35309,7 +35195,6 @@ impl std::fmt::Debug for Session {
         debug_struct.field("state_history", &self.state_history);
         debug_struct.field("session_template", &self.session_template);
         debug_struct.field("session_config", &self.session_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35528,7 +35413,6 @@ pub mod session {
             debug_struct.field("state", &self.state);
             debug_struct.field("state_message", &self.state_message);
             debug_struct.field("state_start_time", &self.state_start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35861,7 +35745,6 @@ impl std::fmt::Debug for JupyterConfig {
         let mut debug_struct = f.debug_struct("JupyterConfig");
         debug_struct.field("kernel", &self.kernel);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36113,7 +35996,6 @@ impl serde::ser::Serialize for SparkConnectConfig {
 impl std::fmt::Debug for SparkConnectConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SparkConnectConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36421,7 +36303,6 @@ impl std::fmt::Debug for RuntimeConfig {
         debug_struct.field("repository_config", &self.repository_config);
         debug_struct.field("autotuning_config", &self.autotuning_config);
         debug_struct.field("cohort", &self.cohort);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36614,7 +36495,6 @@ impl std::fmt::Debug for EnvironmentConfig {
         let mut debug_struct = f.debug_struct("EnvironmentConfig");
         debug_struct.field("execution_config", &self.execution_config);
         debug_struct.field("peripherals_config", &self.peripherals_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37093,7 +36973,6 @@ impl std::fmt::Debug for ExecutionConfig {
         debug_struct.field("staging_bucket", &self.staging_bucket);
         debug_struct.field("authentication_config", &self.authentication_config);
         debug_struct.field("network", &self.network);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37260,7 +37139,6 @@ impl std::fmt::Debug for SparkHistoryServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SparkHistoryServerConfig");
         debug_struct.field("dataproc_cluster", &self.dataproc_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37457,7 +37335,6 @@ impl std::fmt::Debug for PeripheralsConfig {
             "spark_history_server_config",
             &self.spark_history_server_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37751,7 +37628,6 @@ impl std::fmt::Debug for RuntimeInfo {
         debug_struct.field("diagnostic_output_uri", &self.diagnostic_output_uri);
         debug_struct.field("approximate_usage", &self.approximate_usage);
         debug_struct.field("current_usage", &self.current_usage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38055,7 +37931,6 @@ impl std::fmt::Debug for UsageMetrics {
         );
         debug_struct.field("milli_accelerator_seconds", &self.milli_accelerator_seconds);
         debug_struct.field("accelerator_type", &self.accelerator_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38481,7 +38356,6 @@ impl std::fmt::Debug for UsageSnapshot {
         debug_struct.field("milli_accelerator", &self.milli_accelerator);
         debug_struct.field("accelerator_type", &self.accelerator_type);
         debug_struct.field("snapshot_time", &self.snapshot_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38670,7 +38544,6 @@ impl std::fmt::Debug for GkeClusterConfig {
         let mut debug_struct = f.debug_struct("GkeClusterConfig");
         debug_struct.field("gke_cluster_target", &self.gke_cluster_target);
         debug_struct.field("node_pool_target", &self.node_pool_target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38939,7 +38812,6 @@ impl std::fmt::Debug for KubernetesClusterConfig {
             &self.kubernetes_software_config,
         );
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39154,7 +39026,6 @@ impl std::fmt::Debug for KubernetesSoftwareConfig {
         let mut debug_struct = f.debug_struct("KubernetesSoftwareConfig");
         debug_struct.field("component_version", &self.component_version);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39380,7 +39251,6 @@ impl std::fmt::Debug for GkeNodePoolTarget {
         debug_struct.field("node_pool", &self.node_pool);
         debug_struct.field("roles", &self.roles);
         debug_struct.field("node_pool_config", &self.node_pool_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39775,7 +39645,6 @@ impl std::fmt::Debug for GkeNodePoolConfig {
         debug_struct.field("config", &self.config);
         debug_struct.field("locations", &self.locations);
         debug_struct.field("autoscaling", &self.autoscaling);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40146,7 +40015,6 @@ pub mod gke_node_pool_config {
             debug_struct.field("min_cpu_platform", &self.min_cpu_platform);
             debug_struct.field("boot_disk_kms_key", &self.boot_disk_kms_key);
             debug_struct.field("spot", &self.spot);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40372,7 +40240,6 @@ pub mod gke_node_pool_config {
             debug_struct.field("accelerator_count", &self.accelerator_count);
             debug_struct.field("accelerator_type", &self.accelerator_type);
             debug_struct.field("gpu_partition_size", &self.gpu_partition_size);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40586,7 +40453,6 @@ pub mod gke_node_pool_config {
             let mut debug_struct = f.debug_struct("GkeNodePoolAutoscalingConfig");
             debug_struct.field("min_node_count", &self.min_node_count);
             debug_struct.field("max_node_count", &self.max_node_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40750,7 +40616,6 @@ impl std::fmt::Debug for AuthenticationConfig {
             "user_workload_authentication_type",
             &self.user_workload_authentication_type,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41040,7 +40905,6 @@ impl std::fmt::Debug for AutotuningConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutotuningConfig");
         debug_struct.field("scenarios", &self.scenarios);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41354,7 +41218,6 @@ impl std::fmt::Debug for RepositoryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RepositoryConfig");
         debug_struct.field("pypi_repository_config", &self.pypi_repository_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41497,7 +41360,6 @@ impl std::fmt::Debug for PyPiRepositoryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PyPiRepositoryConfig");
         debug_struct.field("pypi_repository", &self.pypi_repository);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42028,7 +41890,6 @@ impl std::fmt::Debug for WorkflowTemplate {
         debug_struct.field("parameters", &self.parameters);
         debug_struct.field("dag_timeout", &self.dag_timeout);
         debug_struct.field("encryption_config", &self.encryption_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42206,7 +42067,6 @@ pub mod workflow_template {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EncryptionConfig");
             debug_struct.field("kms_key", &self.kms_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42457,7 +42317,6 @@ impl std::fmt::Debug for WorkflowTemplatePlacement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WorkflowTemplatePlacement");
         debug_struct.field("placement", &self.placement);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42706,7 +42565,6 @@ impl std::fmt::Debug for ManagedCluster {
         debug_struct.field("cluster_name", &self.cluster_name);
         debug_struct.field("config", &self.config);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42890,7 +42748,6 @@ impl std::fmt::Debug for ClusterSelector {
         let mut debug_struct = f.debug_struct("ClusterSelector");
         debug_struct.field("zone", &self.zone);
         debug_struct.field("cluster_labels", &self.cluster_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43688,7 +43545,6 @@ impl std::fmt::Debug for OrderedJob {
         debug_struct.field("scheduling", &self.scheduling);
         debug_struct.field("prerequisite_step_ids", &self.prerequisite_step_ids);
         debug_struct.field("job_type", &self.job_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44013,7 +43869,6 @@ impl std::fmt::Debug for TemplateParameter {
         debug_struct.field("fields", &self.fields);
         debug_struct.field("description", &self.description);
         debug_struct.field("validation", &self.validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44254,7 +44109,6 @@ impl std::fmt::Debug for ParameterValidation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ParameterValidation");
         debug_struct.field("validation_type", &self.validation_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44417,7 +44271,6 @@ impl std::fmt::Debug for RegexValidation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RegexValidation");
         debug_struct.field("regexes", &self.regexes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44562,7 +44415,6 @@ impl std::fmt::Debug for ValueValidation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ValueValidation");
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45179,7 +45031,6 @@ impl std::fmt::Debug for WorkflowMetadata {
         debug_struct.field("dag_timeout", &self.dag_timeout);
         debug_struct.field("dag_start_time", &self.dag_start_time);
         debug_struct.field("dag_end_time", &self.dag_end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45517,7 +45368,6 @@ impl std::fmt::Debug for ClusterOperation {
         debug_struct.field("operation_id", &self.operation_id);
         debug_struct.field("error", &self.error);
         debug_struct.field("done", &self.done);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45662,7 +45512,6 @@ impl std::fmt::Debug for WorkflowGraph {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WorkflowGraph");
         debug_struct.field("nodes", &self.nodes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45911,7 +45760,6 @@ impl std::fmt::Debug for WorkflowNode {
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("state", &self.state);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46260,7 +46108,6 @@ impl std::fmt::Debug for CreateWorkflowTemplateRequest {
         let mut debug_struct = f.debug_struct("CreateWorkflowTemplateRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("template", &self.template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46458,7 +46305,6 @@ impl std::fmt::Debug for GetWorkflowTemplateRequest {
         let mut debug_struct = f.debug_struct("GetWorkflowTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46729,7 +46575,6 @@ impl std::fmt::Debug for InstantiateWorkflowTemplateRequest {
         debug_struct.field("version", &self.version);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46953,7 +46798,6 @@ impl std::fmt::Debug for InstantiateInlineWorkflowTemplateRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("template", &self.template);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47109,7 +46953,6 @@ impl std::fmt::Debug for UpdateWorkflowTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateWorkflowTemplateRequest");
         debug_struct.field("template", &self.template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47332,7 +47175,6 @@ impl std::fmt::Debug for ListWorkflowTemplatesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47553,7 +47395,6 @@ impl std::fmt::Debug for ListWorkflowTemplatesResponse {
         debug_struct.field("templates", &self.templates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47752,7 +47593,6 @@ impl std::fmt::Debug for DeleteWorkflowTemplateRequest {
         let mut debug_struct = f.debug_struct("DeleteWorkflowTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -668,7 +668,6 @@ impl std::fmt::Debug for DiscoverConnectionProfileRequest {
         debug_struct.field("target", &self.target);
         debug_struct.field("hierarchy", &self.hierarchy);
         debug_struct.field("data_object", &self.data_object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1063,7 +1062,6 @@ impl std::fmt::Debug for DiscoverConnectionProfileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoverConnectionProfileResponse");
         debug_struct.field("data_object", &self.data_object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1297,7 +1295,6 @@ impl std::fmt::Debug for FetchStaticIpsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1470,7 +1467,6 @@ impl std::fmt::Debug for FetchStaticIpsResponse {
         let mut debug_struct = f.debug_struct("FetchStaticIpsResponse");
         debug_struct.field("static_ips", &self.static_ips);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1739,7 +1735,6 @@ impl std::fmt::Debug for ListConnectionProfilesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1958,7 +1953,6 @@ impl std::fmt::Debug for ListConnectionProfilesResponse {
         debug_struct.field("connection_profiles", &self.connection_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2100,7 +2094,6 @@ impl std::fmt::Debug for GetConnectionProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2399,7 +2392,6 @@ impl std::fmt::Debug for CreateConnectionProfileRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2685,7 +2677,6 @@ impl std::fmt::Debug for UpdateConnectionProfileRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2865,7 +2856,6 @@ impl std::fmt::Debug for DeleteConnectionProfileRequest {
         let mut debug_struct = f.debug_struct("DeleteConnectionProfileRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3134,7 +3124,6 @@ impl std::fmt::Debug for ListStreamsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3348,7 +3337,6 @@ impl std::fmt::Debug for ListStreamsResponse {
         debug_struct.field("streams", &self.streams);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3490,7 +3478,6 @@ impl std::fmt::Debug for GetStreamRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStreamRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3784,7 +3771,6 @@ impl std::fmt::Debug for CreateStreamRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4068,7 +4054,6 @@ impl std::fmt::Debug for UpdateStreamRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4248,7 +4233,6 @@ impl std::fmt::Debug for DeleteStreamRequest {
         let mut debug_struct = f.debug_struct("DeleteStreamRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4454,7 +4438,6 @@ impl std::fmt::Debug for RunStreamRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("cdc_strategy", &self.cdc_strategy);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4596,7 +4579,6 @@ impl std::fmt::Debug for GetStreamObjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStreamObjectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4778,7 +4760,6 @@ impl std::fmt::Debug for LookupStreamObjectRequest {
         let mut debug_struct = f.debug_struct("LookupStreamObjectRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source_object_identifier", &self.source_object_identifier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4921,7 +4902,6 @@ impl std::fmt::Debug for StartBackfillJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartBackfillJobRequest");
         debug_struct.field("object", &self.object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5074,7 +5054,6 @@ impl std::fmt::Debug for StartBackfillJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartBackfillJobResponse");
         debug_struct.field("object", &self.object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5218,7 +5197,6 @@ impl std::fmt::Debug for StopBackfillJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopBackfillJobRequest");
         debug_struct.field("object", &self.object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5371,7 +5349,6 @@ impl std::fmt::Debug for StopBackfillJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopBackfillJobResponse");
         debug_struct.field("object", &self.object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5589,7 +5566,6 @@ impl std::fmt::Debug for ListStreamObjectsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5775,7 +5751,6 @@ impl std::fmt::Debug for ListStreamObjectsResponse {
         let mut debug_struct = f.debug_struct("ListStreamObjectsResponse");
         debug_struct.field("stream_objects", &self.stream_objects);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6140,7 +6115,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("validation_result", &self.validation_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6412,7 +6386,6 @@ impl std::fmt::Debug for CreatePrivateConnectionRequest {
         debug_struct.field("private_connection", &self.private_connection);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6684,7 +6657,6 @@ impl std::fmt::Debug for ListPrivateConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6903,7 +6875,6 @@ impl std::fmt::Debug for ListPrivateConnectionsResponse {
         debug_struct.field("private_connections", &self.private_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7109,7 +7080,6 @@ impl std::fmt::Debug for DeletePrivateConnectionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7251,7 +7221,6 @@ impl std::fmt::Debug for GetPrivateConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPrivateConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7493,7 +7462,6 @@ impl std::fmt::Debug for CreateRouteRequest {
         debug_struct.field("route_id", &self.route_id);
         debug_struct.field("route", &self.route);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7764,7 +7732,6 @@ impl std::fmt::Debug for ListRoutesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7978,7 +7945,6 @@ impl std::fmt::Debug for ListRoutesResponse {
         debug_struct.field("routes", &self.routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8158,7 +8124,6 @@ impl std::fmt::Debug for DeleteRouteRequest {
         let mut debug_struct = f.debug_struct("DeleteRouteRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8300,7 +8265,6 @@ impl std::fmt::Debug for GetRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8718,7 +8682,6 @@ impl std::fmt::Debug for OracleProfile {
             "secret_manager_stored_password",
             &self.secret_manager_stored_password,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9095,7 +9058,6 @@ impl std::fmt::Debug for OracleAsmConfig {
             "secret_manager_stored_password",
             &self.secret_manager_stored_password,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9409,7 +9371,6 @@ impl std::fmt::Debug for MysqlProfile {
             "secret_manager_stored_password",
             &self.secret_manager_stored_password,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9751,7 +9712,6 @@ impl std::fmt::Debug for PostgresqlProfile {
             &self.secret_manager_stored_password,
         );
         debug_struct.field("ssl_config", &self.ssl_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10053,7 +10013,6 @@ impl std::fmt::Debug for SqlServerProfile {
             "secret_manager_stored_password",
             &self.secret_manager_stored_password,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10337,7 +10296,6 @@ impl std::fmt::Debug for SalesforceProfile {
         let mut debug_struct = f.debug_struct("SalesforceProfile");
         debug_struct.field("domain", &self.domain);
         debug_struct.field("credentials", &self.credentials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10629,7 +10587,6 @@ pub mod salesforce_profile {
                 "secret_manager_stored_security_token",
                 &self.secret_manager_stored_security_token,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10849,7 +10806,6 @@ pub mod salesforce_profile {
                 "secret_manager_stored_client_secret",
                 &self.secret_manager_stored_client_secret,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11030,7 +10986,6 @@ impl std::fmt::Debug for GcsProfile {
         let mut debug_struct = f.debug_struct("GcsProfile");
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("root_path", &self.root_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11144,7 +11099,6 @@ impl serde::ser::Serialize for BigQueryProfile {
 impl std::fmt::Debug for BigQueryProfile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryProfile");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11260,7 +11214,6 @@ impl serde::ser::Serialize for StaticServiceIpConnectivity {
 impl std::fmt::Debug for StaticServiceIpConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StaticServiceIpConnectivity");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11589,7 +11542,6 @@ impl std::fmt::Debug for ForwardSshTunnelConnectivity {
         debug_struct.field("username", &self.username);
         debug_struct.field("port", &self.port);
         debug_struct.field("authentication_method", &self.authentication_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11773,7 +11725,6 @@ impl std::fmt::Debug for VpcPeeringConfig {
         let mut debug_struct = f.debug_struct("VpcPeeringConfig");
         debug_struct.field("vpc", &self.vpc);
         debug_struct.field("subnet", &self.subnet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12225,7 +12176,6 @@ impl std::fmt::Debug for PrivateConnection {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("vpc_peering_config", &self.vpc_peering_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12531,7 +12481,6 @@ impl std::fmt::Debug for PrivateConnectivity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrivateConnectivity");
         debug_struct.field("private_connection", &self.private_connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12884,7 +12833,6 @@ impl std::fmt::Debug for Route {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("destination_address", &self.destination_address);
         debug_struct.field("destination_port", &self.destination_port);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13166,7 +13114,6 @@ impl std::fmt::Debug for MysqlSslConfig {
         debug_struct.field("client_certificate_set", &self.client_certificate_set);
         debug_struct.field("ca_certificate", &self.ca_certificate);
         debug_struct.field("ca_certificate_set", &self.ca_certificate_set);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13337,7 +13284,6 @@ impl std::fmt::Debug for OracleSslConfig {
         let mut debug_struct = f.debug_struct("OracleSslConfig");
         debug_struct.field("ca_certificate", &self.ca_certificate);
         debug_struct.field("ca_certificate_set", &self.ca_certificate_set);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13602,7 +13548,6 @@ impl std::fmt::Debug for PostgresqlSslConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PostgresqlSslConfig");
         debug_struct.field("encryption_setting", &self.encryption_setting);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13758,7 +13703,6 @@ pub mod postgresql_ssl_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ServerVerification");
             debug_struct.field("ca_certificate", &self.ca_certificate);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13973,7 +13917,6 @@ pub mod postgresql_ssl_config {
             debug_struct.field("client_certificate", &self.client_certificate);
             debug_struct.field("client_key", &self.client_key);
             debug_struct.field("ca_certificate", &self.ca_certificate);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14955,7 +14898,6 @@ impl std::fmt::Debug for ConnectionProfile {
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("profile", &self.profile);
         debug_struct.field("connectivity", &self.connectivity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15411,7 +15353,6 @@ impl std::fmt::Debug for OracleColumn {
         debug_struct.field("primary_key", &self.primary_key);
         debug_struct.field("nullable", &self.nullable);
         debug_struct.field("ordinal_position", &self.ordinal_position);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15584,7 +15525,6 @@ impl std::fmt::Debug for OracleTable {
         let mut debug_struct = f.debug_struct("OracleTable");
         debug_struct.field("table", &self.table);
         debug_struct.field("oracle_columns", &self.oracle_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15755,7 +15695,6 @@ impl std::fmt::Debug for OracleSchema {
         let mut debug_struct = f.debug_struct("OracleSchema");
         debug_struct.field("schema", &self.schema);
         debug_struct.field("oracle_tables", &self.oracle_tables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15901,7 +15840,6 @@ impl std::fmt::Debug for OracleRdbms {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OracleRdbms");
         debug_struct.field("oracle_schemas", &self.oracle_schemas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16471,7 +16409,6 @@ impl std::fmt::Debug for OracleSourceConfig {
         );
         debug_struct.field("large_objects_handling", &self.large_objects_handling);
         debug_struct.field("cdc_method", &self.cdc_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16593,7 +16530,6 @@ pub mod oracle_source_config {
     impl std::fmt::Debug for DropLargeObjects {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DropLargeObjects");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16710,7 +16646,6 @@ pub mod oracle_source_config {
     impl std::fmt::Debug for StreamLargeObjects {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StreamLargeObjects");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16827,7 +16762,6 @@ pub mod oracle_source_config {
     impl std::fmt::Debug for LogMiner {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LogMiner");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17092,7 +17026,6 @@ pub mod oracle_source_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BinaryLogParser");
             debug_struct.field("log_file_access", &self.log_file_access);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17217,7 +17150,6 @@ pub mod oracle_source_config {
         impl std::fmt::Debug for OracleAsmLogFileAccess {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("OracleAsmLogFileAccess");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17408,7 +17340,6 @@ pub mod oracle_source_config {
                 let mut debug_struct = f.debug_struct("LogFileDirectories");
                 debug_struct.field("online_log_directory", &self.online_log_directory);
                 debug_struct.field("archived_log_directory", &self.archived_log_directory);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17841,7 +17772,6 @@ impl std::fmt::Debug for PostgresqlColumn {
         debug_struct.field("primary_key", &self.primary_key);
         debug_struct.field("nullable", &self.nullable);
         debug_struct.field("ordinal_position", &self.ordinal_position);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18018,7 +17948,6 @@ impl std::fmt::Debug for PostgresqlTable {
         let mut debug_struct = f.debug_struct("PostgresqlTable");
         debug_struct.field("table", &self.table);
         debug_struct.field("postgresql_columns", &self.postgresql_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18193,7 +18122,6 @@ impl std::fmt::Debug for PostgresqlSchema {
         let mut debug_struct = f.debug_struct("PostgresqlSchema");
         debug_struct.field("schema", &self.schema);
         debug_struct.field("postgresql_tables", &self.postgresql_tables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18343,7 +18271,6 @@ impl std::fmt::Debug for PostgresqlRdbms {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PostgresqlRdbms");
         debug_struct.field("postgresql_schemas", &self.postgresql_schemas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18649,7 +18576,6 @@ impl std::fmt::Debug for PostgresqlSourceConfig {
             "max_concurrent_backfill_tasks",
             &self.max_concurrent_backfill_tasks,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19042,7 +18968,6 @@ impl std::fmt::Debug for SqlServerColumn {
         debug_struct.field("primary_key", &self.primary_key);
         debug_struct.field("nullable", &self.nullable);
         debug_struct.field("ordinal_position", &self.ordinal_position);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19218,7 +19143,6 @@ impl std::fmt::Debug for SqlServerTable {
         let mut debug_struct = f.debug_struct("SqlServerTable");
         debug_struct.field("table", &self.table);
         debug_struct.field("columns", &self.columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19392,7 +19316,6 @@ impl std::fmt::Debug for SqlServerSchema {
         let mut debug_struct = f.debug_struct("SqlServerSchema");
         debug_struct.field("schema", &self.schema);
         debug_struct.field("tables", &self.tables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19541,7 +19464,6 @@ impl std::fmt::Debug for SqlServerRdbms {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlServerRdbms");
         debug_struct.field("schemas", &self.schemas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19973,7 +19895,6 @@ impl std::fmt::Debug for SqlServerSourceConfig {
             &self.max_concurrent_backfill_tasks,
         );
         debug_struct.field("cdc_method", &self.cdc_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20103,7 +20024,6 @@ impl serde::ser::Serialize for SqlServerTransactionLogs {
 impl std::fmt::Debug for SqlServerTransactionLogs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlServerTransactionLogs");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20217,7 +20137,6 @@ impl serde::ser::Serialize for SqlServerChangeTables {
 impl std::fmt::Debug for SqlServerChangeTables {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlServerChangeTables");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20636,7 +20555,6 @@ impl std::fmt::Debug for MysqlColumn {
         debug_struct.field("ordinal_position", &self.ordinal_position);
         debug_struct.field("precision", &self.precision);
         debug_struct.field("scale", &self.scale);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20809,7 +20727,6 @@ impl std::fmt::Debug for MysqlTable {
         let mut debug_struct = f.debug_struct("MysqlTable");
         debug_struct.field("table", &self.table);
         debug_struct.field("mysql_columns", &self.mysql_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20980,7 +20897,6 @@ impl std::fmt::Debug for MysqlDatabase {
         let mut debug_struct = f.debug_struct("MysqlDatabase");
         debug_struct.field("database", &self.database);
         debug_struct.field("mysql_tables", &self.mysql_tables);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21126,7 +21042,6 @@ impl std::fmt::Debug for MysqlRdbms {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MysqlRdbms");
         debug_struct.field("mysql_databases", &self.mysql_databases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21558,7 +21473,6 @@ impl std::fmt::Debug for MysqlSourceConfig {
             &self.max_concurrent_backfill_tasks,
         );
         debug_struct.field("cdc_method", &self.cdc_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21680,7 +21594,6 @@ pub mod mysql_source_config {
     impl std::fmt::Debug for BinaryLogPosition {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BinaryLogPosition");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21797,7 +21710,6 @@ pub mod mysql_source_config {
     impl std::fmt::Debug for Gtid {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Gtid");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22038,7 +21950,6 @@ impl std::fmt::Debug for SalesforceSourceConfig {
         debug_struct.field("include_objects", &self.include_objects);
         debug_struct.field("exclude_objects", &self.exclude_objects);
         debug_struct.field("polling_interval", &self.polling_interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22187,7 +22098,6 @@ impl std::fmt::Debug for SalesforceOrg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SalesforceOrg");
         debug_struct.field("objects", &self.objects);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22365,7 +22275,6 @@ impl std::fmt::Debug for SalesforceObject {
         let mut debug_struct = f.debug_struct("SalesforceObject");
         debug_struct.field("object_name", &self.object_name);
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22558,7 +22467,6 @@ impl std::fmt::Debug for SalesforceField {
         debug_struct.field("name", &self.name);
         debug_struct.field("data_type", &self.data_type);
         debug_struct.field("nillable", &self.nillable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23014,7 +22922,6 @@ impl std::fmt::Debug for SourceConfig {
         let mut debug_struct = f.debug_struct("SourceConfig");
         debug_struct.field("source_connection_profile", &self.source_connection_profile);
         debug_struct.field("source_stream_config", &self.source_stream_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23150,7 +23057,6 @@ impl serde::ser::Serialize for AvroFileFormat {
 impl std::fmt::Debug for AvroFileFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AvroFileFormat");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23332,7 +23238,6 @@ impl std::fmt::Debug for JsonFileFormat {
         let mut debug_struct = f.debug_struct("JsonFileFormat");
         debug_struct.field("schema_file_format", &self.schema_file_format);
         debug_struct.field("compression", &self.compression);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23962,7 +23867,6 @@ impl std::fmt::Debug for GcsDestinationConfig {
         debug_struct.field("file_rotation_mb", &self.file_rotation_mb);
         debug_struct.field("file_rotation_interval", &self.file_rotation_interval);
         debug_struct.field("file_format", &self.file_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24462,7 +24366,6 @@ impl std::fmt::Debug for BigQueryDestinationConfig {
         debug_struct.field("blmt_config", &self.blmt_config);
         debug_struct.field("dataset_config", &self.dataset_config);
         debug_struct.field("write_mode", &self.write_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24615,7 +24518,6 @@ pub mod big_query_destination_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SingleTargetDataset");
             debug_struct.field("dataset_id", &self.dataset_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24773,7 +24675,6 @@ pub mod big_query_destination_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SourceHierarchyDatasets");
             debug_struct.field("dataset_template", &self.dataset_template);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25003,7 +24904,6 @@ pub mod big_query_destination_config {
                 debug_struct.field("location", &self.location);
                 debug_struct.field("dataset_id_prefix", &self.dataset_id_prefix);
                 debug_struct.field("kms_key_name", &self.kms_key_name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25265,7 +25165,6 @@ pub mod big_query_destination_config {
             debug_struct.field("connection_name", &self.connection_name);
             debug_struct.field("file_format", &self.file_format);
             debug_struct.field("table_format", &self.table_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25645,7 +25544,6 @@ pub mod big_query_destination_config {
     impl std::fmt::Debug for AppendOnly {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AppendOnly");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25763,7 +25661,6 @@ pub mod big_query_destination_config {
     impl std::fmt::Debug for Merge {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Merge");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26083,7 +25980,6 @@ impl std::fmt::Debug for DestinationConfig {
             &self.destination_connection_profile,
         );
         debug_struct.field("destination_stream_config", &self.destination_stream_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26798,7 +26694,6 @@ impl std::fmt::Debug for Stream {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("backfill_strategy", &self.backfill_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27240,7 +27135,6 @@ pub mod stream {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BackfillAllStrategy");
             debug_struct.field("excluded_objects", &self.excluded_objects);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27379,7 +27273,6 @@ pub mod stream {
     impl std::fmt::Debug for BackfillNoneStrategy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BackfillNoneStrategy");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27913,7 +27806,6 @@ impl std::fmt::Debug for StreamObject {
         debug_struct.field("errors", &self.errors);
         debug_struct.field("backfill_job", &self.backfill_job);
         debug_struct.field("source_object", &self.source_object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28350,7 +28242,6 @@ impl std::fmt::Debug for SourceObjectIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceObjectIdentifier");
         debug_struct.field("source_identifier", &self.source_identifier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28525,7 +28416,6 @@ pub mod source_object_identifier {
             let mut debug_struct = f.debug_struct("OracleObjectIdentifier");
             debug_struct.field("schema", &self.schema);
             debug_struct.field("table", &self.table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28695,7 +28585,6 @@ pub mod source_object_identifier {
             let mut debug_struct = f.debug_struct("PostgresqlObjectIdentifier");
             debug_struct.field("schema", &self.schema);
             debug_struct.field("table", &self.table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28865,7 +28754,6 @@ pub mod source_object_identifier {
             let mut debug_struct = f.debug_struct("MysqlObjectIdentifier");
             debug_struct.field("database", &self.database);
             debug_struct.field("table", &self.table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29035,7 +28923,6 @@ pub mod source_object_identifier {
             let mut debug_struct = f.debug_struct("SqlServerObjectIdentifier");
             debug_struct.field("schema", &self.schema);
             debug_struct.field("table", &self.table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29181,7 +29068,6 @@ pub mod source_object_identifier {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SalesforceObjectIdentifier");
             debug_struct.field("object_name", &self.object_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29479,7 +29365,6 @@ impl std::fmt::Debug for BackfillJob {
         debug_struct.field("last_start_time", &self.last_start_time);
         debug_struct.field("last_end_time", &self.last_end_time);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30055,7 +29940,6 @@ impl std::fmt::Debug for Error {
         debug_struct.field("message", &self.message);
         debug_struct.field("error_time", &self.error_time);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30201,7 +30085,6 @@ impl std::fmt::Debug for ValidationResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ValidationResult");
         debug_struct.field("validations", &self.validations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30429,7 +30312,6 @@ impl std::fmt::Debug for Validation {
         debug_struct.field("state", &self.state);
         debug_struct.field("message", &self.message);
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30810,7 +30692,6 @@ impl std::fmt::Debug for ValidationMessage {
         debug_struct.field("level", &self.level);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31271,7 +31152,6 @@ impl std::fmt::Debug for CdcStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CdcStrategy");
         debug_struct.field("start_position", &self.start_position);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31394,7 +31274,6 @@ pub mod cdc_strategy {
     impl std::fmt::Debug for MostRecentStartPosition {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MostRecentStartPosition");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31512,7 +31391,6 @@ pub mod cdc_strategy {
     impl std::fmt::Debug for NextAvailableStartPosition {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NextAvailableStartPosition");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31878,7 +31756,6 @@ pub mod cdc_strategy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SpecificStartPosition");
             debug_struct.field("position", &self.position);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32059,7 +31936,6 @@ impl std::fmt::Debug for SqlServerLsnPosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlServerLsnPosition");
         debug_struct.field("lsn", &self.lsn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32219,7 +32095,6 @@ impl std::fmt::Debug for OracleScnPosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OracleScnPosition");
         debug_struct.field("scn", &self.scn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32420,7 +32295,6 @@ impl std::fmt::Debug for MysqlLogPosition {
         let mut debug_struct = f.debug_struct("MysqlLogPosition");
         debug_struct.field("log_file", &self.log_file);
         debug_struct.field("log_position", &self.log_position);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32563,7 +32437,6 @@ impl std::fmt::Debug for MysqlGtidPosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MysqlGtidPosition");
         debug_struct.field("gtid_set", &self.gtid_set);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -247,7 +247,6 @@ impl std::fmt::Debug for AutomationEvent {
         debug_struct.field("automation", &self.automation);
         debug_struct.field("pipeline_uid", &self.pipeline_uid);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -549,7 +548,6 @@ impl std::fmt::Debug for AutomationRunEvent {
         debug_struct.field("rule_id", &self.rule_id);
         debug_struct.field("destination_target_id", &self.destination_target_id);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1071,7 +1069,6 @@ impl std::fmt::Debug for DeliveryPipeline {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("suspended", &self.suspended);
         debug_struct.field("pipeline", &self.pipeline);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1232,7 +1229,6 @@ impl std::fmt::Debug for SerialPipeline {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SerialPipeline");
         debug_struct.field("stages", &self.stages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1478,7 +1474,6 @@ impl std::fmt::Debug for Stage {
         debug_struct.field("profiles", &self.profiles);
         debug_struct.field("strategy", &self.strategy);
         debug_struct.field("deploy_parameters", &self.deploy_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1670,7 +1665,6 @@ impl std::fmt::Debug for DeployParameters {
         let mut debug_struct = f.debug_struct("DeployParameters");
         debug_struct.field("values", &self.values);
         debug_struct.field("match_target_labels", &self.match_target_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1907,7 +1901,6 @@ impl std::fmt::Debug for Strategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Strategy");
         debug_struct.field("deployment_strategy", &self.deployment_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2071,7 +2064,6 @@ impl std::fmt::Debug for Predeploy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Predeploy");
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2217,7 +2209,6 @@ impl std::fmt::Debug for Postdeploy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Postdeploy");
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2433,7 +2424,6 @@ impl std::fmt::Debug for Standard {
         debug_struct.field("verify", &self.verify);
         debug_struct.field("predeploy", &self.predeploy);
         debug_struct.field("postdeploy", &self.postdeploy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2717,7 +2707,6 @@ impl std::fmt::Debug for Canary {
         let mut debug_struct = f.debug_struct("Canary");
         debug_struct.field("runtime_config", &self.runtime_config);
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3009,7 +2998,6 @@ impl std::fmt::Debug for CanaryDeployment {
         debug_struct.field("verify", &self.verify);
         debug_struct.field("predeploy", &self.predeploy);
         debug_struct.field("postdeploy", &self.postdeploy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3163,7 +3151,6 @@ impl std::fmt::Debug for CustomCanaryDeployment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomCanaryDeployment");
         debug_struct.field("phase_configs", &self.phase_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3494,7 +3481,6 @@ pub mod custom_canary_deployment {
             debug_struct.field("verify", &self.verify);
             debug_struct.field("predeploy", &self.predeploy);
             debug_struct.field("postdeploy", &self.postdeploy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3742,7 +3728,6 @@ impl std::fmt::Debug for KubernetesConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("KubernetesConfig");
         debug_struct.field("service_definition", &self.service_definition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4106,7 +4091,6 @@ pub mod kubernetes_config {
             debug_struct.field("stable_cutback_duration", &self.stable_cutback_duration);
             debug_struct.field("pod_selector_label", &self.pod_selector_label);
             debug_struct.field("route_destinations", &self.route_destinations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4300,7 +4284,6 @@ pub mod kubernetes_config {
                 let mut debug_struct = f.debug_struct("RouteDestinations");
                 debug_struct.field("destination_ids", &self.destination_ids);
                 debug_struct.field("propagate_service", &self.propagate_service);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4544,7 +4527,6 @@ pub mod kubernetes_config {
                 &self.disable_pod_overprovisioning,
             );
             debug_struct.field("pod_selector_label", &self.pod_selector_label);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4795,7 +4777,6 @@ impl std::fmt::Debug for CloudRunConfig {
         debug_struct.field("canary_revision_tags", &self.canary_revision_tags);
         debug_struct.field("prior_revision_tags", &self.prior_revision_tags);
         debug_struct.field("stable_revision_tags", &self.stable_revision_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5042,7 +5023,6 @@ impl std::fmt::Debug for RuntimeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RuntimeConfig");
         debug_struct.field("runtime_config", &self.runtime_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5241,7 +5221,6 @@ impl std::fmt::Debug for PipelineReadyCondition {
         let mut debug_struct = f.debug_struct("PipelineReadyCondition");
         debug_struct.field("status", &self.status);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5451,7 +5430,6 @@ impl std::fmt::Debug for TargetsPresentCondition {
         debug_struct.field("status", &self.status);
         debug_struct.field("missing_targets", &self.missing_targets);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5622,7 +5600,6 @@ impl std::fmt::Debug for TargetsTypeCondition {
         let mut debug_struct = f.debug_struct("TargetsTypeCondition");
         debug_struct.field("status", &self.status);
         debug_struct.field("error_details", &self.error_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5857,7 +5834,6 @@ impl std::fmt::Debug for PipelineCondition {
         debug_struct.field("pipeline_ready_condition", &self.pipeline_ready_condition);
         debug_struct.field("targets_present_condition", &self.targets_present_condition);
         debug_struct.field("targets_type_condition", &self.targets_type_condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6129,7 +6105,6 @@ impl std::fmt::Debug for ListDeliveryPipelinesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6348,7 +6323,6 @@ impl std::fmt::Debug for ListDeliveryPipelinesResponse {
         debug_struct.field("delivery_pipelines", &self.delivery_pipelines);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6491,7 +6465,6 @@ impl std::fmt::Debug for GetDeliveryPipelineRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeliveryPipelineRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6766,7 +6739,6 @@ impl std::fmt::Debug for CreateDeliveryPipelineRequest {
         debug_struct.field("delivery_pipeline", &self.delivery_pipeline);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7054,7 +7026,6 @@ impl std::fmt::Debug for UpdateDeliveryPipelineRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7343,7 +7314,6 @@ impl std::fmt::Debug for DeleteDeliveryPipelineRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7526,7 +7496,6 @@ impl std::fmt::Debug for RollbackTargetConfig {
         let mut debug_struct = f.debug_struct("RollbackTargetConfig");
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("starting_phase_id", &self.starting_phase_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7874,7 +7843,6 @@ impl std::fmt::Debug for RollbackTargetRequest {
         debug_struct.field("rollback_config", &self.rollback_config);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8028,7 +7996,6 @@ impl std::fmt::Debug for RollbackTargetResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RollbackTargetResponse");
         debug_struct.field("rollback_config", &self.rollback_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8867,7 +8834,6 @@ impl std::fmt::Debug for Target {
         debug_struct.field("execution_configs", &self.execution_configs);
         debug_struct.field("deploy_parameters", &self.deploy_parameters);
         debug_struct.field("deployment_target", &self.deployment_target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9324,7 +9290,6 @@ impl std::fmt::Debug for ExecutionConfig {
         debug_struct.field("execution_timeout", &self.execution_timeout);
         debug_struct.field("verbose", &self.verbose);
         debug_struct.field("execution_environment", &self.execution_environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9674,7 +9639,6 @@ impl std::fmt::Debug for DefaultPool {
         let mut debug_struct = f.debug_struct("DefaultPool");
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("artifact_storage", &self.artifact_storage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9878,7 +9842,6 @@ impl std::fmt::Debug for PrivatePool {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("artifact_storage", &self.artifact_storage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10110,7 +10073,6 @@ impl std::fmt::Debug for GkeCluster {
         debug_struct.field("internal_ip", &self.internal_ip);
         debug_struct.field("proxy_url", &self.proxy_url);
         debug_struct.field("dns_endpoint", &self.dns_endpoint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10254,7 +10216,6 @@ impl std::fmt::Debug for AnthosCluster {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnthosCluster");
         debug_struct.field("membership", &self.membership);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10397,7 +10358,6 @@ impl std::fmt::Debug for CloudRunLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudRunLocation");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10543,7 +10503,6 @@ impl std::fmt::Debug for MultiTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MultiTarget");
         debug_struct.field("target_ids", &self.target_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10690,7 +10649,6 @@ impl std::fmt::Debug for CustomTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomTarget");
         debug_struct.field("custom_target_type", &self.custom_target_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10865,7 +10823,6 @@ impl std::fmt::Debug for AssociatedEntities {
         let mut debug_struct = f.debug_struct("AssociatedEntities");
         debug_struct.field("gke_clusters", &self.gke_clusters);
         debug_struct.field("anthos_clusters", &self.anthos_clusters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11138,7 +11095,6 @@ impl std::fmt::Debug for ListTargetsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11352,7 +11308,6 @@ impl std::fmt::Debug for ListTargetsResponse {
         debug_struct.field("targets", &self.targets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11495,7 +11450,6 @@ impl std::fmt::Debug for GetTargetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTargetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11766,7 +11720,6 @@ impl std::fmt::Debug for CreateTargetRequest {
         debug_struct.field("target", &self.target);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12052,7 +12005,6 @@ impl std::fmt::Debug for UpdateTargetRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12314,7 +12266,6 @@ impl std::fmt::Debug for DeleteTargetRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12805,7 +12756,6 @@ impl std::fmt::Debug for CustomTargetType {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("definition", &self.definition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13028,7 +12978,6 @@ impl std::fmt::Debug for CustomTargetSkaffoldActions {
         debug_struct.field("render_action", &self.render_action);
         debug_struct.field("deploy_action", &self.deploy_action);
         debug_struct.field("include_skaffold_modules", &self.include_skaffold_modules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13370,7 +13319,6 @@ impl std::fmt::Debug for SkaffoldModules {
         let mut debug_struct = f.debug_struct("SkaffoldModules");
         debug_struct.field("configs", &self.configs);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13570,7 +13518,6 @@ pub mod skaffold_modules {
             debug_struct.field("repo", &self.repo);
             debug_struct.field("path", &self.path);
             debug_struct.field("r#ref", &self.r#ref);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13742,7 +13689,6 @@ pub mod skaffold_modules {
             let mut debug_struct = f.debug_struct("SkaffoldGCSSource");
             debug_struct.field("source", &self.source);
             debug_struct.field("path", &self.path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13940,7 +13886,6 @@ pub mod skaffold_modules {
             debug_struct.field("repository", &self.repository);
             debug_struct.field("path", &self.path);
             debug_struct.field("r#ref", &self.r#ref);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14229,7 +14174,6 @@ impl std::fmt::Debug for ListCustomTargetTypesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14448,7 +14392,6 @@ impl std::fmt::Debug for ListCustomTargetTypesResponse {
         debug_struct.field("custom_target_types", &self.custom_target_types);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14591,7 +14534,6 @@ impl std::fmt::Debug for GetCustomTargetTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCustomTargetTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14866,7 +14808,6 @@ impl std::fmt::Debug for CreateCustomTargetTypeRequest {
         debug_struct.field("custom_target_type", &self.custom_target_type);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15154,7 +15095,6 @@ impl std::fmt::Debug for UpdateCustomTargetTypeRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15416,7 +15356,6 @@ impl std::fmt::Debug for DeleteCustomTargetTypeRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15902,7 +15841,6 @@ impl std::fmt::Debug for DeployPolicy {
         debug_struct.field("selectors", &self.selectors);
         debug_struct.field("rules", &self.rules);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16237,7 +16175,6 @@ impl std::fmt::Debug for DeployPolicyResourceSelector {
         let mut debug_struct = f.debug_struct("DeployPolicyResourceSelector");
         debug_struct.field("delivery_pipeline", &self.delivery_pipeline);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16419,7 +16356,6 @@ impl std::fmt::Debug for DeliveryPipelineAttribute {
         let mut debug_struct = f.debug_struct("DeliveryPipelineAttribute");
         debug_struct.field("id", &self.id);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16602,7 +16538,6 @@ impl std::fmt::Debug for TargetAttribute {
         let mut debug_struct = f.debug_struct("TargetAttribute");
         debug_struct.field("id", &self.id);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16790,7 +16725,6 @@ impl std::fmt::Debug for PolicyRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PolicyRule");
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17051,7 +16985,6 @@ impl std::fmt::Debug for RolloutRestriction {
         debug_struct.field("invokers", &self.invokers);
         debug_struct.field("actions", &self.actions);
         debug_struct.field("time_windows", &self.time_windows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17435,7 +17368,6 @@ impl std::fmt::Debug for TimeWindows {
         debug_struct.field("time_zone", &self.time_zone);
         debug_struct.field("one_time_windows", &self.one_time_windows);
         debug_struct.field("weekly_windows", &self.weekly_windows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17701,7 +17633,6 @@ impl std::fmt::Debug for OneTimeWindow {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_date", &self.end_date);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17927,7 +17858,6 @@ impl std::fmt::Debug for WeeklyWindow {
         debug_struct.field("days_of_week", &self.days_of_week);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18081,7 +18011,6 @@ impl std::fmt::Debug for PolicyViolation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PolicyViolation");
         debug_struct.field("policy_violation_details", &self.policy_violation_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18278,7 +18207,6 @@ impl std::fmt::Debug for PolicyViolationDetails {
         debug_struct.field("policy", &self.policy);
         debug_struct.field("rule_id", &self.rule_id);
         debug_struct.field("failure_message", &self.failure_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19141,7 +19069,6 @@ impl std::fmt::Debug for Release {
         debug_struct.field("target_renders", &self.target_renders);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("deploy_parameters", &self.deploy_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19430,7 +19357,6 @@ pub mod release {
             debug_struct.field("metadata", &self.metadata);
             debug_struct.field("failure_cause", &self.failure_cause);
             debug_struct.field("failure_message", &self.failure_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19921,7 +19847,6 @@ pub mod release {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReleaseReadyCondition");
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20178,7 +20103,6 @@ pub mod release {
             debug_struct.field("skaffold_support_state", &self.skaffold_support_state);
             debug_struct.field("maintenance_mode_time", &self.maintenance_mode_time);
             debug_struct.field("support_expiration_time", &self.support_expiration_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20396,7 +20320,6 @@ pub mod release {
                 "skaffold_supported_condition",
                 &self.skaffold_supported_condition,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20810,7 +20733,6 @@ impl std::fmt::Debug for CreateDeployPolicyRequest {
         debug_struct.field("deploy_policy", &self.deploy_policy);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21097,7 +21019,6 @@ impl std::fmt::Debug for UpdateDeployPolicyRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21359,7 +21280,6 @@ impl std::fmt::Debug for DeleteDeployPolicyRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21631,7 +21551,6 @@ impl std::fmt::Debug for ListDeployPoliciesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21846,7 +21765,6 @@ impl std::fmt::Debug for ListDeployPoliciesResponse {
         debug_struct.field("deploy_policies", &self.deploy_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21989,7 +21907,6 @@ impl std::fmt::Debug for GetDeployPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeployPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22158,7 +22075,6 @@ impl std::fmt::Debug for BuildArtifact {
         let mut debug_struct = f.debug_struct("BuildArtifact");
         debug_struct.field("image", &self.image);
         debug_struct.field("tag", &self.tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22435,7 +22351,6 @@ impl std::fmt::Debug for TargetArtifact {
         debug_struct.field("manifest_path", &self.manifest_path);
         debug_struct.field("phase_artifacts", &self.phase_artifacts);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22649,7 +22564,6 @@ pub mod target_artifact {
             debug_struct.field("skaffold_config_path", &self.skaffold_config_path);
             debug_struct.field("manifest_path", &self.manifest_path);
             debug_struct.field("job_manifests_path", &self.job_manifests_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22833,7 +22747,6 @@ impl std::fmt::Debug for DeployArtifact {
         let mut debug_struct = f.debug_struct("DeployArtifact");
         debug_struct.field("artifact_uri", &self.artifact_uri);
         debug_struct.field("manifest_paths", &self.manifest_paths);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22977,7 +22890,6 @@ impl std::fmt::Debug for CloudRunRenderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudRunRenderMetadata");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23168,7 +23080,6 @@ impl std::fmt::Debug for RenderMetadata {
         let mut debug_struct = f.debug_struct("RenderMetadata");
         debug_struct.field("cloud_run", &self.cloud_run);
         debug_struct.field("custom", &self.custom);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23441,7 +23352,6 @@ impl std::fmt::Debug for ListReleasesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23655,7 +23565,6 @@ impl std::fmt::Debug for ListReleasesResponse {
         debug_struct.field("releases", &self.releases);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23798,7 +23707,6 @@ impl std::fmt::Debug for GetReleaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReleaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24099,7 +24007,6 @@ impl std::fmt::Debug for CreateReleaseRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24946,7 +24853,6 @@ impl std::fmt::Debug for Rollout {
             "active_repair_automation_run",
             &self.active_repair_automation_run,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25701,7 +25607,6 @@ impl std::fmt::Debug for Metadata {
         debug_struct.field("cloud_run", &self.cloud_run);
         debug_struct.field("automation", &self.automation);
         debug_struct.field("custom", &self.custom);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25932,7 +25837,6 @@ impl std::fmt::Debug for DeployJobRunMetadata {
         debug_struct.field("cloud_run", &self.cloud_run);
         debug_struct.field("custom_target", &self.custom_target);
         debug_struct.field("custom", &self.custom);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26158,7 +26062,6 @@ impl std::fmt::Debug for CloudRunMetadata {
         debug_struct.field("service_urls", &self.service_urls);
         debug_struct.field("revision", &self.revision);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26303,7 +26206,6 @@ impl std::fmt::Debug for CustomTargetDeployMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomTargetDeployMetadata");
         debug_struct.field("skip_message", &self.skip_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26511,7 +26413,6 @@ impl std::fmt::Debug for AutomationRolloutMetadata {
         debug_struct.field("promote_automation_run", &self.promote_automation_run);
         debug_struct.field("advance_automation_runs", &self.advance_automation_runs);
         debug_struct.field("repair_automation_runs", &self.repair_automation_runs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26664,7 +26565,6 @@ impl std::fmt::Debug for CustomMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomMetadata");
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26984,7 +26884,6 @@ impl std::fmt::Debug for Phase {
         debug_struct.field("state", &self.state);
         debug_struct.field("skip_message", &self.skip_message);
         debug_struct.field("jobs", &self.jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27425,7 +27324,6 @@ impl std::fmt::Debug for DeploymentJobs {
         debug_struct.field("deploy_job", &self.deploy_job);
         debug_struct.field("verify_job", &self.verify_job);
         debug_struct.field("postdeploy_job", &self.postdeploy_job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27600,7 +27498,6 @@ impl std::fmt::Debug for ChildRolloutJobs {
         let mut debug_struct = f.debug_struct("ChildRolloutJobs");
         debug_struct.field("create_rollout_jobs", &self.create_rollout_jobs);
         debug_struct.field("advance_rollout_jobs", &self.advance_rollout_jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28157,7 +28054,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("skip_message", &self.skip_message);
         debug_struct.field("job_run", &self.job_run);
         debug_struct.field("job_type", &self.job_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28469,7 +28365,6 @@ impl serde::ser::Serialize for DeployJob {
 impl std::fmt::Debug for DeployJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployJob");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28583,7 +28478,6 @@ impl serde::ser::Serialize for VerifyJob {
 impl std::fmt::Debug for VerifyJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerifyJob");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28728,7 +28622,6 @@ impl std::fmt::Debug for PredeployJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PredeployJob");
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28873,7 +28766,6 @@ impl std::fmt::Debug for PostdeployJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PostdeployJob");
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28987,7 +28879,6 @@ impl serde::ser::Serialize for CreateChildRolloutJob {
 impl std::fmt::Debug for CreateChildRolloutJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateChildRolloutJob");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29101,7 +28992,6 @@ impl serde::ser::Serialize for AdvanceChildRolloutJob {
 impl std::fmt::Debug for AdvanceChildRolloutJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdvanceChildRolloutJob");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29373,7 +29263,6 @@ impl std::fmt::Debug for ListRolloutsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29587,7 +29476,6 @@ impl std::fmt::Debug for ListRolloutsResponse {
         debug_struct.field("rollouts", &self.rollouts);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29730,7 +29618,6 @@ impl std::fmt::Debug for GetRolloutRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRolloutRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30061,7 +29948,6 @@ impl std::fmt::Debug for CreateRolloutRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
         debug_struct.field("starting_phase_id", &self.starting_phase_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30388,7 +30274,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30586,7 +30471,6 @@ impl std::fmt::Debug for ApproveRolloutRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("approved", &self.approved);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30700,7 +30584,6 @@ impl serde::ser::Serialize for ApproveRolloutResponse {
 impl std::fmt::Debug for ApproveRolloutResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApproveRolloutResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30899,7 +30782,6 @@ impl std::fmt::Debug for AdvanceRolloutRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("phase_id", &self.phase_id);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31013,7 +30895,6 @@ impl serde::ser::Serialize for AdvanceRolloutResponse {
 impl std::fmt::Debug for AdvanceRolloutResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdvanceRolloutResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31186,7 +31067,6 @@ impl std::fmt::Debug for CancelRolloutRequest {
         let mut debug_struct = f.debug_struct("CancelRolloutRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31300,7 +31180,6 @@ impl serde::ser::Serialize for CancelRolloutResponse {
 impl std::fmt::Debug for CancelRolloutResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelRolloutResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31525,7 +31404,6 @@ impl std::fmt::Debug for IgnoreJobRequest {
         debug_struct.field("phase_id", &self.phase_id);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31639,7 +31517,6 @@ impl serde::ser::Serialize for IgnoreJobResponse {
 impl std::fmt::Debug for IgnoreJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IgnoreJobResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31864,7 +31741,6 @@ impl std::fmt::Debug for RetryJobRequest {
         debug_struct.field("phase_id", &self.phase_id);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31978,7 +31854,6 @@ impl serde::ser::Serialize for RetryJobResponse {
 impl std::fmt::Debug for RetryJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetryJobResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32121,7 +31996,6 @@ impl std::fmt::Debug for AbandonReleaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AbandonReleaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32235,7 +32109,6 @@ impl serde::ser::Serialize for AbandonReleaseResponse {
 impl std::fmt::Debug for AbandonReleaseResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AbandonReleaseResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32982,7 +32855,6 @@ impl std::fmt::Debug for JobRun {
         debug_struct.field("state", &self.state);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("job_run", &self.job_run);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33430,7 +33302,6 @@ impl std::fmt::Debug for DeployJobRun {
         debug_struct.field("failure_message", &self.failure_message);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("artifact", &self.artifact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33859,7 +33730,6 @@ impl std::fmt::Debug for VerifyJobRun {
         debug_struct.field("event_log_path", &self.event_log_path);
         debug_struct.field("failure_cause", &self.failure_cause);
         debug_struct.field("failure_message", &self.failure_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34231,7 +34101,6 @@ impl std::fmt::Debug for PredeployJobRun {
         debug_struct.field("build", &self.build);
         debug_struct.field("failure_cause", &self.failure_cause);
         debug_struct.field("failure_message", &self.failure_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34594,7 +34463,6 @@ impl std::fmt::Debug for PostdeployJobRun {
         debug_struct.field("build", &self.build);
         debug_struct.field("failure_cause", &self.failure_cause);
         debug_struct.field("failure_message", &self.failure_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34925,7 +34793,6 @@ impl std::fmt::Debug for CreateChildRolloutJobRun {
         let mut debug_struct = f.debug_struct("CreateChildRolloutJobRun");
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("rollout_phase_id", &self.rollout_phase_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35098,7 +34965,6 @@ impl std::fmt::Debug for AdvanceChildRolloutJobRun {
         let mut debug_struct = f.debug_struct("AdvanceChildRolloutJobRun");
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("rollout_phase_id", &self.rollout_phase_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35370,7 +35236,6 @@ impl std::fmt::Debug for ListJobRunsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35585,7 +35450,6 @@ impl std::fmt::Debug for ListJobRunsResponse {
         debug_struct.field("job_runs", &self.job_runs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35728,7 +35592,6 @@ impl std::fmt::Debug for GetJobRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35901,7 +35764,6 @@ impl std::fmt::Debug for TerminateJobRunRequest {
         let mut debug_struct = f.debug_struct("TerminateJobRunRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("override_deploy_policy", &self.override_deploy_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36015,7 +35877,6 @@ impl serde::ser::Serialize for TerminateJobRunResponse {
 impl std::fmt::Debug for TerminateJobRunResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TerminateJobRunResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36222,7 +36083,6 @@ impl std::fmt::Debug for Config {
         debug_struct.field("name", &self.name);
         debug_struct.field("supported_versions", &self.supported_versions);
         debug_struct.field("default_skaffold_version", &self.default_skaffold_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36475,7 +36335,6 @@ impl std::fmt::Debug for SkaffoldVersion {
         debug_struct.field("maintenance_mode_time", &self.maintenance_mode_time);
         debug_struct.field("support_expiration_time", &self.support_expiration_time);
         debug_struct.field("support_end_date", &self.support_end_date);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36617,7 +36476,6 @@ impl std::fmt::Debug for GetConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37139,7 +36997,6 @@ impl std::fmt::Debug for Automation {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("selector", &self.selector);
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37289,7 +37146,6 @@ impl std::fmt::Debug for AutomationResourceSelector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutomationResourceSelector");
         debug_struct.field("targets", &self.targets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37660,7 +37516,6 @@ impl std::fmt::Debug for AutomationRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutomationRule");
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37983,7 +37838,6 @@ impl std::fmt::Debug for TimedPromoteReleaseRule {
         debug_struct.field("time_zone", &self.time_zone);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("destination_phase", &self.destination_phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38264,7 +38118,6 @@ impl std::fmt::Debug for PromoteReleaseRule {
         debug_struct.field("destination_target_id", &self.destination_target_id);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("destination_phase", &self.destination_phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38513,7 +38366,6 @@ impl std::fmt::Debug for AdvanceRolloutRule {
         debug_struct.field("source_phases", &self.source_phases);
         debug_struct.field("wait", &self.wait);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38794,7 +38646,6 @@ impl std::fmt::Debug for RepairRolloutRule {
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("repair_phases", &self.repair_phases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39036,7 +38887,6 @@ impl std::fmt::Debug for RepairPhaseConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RepairPhaseConfig");
         debug_struct.field("repair_phase", &self.repair_phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39279,7 +39129,6 @@ impl std::fmt::Debug for Retry {
         debug_struct.field("attempts", &self.attempts);
         debug_struct.field("wait", &self.wait);
         debug_struct.field("backoff_mode", &self.backoff_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39466,7 +39315,6 @@ impl std::fmt::Debug for Rollback {
             "disable_rollback_if_rollout_pending",
             &self.disable_rollback_if_rollout_pending,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39705,7 +39553,6 @@ impl std::fmt::Debug for AutomationRuleCondition {
         let mut debug_struct = f.debug_struct("AutomationRuleCondition");
         debug_struct.field("targets_present_condition", &self.targets_present_condition);
         debug_struct.field("rule_type_condition", &self.rule_type_condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39910,7 +39757,6 @@ impl std::fmt::Debug for TimedPromoteReleaseCondition {
         let mut debug_struct = f.debug_struct("TimedPromoteReleaseCondition");
         debug_struct.field("next_promotion_time", &self.next_promotion_time);
         debug_struct.field("targets_list", &self.targets_list);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40093,7 +39939,6 @@ pub mod timed_promote_release_condition {
             let mut debug_struct = f.debug_struct("Targets");
             debug_struct.field("source_target_id", &self.source_target_id);
             debug_struct.field("destination_target_id", &self.destination_target_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40365,7 +40210,6 @@ impl std::fmt::Debug for CreateAutomationRequest {
         debug_struct.field("automation", &self.automation);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40651,7 +40495,6 @@ impl std::fmt::Debug for UpdateAutomationRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40914,7 +40757,6 @@ impl std::fmt::Debug for DeleteAutomationRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41187,7 +41029,6 @@ impl std::fmt::Debug for ListAutomationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41401,7 +41242,6 @@ impl std::fmt::Debug for ListAutomationsResponse {
         debug_struct.field("automations", &self.automations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41544,7 +41384,6 @@ impl std::fmt::Debug for GetAutomationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAutomationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42369,7 +42208,6 @@ impl std::fmt::Debug for AutomationRun {
         debug_struct.field("automation_id", &self.automation_id);
         debug_struct.field("wait_until_time", &self.wait_until_time);
         debug_struct.field("operation", &self.operation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42780,7 +42618,6 @@ impl std::fmt::Debug for PromoteReleaseOperation {
         debug_struct.field("wait", &self.wait);
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("phase", &self.phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43012,7 +42849,6 @@ impl std::fmt::Debug for AdvanceRolloutOperation {
         debug_struct.field("wait", &self.wait);
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("destination_phase", &self.destination_phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43292,7 +43128,6 @@ impl std::fmt::Debug for RepairRolloutOperation {
         debug_struct.field("repair_phases", &self.repair_phases);
         debug_struct.field("phase_id", &self.phase_id);
         debug_struct.field("job_id", &self.job_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43487,7 +43322,6 @@ impl std::fmt::Debug for TimedPromoteReleaseOperation {
         debug_struct.field("target_id", &self.target_id);
         debug_struct.field("release", &self.release);
         debug_struct.field("phase", &self.phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43723,7 +43557,6 @@ impl std::fmt::Debug for RepairPhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RepairPhase");
         debug_struct.field("repair_phase", &self.repair_phase);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43960,7 +43793,6 @@ impl std::fmt::Debug for RetryPhase {
         debug_struct.field("total_attempts", &self.total_attempts);
         debug_struct.field("backoff_mode", &self.backoff_mode);
         debug_struct.field("attempts", &self.attempts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44206,7 +44038,6 @@ impl std::fmt::Debug for RetryAttempt {
         debug_struct.field("wait", &self.wait);
         debug_struct.field("state", &self.state);
         debug_struct.field("state_desc", &self.state_desc);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44468,7 +44299,6 @@ impl std::fmt::Debug for RollbackAttempt {
             "disable_rollback_if_rollout_pending",
             &self.disable_rollback_if_rollout_pending,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44741,7 +44571,6 @@ impl std::fmt::Debug for ListAutomationRunsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44956,7 +44785,6 @@ impl std::fmt::Debug for ListAutomationRunsResponse {
         debug_struct.field("automation_runs", &self.automation_runs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45099,7 +44927,6 @@ impl std::fmt::Debug for GetAutomationRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAutomationRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45242,7 +45069,6 @@ impl std::fmt::Debug for CancelAutomationRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelAutomationRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45356,7 +45182,6 @@ impl serde::ser::Serialize for CancelAutomationRunResponse {
 impl std::fmt::Debug for CancelAutomationRunResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelAutomationRunResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45583,7 +45408,6 @@ impl std::fmt::Debug for CustomTargetTypeNotificationEvent {
         debug_struct.field("custom_target_type_uid", &self.custom_target_type_uid);
         debug_struct.field("custom_target_type", &self.custom_target_type);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45807,7 +45631,6 @@ impl std::fmt::Debug for DeliveryPipelineNotificationEvent {
         debug_struct.field("pipeline_uid", &self.pipeline_uid);
         debug_struct.field("delivery_pipeline", &self.delivery_pipeline);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46281,7 +46104,6 @@ impl std::fmt::Debug for DeployPolicyEvaluationEvent {
         debug_struct.field("allowed", &self.allowed);
         debug_struct.field("verdict", &self.verdict);
         debug_struct.field("overrides", &self.overrides);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46781,7 +46603,6 @@ impl std::fmt::Debug for DeployPolicyNotificationEvent {
         debug_struct.field("deploy_policy", &self.deploy_policy);
         debug_struct.field("deploy_policy_uid", &self.deploy_policy_uid);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47130,7 +46951,6 @@ impl std::fmt::Debug for JobRunNotificationEvent {
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("target_id", &self.target_id);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47376,7 +47196,6 @@ impl std::fmt::Debug for ReleaseNotificationEvent {
         debug_struct.field("release_uid", &self.release_uid);
         debug_struct.field("release", &self.release);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47625,7 +47444,6 @@ impl std::fmt::Debug for ReleaseRenderEvent {
         debug_struct.field("release", &self.release);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("release_render_state", &self.release_render_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47948,7 +47766,6 @@ impl std::fmt::Debug for RolloutNotificationEvent {
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("target_id", &self.target_id);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48279,7 +48096,6 @@ impl std::fmt::Debug for RolloutUpdateEvent {
         debug_struct.field("target_id", &self.target_id);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("rollout_update_type", &self.rollout_update_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48688,7 +48504,6 @@ impl std::fmt::Debug for TargetNotificationEvent {
         debug_struct.field("message", &self.message);
         debug_struct.field("target", &self.target);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -290,7 +290,6 @@ impl std::fmt::Debug for ListUsersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -503,7 +502,6 @@ impl std::fmt::Debug for ListUsersResponse {
         debug_struct.field("users", &self.users);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1418,7 +1416,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("crypto_key_config", &self.crypto_key_config);
         debug_struct.field("git_proxy_config", &self.git_proxy_config);
         debug_struct.field("connection_config", &self.connection_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1588,7 +1585,6 @@ impl std::fmt::Debug for CryptoKeyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CryptoKeyConfig");
         debug_struct.field("key_reference", &self.key_reference);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1731,7 +1727,6 @@ impl std::fmt::Debug for GitProxyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GitProxyConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1929,7 +1924,6 @@ impl std::fmt::Debug for InstallationState {
         debug_struct.field("stage", &self.stage);
         debug_struct.field("message", &self.message);
         debug_struct.field("action_uri", &self.action_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2342,7 +2336,6 @@ impl std::fmt::Debug for GitHubConfig {
         debug_struct.field("authorizer_credential", &self.authorizer_credential);
         debug_struct.field("app_installation_id", &self.app_installation_id);
         debug_struct.field("installation_uri", &self.installation_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2944,7 +2937,6 @@ impl std::fmt::Debug for GitHubEnterpriseConfig {
         debug_struct.field("service_directory_config", &self.service_directory_config);
         debug_struct.field("server_version", &self.server_version);
         debug_struct.field("ssl_ca_certificate", &self.ssl_ca_certificate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3089,7 +3081,6 @@ impl std::fmt::Debug for ServiceDirectoryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceDirectoryConfig");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3269,7 +3260,6 @@ impl std::fmt::Debug for OAuthCredential {
             &self.oauth_token_secret_version,
         );
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3516,7 +3506,6 @@ impl std::fmt::Debug for GitLabConfig {
             &self.read_authorizer_credential,
         );
         debug_struct.field("authorizer_credential", &self.authorizer_credential);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3692,7 +3681,6 @@ impl std::fmt::Debug for UserCredential {
         let mut debug_struct = f.debug_struct("UserCredential");
         debug_struct.field("user_token_secret_version", &self.user_token_secret_version);
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4065,7 +4053,6 @@ impl std::fmt::Debug for GitLabEnterpriseConfig {
         debug_struct.field("service_directory_config", &self.service_directory_config);
         debug_struct.field("ssl_ca_certificate", &self.ssl_ca_certificate);
         debug_struct.field("server_version", &self.server_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4435,7 +4422,6 @@ impl std::fmt::Debug for BitbucketDataCenterConfig {
         debug_struct.field("service_directory_config", &self.service_directory_config);
         debug_struct.field("ssl_ca_certificate", &self.ssl_ca_certificate);
         debug_struct.field("server_version", &self.server_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4708,7 +4694,6 @@ impl std::fmt::Debug for BitbucketCloudConfig {
             &self.read_authorizer_credential,
         );
         debug_struct.field("authorizer_credential", &self.authorizer_credential);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4972,7 +4957,6 @@ impl std::fmt::Debug for ListConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5185,7 +5169,6 @@ impl std::fmt::Debug for ListConnectionsResponse {
         debug_struct.field("connections", &self.connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5327,7 +5310,6 @@ impl std::fmt::Debug for GetConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5597,7 +5579,6 @@ impl std::fmt::Debug for CreateConnectionRequest {
         debug_struct.field("connection", &self.connection);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5885,7 +5866,6 @@ impl std::fmt::Debug for UpdateConnectionRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6118,7 +6098,6 @@ impl std::fmt::Debug for DeleteConnectionRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6382,7 +6361,6 @@ impl std::fmt::Debug for ListAccountConnectorsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6600,7 +6578,6 @@ impl std::fmt::Debug for ListAccountConnectorsResponse {
         debug_struct.field("account_connectors", &self.account_connectors);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6742,7 +6719,6 @@ impl std::fmt::Debug for GetAccountConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAccountConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7017,7 +6993,6 @@ impl std::fmt::Debug for CreateAccountConnectorRequest {
         debug_struct.field("account_connector", &self.account_connector);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7302,7 +7277,6 @@ impl std::fmt::Debug for UpdateAccountConnectorRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7563,7 +7537,6 @@ impl std::fmt::Debug for DeleteAccountConnectorRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7796,7 +7769,6 @@ impl std::fmt::Debug for DeleteUserRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8123,7 +8095,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8265,7 +8236,6 @@ impl std::fmt::Debug for FetchSelfRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchSelfRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8407,7 +8377,6 @@ impl std::fmt::Debug for DeleteSelfRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSelfRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8554,7 +8523,6 @@ impl std::fmt::Debug for FetchAccessTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchAccessTokenRequest");
         debug_struct.field("account_connector", &self.account_connector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8798,7 +8766,6 @@ impl std::fmt::Debug for FetchAccessTokenResponse {
         debug_struct.field("expiration_time", &self.expiration_time);
         debug_struct.field("scopes", &self.scopes);
         debug_struct.field("exchange_error", &self.exchange_error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8966,7 +8933,6 @@ impl std::fmt::Debug for ExchangeError {
         let mut debug_struct = f.debug_struct("ExchangeError");
         debug_struct.field("code", &self.code);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9450,7 +9416,6 @@ impl std::fmt::Debug for GitRepositoryLink {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("webhook_id", &self.webhook_id);
         debug_struct.field("git_proxy_uri", &self.git_proxy_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9726,7 +9691,6 @@ impl std::fmt::Debug for CreateGitRepositoryLinkRequest {
         debug_struct.field("git_repository_link_id", &self.git_repository_link_id);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9959,7 +9923,6 @@ impl std::fmt::Debug for DeleteGitRepositoryLinkRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10223,7 +10186,6 @@ impl std::fmt::Debug for ListGitRepositoryLinksRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10441,7 +10403,6 @@ impl std::fmt::Debug for ListGitRepositoryLinksResponse {
         debug_struct.field("git_repository_links", &self.git_repository_links);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10583,7 +10544,6 @@ impl std::fmt::Debug for GetGitRepositoryLinkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGitRepositoryLinkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10730,7 +10690,6 @@ impl std::fmt::Debug for FetchReadWriteTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchReadWriteTokenRequest");
         debug_struct.field("git_repository_link", &self.git_repository_link);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10877,7 +10836,6 @@ impl std::fmt::Debug for FetchReadTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchReadTokenRequest");
         debug_struct.field("git_repository_link", &self.git_repository_link);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11084,7 +11042,6 @@ impl std::fmt::Debug for FetchReadTokenResponse {
         debug_struct.field("token", &self.token);
         debug_struct.field("expiration_time", &self.expiration_time);
         debug_struct.field("git_username", &self.git_username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11291,7 +11248,6 @@ impl std::fmt::Debug for FetchReadWriteTokenResponse {
         debug_struct.field("token", &self.token);
         debug_struct.field("expiration_time", &self.expiration_time);
         debug_struct.field("git_username", &self.git_username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11504,7 +11460,6 @@ impl std::fmt::Debug for FetchLinkableGitRepositoriesRequest {
         debug_struct.field("connection", &self.connection);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11698,7 +11653,6 @@ impl std::fmt::Debug for FetchLinkableGitRepositoriesResponse {
         let mut debug_struct = f.debug_struct("FetchLinkableGitRepositoriesResponse");
         debug_struct.field("linkable_git_repositories", &self.linkable_git_repositories);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11842,7 +11796,6 @@ impl std::fmt::Debug for LinkableGitRepository {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LinkableGitRepository");
         debug_struct.field("clone_uri", &self.clone_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11985,7 +11938,6 @@ impl std::fmt::Debug for FetchGitHubInstallationsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchGitHubInstallationsRequest");
         debug_struct.field("connection", &self.connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12132,7 +12084,6 @@ impl std::fmt::Debug for FetchGitHubInstallationsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchGitHubInstallationsResponse");
         debug_struct.field("installations", &self.installations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12350,7 +12301,6 @@ pub mod fetch_git_hub_installations_response {
             debug_struct.field("id", &self.id);
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12599,7 +12549,6 @@ impl std::fmt::Debug for FetchGitRefsRequest {
         debug_struct.field("ref_type", &self.ref_type);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12909,7 +12858,6 @@ impl std::fmt::Debug for FetchGitRefsResponse {
         let mut debug_struct = f.debug_struct("FetchGitRefsResponse");
         debug_struct.field("ref_names", &self.ref_names);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13332,7 +13280,6 @@ impl std::fmt::Debug for AccountConnector {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("oauth_start_uri", &self.oauth_start_uri);
         debug_struct.field("account_connector_config", &self.account_connector_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13591,7 +13538,6 @@ impl std::fmt::Debug for User {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("last_token_request_time", &self.last_token_request_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13811,7 +13757,6 @@ impl std::fmt::Debug for ProviderOAuthConfig {
         let mut debug_struct = f.debug_struct("ProviderOAuthConfig");
         debug_struct.field("scopes", &self.scopes);
         debug_struct.field("oauth_provider_id", &self.oauth_provider_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14341,7 +14286,6 @@ impl std::fmt::Debug for InsightsConfig {
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("insights_config_context", &self.insights_config_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14812,7 +14756,6 @@ impl std::fmt::Debug for RuntimeConfig {
         debug_struct.field("state", &self.state);
         debug_struct.field("runtime", &self.runtime);
         debug_struct.field("derived_from", &self.derived_from);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15138,7 +15081,6 @@ impl std::fmt::Debug for GKEWorkload {
         let mut debug_struct = f.debug_struct("GKEWorkload");
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("deployment", &self.deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15332,7 +15274,6 @@ impl std::fmt::Debug for AppHubWorkload {
         debug_struct.field("workload", &self.workload);
         debug_struct.field("criticality", &self.criticality);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15634,7 +15575,6 @@ impl std::fmt::Debug for ArtifactConfig {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("artifact_storage", &self.artifact_storage);
         debug_struct.field("artifact_metadata_storage", &self.artifact_metadata_storage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15799,7 +15739,6 @@ impl std::fmt::Debug for GoogleArtifactAnalysis {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GoogleArtifactAnalysis");
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15975,7 +15914,6 @@ impl std::fmt::Debug for GoogleArtifactRegistry {
         let mut debug_struct = f.debug_struct("GoogleArtifactRegistry");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("artifact_registry_package", &self.artifact_registry_package);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16210,7 +16148,6 @@ impl std::fmt::Debug for CreateInsightsConfigRequest {
         debug_struct.field("insights_config_id", &self.insights_config_id);
         debug_struct.field("insights_config", &self.insights_config);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16352,7 +16289,6 @@ impl std::fmt::Debug for GetInsightsConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInsightsConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16619,7 +16555,6 @@ impl std::fmt::Debug for ListInsightsConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16837,7 +16772,6 @@ impl std::fmt::Debug for ListInsightsConfigsResponse {
         debug_struct.field("insights_configs", &self.insights_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17070,7 +17004,6 @@ impl std::fmt::Debug for DeleteInsightsConfigRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17319,7 +17252,6 @@ impl std::fmt::Debug for UpdateInsightsConfigRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/devicestreaming/v1/src/model.rs
+++ b/src/generated/cloud/devicestreaming/v1/src/model.rs
@@ -315,7 +315,6 @@ impl std::fmt::Debug for DeviceMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeviceMessage");
         debug_struct.field("contents", &self.contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -568,7 +567,6 @@ impl std::fmt::Debug for AdbMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdbMessage");
         debug_struct.field("contents", &self.contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -787,7 +785,6 @@ impl std::fmt::Debug for StatusUpdate {
         debug_struct.field("state", &self.state);
         debug_struct.field("properties", &self.properties);
         debug_struct.field("features", &self.features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1255,7 +1252,6 @@ impl std::fmt::Debug for StreamStatus {
         let mut debug_struct = f.debug_struct("StreamStatus");
         debug_struct.field("stream_id", &self.stream_id);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1458,7 +1454,6 @@ impl std::fmt::Debug for Open {
         let mut debug_struct = f.debug_struct("Open");
         debug_struct.field("stream_id", &self.stream_id);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1753,7 +1748,6 @@ impl std::fmt::Debug for StreamData {
         let mut debug_struct = f.debug_struct("StreamData");
         debug_struct.field("stream_id", &self.stream_id);
         debug_struct.field("contents", &self.contents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1884,7 +1878,6 @@ impl serde::ser::Serialize for Okay {
 impl std::fmt::Debug for Okay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Okay");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2026,7 +2019,6 @@ impl std::fmt::Debug for Fail {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Fail");
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2140,7 +2132,6 @@ impl serde::ser::Serialize for Close {
 impl std::fmt::Debug for Close {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Close");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2353,7 +2344,6 @@ impl std::fmt::Debug for CreateDeviceSessionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("device_session", &self.device_session);
         debug_struct.field("device_session_id", &self.device_session_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2591,7 +2581,6 @@ impl std::fmt::Debug for ListDeviceSessionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2778,7 +2767,6 @@ impl std::fmt::Debug for ListDeviceSessionsResponse {
         let mut debug_struct = f.debug_struct("ListDeviceSessionsResponse");
         debug_struct.field("device_sessions", &self.device_sessions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2921,7 +2909,6 @@ impl std::fmt::Debug for GetDeviceSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeviceSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3064,7 +3051,6 @@ impl std::fmt::Debug for CancelDeviceSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelDeviceSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3257,7 +3243,6 @@ impl std::fmt::Debug for UpdateDeviceSessionRequest {
         let mut debug_struct = f.debug_struct("UpdateDeviceSessionRequest");
         debug_struct.field("device_session", &self.device_session);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3746,7 +3731,6 @@ impl std::fmt::Debug for DeviceSession {
         debug_struct.field("active_start_time", &self.active_start_time);
         debug_struct.field("android_device", &self.android_device);
         debug_struct.field("expiration", &self.expiration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3972,7 +3956,6 @@ pub mod device_session {
             debug_struct.field("session_state", &self.session_state);
             debug_struct.field("event_time", &self.event_time);
             debug_struct.field("state_message", &self.state_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4392,7 +4375,6 @@ impl std::fmt::Debug for AndroidDevice {
         debug_struct.field("android_version_id", &self.android_version_id);
         debug_struct.field("locale", &self.locale);
         debug_struct.field("orientation", &self.orientation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -386,7 +386,6 @@ impl std::fmt::Debug for AdvancedSettings {
         debug_struct.field("speech_settings", &self.speech_settings);
         debug_struct.field("dtmf_settings", &self.dtmf_settings);
         debug_struct.field("logging_settings", &self.logging_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -735,7 +734,6 @@ pub mod advanced_settings {
                 &self.use_timeout_based_endpointing,
             );
             debug_struct.field("models", &self.models);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1107,7 +1105,6 @@ pub mod advanced_settings {
                 "endpointing_timeout_duration",
                 &self.endpointing_timeout_duration,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1388,7 +1385,6 @@ pub mod advanced_settings {
                 "enable_consent_based_redaction",
                 &self.enable_consent_based_redaction,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1540,7 +1536,6 @@ impl std::fmt::Debug for SpeechToTextSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SpeechToTextSettings");
         debug_struct.field("enable_speech_adaptation", &self.enable_speech_adaptation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2487,7 +2482,6 @@ impl std::fmt::Debug for Agent {
         );
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2701,7 +2695,6 @@ pub mod agent {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GitIntegrationSettings");
             debug_struct.field("git_settings", &self.git_settings);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2991,7 +2984,6 @@ pub mod agent {
                 debug_struct.field("tracking_branch", &self.tracking_branch);
                 debug_struct.field("access_token", &self.access_token);
                 debug_struct.field("branches", &self.branches);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3156,7 +3148,6 @@ pub mod agent {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GenAppBuilderSettings");
             debug_struct.field("engine", &self.engine);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3315,7 +3306,6 @@ pub mod agent {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AnswerFeedbackSettings");
             debug_struct.field("enable_answer_feedback", &self.enable_answer_feedback);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3495,7 +3485,6 @@ pub mod agent {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PersonalizationSettings");
             debug_struct.field("default_end_user_metadata", &self.default_end_user_metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3707,7 +3696,6 @@ pub mod agent {
             debug_struct.field("ssl_certificate", &self.ssl_certificate);
             debug_struct.field("private_key", &self.private_key);
             debug_struct.field("passphrase", &self.passphrase);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3931,7 +3919,6 @@ impl std::fmt::Debug for ListAgentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4128,7 +4115,6 @@ impl std::fmt::Debug for ListAgentsResponse {
         let mut debug_struct = f.debug_struct("ListAgentsResponse");
         debug_struct.field("agents", &self.agents);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4280,7 +4266,6 @@ impl std::fmt::Debug for GetAgentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAgentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4468,7 +4453,6 @@ impl std::fmt::Debug for CreateAgentRequest {
         let mut debug_struct = f.debug_struct("CreateAgentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("agent", &self.agent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4668,7 +4652,6 @@ impl std::fmt::Debug for UpdateAgentRequest {
         let mut debug_struct = f.debug_struct("UpdateAgentRequest");
         debug_struct.field("agent", &self.agent);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4820,7 +4803,6 @@ impl std::fmt::Debug for DeleteAgentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAgentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5145,7 +5127,6 @@ impl std::fmt::Debug for ExportAgentRequest {
             "include_bigquery_export_settings",
             &self.include_bigquery_export_settings,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5335,7 +5316,6 @@ pub mod export_agent_request {
             let mut debug_struct = f.debug_struct("GitDestination");
             debug_struct.field("tracking_branch", &self.tracking_branch);
             debug_struct.field("commit_message", &self.commit_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5785,7 +5765,6 @@ impl std::fmt::Debug for ExportAgentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportAgentResponse");
         debug_struct.field("agent", &self.agent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6195,7 +6174,6 @@ impl std::fmt::Debug for RestoreAgentRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("restore_option", &self.restore_option);
         debug_struct.field("agent", &self.agent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6356,7 +6334,6 @@ pub mod restore_agent_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GitSource");
             debug_struct.field("tracking_branch", &self.tracking_branch);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6700,7 +6677,6 @@ impl std::fmt::Debug for ValidateAgentRequest {
         let mut debug_struct = f.debug_struct("ValidateAgentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6879,7 +6855,6 @@ impl std::fmt::Debug for GetAgentValidationResultRequest {
         let mut debug_struct = f.debug_struct("GetAgentValidationResultRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7065,7 +7040,6 @@ impl std::fmt::Debug for AgentValidationResult {
         let mut debug_struct = f.debug_struct("AgentValidationResult");
         debug_struct.field("name", &self.name);
         debug_struct.field("flow_validation_results", &self.flow_validation_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7244,7 +7218,6 @@ impl std::fmt::Debug for GetGenerativeSettingsRequest {
         let mut debug_struct = f.debug_struct("GetGenerativeSettingsRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7446,7 +7419,6 @@ impl std::fmt::Debug for UpdateGenerativeSettingsRequest {
         let mut debug_struct = f.debug_struct("UpdateGenerativeSettingsRequest");
         debug_struct.field("generative_settings", &self.generative_settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7721,7 +7693,6 @@ impl std::fmt::Debug for SpeechWordInfo {
         debug_struct.field("start_offset", &self.start_offset);
         debug_struct.field("end_offset", &self.end_offset);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7943,7 +7914,6 @@ impl std::fmt::Debug for BargeInConfig {
         let mut debug_struct = f.debug_struct("BargeInConfig");
         debug_struct.field("no_barge_in_duration", &self.no_barge_in_duration);
         debug_struct.field("total_duration", &self.total_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8382,7 +8352,6 @@ impl std::fmt::Debug for InputAudioConfig {
             "opt_out_conformer_model_migration",
             &self.opt_out_conformer_model_migration,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8573,7 +8542,6 @@ impl std::fmt::Debug for VoiceSelectionParams {
         let mut debug_struct = f.debug_struct("VoiceSelectionParams");
         debug_struct.field("name", &self.name);
         debug_struct.field("ssml_gender", &self.ssml_gender);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8908,7 +8876,6 @@ impl std::fmt::Debug for SynthesizeSpeechConfig {
         debug_struct.field("volume_gain_db", &self.volume_gain_db);
         debug_struct.field("effects_profile_id", &self.effects_profile_id);
         debug_struct.field("voice", &self.voice);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9151,7 +9118,6 @@ impl std::fmt::Debug for OutputAudioConfig {
         debug_struct.field("audio_encoding", &self.audio_encoding);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("synthesize_speech_config", &self.synthesize_speech_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9337,7 +9303,6 @@ impl std::fmt::Debug for TextToSpeechSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TextToSpeechSettings");
         debug_struct.field("synthesize_speech_configs", &self.synthesize_speech_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9605,7 +9570,6 @@ impl std::fmt::Debug for ListChangelogsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9803,7 +9767,6 @@ impl std::fmt::Debug for ListChangelogsResponse {
         let mut debug_struct = f.debug_struct("ListChangelogsResponse");
         debug_struct.field("changelogs", &self.changelogs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9956,7 +9919,6 @@ impl std::fmt::Debug for GetChangelogRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetChangelogRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10296,7 +10258,6 @@ impl std::fmt::Debug for Changelog {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10541,7 +10502,6 @@ impl std::fmt::Debug for DataStoreConnection {
         debug_struct.field("data_store_type", &self.data_store_type);
         debug_struct.field("data_store", &self.data_store);
         debug_struct.field("document_processing_mode", &self.document_processing_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11012,7 +10972,6 @@ impl std::fmt::Debug for DataStoreConnectionSignals {
         debug_struct.field("cited_snippets", &self.cited_snippets);
         debug_struct.field("grounding_signals", &self.grounding_signals);
         debug_struct.field("safety_signals", &self.safety_signals);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11228,7 +11187,6 @@ pub mod data_store_connection_signals {
             debug_struct.field("rendered_prompt", &self.rendered_prompt);
             debug_struct.field("model_output", &self.model_output);
             debug_struct.field("model", &self.model);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11437,7 +11395,6 @@ pub mod data_store_connection_signals {
             debug_struct.field("document_title", &self.document_title);
             debug_struct.field("document_uri", &self.document_uri);
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11647,7 +11604,6 @@ pub mod data_store_connection_signals {
             debug_struct.field("rendered_prompt", &self.rendered_prompt);
             debug_struct.field("model_output", &self.model_output);
             debug_struct.field("model", &self.model);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11855,7 +11811,6 @@ pub mod data_store_connection_signals {
             let mut debug_struct = f.debug_struct("AnswerPart");
             debug_struct.field("text", &self.text);
             debug_struct.field("supporting_indices", &self.supporting_indices);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12065,7 +12020,6 @@ pub mod data_store_connection_signals {
             let mut debug_struct = f.debug_struct("CitedSnippet");
             debug_struct.field("search_snippet", &self.search_snippet);
             debug_struct.field("snippet_index", &self.snippet_index);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12239,7 +12193,6 @@ pub mod data_store_connection_signals {
             let mut debug_struct = f.debug_struct("GroundingSignals");
             debug_struct.field("decision", &self.decision);
             debug_struct.field("score", &self.score);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12774,7 +12727,6 @@ pub mod data_store_connection_signals {
             debug_struct.field("decision", &self.decision);
             debug_struct.field("banned_phrase_match", &self.banned_phrase_match);
             debug_struct.field("matched_banned_phrase", &self.matched_banned_phrase);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13403,7 +13355,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("result", &self.result);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13597,7 +13548,6 @@ pub mod deployment {
             let mut debug_struct = f.debug_struct("Result");
             debug_struct.field("deployment_test_results", &self.deployment_test_results);
             debug_struct.field("experiment", &self.experiment);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13972,7 +13922,6 @@ impl std::fmt::Debug for ListDeploymentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14171,7 +14120,6 @@ impl std::fmt::Debug for ListDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListDeploymentsResponse");
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14326,7 +14274,6 @@ impl std::fmt::Debug for GetDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14746,7 +14693,6 @@ impl std::fmt::Debug for EntityType {
         debug_struct.field("excluded_phrases", &self.excluded_phrases);
         debug_struct.field("enable_fuzzy_extraction", &self.enable_fuzzy_extraction);
         debug_struct.field("redact", &self.redact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14976,7 +14922,6 @@ pub mod entity_type {
             let mut debug_struct = f.debug_struct("Entity");
             debug_struct.field("value", &self.value);
             debug_struct.field("synonyms", &self.synonyms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15151,7 +15096,6 @@ pub mod entity_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ExcludedPhrase");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15892,7 +15836,6 @@ impl std::fmt::Debug for ExportEntityTypesRequest {
         debug_struct.field("data_format", &self.data_format);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16319,7 +16262,6 @@ impl std::fmt::Debug for ExportEntityTypesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportEntityTypesResponse");
         debug_struct.field("exported_entity_types", &self.exported_entity_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16469,7 +16411,6 @@ impl serde::ser::Serialize for ExportEntityTypesMetadata {
 impl std::fmt::Debug for ExportEntityTypesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportEntityTypesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16819,7 +16760,6 @@ impl std::fmt::Debug for ImportEntityTypesRequest {
         debug_struct.field("merge_option", &self.merge_option);
         debug_struct.field("target_entity_type", &self.target_entity_type);
         debug_struct.field("entity_types", &self.entity_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17210,7 +17150,6 @@ impl std::fmt::Debug for ImportEntityTypesResponse {
         let mut debug_struct = f.debug_struct("ImportEntityTypesResponse");
         debug_struct.field("entity_types", &self.entity_types);
         debug_struct.field("conflicting_resources", &self.conflicting_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17406,7 +17345,6 @@ pub mod import_entity_types_response {
             let mut debug_struct = f.debug_struct("ConflictingResources");
             debug_struct.field("entity_type_display_names", &self.entity_type_display_names);
             debug_struct.field("entity_display_names", &self.entity_display_names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17531,7 +17469,6 @@ impl serde::ser::Serialize for ImportEntityTypesMetadata {
 impl std::fmt::Debug for ImportEntityTypesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportEntityTypesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17791,7 +17728,6 @@ impl std::fmt::Debug for ListEntityTypesRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17989,7 +17925,6 @@ impl std::fmt::Debug for ListEntityTypesResponse {
         let mut debug_struct = f.debug_struct("ListEntityTypesResponse");
         debug_struct.field("entity_types", &self.entity_types);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18179,7 +18114,6 @@ impl std::fmt::Debug for GetEntityTypeRequest {
         let mut debug_struct = f.debug_struct("GetEntityTypeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18404,7 +18338,6 @@ impl std::fmt::Debug for CreateEntityTypeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18640,7 +18573,6 @@ impl std::fmt::Debug for UpdateEntityTypeRequest {
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18832,7 +18764,6 @@ impl std::fmt::Debug for DeleteEntityTypeRequest {
         let mut debug_struct = f.debug_struct("DeleteEntityTypeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19191,7 +19122,6 @@ impl std::fmt::Debug for Environment {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("test_cases_config", &self.test_cases_config);
         debug_struct.field("webhook_config", &self.webhook_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19352,7 +19282,6 @@ pub mod environment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("VersionConfig");
             debug_struct.field("version", &self.version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19573,7 +19502,6 @@ pub mod environment {
             debug_struct.field("test_cases", &self.test_cases);
             debug_struct.field("enable_continuous_run", &self.enable_continuous_run);
             debug_struct.field("enable_predeployment_run", &self.enable_predeployment_run);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19735,7 +19663,6 @@ pub mod environment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("WebhookConfig");
             debug_struct.field("webhook_overrides", &self.webhook_overrides);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19962,7 +19889,6 @@ impl std::fmt::Debug for ListEnvironmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20161,7 +20087,6 @@ impl std::fmt::Debug for ListEnvironmentsResponse {
         let mut debug_struct = f.debug_struct("ListEnvironmentsResponse");
         debug_struct.field("environments", &self.environments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20316,7 +20241,6 @@ impl std::fmt::Debug for GetEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20508,7 +20432,6 @@ impl std::fmt::Debug for CreateEnvironmentRequest {
         let mut debug_struct = f.debug_struct("CreateEnvironmentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20707,7 +20630,6 @@ impl std::fmt::Debug for UpdateEnvironmentRequest {
         let mut debug_struct = f.debug_struct("UpdateEnvironmentRequest");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20862,7 +20784,6 @@ impl std::fmt::Debug for DeleteEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21086,7 +21007,6 @@ impl std::fmt::Debug for LookupEnvironmentHistoryRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21286,7 +21206,6 @@ impl std::fmt::Debug for LookupEnvironmentHistoryResponse {
         let mut debug_struct = f.debug_struct("LookupEnvironmentHistoryResponse");
         debug_struct.field("environments", &self.environments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21534,7 +21453,6 @@ impl std::fmt::Debug for ContinuousTestResult {
         debug_struct.field("result", &self.result);
         debug_struct.field("test_case_results", &self.test_case_results);
         debug_struct.field("run_time", &self.run_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21836,7 +21754,6 @@ impl std::fmt::Debug for RunContinuousTestRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunContinuousTestRequest");
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21999,7 +21916,6 @@ impl std::fmt::Debug for RunContinuousTestResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunContinuousTestResponse");
         debug_struct.field("continuous_test_result", &self.continuous_test_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22154,7 +22070,6 @@ impl std::fmt::Debug for RunContinuousTestMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunContinuousTestMetadata");
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22378,7 +22293,6 @@ impl std::fmt::Debug for ListContinuousTestResultsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22576,7 +22490,6 @@ impl std::fmt::Debug for ListContinuousTestResultsResponse {
         let mut debug_struct = f.debug_struct("ListContinuousTestResultsResponse");
         debug_struct.field("continuous_test_results", &self.continuous_test_results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22757,7 +22670,6 @@ impl std::fmt::Debug for DeployFlowRequest {
         let mut debug_struct = f.debug_struct("DeployFlowRequest");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("flow_version", &self.flow_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22948,7 +22860,6 @@ impl std::fmt::Debug for DeployFlowResponse {
         let mut debug_struct = f.debug_struct("DeployFlowResponse");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("deployment", &self.deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23104,7 +23015,6 @@ impl std::fmt::Debug for DeployFlowMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployFlowMetadata");
         debug_struct.field("test_errors", &self.test_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23738,7 +23648,6 @@ impl std::fmt::Debug for Experiment {
         debug_struct.field("last_update_time", &self.last_update_time);
         debug_struct.field("experiment_length", &self.experiment_length);
         debug_struct.field("variants_history", &self.variants_history);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23975,7 +23884,6 @@ pub mod experiment {
             let mut debug_struct = f.debug_struct("Definition");
             debug_struct.field("condition", &self.condition);
             debug_struct.field("variants", &self.variants);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24192,7 +24100,6 @@ pub mod experiment {
             let mut debug_struct = f.debug_struct("Result");
             debug_struct.field("version_metrics", &self.version_metrics);
             debug_struct.field("last_update_time", &self.last_update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24527,7 +24434,6 @@ pub mod experiment {
                 debug_struct.field("ratio", &self.ratio);
                 debug_struct.field("lower_bound", &self.lower_bound);
                 debug_struct.field("upper_bound", &self.upper_bound);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -24930,7 +24836,6 @@ pub mod experiment {
                 debug_struct.field("count_type", &self.count_type);
                 debug_struct.field("confidence_interval", &self.confidence_interval);
                 debug_struct.field("value", &self.value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25193,7 +25098,6 @@ pub mod experiment {
                 debug_struct.field("version", &self.version);
                 debug_struct.field("metrics", &self.metrics);
                 debug_struct.field("session_count", &self.session_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25828,7 +25732,6 @@ impl std::fmt::Debug for VersionVariants {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VersionVariants");
         debug_struct.field("variants", &self.variants);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26059,7 +25962,6 @@ pub mod version_variants {
             debug_struct.field("version", &self.version);
             debug_struct.field("traffic_allocation", &self.traffic_allocation);
             debug_struct.field("is_control_group", &self.is_control_group);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26297,7 +26199,6 @@ impl std::fmt::Debug for VariantsHistory {
         let mut debug_struct = f.debug_struct("VariantsHistory");
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("variants", &self.variants);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26536,7 +26437,6 @@ impl std::fmt::Debug for RolloutConfig {
         debug_struct.field("rollout_steps", &self.rollout_steps);
         debug_struct.field("rollout_condition", &self.rollout_condition);
         debug_struct.field("failure_condition", &self.failure_condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26782,7 +26682,6 @@ pub mod rollout_config {
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("traffic_percent", &self.traffic_percent);
             debug_struct.field("min_duration", &self.min_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27012,7 +26911,6 @@ impl std::fmt::Debug for RolloutState {
         debug_struct.field("step", &self.step);
         debug_struct.field("step_index", &self.step_index);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27238,7 +27136,6 @@ impl std::fmt::Debug for ListExperimentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27437,7 +27334,6 @@ impl std::fmt::Debug for ListExperimentsResponse {
         let mut debug_struct = f.debug_struct("ListExperimentsResponse");
         debug_struct.field("experiments", &self.experiments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27592,7 +27488,6 @@ impl std::fmt::Debug for GetExperimentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetExperimentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27784,7 +27679,6 @@ impl std::fmt::Debug for CreateExperimentRequest {
         let mut debug_struct = f.debug_struct("CreateExperimentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("experiment", &self.experiment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27983,7 +27877,6 @@ impl std::fmt::Debug for UpdateExperimentRequest {
         let mut debug_struct = f.debug_struct("UpdateExperimentRequest");
         debug_struct.field("experiment", &self.experiment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28138,7 +28031,6 @@ impl std::fmt::Debug for DeleteExperimentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteExperimentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28291,7 +28183,6 @@ impl std::fmt::Debug for StartExperimentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartExperimentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28444,7 +28335,6 @@ impl std::fmt::Debug for StopExperimentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopExperimentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28713,7 +28603,6 @@ impl std::fmt::Debug for NluSettings {
         debug_struct.field("model_type", &self.model_type);
         debug_struct.field("classification_threshold", &self.classification_threshold);
         debug_struct.field("model_training_mode", &self.model_training_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29637,7 +29526,6 @@ impl std::fmt::Debug for Flow {
         );
         debug_struct.field("multi_language_settings", &self.multi_language_settings);
         debug_struct.field("locked", &self.locked);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29861,7 +29749,6 @@ pub mod flow {
                 "supported_response_language_codes",
                 &self.supported_response_language_codes,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30087,7 +29974,6 @@ impl std::fmt::Debug for CreateFlowRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("flow", &self.flow);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30277,7 +30163,6 @@ impl std::fmt::Debug for DeleteFlowRequest {
         let mut debug_struct = f.debug_struct("DeleteFlowRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30538,7 +30423,6 @@ impl std::fmt::Debug for ListFlowsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30735,7 +30619,6 @@ impl std::fmt::Debug for ListFlowsResponse {
         let mut debug_struct = f.debug_struct("ListFlowsResponse");
         debug_struct.field("flows", &self.flows);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30926,7 +30809,6 @@ impl std::fmt::Debug for GetFlowRequest {
         let mut debug_struct = f.debug_struct("GetFlowRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31163,7 +31045,6 @@ impl std::fmt::Debug for UpdateFlowRequest {
         debug_struct.field("flow", &self.flow);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31316,7 +31197,6 @@ impl std::fmt::Debug for TrainFlowRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TrainFlowRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31495,7 +31375,6 @@ impl std::fmt::Debug for ValidateFlowRequest {
         let mut debug_struct = f.debug_struct("ValidateFlowRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31674,7 +31553,6 @@ impl std::fmt::Debug for GetFlowValidationResultRequest {
         let mut debug_struct = f.debug_struct("GetFlowValidationResultRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31897,7 +31775,6 @@ impl std::fmt::Debug for FlowValidationResult {
         debug_struct.field("name", &self.name);
         debug_struct.field("validation_messages", &self.validation_messages);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32250,7 +32127,6 @@ impl std::fmt::Debug for ImportFlowRequest {
         debug_struct.field("import_option", &self.import_option);
         debug_struct.field("flow_import_strategy", &self.flow_import_strategy);
         debug_struct.field("flow", &self.flow);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32579,7 +32455,6 @@ impl std::fmt::Debug for FlowImportStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FlowImportStrategy");
         debug_struct.field("global_import_strategy", &self.global_import_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32732,7 +32607,6 @@ impl std::fmt::Debug for ImportFlowResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportFlowResponse");
         debug_struct.field("flow", &self.flow);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32948,7 +32822,6 @@ impl std::fmt::Debug for ExportFlowRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("flow_uri", &self.flow_uri);
         debug_struct.field("include_referenced_flows", &self.include_referenced_flows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33206,7 +33079,6 @@ impl std::fmt::Debug for ExportFlowResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportFlowResponse");
         debug_struct.field("flow", &self.flow);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33712,7 +33584,6 @@ impl std::fmt::Debug for Fulfillment {
             &self.enable_generative_fallback,
         );
         debug_struct.field("generators", &self.generators);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33948,7 +33819,6 @@ pub mod fulfillment {
             let mut debug_struct = f.debug_struct("SetParameterAction");
             debug_struct.field("parameter", &self.parameter);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34145,7 +34015,6 @@ pub mod fulfillment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConditionalCases");
             debug_struct.field("cases", &self.cases);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34396,7 +34265,6 @@ pub mod fulfillment {
                 let mut debug_struct = f.debug_struct("Case");
                 debug_struct.field("condition", &self.condition);
                 debug_struct.field("case_content", &self.case_content);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -34716,7 +34584,6 @@ pub mod fulfillment {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("CaseContent");
                     debug_struct.field("cases_or_message", &self.cases_or_message);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -35015,7 +34882,6 @@ pub mod fulfillment {
             debug_struct.field("generator", &self.generator);
             debug_struct.field("input_parameters", &self.input_parameters);
             debug_struct.field("output_parameter", &self.output_parameter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35209,7 +35075,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35517,7 +35382,6 @@ impl std::fmt::Debug for GenerativeSettings {
             &self.knowledge_connector_settings,
         );
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35711,7 +35575,6 @@ pub mod generative_settings {
             let mut debug_struct = f.debug_struct("FallbackSettings");
             debug_struct.field("selected_prompt", &self.selected_prompt);
             debug_struct.field("prompt_templates", &self.prompt_templates);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35936,7 +35799,6 @@ pub mod generative_settings {
                 debug_struct.field("display_name", &self.display_name);
                 debug_struct.field("prompt_text", &self.prompt_text);
                 debug_struct.field("frozen", &self.frozen);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -36244,7 +36106,6 @@ pub mod generative_settings {
                 "disable_data_store_fallback",
                 &self.disable_data_store_fallback,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36538,7 +36399,6 @@ impl std::fmt::Debug for Generator {
         debug_struct.field("prompt_text", &self.prompt_text);
         debug_struct.field("placeholders", &self.placeholders);
         debug_struct.field("model_parameter", &self.model_parameter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36720,7 +36580,6 @@ pub mod generator {
             let mut debug_struct = f.debug_struct("Placeholder");
             debug_struct.field("id", &self.id);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37089,7 +36948,6 @@ pub mod generator {
             debug_struct.field("max_decode_steps", &self.max_decode_steps);
             debug_struct.field("top_p", &self.top_p);
             debug_struct.field("top_k", &self.top_k);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37238,7 +37096,6 @@ impl std::fmt::Debug for Phrase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Phrase");
         debug_struct.field("text", &self.text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37487,7 +37344,6 @@ impl std::fmt::Debug for ListGeneratorsRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37684,7 +37540,6 @@ impl std::fmt::Debug for ListGeneratorsResponse {
         let mut debug_struct = f.debug_struct("ListGeneratorsResponse");
         debug_struct.field("generators", &self.generators);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37863,7 +37718,6 @@ impl std::fmt::Debug for GetGeneratorRequest {
         let mut debug_struct = f.debug_struct("GetGeneratorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38080,7 +37934,6 @@ impl std::fmt::Debug for CreateGeneratorRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("generator", &self.generator);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38306,7 +38159,6 @@ impl std::fmt::Debug for UpdateGeneratorRequest {
         debug_struct.field("generator", &self.generator);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38491,7 +38343,6 @@ impl std::fmt::Debug for DeleteGeneratorRequest {
         let mut debug_struct = f.debug_struct("DeleteGeneratorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38661,7 +38512,6 @@ impl std::fmt::Debug for InlineDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InlineDestination");
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38830,7 +38680,6 @@ impl std::fmt::Debug for InlineSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InlineSource");
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39239,7 +39088,6 @@ impl std::fmt::Debug for Intent {
         debug_struct.field("is_fallback", &self.is_fallback);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39494,7 +39342,6 @@ pub mod intent {
             debug_struct.field("id", &self.id);
             debug_struct.field("parts", &self.parts);
             debug_struct.field("repeat_count", &self.repeat_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39689,7 +39536,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("Part");
                 debug_struct.field("text", &self.text);
                 debug_struct.field("parameter_id", &self.parameter_id);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -39937,7 +39783,6 @@ pub mod intent {
             debug_struct.field("entity_type", &self.entity_type);
             debug_struct.field("is_list", &self.is_list);
             debug_struct.field("redact", &self.redact);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40225,7 +40070,6 @@ impl std::fmt::Debug for ListIntentsRequest {
         debug_struct.field("intent_view", &self.intent_view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40422,7 +40266,6 @@ impl std::fmt::Debug for ListIntentsResponse {
         let mut debug_struct = f.debug_struct("ListIntentsResponse");
         debug_struct.field("intents", &self.intents);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40610,7 +40453,6 @@ impl std::fmt::Debug for GetIntentRequest {
         let mut debug_struct = f.debug_struct("GetIntentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40832,7 +40674,6 @@ impl std::fmt::Debug for CreateIntentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("intent", &self.intent);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41066,7 +40907,6 @@ impl std::fmt::Debug for UpdateIntentRequest {
         debug_struct.field("intent", &self.intent);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41219,7 +41059,6 @@ impl std::fmt::Debug for DeleteIntentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIntentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41529,7 +41368,6 @@ impl std::fmt::Debug for ImportIntentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("merge_option", &self.merge_option);
         debug_struct.field("intents", &self.intents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41930,7 +41768,6 @@ impl std::fmt::Debug for ImportIntentsResponse {
         let mut debug_struct = f.debug_struct("ImportIntentsResponse");
         debug_struct.field("intents", &self.intents);
         debug_struct.field("conflicting_resources", &self.conflicting_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42122,7 +41959,6 @@ pub mod import_intents_response {
             let mut debug_struct = f.debug_struct("ConflictingResources");
             debug_struct.field("intent_display_names", &self.intent_display_names);
             debug_struct.field("entity_display_names", &self.entity_display_names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42247,7 +42083,6 @@ impl serde::ser::Serialize for ImportIntentsMetadata {
 impl std::fmt::Debug for ImportIntentsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportIntentsMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42578,7 +42413,6 @@ impl std::fmt::Debug for ExportIntentsRequest {
         debug_struct.field("intents", &self.intents);
         debug_struct.field("data_format", &self.data_format);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43004,7 +42838,6 @@ impl std::fmt::Debug for ExportIntentsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportIntentsResponse");
         debug_struct.field("intents", &self.intents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43154,7 +42987,6 @@ impl serde::ser::Serialize for ExportIntentsMetadata {
 impl std::fmt::Debug for ExportIntentsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportIntentsMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43673,7 +43505,6 @@ impl std::fmt::Debug for Page {
             "knowledge_connector_settings",
             &self.knowledge_connector_settings,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43836,7 +43667,6 @@ impl std::fmt::Debug for Form {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Form");
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44230,7 +44060,6 @@ pub mod form {
             debug_struct.field("default_value", &self.default_value);
             debug_struct.field("redact", &self.redact);
             debug_struct.field("advanced_settings", &self.advanced_settings);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44490,7 +44319,6 @@ pub mod form {
                     &self.initial_prompt_fulfillment,
                 );
                 debug_struct.field("reprompt_event_handlers", &self.reprompt_event_handlers);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -44870,7 +44698,6 @@ impl std::fmt::Debug for EventHandler {
         debug_struct.field("event", &self.event);
         debug_struct.field("trigger_fulfillment", &self.trigger_fulfillment);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45361,7 +45188,6 @@ impl std::fmt::Debug for TransitionRoute {
         debug_struct.field("condition", &self.condition);
         debug_struct.field("trigger_fulfillment", &self.trigger_fulfillment);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45672,7 +45498,6 @@ impl std::fmt::Debug for ListPagesRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45869,7 +45694,6 @@ impl std::fmt::Debug for ListPagesResponse {
         let mut debug_struct = f.debug_struct("ListPagesResponse");
         debug_struct.field("pages", &self.pages);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46070,7 +45894,6 @@ impl std::fmt::Debug for GetPageRequest {
         let mut debug_struct = f.debug_struct("GetPageRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46306,7 +46129,6 @@ impl std::fmt::Debug for CreatePageRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page", &self.page);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46553,7 +46375,6 @@ impl std::fmt::Debug for UpdatePageRequest {
         debug_struct.field("page", &self.page);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46743,7 +46564,6 @@ impl std::fmt::Debug for DeletePageRequest {
         let mut debug_struct = f.debug_struct("DeletePageRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47120,7 +46940,6 @@ impl std::fmt::Debug for KnowledgeConnectorSettings {
         debug_struct.field("trigger_fulfillment", &self.trigger_fulfillment);
         debug_struct.field("data_store_connections", &self.data_store_connections);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47990,7 +47809,6 @@ impl std::fmt::Debug for ResponseMessage {
         debug_struct.field("response_type", &self.response_type);
         debug_struct.field("channel", &self.channel);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48234,7 +48052,6 @@ pub mod response_message {
                 "allow_playback_interruption",
                 &self.allow_playback_interruption,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -48450,7 +48267,6 @@ pub mod response_message {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LiveAgentHandoff");
             debug_struct.field("metadata", &self.metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -48668,7 +48484,6 @@ pub mod response_message {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConversationSuccess");
             debug_struct.field("metadata", &self.metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -48990,7 +48805,6 @@ pub mod response_message {
                 &self.allow_playback_interruption,
             );
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49182,7 +48996,6 @@ pub mod response_message {
     impl std::fmt::Debug for EndInteraction {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EndInteraction");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49412,7 +49225,6 @@ pub mod response_message {
                 "allow_playback_interruption",
                 &self.allow_playback_interruption,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49616,7 +49428,6 @@ pub mod response_message {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MixedAudio");
             debug_struct.field("segments", &self.segments);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49987,7 +49798,6 @@ pub mod response_message {
                     &self.allow_playback_interruption,
                 );
                 debug_struct.field("content", &self.content);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -50259,7 +50069,6 @@ pub mod response_message {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TelephonyTransferCall");
             debug_struct.field("endpoint", &self.endpoint);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50451,7 +50260,6 @@ pub mod response_message {
     impl std::fmt::Debug for KnowledgeInfoCard {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("KnowledgeInfoCard");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50878,7 +50686,6 @@ impl std::fmt::Debug for SafetySettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SafetySettings");
         debug_struct.field("banned_phrases", &self.banned_phrases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51064,7 +50871,6 @@ pub mod safety_settings {
             let mut debug_struct = f.debug_struct("Phrase");
             debug_struct.field("text", &self.text);
             debug_struct.field("language_code", &self.language_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51218,7 +51024,6 @@ impl std::fmt::Debug for GetSecuritySettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSecuritySettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51421,7 +51226,6 @@ impl std::fmt::Debug for UpdateSecuritySettingsRequest {
         let mut debug_struct = f.debug_struct("UpdateSecuritySettingsRequest");
         debug_struct.field("security_settings", &self.security_settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51641,7 +51445,6 @@ impl std::fmt::Debug for ListSecuritySettingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51839,7 +51642,6 @@ impl std::fmt::Debug for ListSecuritySettingsResponse {
         let mut debug_struct = f.debug_struct("ListSecuritySettingsResponse");
         debug_struct.field("security_settings", &self.security_settings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52029,7 +51831,6 @@ impl std::fmt::Debug for CreateSecuritySettingsRequest {
         let mut debug_struct = f.debug_struct("CreateSecuritySettingsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("security_settings", &self.security_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52182,7 +51983,6 @@ impl std::fmt::Debug for DeleteSecuritySettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSecuritySettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52813,7 +52613,6 @@ impl std::fmt::Debug for SecuritySettings {
         debug_struct.field("audio_export_settings", &self.audio_export_settings);
         debug_struct.field("insights_export_settings", &self.insights_export_settings);
         debug_struct.field("data_retention", &self.data_retention);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53091,7 +52890,6 @@ pub mod security_settings {
             debug_struct.field("enable_audio_redaction", &self.enable_audio_redaction);
             debug_struct.field("audio_format", &self.audio_format);
             debug_struct.field("store_tts_audio", &self.store_tts_audio);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -53405,7 +53203,6 @@ pub mod security_settings {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InsightsExportSettings");
             debug_struct.field("enable_insights_export", &self.enable_insights_export);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -54189,7 +53986,6 @@ impl std::fmt::Debug for AnswerFeedback {
         debug_struct.field("rating", &self.rating);
         debug_struct.field("rating_reason", &self.rating_reason);
         debug_struct.field("custom_rating", &self.custom_rating);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54378,7 +54174,6 @@ pub mod answer_feedback {
             let mut debug_struct = f.debug_struct("RatingReason");
             debug_struct.field("reason_labels", &self.reason_labels);
             debug_struct.field("feedback", &self.feedback);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -54771,7 +54566,6 @@ impl std::fmt::Debug for SubmitAnswerFeedbackRequest {
         debug_struct.field("response_id", &self.response_id);
         debug_struct.field("answer_feedback", &self.answer_feedback);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55048,7 +54842,6 @@ impl std::fmt::Debug for DetectIntentRequest {
         debug_struct.field("query_params", &self.query_params);
         debug_struct.field("query_input", &self.query_input);
         debug_struct.field("output_audio_config", &self.output_audio_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55390,7 +55183,6 @@ impl std::fmt::Debug for DetectIntentResponse {
         debug_struct.field("output_audio_config", &self.output_audio_config);
         debug_struct.field("response_type", &self.response_type);
         debug_struct.field("allow_cancellation", &self.allow_cancellation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55913,7 +55705,6 @@ impl std::fmt::Debug for StreamingDetectIntentRequest {
         debug_struct.field("output_audio_config", &self.output_audio_config);
         debug_struct.field("enable_partial_response", &self.enable_partial_response);
         debug_struct.field("enable_debugging_info", &self.enable_debugging_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56751,7 +56542,6 @@ impl std::fmt::Debug for CloudConversationDebuggingInfo {
             "client_half_close_streaming_time_offset",
             &self.client_half_close_streaming_time_offset,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57071,7 +56861,6 @@ impl std::fmt::Debug for StreamingDetectIntentResponse {
         let mut debug_struct = f.debug_struct("StreamingDetectIntentResponse");
         debug_struct.field("debugging_info", &self.debugging_info);
         debug_struct.field("response", &self.response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57538,7 +57327,6 @@ impl std::fmt::Debug for StreamingRecognitionResult {
         debug_struct.field("speech_word_info", &self.speech_word_info);
         debug_struct.field("speech_end_offset", &self.speech_end_offset);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58426,7 +58214,6 @@ impl std::fmt::Debug for QueryParameters {
             "populate_data_store_connection_signals",
             &self.populate_data_store_connection_signals,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58616,7 +58403,6 @@ impl std::fmt::Debug for SearchConfig {
         let mut debug_struct = f.debug_struct("SearchConfig");
         debug_struct.field("boost_specs", &self.boost_specs);
         debug_struct.field("filter_specs", &self.filter_specs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58778,7 +58564,6 @@ impl std::fmt::Debug for BoostSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BoostSpec");
         debug_struct.field("condition_boost_specs", &self.condition_boost_specs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59040,7 +58825,6 @@ pub mod boost_spec {
             debug_struct.field("condition", &self.condition);
             debug_struct.field("boost", &self.boost);
             debug_struct.field("boost_control_spec", &self.boost_control_spec);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -59300,7 +59084,6 @@ pub mod boost_spec {
                 debug_struct.field("attribute_type", &self.attribute_type);
                 debug_struct.field("interpolation_type", &self.interpolation_type);
                 debug_struct.field("control_points", &self.control_points);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -59537,7 +59320,6 @@ pub mod boost_spec {
                     let mut debug_struct = f.debug_struct("ControlPoint");
                     debug_struct.field("attribute_value", &self.attribute_value);
                     debug_struct.field("boost_amount", &self.boost_amount);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -60017,7 +59799,6 @@ impl std::fmt::Debug for BoostSpecs {
         let mut debug_struct = f.debug_struct("BoostSpecs");
         debug_struct.field("data_stores", &self.data_stores);
         debug_struct.field("spec", &self.spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60199,7 +59980,6 @@ impl std::fmt::Debug for FilterSpecs {
         let mut debug_struct = f.debug_struct("FilterSpecs");
         debug_struct.field("data_stores", &self.data_stores);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60623,7 +60403,6 @@ impl std::fmt::Debug for QueryInput {
         let mut debug_struct = f.debug_struct("QueryInput");
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("input", &self.input);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61765,7 +61544,6 @@ impl std::fmt::Debug for QueryResult {
             &self.data_store_connection_signals,
         );
         debug_struct.field("query", &self.query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61955,7 +61733,6 @@ impl std::fmt::Debug for TextInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TextInput");
         debug_struct.field("text", &self.text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62106,7 +61883,6 @@ impl std::fmt::Debug for IntentInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IntentInput");
         debug_struct.field("intent", &self.intent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62320,7 +62096,6 @@ impl std::fmt::Debug for AudioInput {
         let mut debug_struct = f.debug_struct("AudioInput");
         debug_struct.field("config", &self.config);
         debug_struct.field("audio", &self.audio);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62468,7 +62243,6 @@ impl std::fmt::Debug for EventInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EventInput");
         debug_struct.field("event", &self.event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62642,7 +62416,6 @@ impl std::fmt::Debug for DtmfInput {
         let mut debug_struct = f.debug_struct("DtmfInput");
         debug_struct.field("digits", &self.digits);
         debug_struct.field("finish_digit", &self.finish_digit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62991,7 +62764,6 @@ impl std::fmt::Debug for Match {
         debug_struct.field("resolved_input", &self.resolved_input);
         debug_struct.field("match_type", &self.match_type);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63446,7 +63218,6 @@ impl std::fmt::Debug for MatchIntentRequest {
         debug_struct.field("query_params", &self.query_params);
         debug_struct.field("query_input", &self.query_input);
         debug_struct.field("persist_parameter_changes", &self.persist_parameter_changes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63848,7 +63619,6 @@ impl std::fmt::Debug for MatchIntentResponse {
         debug_struct.field("matches", &self.matches);
         debug_struct.field("current_page", &self.current_page);
         debug_struct.field("query", &self.query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64119,7 +63889,6 @@ impl std::fmt::Debug for FulfillIntentRequest {
         debug_struct.field("match_intent_request", &self.match_intent_request);
         debug_struct.field("r#match", &self.r#match);
         debug_struct.field("output_audio_config", &self.output_audio_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64400,7 +64169,6 @@ impl std::fmt::Debug for FulfillIntentResponse {
         debug_struct.field("query_result", &self.query_result);
         debug_struct.field("output_audio", &self.output_audio);
         debug_struct.field("output_audio_config", &self.output_audio_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64613,7 +64381,6 @@ impl std::fmt::Debug for SentimentAnalysisResult {
         let mut debug_struct = f.debug_struct("SentimentAnalysisResult");
         debug_struct.field("score", &self.score);
         debug_struct.field("magnitude", &self.magnitude);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64848,7 +64615,6 @@ impl std::fmt::Debug for SessionEntityType {
         debug_struct.field("name", &self.name);
         debug_struct.field("entity_override_mode", &self.entity_override_mode);
         debug_struct.field("entities", &self.entities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65236,7 +65002,6 @@ impl std::fmt::Debug for ListSessionEntityTypesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65438,7 +65203,6 @@ impl std::fmt::Debug for ListSessionEntityTypesResponse {
         let mut debug_struct = f.debug_struct("ListSessionEntityTypesResponse");
         debug_struct.field("session_entity_types", &self.session_entity_types);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65595,7 +65359,6 @@ impl std::fmt::Debug for GetSessionEntityTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSessionEntityTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65790,7 +65553,6 @@ impl std::fmt::Debug for CreateSessionEntityTypeRequest {
         let mut debug_struct = f.debug_struct("CreateSessionEntityTypeRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("session_entity_type", &self.session_entity_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65997,7 +65759,6 @@ impl std::fmt::Debug for UpdateSessionEntityTypeRequest {
         let mut debug_struct = f.debug_struct("UpdateSessionEntityTypeRequest");
         debug_struct.field("session_entity_type", &self.session_entity_type);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66154,7 +65915,6 @@ impl std::fmt::Debug for DeleteSessionEntityTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSessionEntityTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66546,7 +66306,6 @@ impl std::fmt::Debug for TestCase {
         );
         debug_struct.field("creation_time", &self.creation_time);
         debug_struct.field("last_test_result", &self.last_test_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66821,7 +66580,6 @@ impl std::fmt::Debug for TestCaseResult {
         debug_struct.field("conversation_turns", &self.conversation_turns);
         debug_struct.field("test_result", &self.test_result);
         debug_struct.field("test_time", &self.test_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67037,7 +66795,6 @@ impl std::fmt::Debug for TestConfig {
         debug_struct.field("tracking_parameters", &self.tracking_parameters);
         debug_struct.field("flow", &self.flow);
         debug_struct.field("page", &self.page);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67237,7 +66994,6 @@ impl std::fmt::Debug for ConversationTurn {
         let mut debug_struct = f.debug_struct("ConversationTurn");
         debug_struct.field("user_input", &self.user_input);
         debug_struct.field("virtual_agent_output", &self.virtual_agent_output);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67509,7 +67265,6 @@ pub mod conversation_turn {
             debug_struct.field("injected_parameters", &self.injected_parameters);
             debug_struct.field("is_webhook_enabled", &self.is_webhook_enabled);
             debug_struct.field("enable_sentiment_analysis", &self.enable_sentiment_analysis);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -67900,7 +67655,6 @@ pub mod conversation_turn {
             debug_struct.field("current_page", &self.current_page);
             debug_struct.field("text_responses", &self.text_responses);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -68080,7 +67834,6 @@ impl std::fmt::Debug for TestRunDifference {
         let mut debug_struct = f.debug_struct("TestRunDifference");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68451,7 +68204,6 @@ impl std::fmt::Debug for TransitionCoverage {
         let mut debug_struct = f.debug_struct("TransitionCoverage");
         debug_struct.field("transitions", &self.transitions);
         debug_struct.field("coverage_score", &self.coverage_score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68709,7 +68461,6 @@ pub mod transition_coverage {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TransitionNode");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -69132,7 +68883,6 @@ pub mod transition_coverage {
             debug_struct.field("target", &self.target);
             debug_struct.field("covered", &self.covered);
             debug_struct.field("detail", &self.detail);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -69356,7 +69106,6 @@ impl std::fmt::Debug for TransitionRouteGroupCoverage {
         let mut debug_struct = f.debug_struct("TransitionRouteGroupCoverage");
         debug_struct.field("coverages", &self.coverages);
         debug_struct.field("coverage_score", &self.coverage_score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69602,7 +69351,6 @@ pub mod transition_route_group_coverage {
             debug_struct.field("route_group", &self.route_group);
             debug_struct.field("transitions", &self.transitions);
             debug_struct.field("coverage_score", &self.coverage_score);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -69804,7 +69552,6 @@ pub mod transition_route_group_coverage {
                 let mut debug_struct = f.debug_struct("Transition");
                 debug_struct.field("transition_route", &self.transition_route);
                 debug_struct.field("covered", &self.covered);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -70007,7 +69754,6 @@ impl std::fmt::Debug for IntentCoverage {
         let mut debug_struct = f.debug_struct("IntentCoverage");
         debug_struct.field("intents", &self.intents);
         debug_struct.field("coverage_score", &self.coverage_score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70190,7 +69936,6 @@ pub mod intent_coverage {
             let mut debug_struct = f.debug_struct("Intent");
             debug_struct.field("intent", &self.intent);
             debug_struct.field("covered", &self.covered);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -70375,7 +70120,6 @@ impl std::fmt::Debug for CalculateCoverageRequest {
         let mut debug_struct = f.debug_struct("CalculateCoverageRequest");
         debug_struct.field("agent", &self.agent);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70867,7 +70611,6 @@ impl std::fmt::Debug for CalculateCoverageResponse {
         let mut debug_struct = f.debug_struct("CalculateCoverageResponse");
         debug_struct.field("agent", &self.agent);
         debug_struct.field("coverage_type", &self.coverage_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71141,7 +70884,6 @@ impl std::fmt::Debug for ListTestCasesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71489,7 +71231,6 @@ impl std::fmt::Debug for ListTestCasesResponse {
         let mut debug_struct = f.debug_struct("ListTestCasesResponse");
         debug_struct.field("test_cases", &self.test_cases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71670,7 +71411,6 @@ impl std::fmt::Debug for BatchDeleteTestCasesRequest {
         let mut debug_struct = f.debug_struct("BatchDeleteTestCasesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71859,7 +71599,6 @@ impl std::fmt::Debug for CreateTestCaseRequest {
         let mut debug_struct = f.debug_struct("CreateTestCaseRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("test_case", &self.test_case);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72065,7 +71804,6 @@ impl std::fmt::Debug for UpdateTestCaseRequest {
         let mut debug_struct = f.debug_struct("UpdateTestCaseRequest");
         debug_struct.field("test_case", &self.test_case);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72218,7 +71956,6 @@ impl std::fmt::Debug for GetTestCaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTestCaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72397,7 +72134,6 @@ impl std::fmt::Debug for RunTestCaseRequest {
         let mut debug_struct = f.debug_struct("RunTestCaseRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72560,7 +72296,6 @@ impl std::fmt::Debug for RunTestCaseResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunTestCaseResponse");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72684,7 +72419,6 @@ impl serde::ser::Serialize for RunTestCaseMetadata {
 impl std::fmt::Debug for RunTestCaseMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunTestCaseMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72892,7 +72626,6 @@ impl std::fmt::Debug for BatchRunTestCasesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("test_cases", &self.test_cases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73055,7 +72788,6 @@ impl std::fmt::Debug for BatchRunTestCasesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchRunTestCasesResponse");
         debug_struct.field("results", &self.results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73210,7 +72942,6 @@ impl std::fmt::Debug for BatchRunTestCasesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchRunTestCasesMetadata");
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73432,7 +73163,6 @@ impl std::fmt::Debug for TestError {
         debug_struct.field("test_case", &self.test_case);
         debug_struct.field("status", &self.status);
         debug_struct.field("test_time", &self.test_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73718,7 +73448,6 @@ impl std::fmt::Debug for ImportTestCasesRequest {
         let mut debug_struct = f.debug_struct("ImportTestCasesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73900,7 +73629,6 @@ impl std::fmt::Debug for ImportTestCasesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportTestCasesResponse");
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74055,7 +73783,6 @@ impl std::fmt::Debug for ImportTestCasesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportTestCasesMetadata");
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74251,7 +73978,6 @@ impl std::fmt::Debug for TestCaseError {
         let mut debug_struct = f.debug_struct("TestCaseError");
         debug_struct.field("test_case", &self.test_case);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74540,7 +74266,6 @@ impl std::fmt::Debug for ExportTestCasesRequest {
         debug_struct.field("data_format", &self.data_format);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74968,7 +74693,6 @@ impl std::fmt::Debug for ExportTestCasesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportTestCasesResponse");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75114,7 +74838,6 @@ impl serde::ser::Serialize for ExportTestCasesMetadata {
 impl std::fmt::Debug for ExportTestCasesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportTestCasesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75389,7 +75112,6 @@ impl std::fmt::Debug for ListTestCaseResultsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75590,7 +75312,6 @@ impl std::fmt::Debug for ListTestCaseResultsResponse {
         let mut debug_struct = f.debug_struct("ListTestCaseResultsResponse");
         debug_struct.field("test_case_results", &self.test_case_results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75743,7 +75464,6 @@ impl std::fmt::Debug for GetTestCaseResultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTestCaseResultRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75965,7 +75685,6 @@ impl std::fmt::Debug for TransitionRouteGroup {
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("transition_routes", &self.transition_routes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76227,7 +75946,6 @@ impl std::fmt::Debug for ListTransitionRouteGroupsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76431,7 +76149,6 @@ impl std::fmt::Debug for ListTransitionRouteGroupsResponse {
         let mut debug_struct = f.debug_struct("ListTransitionRouteGroupsResponse");
         debug_struct.field("transition_route_groups", &self.transition_route_groups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76626,7 +76343,6 @@ impl std::fmt::Debug for GetTransitionRouteGroupRequest {
         let mut debug_struct = f.debug_struct("GetTransitionRouteGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76857,7 +76573,6 @@ impl std::fmt::Debug for CreateTransitionRouteGroupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("transition_route_group", &self.transition_route_group);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77093,7 +76808,6 @@ impl std::fmt::Debug for UpdateTransitionRouteGroupRequest {
         debug_struct.field("transition_route_group", &self.transition_route_group);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77282,7 +76996,6 @@ impl std::fmt::Debug for DeleteTransitionRouteGroupRequest {
         let mut debug_struct = f.debug_struct("DeleteTransitionRouteGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77548,7 +77261,6 @@ impl std::fmt::Debug for ValidationMessage {
         debug_struct.field("resource_names", &self.resource_names);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78104,7 +77816,6 @@ impl std::fmt::Debug for ResourceName {
         let mut debug_struct = f.debug_struct("ResourceName");
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78257,7 +77968,6 @@ impl std::fmt::Debug for CreateVersionOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateVersionOperationMetadata");
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78560,7 +78270,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("nlu_settings", &self.nlu_settings);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78941,7 +78650,6 @@ impl std::fmt::Debug for ListVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79139,7 +78847,6 @@ impl std::fmt::Debug for ListVersionsResponse {
         let mut debug_struct = f.debug_struct("ListVersionsResponse");
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79294,7 +79001,6 @@ impl std::fmt::Debug for GetVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79486,7 +79192,6 @@ impl std::fmt::Debug for CreateVersionRequest {
         let mut debug_struct = f.debug_struct("CreateVersionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79686,7 +79391,6 @@ impl std::fmt::Debug for UpdateVersionRequest {
         let mut debug_struct = f.debug_struct("UpdateVersionRequest");
         debug_struct.field("version", &self.version);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79841,7 +79545,6 @@ impl std::fmt::Debug for DeleteVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80035,7 +79738,6 @@ impl std::fmt::Debug for LoadVersionRequest {
             "allow_override_agent_resources",
             &self.allow_override_agent_resources,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80252,7 +79954,6 @@ impl std::fmt::Debug for CompareVersionsRequest {
         debug_struct.field("base_version", &self.base_version);
         debug_struct.field("target_version", &self.target_version);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80485,7 +80186,6 @@ impl std::fmt::Debug for CompareVersionsResponse {
             &self.target_version_content_json,
         );
         debug_struct.field("compare_time", &self.compare_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80864,7 +80564,6 @@ impl std::fmt::Debug for Webhook {
         debug_struct.field("timeout", &self.timeout);
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("webhook", &self.webhook);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81395,7 +81094,6 @@ pub mod webhook {
             debug_struct.field("http_method", &self.http_method);
             debug_struct.field("request_body", &self.request_body);
             debug_struct.field("parameter_mapping", &self.parameter_mapping);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -81653,7 +81351,6 @@ pub mod webhook {
                 debug_struct.field("client_secret", &self.client_secret);
                 debug_struct.field("token_endpoint", &self.token_endpoint);
                 debug_struct.field("scopes", &self.scopes);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -82335,7 +82032,6 @@ pub mod webhook {
             let mut debug_struct = f.debug_struct("ServiceDirectoryConfig");
             debug_struct.field("service", &self.service);
             debug_struct.field("generic_web_service", &self.generic_web_service);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -82571,7 +82267,6 @@ impl std::fmt::Debug for ListWebhooksRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82768,7 +82463,6 @@ impl std::fmt::Debug for ListWebhooksResponse {
         let mut debug_struct = f.debug_struct("ListWebhooksResponse");
         debug_struct.field("webhooks", &self.webhooks);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82921,7 +82615,6 @@ impl std::fmt::Debug for GetWebhookRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWebhookRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83109,7 +82802,6 @@ impl std::fmt::Debug for CreateWebhookRequest {
         let mut debug_struct = f.debug_struct("CreateWebhookRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("webhook", &self.webhook);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83309,7 +83001,6 @@ impl std::fmt::Debug for UpdateWebhookRequest {
         let mut debug_struct = f.debug_struct("UpdateWebhookRequest");
         debug_struct.field("webhook", &self.webhook);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83499,7 +83190,6 @@ impl std::fmt::Debug for DeleteWebhookRequest {
         let mut debug_struct = f.debug_struct("DeleteWebhookRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84352,7 +84042,6 @@ impl std::fmt::Debug for WebhookRequest {
         debug_struct.field("sentiment_analysis_result", &self.sentiment_analysis_result);
         debug_struct.field("language_info", &self.language_info);
         debug_struct.field("query", &self.query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84643,7 +84332,6 @@ pub mod webhook_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FulfillmentInfo");
             debug_struct.field("tag", &self.tag);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -85023,7 +84711,6 @@ pub mod webhook_request {
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("parameters", &self.parameters);
             debug_struct.field("confidence", &self.confidence);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -85356,7 +85043,6 @@ pub mod webhook_request {
                 let mut debug_struct = f.debug_struct("IntentParameterValue");
                 debug_struct.field("original_value", &self.original_value);
                 debug_struct.field("resolved_value", &self.resolved_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -85681,7 +85367,6 @@ pub mod webhook_request {
             let mut debug_struct = f.debug_struct("SentimentAnalysisResult");
             debug_struct.field("score", &self.score);
             debug_struct.field("magnitude", &self.magnitude);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -86219,7 +85904,6 @@ impl std::fmt::Debug for WebhookResponse {
         debug_struct.field("session_info", &self.session_info);
         debug_struct.field("payload", &self.payload);
         debug_struct.field("transition", &self.transition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86538,7 +86222,6 @@ pub mod webhook_response {
             let mut debug_struct = f.debug_struct("FulfillmentResponse");
             debug_struct.field("messages", &self.messages);
             debug_struct.field("merge_behavior", &self.merge_behavior);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -87226,7 +86909,6 @@ impl std::fmt::Debug for PageInfo {
         debug_struct.field("current_page", &self.current_page);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("form_info", &self.form_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -87526,7 +87208,6 @@ pub mod page_info {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FormInfo");
             debug_struct.field("parameter_info", &self.parameter_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -87981,7 +87662,6 @@ pub mod page_info {
                 debug_struct.field("state", &self.state);
                 debug_struct.field("value", &self.value);
                 debug_struct.field("just_collected", &self.just_collected);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -88637,7 +88317,6 @@ impl std::fmt::Debug for SessionInfo {
         let mut debug_struct = f.debug_struct("SessionInfo");
         debug_struct.field("session", &self.session);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88975,7 +88654,6 @@ impl std::fmt::Debug for LanguageInfo {
         debug_struct.field("input_language_code", &self.input_language_code);
         debug_struct.field("resolved_language_code", &self.resolved_language_code);
         debug_struct.field("confidence_score", &self.confidence_score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -531,7 +531,6 @@ impl std::fmt::Debug for Agent {
         debug_struct.field("classification_threshold", &self.classification_threshold);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("tier", &self.tier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1131,7 +1130,6 @@ impl std::fmt::Debug for GetAgentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAgentRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1330,7 +1328,6 @@ impl std::fmt::Debug for SetAgentRequest {
         let mut debug_struct = f.debug_struct("SetAgentRequest");
         debug_struct.field("agent", &self.agent);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1482,7 +1479,6 @@ impl std::fmt::Debug for DeleteAgentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAgentRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1705,7 +1701,6 @@ impl std::fmt::Debug for SearchAgentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1902,7 +1897,6 @@ impl std::fmt::Debug for SearchAgentsResponse {
         let mut debug_struct = f.debug_struct("SearchAgentsResponse");
         debug_struct.field("agents", &self.agents);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2054,7 +2048,6 @@ impl std::fmt::Debug for TrainAgentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TrainAgentRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2241,7 +2234,6 @@ impl std::fmt::Debug for ExportAgentRequest {
         let mut debug_struct = f.debug_struct("ExportAgentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("agent_uri", &self.agent_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2500,7 +2492,6 @@ impl std::fmt::Debug for ExportAgentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportAgentResponse");
         debug_struct.field("agent", &self.agent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2804,7 +2795,6 @@ impl std::fmt::Debug for ImportAgentRequest {
         let mut debug_struct = f.debug_struct("ImportAgentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("agent", &self.agent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3114,7 +3104,6 @@ impl std::fmt::Debug for RestoreAgentRequest {
         let mut debug_struct = f.debug_struct("RestoreAgentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("agent", &self.agent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3321,7 +3310,6 @@ impl std::fmt::Debug for GetValidationResultRequest {
         let mut debug_struct = f.debug_struct("GetValidationResultRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3620,7 +3608,6 @@ impl std::fmt::Debug for AnswerRecord {
         debug_struct.field("name", &self.name);
         debug_struct.field("answer_feedback", &self.answer_feedback);
         debug_struct.field("record", &self.record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3909,7 +3896,6 @@ impl std::fmt::Debug for ListAnswerRecordsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4112,7 +4098,6 @@ impl std::fmt::Debug for ListAnswerRecordsResponse {
         let mut debug_struct = f.debug_struct("ListAnswerRecordsResponse");
         debug_struct.field("answer_records", &self.answer_records);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4312,7 +4297,6 @@ impl std::fmt::Debug for UpdateAnswerRecordRequest {
         let mut debug_struct = f.debug_struct("UpdateAnswerRecordRequest");
         debug_struct.field("answer_record", &self.answer_record);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4674,7 +4658,6 @@ impl std::fmt::Debug for AnswerFeedback {
         debug_struct.field("displayed", &self.displayed);
         debug_struct.field("display_time", &self.display_time);
         debug_struct.field("detail_feedback", &self.detail_feedback);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5216,7 +5199,6 @@ impl std::fmt::Debug for AgentAssistantFeedback {
         debug_struct.field("summarization_feedback", &self.summarization_feedback);
         debug_struct.field("knowledge_search_feedback", &self.knowledge_search_feedback);
         debug_struct.field("knowledge_assist_feedback", &self.knowledge_assist_feedback);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5488,7 +5470,6 @@ pub mod agent_assistant_feedback {
             debug_struct.field("submit_time", &self.submit_time);
             debug_struct.field("summary_text", &self.summary_text);
             debug_struct.field("text_sections", &self.text_sections);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5681,7 +5662,6 @@ pub mod agent_assistant_feedback {
             let mut debug_struct = f.debug_struct("KnowledgeSearchFeedback");
             debug_struct.field("answer_copied", &self.answer_copied);
             debug_struct.field("clicked_uris", &self.clicked_uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5873,7 +5853,6 @@ pub mod agent_assistant_feedback {
             let mut debug_struct = f.debug_struct("KnowledgeAssistFeedback");
             debug_struct.field("answer_copied", &self.answer_copied);
             debug_struct.field("clicked_uris", &self.clicked_uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6608,7 +6587,6 @@ impl std::fmt::Debug for AgentAssistantRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AgentAssistantRecord");
         debug_struct.field("answer", &self.answer);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6843,7 +6821,6 @@ impl std::fmt::Debug for SpeechContext {
         let mut debug_struct = f.debug_struct("SpeechContext");
         debug_struct.field("phrases", &self.phrases);
         debug_struct.field("boost", &self.boost);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7118,7 +7095,6 @@ impl std::fmt::Debug for SpeechWordInfo {
         debug_struct.field("start_offset", &self.start_offset);
         debug_struct.field("end_offset", &self.end_offset);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7700,7 +7676,6 @@ impl std::fmt::Debug for InputAudioConfig {
             "opt_out_conformer_model_migration",
             &self.opt_out_conformer_model_migration,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7924,7 +7899,6 @@ impl std::fmt::Debug for VoiceSelectionParams {
         let mut debug_struct = f.debug_struct("VoiceSelectionParams");
         debug_struct.field("name", &self.name);
         debug_struct.field("ssml_gender", &self.ssml_gender);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8295,7 +8269,6 @@ impl std::fmt::Debug for SynthesizeSpeechConfig {
         debug_struct.field("volume_gain_db", &self.volume_gain_db);
         debug_struct.field("effects_profile_id", &self.effects_profile_id);
         debug_struct.field("voice", &self.voice);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8535,7 +8508,6 @@ impl std::fmt::Debug for OutputAudioConfig {
         debug_struct.field("audio_encoding", &self.audio_encoding);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("synthesize_speech_config", &self.synthesize_speech_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8687,7 +8659,6 @@ impl std::fmt::Debug for TelephonyDtmfEvents {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TelephonyDtmfEvents");
         debug_struct.field("dtmf_events", &self.dtmf_events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9106,7 +9077,6 @@ impl std::fmt::Debug for SpeechToTextConfig {
             "use_timeout_based_endpointing",
             &self.use_timeout_based_endpointing,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9417,7 +9387,6 @@ impl std::fmt::Debug for Context {
         debug_struct.field("name", &self.name);
         debug_struct.field("lifespan_count", &self.lifespan_count);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9644,7 +9613,6 @@ impl std::fmt::Debug for ListContextsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9841,7 +9809,6 @@ impl std::fmt::Debug for ListContextsResponse {
         let mut debug_struct = f.debug_struct("ListContextsResponse");
         debug_struct.field("contexts", &self.contexts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9997,7 +9964,6 @@ impl std::fmt::Debug for GetContextRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetContextRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10189,7 +10155,6 @@ impl std::fmt::Debug for CreateContextRequest {
         let mut debug_struct = f.debug_struct("CreateContextRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("context", &self.context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10388,7 +10353,6 @@ impl std::fmt::Debug for UpdateContextRequest {
         let mut debug_struct = f.debug_struct("UpdateContextRequest");
         debug_struct.field("context", &self.context);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10544,7 +10508,6 @@ impl std::fmt::Debug for DeleteContextRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteContextRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10700,7 +10663,6 @@ impl std::fmt::Debug for DeleteAllContextsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAllContextsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11172,7 +11134,6 @@ impl std::fmt::Debug for Conversation {
             "ingested_context_references",
             &self.ingested_context_references,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11422,7 +11383,6 @@ pub mod conversation {
             debug_struct.field("sdp", &self.sdp);
             debug_struct.field("sip_headers", &self.sip_headers);
             debug_struct.field("extra_mime_contents", &self.extra_mime_contents);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11607,7 +11567,6 @@ pub mod conversation {
                 let mut debug_struct = f.debug_struct("SipHeader");
                 debug_struct.field("name", &self.name);
                 debug_struct.field("value", &self.value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -11823,7 +11782,6 @@ pub mod conversation {
                 let mut debug_struct = f.debug_struct("MimeContent");
                 debug_struct.field("mime_type", &self.mime_type);
                 debug_struct.field("content", &self.content);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12080,7 +12038,6 @@ pub mod conversation {
             debug_struct.field("update_mode", &self.update_mode);
             debug_struct.field("language_code", &self.language_code);
             debug_struct.field("create_time", &self.create_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12309,7 +12266,6 @@ pub mod conversation {
                 debug_struct.field("content", &self.content);
                 debug_struct.field("content_format", &self.content_format);
                 debug_struct.field("ingestion_time", &self.ingestion_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -13118,7 +13074,6 @@ impl std::fmt::Debug for CreateConversationRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("conversation_id", &self.conversation_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13373,7 +13328,6 @@ impl std::fmt::Debug for ListConversationsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13570,7 +13524,6 @@ impl std::fmt::Debug for ListConversationsResponse {
         let mut debug_struct = f.debug_struct("ListConversationsResponse");
         debug_struct.field("conversations", &self.conversations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13723,7 +13676,6 @@ impl std::fmt::Debug for GetConversationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConversationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13876,7 +13828,6 @@ impl std::fmt::Debug for CompleteConversationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CompleteConversationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14132,7 +14083,6 @@ impl std::fmt::Debug for ListMessagesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14330,7 +14280,6 @@ impl std::fmt::Debug for ListMessagesResponse {
         let mut debug_struct = f.debug_struct("ListMessagesResponse");
         debug_struct.field("messages", &self.messages);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14524,7 +14473,6 @@ impl std::fmt::Debug for ConversationPhoneNumber {
         let mut debug_struct = f.debug_struct("ConversationPhoneNumber");
         debug_struct.field("country_code", &self.country_code);
         debug_struct.field("phone_number", &self.phone_number);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14717,7 +14665,6 @@ impl std::fmt::Debug for IngestContextReferencesRequest {
         let mut debug_struct = f.debug_struct("IngestContextReferencesRequest");
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("context_references", &self.context_references);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14891,7 +14838,6 @@ impl std::fmt::Debug for IngestContextReferencesResponse {
             "ingested_context_references",
             &self.ingested_context_references,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15159,7 +15105,6 @@ impl std::fmt::Debug for SuggestConversationSummaryRequest {
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
         debug_struct.field("assist_query_params", &self.assist_query_params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15404,7 +15349,6 @@ impl std::fmt::Debug for SuggestConversationSummaryResponse {
         debug_struct.field("summary", &self.summary);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15662,7 +15606,6 @@ pub mod suggest_conversation_summary_response {
             debug_struct.field("text_sections", &self.text_sections);
             debug_struct.field("answer_record", &self.answer_record);
             debug_struct.field("baseline_model_version", &self.baseline_model_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15947,7 +15890,6 @@ impl std::fmt::Debug for GenerateStatelessSummaryRequest {
         debug_struct.field("conversation_profile", &self.conversation_profile);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("max_context_size", &self.max_context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16138,7 +16080,6 @@ pub mod generate_stateless_summary_request {
             let mut debug_struct = f.debug_struct("MinimalConversation");
             debug_struct.field("messages", &self.messages);
             debug_struct.field("parent", &self.parent);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16382,7 +16323,6 @@ impl std::fmt::Debug for GenerateStatelessSummaryResponse {
         debug_struct.field("summary", &self.summary);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16610,7 +16550,6 @@ pub mod generate_stateless_summary_response {
             debug_struct.field("text", &self.text);
             debug_struct.field("text_sections", &self.text_sections);
             debug_struct.field("baseline_model_version", &self.baseline_model_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16996,7 +16935,6 @@ impl std::fmt::Debug for GenerateStatelessSuggestionRequest {
         debug_struct.field("conversation_context", &self.conversation_context);
         debug_struct.field("trigger_events", &self.trigger_events);
         debug_struct.field("generator_resource", &self.generator_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17179,7 +17117,6 @@ impl std::fmt::Debug for GenerateStatelessSuggestionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateStatelessSuggestionResponse");
         debug_struct.field("generator_suggestion", &self.generator_suggestion);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17637,7 +17574,6 @@ impl std::fmt::Debug for SearchKnowledgeRequest {
         debug_struct.field("end_user_metadata", &self.end_user_metadata);
         debug_struct.field("search_config", &self.search_config);
         debug_struct.field("exact_search", &self.exact_search);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17842,7 +17778,6 @@ pub mod search_knowledge_request {
             let mut debug_struct = f.debug_struct("SearchConfig");
             debug_struct.field("boost_specs", &self.boost_specs);
             debug_struct.field("filter_specs", &self.filter_specs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18041,7 +17976,6 @@ pub mod search_knowledge_request {
                 let mut debug_struct = f.debug_struct("BoostSpecs");
                 debug_struct.field("data_stores", &self.data_stores);
                 debug_struct.field("spec", &self.spec);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -18225,7 +18159,6 @@ pub mod search_knowledge_request {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("BoostSpec");
                     debug_struct.field("condition_boost_specs", &self.condition_boost_specs);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -18519,7 +18452,6 @@ pub mod search_knowledge_request {
                         debug_struct.field("condition", &self.condition);
                         debug_struct.field("boost", &self.boost);
                         debug_struct.field("boost_control_spec", &self.boost_control_spec);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -18804,7 +18736,6 @@ pub mod search_knowledge_request {
                             debug_struct.field("attribute_type", &self.attribute_type);
                             debug_struct.field("interpolation_type", &self.interpolation_type);
                             debug_struct.field("control_points", &self.control_points);
-
                             if !self._unknown_fields.is_empty() {
                                 debug_struct.field("_unknown_fields", &self._unknown_fields);
                             }
@@ -19076,7 +19007,6 @@ pub mod search_knowledge_request {
                                 let mut debug_struct = f.debug_struct("ControlPoint");
                                 debug_struct.field("attribute_value", &self.attribute_value);
                                 debug_struct.field("boost_amount", &self.boost_amount);
-
                                 if !self._unknown_fields.is_empty() {
                                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                                 }
@@ -19576,7 +19506,6 @@ pub mod search_knowledge_request {
                 let mut debug_struct = f.debug_struct("FilterSpecs");
                 debug_struct.field("data_stores", &self.data_stores);
                 debug_struct.field("filter", &self.filter);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -19913,7 +19842,6 @@ impl std::fmt::Debug for SearchKnowledgeResponse {
         let mut debug_struct = f.debug_struct("SearchKnowledgeResponse");
         debug_struct.field("answers", &self.answers);
         debug_struct.field("rewritten_query", &self.rewritten_query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20158,7 +20086,6 @@ impl std::fmt::Debug for SearchKnowledgeAnswer {
         debug_struct.field("answer_type", &self.answer_type);
         debug_struct.field("answer_sources", &self.answer_sources);
         debug_struct.field("answer_record", &self.answer_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20401,7 +20328,6 @@ pub mod search_knowledge_answer {
             debug_struct.field("uri", &self.uri);
             debug_struct.field("snippet", &self.snippet);
             debug_struct.field("metadata", &self.metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20764,7 +20690,6 @@ impl std::fmt::Debug for GenerateSuggestionsRequest {
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("trigger_events", &self.trigger_events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20915,7 +20840,6 @@ impl std::fmt::Debug for ConversationInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConversationInfo");
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21108,7 +21032,6 @@ impl std::fmt::Debug for InputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21562,7 +21485,6 @@ impl std::fmt::Debug for ConversationDataset {
         debug_struct.field("conversation_count", &self.conversation_count);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21751,7 +21673,6 @@ impl std::fmt::Debug for CreateConversationDatasetRequest {
         let mut debug_struct = f.debug_struct("CreateConversationDatasetRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("conversation_dataset", &self.conversation_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21904,7 +21825,6 @@ impl std::fmt::Debug for GetConversationDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConversationDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22127,7 +22047,6 @@ impl std::fmt::Debug for ListConversationDatasetsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22328,7 +22247,6 @@ impl std::fmt::Debug for ListConversationDatasetsResponse {
         let mut debug_struct = f.debug_struct("ListConversationDatasetsResponse");
         debug_struct.field("conversation_datasets", &self.conversation_datasets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22481,7 +22399,6 @@ impl std::fmt::Debug for DeleteConversationDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConversationDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22671,7 +22588,6 @@ impl std::fmt::Debug for ImportConversationDataRequest {
         let mut debug_struct = f.debug_struct("ImportConversationDataRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("input_config", &self.input_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22898,7 +22814,6 @@ impl std::fmt::Debug for ImportConversationDataOperationMetadata {
         debug_struct.field("conversation_dataset", &self.conversation_dataset);
         debug_struct.field("partial_failures", &self.partial_failures);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23101,7 +23016,6 @@ impl std::fmt::Debug for ImportConversationDataOperationResponse {
         let mut debug_struct = f.debug_struct("ImportConversationDataOperationResponse");
         debug_struct.field("conversation_dataset", &self.conversation_dataset);
         debug_struct.field("import_count", &self.import_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23257,7 +23171,6 @@ impl std::fmt::Debug for CreateConversationDatasetOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateConversationDatasetOperationMetadata");
         debug_struct.field("conversation_dataset", &self.conversation_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23379,7 +23292,6 @@ impl serde::ser::Serialize for DeleteConversationDatasetOperationMetadata {
 impl std::fmt::Debug for DeleteConversationDatasetOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConversationDatasetOperationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23850,7 +23762,6 @@ impl std::fmt::Debug for ConversationEvent {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("error_status", &self.error_status);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24768,7 +24679,6 @@ impl std::fmt::Debug for ConversationModel {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("model_metadata", &self.model_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25494,7 +25404,6 @@ impl std::fmt::Debug for ConversationModelEvaluation {
             &self.raw_human_eval_template_csv,
         );
         debug_struct.field("metrics", &self.metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25794,7 +25703,6 @@ impl std::fmt::Debug for EvaluationConfig {
         let mut debug_struct = f.debug_struct("EvaluationConfig");
         debug_struct.field("datasets", &self.datasets);
         debug_struct.field("model_specific_config", &self.model_specific_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26005,7 +25913,6 @@ pub mod evaluation_config {
             let mut debug_struct = f.debug_struct("SmartReplyConfig");
             debug_struct.field("allowlist_document", &self.allowlist_document);
             debug_struct.field("max_result_count", &self.max_result_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26210,7 +26117,6 @@ pub mod evaluation_config {
             let mut debug_struct = f.debug_struct("SmartComposeConfig");
             debug_struct.field("allowlist_document", &self.allowlist_document);
             debug_struct.field("max_result_count", &self.max_result_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26373,7 +26279,6 @@ impl std::fmt::Debug for InputDataset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InputDataset");
         debug_struct.field("dataset", &self.dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26530,7 +26435,6 @@ impl std::fmt::Debug for ArticleSuggestionModelMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ArticleSuggestionModelMetadata");
         debug_struct.field("training_model_type", &self.training_model_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26687,7 +26591,6 @@ impl std::fmt::Debug for SmartReplyModelMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SmartReplyModelMetadata");
         debug_struct.field("training_model_type", &self.training_model_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26935,7 +26838,6 @@ impl std::fmt::Debug for SmartReplyMetrics {
         debug_struct.field("allowlist_coverage", &self.allowlist_coverage);
         debug_struct.field("top_n_metrics", &self.top_n_metrics);
         debug_struct.field("conversation_count", &self.conversation_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27158,7 +27060,6 @@ pub mod smart_reply_metrics {
             let mut debug_struct = f.debug_struct("TopNMetrics");
             debug_struct.field("n", &self.n);
             debug_struct.field("recall", &self.recall);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27349,7 +27250,6 @@ impl std::fmt::Debug for CreateConversationModelRequest {
         let mut debug_struct = f.debug_struct("CreateConversationModelRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("conversation_model", &self.conversation_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27501,7 +27401,6 @@ impl std::fmt::Debug for GetConversationModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConversationModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27724,7 +27623,6 @@ impl std::fmt::Debug for ListConversationModelsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27925,7 +27823,6 @@ impl std::fmt::Debug for ListConversationModelsResponse {
         let mut debug_struct = f.debug_struct("ListConversationModelsResponse");
         debug_struct.field("conversation_models", &self.conversation_models);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28077,7 +27974,6 @@ impl std::fmt::Debug for DeleteConversationModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConversationModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28229,7 +28125,6 @@ impl std::fmt::Debug for DeployConversationModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployConversationModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28381,7 +28276,6 @@ impl std::fmt::Debug for UndeployConversationModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployConversationModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28535,7 +28429,6 @@ impl std::fmt::Debug for GetConversationModelEvaluationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConversationModelEvaluationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28759,7 +28652,6 @@ impl std::fmt::Debug for ListConversationModelEvaluationsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28971,7 +28863,6 @@ impl std::fmt::Debug for ListConversationModelEvaluationsResponse {
             &self.conversation_model_evaluations,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29176,7 +29067,6 @@ impl std::fmt::Debug for CreateConversationModelEvaluationRequest {
             "conversation_model_evaluation",
             &self.conversation_model_evaluation,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29400,7 +29290,6 @@ impl std::fmt::Debug for CreateConversationModelOperationMetadata {
         debug_struct.field("conversation_model", &self.conversation_model);
         debug_struct.field("state", &self.state);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29774,7 +29663,6 @@ impl std::fmt::Debug for DeployConversationModelOperationMetadata {
         let mut debug_struct = f.debug_struct("DeployConversationModelOperationMetadata");
         debug_struct.field("conversation_model", &self.conversation_model);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29971,7 +29859,6 @@ impl std::fmt::Debug for UndeployConversationModelOperationMetadata {
         let mut debug_struct = f.debug_struct("UndeployConversationModelOperationMetadata");
         debug_struct.field("conversation_model", &self.conversation_model);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30167,7 +30054,6 @@ impl std::fmt::Debug for DeleteConversationModelOperationMetadata {
         let mut debug_struct = f.debug_struct("DeleteConversationModelOperationMetadata");
         debug_struct.field("conversation_model", &self.conversation_model);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30436,7 +30322,6 @@ impl std::fmt::Debug for CreateConversationModelEvaluationOperationMetadata {
         debug_struct.field("conversation_model", &self.conversation_model);
         debug_struct.field("state", &self.state);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31346,7 +31231,6 @@ impl std::fmt::Debug for ConversationProfile {
         debug_struct.field("time_zone", &self.time_zone);
         debug_struct.field("security_settings", &self.security_settings);
         debug_struct.field("tts_config", &self.tts_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31569,7 +31453,6 @@ impl std::fmt::Debug for ListConversationProfilesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31771,7 +31654,6 @@ impl std::fmt::Debug for ListConversationProfilesResponse {
         let mut debug_struct = f.debug_struct("ListConversationProfilesResponse");
         debug_struct.field("conversation_profiles", &self.conversation_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31924,7 +31806,6 @@ impl std::fmt::Debug for GetConversationProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConversationProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32113,7 +31994,6 @@ impl std::fmt::Debug for CreateConversationProfileRequest {
         let mut debug_struct = f.debug_struct("CreateConversationProfileRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("conversation_profile", &self.conversation_profile);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32313,7 +32193,6 @@ impl std::fmt::Debug for UpdateConversationProfileRequest {
         let mut debug_struct = f.debug_struct("UpdateConversationProfileRequest");
         debug_struct.field("conversation_profile", &self.conversation_profile);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32469,7 +32348,6 @@ impl std::fmt::Debug for DeleteConversationProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConversationProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32674,7 +32552,6 @@ impl std::fmt::Debug for AutomatedAgentConfig {
         let mut debug_struct = f.debug_struct("AutomatedAgentConfig");
         debug_struct.field("agent", &self.agent);
         debug_struct.field("session_ttl", &self.session_ttl);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32976,7 +32853,6 @@ impl std::fmt::Debug for HumanAgentAssistantConfig {
             &self.end_user_suggestion_config,
         );
         debug_struct.field("message_analysis_config", &self.message_analysis_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33161,7 +33037,6 @@ pub mod human_agent_assistant_config {
             let mut debug_struct = f.debug_struct("SuggestionTriggerSettings");
             debug_struct.field("no_smalltalk", &self.no_smalltalk);
             debug_struct.field("only_end_user", &self.only_end_user);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33740,7 +33615,6 @@ pub mod human_agent_assistant_config {
                 "conversation_process_config",
                 &self.conversation_process_config,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34020,7 +33894,6 @@ pub mod human_agent_assistant_config {
                 "disable_high_latency_features_sync_delivery",
                 &self.disable_high_latency_features_sync_delivery,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34551,7 +34424,6 @@ pub mod human_agent_assistant_config {
             debug_struct.field("sections", &self.sections);
             debug_struct.field("context_size", &self.context_size);
             debug_struct.field("query_source", &self.query_source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34722,7 +34594,6 @@ pub mod human_agent_assistant_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("KnowledgeBaseQuerySource");
                 debug_struct.field("knowledge_bases", &self.knowledge_bases);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -34886,7 +34757,6 @@ pub mod human_agent_assistant_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("DocumentQuerySource");
                 debug_struct.field("documents", &self.documents);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35087,7 +34957,6 @@ pub mod human_agent_assistant_config {
                 let mut debug_struct = f.debug_struct("DialogflowQuerySource");
                 debug_struct.field("agent", &self.agent);
                 debug_struct.field("human_agent_side_config", &self.human_agent_side_config);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35262,7 +35131,6 @@ pub mod human_agent_assistant_config {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("HumanAgentSideConfig");
                     debug_struct.field("agent", &self.agent);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -35495,7 +35363,6 @@ pub mod human_agent_assistant_config {
                     &self.drop_virtual_agent_messages,
                 );
                 debug_struct.field("drop_ivr_messages", &self.drop_ivr_messages);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35663,7 +35530,6 @@ pub mod human_agent_assistant_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Sections");
                 debug_struct.field("section_types", &self.section_types);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -36068,7 +35934,6 @@ pub mod human_agent_assistant_config {
             let mut debug_struct = f.debug_struct("ConversationModelConfig");
             debug_struct.field("model", &self.model);
             debug_struct.field("baseline_model_version", &self.baseline_model_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36245,7 +36110,6 @@ pub mod human_agent_assistant_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConversationProcessConfig");
             debug_struct.field("recent_sentences_count", &self.recent_sentences_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36463,7 +36327,6 @@ pub mod human_agent_assistant_config {
             let mut debug_struct = f.debug_struct("MessageAnalysisConfig");
             debug_struct.field("enable_entity_extraction", &self.enable_entity_extraction);
             debug_struct.field("enable_sentiment_analysis", &self.enable_sentiment_analysis);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36737,7 +36600,6 @@ impl std::fmt::Debug for HumanAgentHandoffConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HumanAgentHandoffConfig");
         debug_struct.field("agent_service", &self.agent_service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36899,7 +36761,6 @@ pub mod human_agent_handoff_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LivePersonConfig");
             debug_struct.field("account_number", &self.account_number);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37141,7 +37002,6 @@ pub mod human_agent_handoff_config {
             debug_struct.field("deployment_id", &self.deployment_id);
             debug_struct.field("button_id", &self.button_id);
             debug_struct.field("endpoint_domain", &self.endpoint_domain);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37356,7 +37216,6 @@ impl std::fmt::Debug for NotificationConfig {
         let mut debug_struct = f.debug_struct("NotificationConfig");
         debug_struct.field("topic", &self.topic);
         debug_struct.field("message_format", &self.message_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37666,7 +37525,6 @@ impl std::fmt::Debug for LoggingConfig {
             "enable_stackdriver_logging",
             &self.enable_stackdriver_logging,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37817,7 +37675,6 @@ impl std::fmt::Debug for SuggestionFeature {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SuggestionFeature");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38228,7 +38085,6 @@ impl std::fmt::Debug for SetSuggestionFeatureConfigRequest {
         debug_struct.field("conversation_profile", &self.conversation_profile);
         debug_struct.field("participant_role", &self.participant_role);
         debug_struct.field("suggestion_feature_config", &self.suggestion_feature_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38445,7 +38301,6 @@ impl std::fmt::Debug for ClearSuggestionFeatureConfigRequest {
         debug_struct.field("conversation_profile", &self.conversation_profile);
         debug_struct.field("participant_role", &self.participant_role);
         debug_struct.field("suggestion_feature_type", &self.suggestion_feature_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38702,7 +38557,6 @@ impl std::fmt::Debug for SetSuggestionFeatureConfigOperationMetadata {
         debug_struct.field("participant_role", &self.participant_role);
         debug_struct.field("suggestion_feature_type", &self.suggestion_feature_type);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38959,7 +38813,6 @@ impl std::fmt::Debug for ClearSuggestionFeatureConfigOperationMetadata {
         debug_struct.field("participant_role", &self.participant_role);
         debug_struct.field("suggestion_feature_type", &self.suggestion_feature_type);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39478,7 +39331,6 @@ impl std::fmt::Debug for Document {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("state", &self.state);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39684,7 +39536,6 @@ pub mod document {
             let mut debug_struct = f.debug_struct("ReloadStatus");
             debug_struct.field("time", &self.time);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40185,7 +40036,6 @@ impl std::fmt::Debug for GetDocumentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDocumentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40454,7 +40304,6 @@ impl std::fmt::Debug for ListDocumentsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40650,7 +40499,6 @@ impl std::fmt::Debug for ListDocumentsResponse {
         let mut debug_struct = f.debug_struct("ListDocumentsResponse");
         debug_struct.field("documents", &self.documents);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40839,7 +40687,6 @@ impl std::fmt::Debug for CreateDocumentRequest {
         let mut debug_struct = f.debug_struct("CreateDocumentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("document", &self.document);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41142,7 +40989,6 @@ impl std::fmt::Debug for ImportDocumentsRequest {
             &self.import_gcs_custom_metadata,
         );
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41391,7 +41237,6 @@ impl std::fmt::Debug for ImportDocumentTemplate {
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("knowledge_types", &self.knowledge_types);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41545,7 +41390,6 @@ impl std::fmt::Debug for ImportDocumentsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportDocumentsResponse");
         debug_struct.field("warnings", &self.warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41698,7 +41542,6 @@ impl std::fmt::Debug for DeleteDocumentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDocumentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41899,7 +41742,6 @@ impl std::fmt::Debug for UpdateDocumentRequest {
         let mut debug_struct = f.debug_struct("UpdateDocumentRequest");
         debug_struct.field("document", &self.document);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42197,7 +42039,6 @@ impl std::fmt::Debug for ReloadDocumentRequest {
             &self.smart_messaging_partial_update,
         );
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42517,7 +42358,6 @@ impl std::fmt::Debug for ExportDocumentRequest {
             &self.smart_messaging_partial_update,
         );
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42696,7 +42536,6 @@ impl std::fmt::Debug for ExportOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportOperationMetadata");
         debug_struct.field("exported_gcs_destination", &self.exported_gcs_destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42955,7 +42794,6 @@ impl std::fmt::Debug for KnowledgeOperationMetadata {
         debug_struct.field("state", &self.state);
         debug_struct.field("knowledge_base", &self.knowledge_base);
         debug_struct.field("operation_metadata", &self.operation_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43267,7 +43105,6 @@ impl std::fmt::Debug for GetEncryptionSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEncryptionSpecRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43448,7 +43285,6 @@ impl std::fmt::Debug for EncryptionSpec {
         let mut debug_struct = f.debug_struct("EncryptionSpec");
         debug_struct.field("name", &self.name);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43612,7 +43448,6 @@ impl std::fmt::Debug for InitializeEncryptionSpecRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeEncryptionSpecRequest");
         debug_struct.field("encryption_spec", &self.encryption_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43732,7 +43567,6 @@ impl serde::ser::Serialize for InitializeEncryptionSpecResponse {
 impl std::fmt::Debug for InitializeEncryptionSpecResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeEncryptionSpecResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43892,7 +43726,6 @@ impl std::fmt::Debug for InitializeEncryptionSpecMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeEncryptionSpecMetadata");
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44237,7 +44070,6 @@ impl std::fmt::Debug for EntityType {
         debug_struct.field("auto_expansion_mode", &self.auto_expansion_mode);
         debug_struct.field("entities", &self.entities);
         debug_struct.field("enable_fuzzy_extraction", &self.enable_fuzzy_extraction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44474,7 +44306,6 @@ pub mod entity_type {
             let mut debug_struct = f.debug_struct("Entity");
             debug_struct.field("value", &self.value);
             debug_struct.field("synonyms", &self.synonyms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45107,7 +44938,6 @@ impl std::fmt::Debug for ListEntityTypesRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45305,7 +45135,6 @@ impl std::fmt::Debug for ListEntityTypesResponse {
         let mut debug_struct = f.debug_struct("ListEntityTypesResponse");
         debug_struct.field("entity_types", &self.entity_types);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45487,7 +45316,6 @@ impl std::fmt::Debug for GetEntityTypeRequest {
         let mut debug_struct = f.debug_struct("GetEntityTypeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45706,7 +45534,6 @@ impl std::fmt::Debug for CreateEntityTypeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45936,7 +45763,6 @@ impl std::fmt::Debug for UpdateEntityTypeRequest {
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46088,7 +45914,6 @@ impl std::fmt::Debug for DeleteEntityTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEntityTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46443,7 +46268,6 @@ impl std::fmt::Debug for BatchUpdateEntityTypesRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("entity_type_batch", &self.entity_type_batch);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46624,7 +46448,6 @@ impl std::fmt::Debug for BatchUpdateEntityTypesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchUpdateEntityTypesResponse");
         debug_struct.field("entity_types", &self.entity_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46806,7 +46629,6 @@ impl std::fmt::Debug for BatchDeleteEntityTypesRequest {
         let mut debug_struct = f.debug_struct("BatchDeleteEntityTypesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entity_type_names", &self.entity_type_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47020,7 +46842,6 @@ impl std::fmt::Debug for BatchCreateEntitiesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entities", &self.entities);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47271,7 +47092,6 @@ impl std::fmt::Debug for BatchUpdateEntitiesRequest {
         debug_struct.field("entities", &self.entities);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47484,7 +47304,6 @@ impl std::fmt::Debug for BatchDeleteEntitiesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entity_values", &self.entity_values);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47636,7 +47455,6 @@ impl std::fmt::Debug for EntityTypeBatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EntityTypeBatch");
         debug_struct.field("entity_types", &self.entity_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48003,7 +47821,6 @@ impl std::fmt::Debug for Environment {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("text_to_speech_settings", &self.text_to_speech_settings);
         debug_struct.field("fulfillment", &self.fulfillment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48432,7 +48249,6 @@ impl std::fmt::Debug for TextToSpeechSettings {
         debug_struct.field("output_audio_encoding", &self.output_audio_encoding);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("synthesize_speech_configs", &self.synthesize_speech_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48658,7 +48474,6 @@ impl std::fmt::Debug for ListEnvironmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48855,7 +48670,6 @@ impl std::fmt::Debug for ListEnvironmentsResponse {
         let mut debug_struct = f.debug_struct("ListEnvironmentsResponse");
         debug_struct.field("environments", &self.environments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49013,7 +48827,6 @@ impl std::fmt::Debug for GetEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49230,7 +49043,6 @@ impl std::fmt::Debug for CreateEnvironmentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("environment_id", &self.environment_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49472,7 +49284,6 @@ impl std::fmt::Debug for UpdateEnvironmentRequest {
             "allow_load_to_draft_and_discard_changes",
             &self.allow_load_to_draft_and_discard_changes,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49630,7 +49441,6 @@ impl std::fmt::Debug for DeleteEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49859,7 +49669,6 @@ impl std::fmt::Debug for GetEnvironmentHistoryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50092,7 +49901,6 @@ impl std::fmt::Debug for EnvironmentHistory {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("entries", &self.entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50315,7 +50123,6 @@ pub mod environment_history {
             debug_struct.field("agent_version", &self.agent_version);
             debug_struct.field("description", &self.description);
             debug_struct.field("create_time", &self.create_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50644,7 +50451,6 @@ impl std::fmt::Debug for Fulfillment {
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("features", &self.features);
         debug_struct.field("fulfillment", &self.fulfillment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50929,7 +50735,6 @@ pub mod fulfillment {
             debug_struct.field("password", &self.password);
             debug_struct.field("request_headers", &self.request_headers);
             debug_struct.field("is_cloud_function", &self.is_cloud_function);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51085,7 +50890,6 @@ pub mod fulfillment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Feature");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51391,7 +51195,6 @@ impl std::fmt::Debug for GetFulfillmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFulfillmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51591,7 +51394,6 @@ impl std::fmt::Debug for UpdateFulfillmentRequest {
         let mut debug_struct = f.debug_struct("UpdateFulfillmentRequest");
         debug_struct.field("fulfillment", &self.fulfillment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51744,7 +51546,6 @@ impl std::fmt::Debug for GcsSources {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsSources");
         debug_struct.field("uris", &self.uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51896,7 +51697,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52117,7 +51917,6 @@ impl std::fmt::Debug for CreateGeneratorRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("generator", &self.generator);
         debug_struct.field("generator_id", &self.generator_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52266,7 +52065,6 @@ impl std::fmt::Debug for GetGeneratorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGeneratorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52486,7 +52284,6 @@ impl std::fmt::Debug for ListGeneratorsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52679,7 +52476,6 @@ impl std::fmt::Debug for ListGeneratorsResponse {
         let mut debug_struct = f.debug_struct("ListGeneratorsResponse");
         debug_struct.field("generators", &self.generators);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52828,7 +52624,6 @@ impl std::fmt::Debug for DeleteGeneratorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGeneratorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53025,7 +52820,6 @@ impl std::fmt::Debug for UpdateGeneratorRequest {
         let mut debug_struct = f.debug_struct("UpdateGeneratorRequest");
         debug_struct.field("generator", &self.generator);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53264,7 +53058,6 @@ impl std::fmt::Debug for MessageEntry {
         debug_struct.field("text", &self.text);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53572,7 +53365,6 @@ impl std::fmt::Debug for ConversationContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConversationContext");
         debug_struct.field("message_entries", &self.message_entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53728,7 +53520,6 @@ impl std::fmt::Debug for SummarizationSectionList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SummarizationSectionList");
         debug_struct.field("summarization_sections", &self.summarization_sections);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54041,7 +53832,6 @@ impl std::fmt::Debug for FewShotExample {
         debug_struct.field("extra_info", &self.extra_info);
         debug_struct.field("output", &self.output);
         debug_struct.field("instruction_list", &self.instruction_list);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54428,7 +54218,6 @@ impl std::fmt::Debug for InferenceParameter {
         debug_struct.field("temperature", &self.temperature);
         debug_struct.field("top_k", &self.top_k);
         debug_struct.field("top_p", &self.top_p);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54628,7 +54417,6 @@ impl std::fmt::Debug for SummarizationSection {
         debug_struct.field("key", &self.key);
         debug_struct.field("definition", &self.definition);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55084,7 +54872,6 @@ impl std::fmt::Debug for SummarizationContext {
         debug_struct.field("few_shot_examples", &self.few_shot_examples);
         debug_struct.field("version", &self.version);
         debug_struct.field("output_language_code", &self.output_language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55232,7 +55019,6 @@ impl std::fmt::Debug for FreeFormContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FreeFormContext");
         debug_struct.field("text", &self.text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55747,7 +55533,6 @@ impl std::fmt::Debug for Generator {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("context", &self.context);
         debug_struct.field("foundation_model", &self.foundation_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55953,7 +55738,6 @@ impl std::fmt::Debug for FreeFormSuggestion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FreeFormSuggestion");
         debug_struct.field("response", &self.response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56133,7 +55917,6 @@ impl std::fmt::Debug for SummarySuggestion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SummarySuggestion");
         debug_struct.field("summary_sections", &self.summary_sections);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56343,7 +56126,6 @@ pub mod summary_suggestion {
             let mut debug_struct = f.debug_struct("SummarySection");
             debug_struct.field("section", &self.section);
             debug_struct.field("summary", &self.summary);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -56625,7 +56407,6 @@ impl std::fmt::Debug for GeneratorSuggestion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GeneratorSuggestion");
         debug_struct.field("suggestion", &self.suggestion);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56981,7 +56762,6 @@ impl std::fmt::Debug for HumanAgentAssistantEvent {
         debug_struct.field("conversation", &self.conversation);
         debug_struct.field("participant", &self.participant);
         debug_struct.field("suggestion_results", &self.suggestion_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57799,7 +57579,6 @@ impl std::fmt::Debug for Intent {
             &self.parent_followup_intent_name,
         );
         debug_struct.field("followup_intent_info", &self.followup_intent_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58122,7 +57901,6 @@ pub mod intent {
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("parts", &self.parts);
             debug_struct.field("times_added_count", &self.times_added_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -58407,7 +58185,6 @@ pub mod intent {
                 debug_struct.field("entity_type", &self.entity_type);
                 debug_struct.field("alias", &self.alias);
                 debug_struct.field("user_defined", &self.user_defined);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -58994,7 +58771,6 @@ pub mod intent {
             debug_struct.field("mandatory", &self.mandatory);
             debug_struct.field("prompts", &self.prompts);
             debug_struct.field("is_list", &self.is_list);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60021,7 +59797,6 @@ pub mod intent {
             let mut debug_struct = f.debug_struct("Message");
             debug_struct.field("platform", &self.platform);
             debug_struct.field("message", &self.message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -60219,7 +59994,6 @@ pub mod intent {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Text");
                 debug_struct.field("text", &self.text);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -60441,7 +60215,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("Image");
                 debug_struct.field("image_uri", &self.image_uri);
                 debug_struct.field("accessibility_text", &self.accessibility_text);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -60656,7 +60429,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("QuickReplies");
                 debug_struct.field("title", &self.title);
                 debug_struct.field("quick_replies", &self.quick_replies);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -60937,7 +60709,6 @@ pub mod intent {
                 debug_struct.field("subtitle", &self.subtitle);
                 debug_struct.field("image_uri", &self.image_uri);
                 debug_struct.field("buttons", &self.buttons);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -61176,7 +60947,6 @@ pub mod intent {
                     let mut debug_struct = f.debug_struct("Button");
                     debug_struct.field("text", &self.text);
                     debug_struct.field("postback", &self.postback);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -61426,7 +61196,6 @@ pub mod intent {
                 debug_struct.field("text_to_speech", &self.text_to_speech);
                 debug_struct.field("ssml", &self.ssml);
                 debug_struct.field("display_text", &self.display_text);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -61625,7 +61394,6 @@ pub mod intent {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("SimpleResponses");
                 debug_struct.field("simple_responses", &self.simple_responses);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -61944,7 +61712,6 @@ pub mod intent {
                 debug_struct.field("formatted_text", &self.formatted_text);
                 debug_struct.field("image", &self.image);
                 debug_struct.field("buttons", &self.buttons);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -62196,7 +61963,6 @@ pub mod intent {
                     let mut debug_struct = f.debug_struct("Button");
                     debug_struct.field("title", &self.title);
                     debug_struct.field("open_uri_action", &self.open_uri_action);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -62402,7 +62168,6 @@ pub mod intent {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                         let mut debug_struct = f.debug_struct("OpenUriAction");
                         debug_struct.field("uri", &self.uri);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -62589,7 +62354,6 @@ pub mod intent {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Suggestion");
                 debug_struct.field("title", &self.title);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -62784,7 +62548,6 @@ pub mod intent {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Suggestions");
                 debug_struct.field("suggestions", &self.suggestions);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -63001,7 +62764,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("LinkOutSuggestion");
                 debug_struct.field("destination_name", &self.destination_name);
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -63249,7 +63011,6 @@ pub mod intent {
                 debug_struct.field("title", &self.title);
                 debug_struct.field("items", &self.items);
                 debug_struct.field("subtitle", &self.subtitle);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -63567,7 +63328,6 @@ pub mod intent {
                     debug_struct.field("title", &self.title);
                     debug_struct.field("description", &self.description);
                     debug_struct.field("image", &self.image);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -63755,7 +63515,6 @@ pub mod intent {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CarouselSelect");
                 debug_struct.field("items", &self.items);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -64073,7 +63832,6 @@ pub mod intent {
                     debug_struct.field("title", &self.title);
                     debug_struct.field("description", &self.description);
                     debug_struct.field("image", &self.image);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -64291,7 +64049,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("SelectItemInfo");
                 debug_struct.field("key", &self.key);
                 debug_struct.field("synonyms", &self.synonyms);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -64515,7 +64272,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("MediaContent");
                 debug_struct.field("media_type", &self.media_type);
                 debug_struct.field("media_objects", &self.media_objects);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -64920,7 +64676,6 @@ pub mod intent {
                     debug_struct.field("description", &self.description);
                     debug_struct.field("content_url", &self.content_url);
                     debug_struct.field("image", &self.image);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -65366,7 +65121,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("BrowseCarouselCard");
                 debug_struct.field("items", &self.items);
                 debug_struct.field("image_display_options", &self.image_display_options);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -65715,7 +65469,6 @@ pub mod intent {
                     debug_struct.field("description", &self.description);
                     debug_struct.field("image", &self.image);
                     debug_struct.field("footer", &self.footer);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -65949,7 +65702,6 @@ pub mod intent {
                         let mut debug_struct = f.debug_struct("OpenUrlAction");
                         debug_struct.field("url", &self.url);
                         debug_struct.field("url_type_hint", &self.url_type_hint);
-
                         if !self._unknown_fields.is_empty() {
                             debug_struct.field("_unknown_fields", &self._unknown_fields);
                         }
@@ -66731,7 +66483,6 @@ pub mod intent {
                 debug_struct.field("column_properties", &self.column_properties);
                 debug_struct.field("rows", &self.rows);
                 debug_struct.field("buttons", &self.buttons);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -66954,7 +66705,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("ColumnProperties");
                 debug_struct.field("header", &self.header);
                 debug_struct.field("horizontal_alignment", &self.horizontal_alignment);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -67386,7 +67136,6 @@ pub mod intent {
                 let mut debug_struct = f.debug_struct("TableCardRow");
                 debug_struct.field("cells", &self.cells);
                 debug_struct.field("divider_after", &self.divider_after);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -67573,7 +67322,6 @@ pub mod intent {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("TableCardCell");
                 debug_struct.field("text", &self.text);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -68081,7 +67829,6 @@ pub mod intent {
                 "parent_followup_intent_name",
                 &self.parent_followup_intent_name,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -68561,7 +68308,6 @@ impl std::fmt::Debug for ListIntentsRequest {
         debug_struct.field("intent_view", &self.intent_view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68758,7 +68504,6 @@ impl std::fmt::Debug for ListIntentsResponse {
         let mut debug_struct = f.debug_struct("ListIntentsResponse");
         debug_struct.field("intents", &self.intents);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68969,7 +68714,6 @@ impl std::fmt::Debug for GetIntentRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("intent_view", &self.intent_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69216,7 +68960,6 @@ impl std::fmt::Debug for CreateIntentRequest {
         debug_struct.field("intent", &self.intent);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("intent_view", &self.intent_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69474,7 +69217,6 @@ impl std::fmt::Debug for UpdateIntentRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("intent_view", &self.intent_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69627,7 +69369,6 @@ impl std::fmt::Debug for DeleteIntentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIntentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69997,7 +69738,6 @@ impl std::fmt::Debug for BatchUpdateIntentsRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("intent_view", &self.intent_view);
         debug_struct.field("intent_batch", &self.intent_batch);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70171,7 +69911,6 @@ impl std::fmt::Debug for BatchUpdateIntentsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchUpdateIntentsResponse");
         debug_struct.field("intents", &self.intents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70352,7 +70091,6 @@ impl std::fmt::Debug for BatchDeleteIntentsRequest {
         let mut debug_struct = f.debug_struct("BatchDeleteIntentsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("intents", &self.intents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70503,7 +70241,6 @@ impl std::fmt::Debug for IntentBatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IntentBatch");
         debug_struct.field("intents", &self.intents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70718,7 +70455,6 @@ impl std::fmt::Debug for KnowledgeBase {
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70991,7 +70727,6 @@ impl std::fmt::Debug for ListKnowledgeBasesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71188,7 +70923,6 @@ impl std::fmt::Debug for ListKnowledgeBasesResponse {
         let mut debug_struct = f.debug_struct("ListKnowledgeBasesResponse");
         debug_struct.field("knowledge_bases", &self.knowledge_bases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71341,7 +71075,6 @@ impl std::fmt::Debug for GetKnowledgeBaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKnowledgeBaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71530,7 +71263,6 @@ impl std::fmt::Debug for CreateKnowledgeBaseRequest {
         let mut debug_struct = f.debug_struct("CreateKnowledgeBaseRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("knowledge_base", &self.knowledge_base);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71709,7 +71441,6 @@ impl std::fmt::Debug for DeleteKnowledgeBaseRequest {
         let mut debug_struct = f.debug_struct("DeleteKnowledgeBaseRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71911,7 +71642,6 @@ impl std::fmt::Debug for UpdateKnowledgeBaseRequest {
         let mut debug_struct = f.debug_struct("UpdateKnowledgeBaseRequest");
         debug_struct.field("knowledge_base", &self.knowledge_base);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72292,7 +72022,6 @@ impl std::fmt::Debug for Participant {
             "documents_metadata_filters",
             &self.documents_metadata_filters,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72896,7 +72625,6 @@ impl std::fmt::Debug for Message {
         debug_struct.field("send_time", &self.send_time);
         debug_struct.field("message_annotation", &self.message_annotation);
         debug_struct.field("sentiment_analysis", &self.sentiment_analysis);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73085,7 +72813,6 @@ impl std::fmt::Debug for CreateParticipantRequest {
         let mut debug_struct = f.debug_struct("CreateParticipantRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("participant", &self.participant);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73238,7 +72965,6 @@ impl std::fmt::Debug for GetParticipantRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetParticipantRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73462,7 +73188,6 @@ impl std::fmt::Debug for ListParticipantsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73659,7 +73384,6 @@ impl std::fmt::Debug for ListParticipantsResponse {
         let mut debug_struct = f.debug_struct("ListParticipantsResponse");
         debug_struct.field("participants", &self.participants);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73858,7 +73582,6 @@ impl std::fmt::Debug for UpdateParticipantRequest {
         let mut debug_struct = f.debug_struct("UpdateParticipantRequest");
         debug_struct.field("participant", &self.participant);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74436,7 +74159,6 @@ impl std::fmt::Debug for AnalyzeContentRequest {
         debug_struct.field("cx_parameters", &self.cx_parameters);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("input", &self.input);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74607,7 +74329,6 @@ impl std::fmt::Debug for DtmfParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DtmfParameters");
         debug_struct.field("accepts_dtmf_input", &self.accepts_dtmf_input);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75035,7 +74756,6 @@ impl std::fmt::Debug for AnalyzeContentResponse {
             &self.end_user_suggestion_results,
         );
         debug_struct.field("dtmf_parameters", &self.dtmf_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75842,7 +75562,6 @@ impl std::fmt::Debug for StreamingAnalyzeContentRequest {
         debug_struct.field("enable_debugging_info", &self.enable_debugging_info);
         debug_struct.field("config", &self.config);
         debug_struct.field("input", &self.input);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76419,7 +76138,6 @@ impl std::fmt::Debug for StreamingAnalyzeContentResponse {
         debug_struct.field("dtmf_parameters", &self.dtmf_parameters);
         debug_struct.field("debugging_info", &self.debugging_info);
         debug_struct.field("speech_model", &self.speech_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76688,7 +76406,6 @@ impl std::fmt::Debug for SuggestArticlesRequest {
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
         debug_struct.field("assist_query_params", &self.assist_query_params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -76925,7 +76642,6 @@ impl std::fmt::Debug for SuggestArticlesResponse {
         debug_struct.field("article_answers", &self.article_answers);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77191,7 +76907,6 @@ impl std::fmt::Debug for SuggestFaqAnswersRequest {
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
         debug_struct.field("assist_query_params", &self.assist_query_params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77428,7 +77143,6 @@ impl std::fmt::Debug for SuggestFaqAnswersResponse {
         debug_struct.field("faq_answers", &self.faq_answers);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77626,7 +77340,6 @@ impl std::fmt::Debug for GenerateSuggestionsResponse {
             &self.generator_suggestion_answers,
         );
         debug_struct.field("latest_message", &self.latest_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77856,7 +77569,6 @@ pub mod generate_suggestions_response {
             debug_struct.field("generator_suggestion", &self.generator_suggestion);
             debug_struct.field("source_generator", &self.source_generator);
             debug_struct.field("answer_record", &self.answer_record);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -78125,7 +77837,6 @@ impl std::fmt::Debug for SuggestSmartRepliesRequest {
         debug_struct.field("current_text_input", &self.current_text_input);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78368,7 +78079,6 @@ impl std::fmt::Debug for SuggestSmartRepliesResponse {
         debug_struct.field("smart_reply_answers", &self.smart_reply_answers);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78574,7 +78284,6 @@ impl std::fmt::Debug for AudioInput {
         let mut debug_struct = f.debug_struct("AudioInput");
         debug_struct.field("config", &self.config);
         debug_struct.field("audio", &self.audio);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78778,7 +78487,6 @@ impl std::fmt::Debug for OutputAudio {
         let mut debug_struct = f.debug_struct("OutputAudio");
         debug_struct.field("config", &self.config);
         debug_struct.field("audio", &self.audio);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79038,7 +78746,6 @@ impl std::fmt::Debug for AutomatedAgentReply {
         );
         debug_struct.field("allow_cancellation", &self.allow_cancellation);
         debug_struct.field("cx_current_page", &self.cx_current_page);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79504,7 +79211,6 @@ impl std::fmt::Debug for ArticleAnswer {
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("answer_record", &self.answer_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79815,7 +79521,6 @@ impl std::fmt::Debug for FaqAnswer {
         debug_struct.field("source", &self.source);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("answer_record", &self.answer_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80037,7 +79742,6 @@ impl std::fmt::Debug for SmartReplyAnswer {
         debug_struct.field("reply", &self.reply);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("answer_record", &self.answer_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80276,7 +79980,6 @@ impl std::fmt::Debug for IntentSuggestion {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("intent", &self.intent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80577,7 +80280,6 @@ impl std::fmt::Debug for DialogflowAssistAnswer {
         let mut debug_struct = f.debug_struct("DialogflowAssistAnswer");
         debug_struct.field("answer_record", &self.answer_record);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81105,7 +80807,6 @@ impl std::fmt::Debug for SuggestionResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SuggestionResult");
         debug_struct.field("suggestion_response", &self.suggestion_response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81285,7 +80986,6 @@ impl std::fmt::Debug for InputTextConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InputTextConfig");
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81505,7 +81205,6 @@ impl std::fmt::Debug for AnnotatedMessagePart {
         debug_struct.field("text", &self.text);
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("formatted_value", &self.formatted_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81688,7 +81387,6 @@ impl std::fmt::Debug for MessageAnnotation {
         let mut debug_struct = f.debug_struct("MessageAnnotation");
         debug_struct.field("parts", &self.parts);
         debug_struct.field("contain_entities", &self.contain_entities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81842,7 +81540,6 @@ impl std::fmt::Debug for SuggestionInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SuggestionInput");
         debug_struct.field("answer_record", &self.answer_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82030,7 +81727,6 @@ impl std::fmt::Debug for AssistQueryParameters {
             "documents_metadata_filters",
             &self.documents_metadata_filters,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82295,7 +81991,6 @@ impl std::fmt::Debug for SuggestKnowledgeAssistRequest {
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
         debug_struct.field("previous_suggested_query", &self.previous_suggested_query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82537,7 +82232,6 @@ impl std::fmt::Debug for SuggestKnowledgeAssistResponse {
         debug_struct.field("knowledge_assist_answer", &self.knowledge_assist_answer);
         debug_struct.field("latest_message", &self.latest_message);
         debug_struct.field("context_size", &self.context_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82767,7 +82461,6 @@ impl std::fmt::Debug for KnowledgeAssistAnswer {
         debug_struct.field("suggested_query", &self.suggested_query);
         debug_struct.field("suggested_query_answer", &self.suggested_query_answer);
         debug_struct.field("answer_record", &self.answer_record);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82925,7 +82618,6 @@ pub mod knowledge_assist_answer {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SuggestedQuery");
             debug_struct.field("query_text", &self.query_text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -83227,7 +82919,6 @@ pub mod knowledge_assist_answer {
             let mut debug_struct = f.debug_struct("KnowledgeAnswer");
             debug_struct.field("answer_text", &self.answer_text);
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -83392,7 +83083,6 @@ pub mod knowledge_assist_answer {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("FaqSource");
                 debug_struct.field("question", &self.question);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -83554,7 +83244,6 @@ pub mod knowledge_assist_answer {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("GenerativeSource");
                 debug_struct.field("snippets", &self.snippets);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -83823,7 +83512,6 @@ pub mod knowledge_assist_answer {
                     debug_struct.field("text", &self.text);
                     debug_struct.field("title", &self.title);
                     debug_struct.field("metadata", &self.metadata);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -84224,7 +83912,6 @@ impl std::fmt::Debug for DetectIntentRequest {
         debug_struct.field("output_audio_config", &self.output_audio_config);
         debug_struct.field("output_audio_config_mask", &self.output_audio_config_mask);
         debug_struct.field("input_audio", &self.input_audio);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84540,7 +84227,6 @@ impl std::fmt::Debug for DetectIntentResponse {
         debug_struct.field("webhook_status", &self.webhook_status);
         debug_struct.field("output_audio", &self.output_audio);
         debug_struct.field("output_audio_config", &self.output_audio_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84990,7 +84676,6 @@ impl std::fmt::Debug for QueryParameters {
         );
         debug_struct.field("webhook_headers", &self.webhook_headers);
         debug_struct.field("platform", &self.platform);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85290,7 +84975,6 @@ impl std::fmt::Debug for QueryInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryInput");
         debug_struct.field("input", &self.input);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86072,7 +85756,6 @@ impl std::fmt::Debug for QueryResult {
         );
         debug_struct.field("diagnostic_info", &self.diagnostic_info);
         debug_struct.field("sentiment_analysis_result", &self.sentiment_analysis_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86558,7 +86241,6 @@ impl std::fmt::Debug for StreamingDetectIntentRequest {
         debug_struct.field("output_audio_config_mask", &self.output_audio_config_mask);
         debug_struct.field("input_audio", &self.input_audio);
         debug_struct.field("enable_debugging_info", &self.enable_debugging_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -87396,7 +87078,6 @@ impl std::fmt::Debug for CloudConversationDebuggingInfo {
             "client_half_close_streaming_time_offset",
             &self.client_half_close_streaming_time_offset,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -87810,7 +87491,6 @@ impl std::fmt::Debug for StreamingDetectIntentResponse {
         debug_struct.field("output_audio", &self.output_audio);
         debug_struct.field("output_audio_config", &self.output_audio_config);
         debug_struct.field("debugging_info", &self.debugging_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88208,7 +87888,6 @@ impl std::fmt::Debug for StreamingRecognitionResult {
         debug_struct.field("speech_word_info", &self.speech_word_info);
         debug_struct.field("speech_end_offset", &self.speech_end_offset);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88567,7 +88246,6 @@ impl std::fmt::Debug for TextInput {
         let mut debug_struct = f.debug_struct("TextInput");
         debug_struct.field("text", &self.text);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88804,7 +88482,6 @@ impl std::fmt::Debug for EventInput {
         debug_struct.field("name", &self.name);
         debug_struct.field("parameters", &self.parameters);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88965,7 +88642,6 @@ impl std::fmt::Debug for SentimentAnalysisRequestConfig {
             "analyze_query_text_sentiment",
             &self.analyze_query_text_sentiment,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -89172,7 +88848,6 @@ impl std::fmt::Debug for SentimentAnalysisResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SentimentAnalysisResult");
         debug_struct.field("query_text_sentiment", &self.query_text_sentiment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -89416,7 +89091,6 @@ impl std::fmt::Debug for Sentiment {
         let mut debug_struct = f.debug_struct("Sentiment");
         debug_struct.field("score", &self.score);
         debug_struct.field("magnitude", &self.magnitude);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -89671,7 +89345,6 @@ impl std::fmt::Debug for SessionEntityType {
         debug_struct.field("name", &self.name);
         debug_struct.field("entity_override_mode", &self.entity_override_mode);
         debug_struct.field("entities", &self.entities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90098,7 +89771,6 @@ impl std::fmt::Debug for ListSessionEntityTypesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90300,7 +89972,6 @@ impl std::fmt::Debug for ListSessionEntityTypesResponse {
         let mut debug_struct = f.debug_struct("ListSessionEntityTypesResponse");
         debug_struct.field("session_entity_types", &self.session_entity_types);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90457,7 +90128,6 @@ impl std::fmt::Debug for GetSessionEntityTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSessionEntityTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90651,7 +90321,6 @@ impl std::fmt::Debug for CreateSessionEntityTypeRequest {
         let mut debug_struct = f.debug_struct("CreateSessionEntityTypeRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("session_entity_type", &self.session_entity_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90852,7 +90521,6 @@ impl std::fmt::Debug for UpdateSessionEntityTypeRequest {
         let mut debug_struct = f.debug_struct("UpdateSessionEntityTypeRequest");
         debug_struct.field("session_entity_type", &self.session_entity_type);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91009,7 +90677,6 @@ impl std::fmt::Debug for DeleteSessionEntityTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSessionEntityTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91225,7 +90892,6 @@ impl std::fmt::Debug for ValidationError {
         debug_struct.field("severity", &self.severity);
         debug_struct.field("entries", &self.entries);
         debug_struct.field("error_message", &self.error_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91543,7 +91209,6 @@ impl std::fmt::Debug for ValidationResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ValidationResult");
         debug_struct.field("validation_errors", &self.validation_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91849,7 +91514,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("version_number", &self.version_number);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92230,7 +91894,6 @@ impl std::fmt::Debug for ListVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92427,7 +92090,6 @@ impl std::fmt::Debug for ListVersionsResponse {
         let mut debug_struct = f.debug_struct("ListVersionsResponse");
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92583,7 +92245,6 @@ impl std::fmt::Debug for GetVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92774,7 +92435,6 @@ impl std::fmt::Debug for CreateVersionRequest {
         let mut debug_struct = f.debug_struct("CreateVersionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92978,7 +92638,6 @@ impl std::fmt::Debug for UpdateVersionRequest {
         let mut debug_struct = f.debug_struct("UpdateVersionRequest");
         debug_struct.field("version", &self.version);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -93134,7 +92793,6 @@ impl std::fmt::Debug for DeleteVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -93523,7 +93181,6 @@ impl std::fmt::Debug for WebhookRequest {
             "original_detect_intent_request",
             &self.original_detect_intent_request,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -94048,7 +93705,6 @@ impl std::fmt::Debug for WebhookResponse {
         debug_struct.field("output_contexts", &self.output_contexts);
         debug_struct.field("followup_event_input", &self.followup_event_input);
         debug_struct.field("session_entity_types", &self.session_entity_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -94389,7 +94045,6 @@ impl std::fmt::Debug for OriginalDetectIntentRequest {
         debug_struct.field("source", &self.source);
         debug_struct.field("version", &self.version);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -254,7 +254,6 @@ impl std::fmt::Debug for Barcode {
         debug_struct.field("format", &self.format);
         debug_struct.field("value_format", &self.value_format);
         debug_struct.field("raw_value", &self.raw_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -935,7 +934,6 @@ impl std::fmt::Debug for Document {
         debug_struct.field("document_layout", &self.document_layout);
         debug_struct.field("chunked_document", &self.chunked_document);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1201,7 +1199,6 @@ pub mod document {
             debug_struct.field("shard_index", &self.shard_index);
             debug_struct.field("shard_count", &self.shard_count);
             debug_struct.field("text_offset", &self.text_offset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1587,7 +1584,6 @@ pub mod document {
             debug_struct.field("text_decoration", &self.text_decoration);
             debug_struct.field("font_size", &self.font_size);
             debug_struct.field("font_family", &self.font_family);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1787,7 +1783,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("FontSize");
                 debug_struct.field("size", &self.size);
                 debug_struct.field("unit", &self.unit);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2523,7 +2518,6 @@ pub mod document {
             debug_struct.field("detected_barcodes", &self.detected_barcodes);
             debug_struct.field("image_quality_scores", &self.image_quality_scores);
             debug_struct.field("provenance", &self.provenance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2770,7 +2764,6 @@ pub mod document {
                 debug_struct.field("width", &self.width);
                 debug_struct.field("height", &self.height);
                 debug_struct.field("unit", &self.unit);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3076,7 +3069,6 @@ pub mod document {
                 debug_struct.field("mime_type", &self.mime_type);
                 debug_struct.field("width", &self.width);
                 debug_struct.field("height", &self.height);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3395,7 +3387,6 @@ pub mod document {
                 debug_struct.field("cols", &self.cols);
                 debug_struct.field("r#type", &self.r#type);
                 debug_struct.field("data", &self.data);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3694,7 +3685,6 @@ pub mod document {
                 debug_struct.field("confidence", &self.confidence);
                 debug_struct.field("bounding_poly", &self.bounding_poly);
                 debug_struct.field("orientation", &self.orientation);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4096,7 +4086,6 @@ pub mod document {
                 debug_struct.field("layout", &self.layout);
                 debug_struct.field("detected_languages", &self.detected_languages);
                 debug_struct.field("provenance", &self.provenance);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4339,7 +4328,6 @@ pub mod document {
                 debug_struct.field("layout", &self.layout);
                 debug_struct.field("detected_languages", &self.detected_languages);
                 debug_struct.field("provenance", &self.provenance);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4583,7 +4571,6 @@ pub mod document {
                 debug_struct.field("layout", &self.layout);
                 debug_struct.field("detected_languages", &self.detected_languages);
                 debug_struct.field("provenance", &self.provenance);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4912,7 +4899,6 @@ pub mod document {
                 debug_struct.field("detected_languages", &self.detected_languages);
                 debug_struct.field("provenance", &self.provenance);
                 debug_struct.field("style_info", &self.style_info);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5079,7 +5065,6 @@ pub mod document {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("DetectedBreak");
                     debug_struct.field("r#type", &self.r#type);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -5914,7 +5899,6 @@ pub mod document {
                     debug_struct.field("handwritten", &self.handwritten);
                     debug_struct.field("text_color", &self.text_color);
                     debug_struct.field("background_color", &self.background_color);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -6117,7 +6101,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("Symbol");
                 debug_struct.field("layout", &self.layout);
                 debug_struct.field("detected_languages", &self.detected_languages);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6348,7 +6331,6 @@ pub mod document {
                 debug_struct.field("layout", &self.layout);
                 debug_struct.field("r#type", &self.r#type);
                 debug_struct.field("detected_languages", &self.detected_languages);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6665,7 +6647,6 @@ pub mod document {
                 debug_struct.field("body_rows", &self.body_rows);
                 debug_struct.field("detected_languages", &self.detected_languages);
                 debug_struct.field("provenance", &self.provenance);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6835,7 +6816,6 @@ pub mod document {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("TableRow");
                     debug_struct.field("cells", &self.cells);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7158,7 +7138,6 @@ pub mod document {
                     debug_struct.field("row_span", &self.row_span);
                     debug_struct.field("col_span", &self.col_span);
                     debug_struct.field("detected_languages", &self.detected_languages);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7603,7 +7582,6 @@ pub mod document {
                 debug_struct.field("corrected_key_text", &self.corrected_key_text);
                 debug_struct.field("corrected_value_text", &self.corrected_value_text);
                 debug_struct.field("provenance", &self.provenance);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -7810,7 +7788,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("DetectedBarcode");
                 debug_struct.field("layout", &self.layout);
                 debug_struct.field("barcode", &self.barcode);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8015,7 +7992,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("DetectedLanguage");
                 debug_struct.field("language_code", &self.language_code);
                 debug_struct.field("confidence", &self.confidence);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8222,7 +8198,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("ImageQualityScores");
                 debug_struct.field("quality_score", &self.quality_score);
                 debug_struct.field("detected_defects", &self.detected_defects);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8451,7 +8426,6 @@ pub mod document {
                     let mut debug_struct = f.debug_struct("DetectedDefect");
                     debug_struct.field("r#type", &self.r#type);
                     debug_struct.field("confidence", &self.confidence);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8941,7 +8915,6 @@ pub mod document {
             debug_struct.field("properties", &self.properties);
             debug_struct.field("provenance", &self.provenance);
             debug_struct.field("redacted", &self.redacted);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9563,7 +9536,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("NormalizedValue");
                 debug_struct.field("text", &self.text);
                 debug_struct.field("structured_value", &self.structured_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9798,7 +9770,6 @@ pub mod document {
             debug_struct.field("subject_id", &self.subject_id);
             debug_struct.field("object_id", &self.object_id);
             debug_struct.field("relation", &self.relation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9986,7 +9957,6 @@ pub mod document {
             let mut debug_struct = f.debug_struct("TextAnchor");
             debug_struct.field("text_segments", &self.text_segments);
             debug_struct.field("content", &self.content);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10231,7 +10201,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("TextSegment");
                 debug_struct.field("start_index", &self.start_index);
                 debug_struct.field("end_index", &self.end_index);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -10390,7 +10359,6 @@ pub mod document {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PageAnchor");
             debug_struct.field("page_refs", &self.page_refs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10731,7 +10699,6 @@ pub mod document {
                 debug_struct.field("layout_id", &self.layout_id);
                 debug_struct.field("bounding_poly", &self.bounding_poly);
                 debug_struct.field("confidence", &self.confidence);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -11211,7 +11178,6 @@ pub mod document {
             debug_struct.field("id", &self.id);
             debug_struct.field("parents", &self.parents);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11485,7 +11451,6 @@ pub mod document {
                 debug_struct.field("revision", &self.revision);
                 debug_struct.field("index", &self.index);
                 debug_struct.field("id", &self.id);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12091,7 +12056,6 @@ pub mod document {
             debug_struct.field("create_time", &self.create_time);
             debug_struct.field("human_review", &self.human_review);
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12276,7 +12240,6 @@ pub mod document {
                 let mut debug_struct = f.debug_struct("HumanReview");
                 debug_struct.field("state", &self.state);
                 debug_struct.field("state_message", &self.state_message);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12516,7 +12479,6 @@ pub mod document {
             debug_struct.field("text_anchor", &self.text_anchor);
             debug_struct.field("changed_text", &self.changed_text);
             debug_struct.field("provenance", &self.provenance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12665,7 +12627,6 @@ pub mod document {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DocumentLayout");
             debug_struct.field("blocks", &self.blocks);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13094,7 +13055,6 @@ pub mod document {
                 debug_struct.field("page_span", &self.page_span);
                 debug_struct.field("bounding_box", &self.bounding_box);
                 debug_struct.field("block", &self.block);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -13338,7 +13298,6 @@ pub mod document {
                     let mut debug_struct = f.debug_struct("LayoutPageSpan");
                     debug_struct.field("page_start", &self.page_start);
                     debug_struct.field("page_end", &self.page_end);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -13565,7 +13524,6 @@ pub mod document {
                     debug_struct.field("text", &self.text);
                     debug_struct.field("r#type", &self.r#type);
                     debug_struct.field("blocks", &self.blocks);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -13791,7 +13749,6 @@ pub mod document {
                     debug_struct.field("header_rows", &self.header_rows);
                     debug_struct.field("body_rows", &self.body_rows);
                     debug_struct.field("caption", &self.caption);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -13952,7 +13909,6 @@ pub mod document {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("LayoutTableRow");
                     debug_struct.field("cells", &self.cells);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -14225,7 +14181,6 @@ pub mod document {
                     debug_struct.field("blocks", &self.blocks);
                     debug_struct.field("row_span", &self.row_span);
                     debug_struct.field("col_span", &self.col_span);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -14419,7 +14374,6 @@ pub mod document {
                     let mut debug_struct = f.debug_struct("LayoutListBlock");
                     debug_struct.field("list_entries", &self.list_entries);
                     debug_struct.field("r#type", &self.r#type);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -14582,7 +14536,6 @@ pub mod document {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("LayoutListEntry");
                     debug_struct.field("blocks", &self.blocks);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -14749,7 +14702,6 @@ pub mod document {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ChunkedDocument");
             debug_struct.field("chunks", &self.chunks);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15078,7 +15030,6 @@ pub mod document {
                 debug_struct.field("page_span", &self.page_span);
                 debug_struct.field("page_headers", &self.page_headers);
                 debug_struct.field("page_footers", &self.page_footers);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -15322,7 +15273,6 @@ pub mod document {
                     let mut debug_struct = f.debug_struct("ChunkPageSpan");
                     debug_struct.field("page_start", &self.page_start);
                     debug_struct.field("page_end", &self.page_end);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -15527,7 +15477,6 @@ pub mod document {
                     let mut debug_struct = f.debug_struct("ChunkPageHeader");
                     debug_struct.field("text", &self.text);
                     debug_struct.field("page_span", &self.page_span);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -15732,7 +15681,6 @@ pub mod document {
                     let mut debug_struct = f.debug_struct("ChunkPageFooter");
                     debug_struct.field("text", &self.text);
                     debug_struct.field("page_span", &self.page_span);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -15969,7 +15917,6 @@ impl std::fmt::Debug for RawDocument {
         debug_struct.field("content", &self.content);
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16138,7 +16085,6 @@ impl std::fmt::Debug for GcsDocument {
         let mut debug_struct = f.debug_struct("GcsDocument");
         debug_struct.field("gcs_uri", &self.gcs_uri);
         debug_struct.field("mime_type", &self.mime_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16283,7 +16229,6 @@ impl std::fmt::Debug for GcsDocuments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDocuments");
         debug_struct.field("documents", &self.documents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16426,7 +16371,6 @@ impl std::fmt::Debug for GcsPrefix {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsPrefix");
         debug_struct.field("gcs_uri_prefix", &self.gcs_uri_prefix);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16672,7 +16616,6 @@ impl std::fmt::Debug for BatchDocumentsInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchDocumentsInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16886,7 +16829,6 @@ impl std::fmt::Debug for DocumentOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DocumentOutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17119,7 +17061,6 @@ pub mod document_output_config {
             debug_struct.field("gcs_uri", &self.gcs_uri);
             debug_struct.field("field_mask", &self.field_mask);
             debug_struct.field("sharding_config", &self.sharding_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17347,7 +17288,6 @@ pub mod document_output_config {
                 let mut debug_struct = f.debug_struct("ShardingConfig");
                 debug_struct.field("pages_per_shard", &self.pages_per_shard);
                 debug_struct.field("pages_overlap", &self.pages_overlap);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17749,7 +17689,6 @@ impl std::fmt::Debug for OcrConfig {
             &self.disable_character_boxes_detection,
         );
         debug_struct.field("premium_features", &self.premium_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17908,7 +17847,6 @@ pub mod ocr_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Hints");
             debug_struct.field("language_hints", &self.language_hints);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18120,7 +18058,6 @@ pub mod ocr_config {
             );
             debug_struct.field("compute_style_info", &self.compute_style_info);
             debug_struct.field("enable_math_ocr", &self.enable_math_ocr);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18581,7 +18518,6 @@ impl std::fmt::Debug for ProcessOptions {
         debug_struct.field("layout_config", &self.layout_config);
         debug_struct.field("schema_override", &self.schema_override);
         debug_struct.field("page_range", &self.page_range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18798,7 +18734,6 @@ pub mod process_options {
             debug_struct.field("chunking_config", &self.chunking_config);
             debug_struct.field("return_images", &self.return_images);
             debug_struct.field("return_bounding_boxes", &self.return_bounding_boxes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19015,7 +18950,6 @@ pub mod process_options {
                 let mut debug_struct = f.debug_struct("ChunkingConfig");
                 debug_struct.field("chunk_size", &self.chunk_size);
                 debug_struct.field("include_ancestor_headings", &self.include_ancestor_headings);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -19191,7 +19125,6 @@ pub mod process_options {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IndividualPageSelector");
             debug_struct.field("pages", &self.pages);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19723,7 +19656,6 @@ impl std::fmt::Debug for ProcessRequest {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("imageless_mode", &self.imageless_mode);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19947,7 +19879,6 @@ impl std::fmt::Debug for HumanReviewStatus {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_message", &self.state_message);
         debug_struct.field("human_review_operation", &self.human_review_operation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20301,7 +20232,6 @@ impl std::fmt::Debug for ProcessResponse {
         let mut debug_struct = f.debug_struct("ProcessResponse");
         debug_struct.field("document", &self.document);
         debug_struct.field("human_review_status", &self.human_review_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20642,7 +20572,6 @@ impl std::fmt::Debug for BatchProcessRequest {
         debug_struct.field("skip_human_review", &self.skip_human_review);
         debug_struct.field("process_options", &self.process_options);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20759,7 +20688,6 @@ impl serde::ser::Serialize for BatchProcessResponse {
 impl std::fmt::Debug for BatchProcessResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchProcessResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21050,7 +20978,6 @@ impl std::fmt::Debug for BatchProcessMetadata {
             "individual_process_statuses",
             &self.individual_process_statuses,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21316,7 +21243,6 @@ pub mod batch_process_metadata {
             debug_struct.field("status", &self.status);
             debug_struct.field("output_gcs_destination", &self.output_gcs_destination);
             debug_struct.field("human_review_status", &self.human_review_status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21625,7 +21551,6 @@ impl std::fmt::Debug for FetchProcessorTypesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchProcessorTypesRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21775,7 +21700,6 @@ impl std::fmt::Debug for FetchProcessorTypesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchProcessorTypesResponse");
         debug_struct.field("processor_types", &self.processor_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21995,7 +21919,6 @@ impl std::fmt::Debug for ListProcessorTypesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22185,7 +22108,6 @@ impl std::fmt::Debug for ListProcessorTypesResponse {
         let mut debug_struct = f.debug_struct("ListProcessorTypesResponse");
         debug_struct.field("processor_types", &self.processor_types);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22401,7 +22323,6 @@ impl std::fmt::Debug for ListProcessorsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22590,7 +22511,6 @@ impl std::fmt::Debug for ListProcessorsResponse {
         let mut debug_struct = f.debug_struct("ListProcessorsResponse");
         debug_struct.field("processors", &self.processors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22736,7 +22656,6 @@ impl std::fmt::Debug for GetProcessorTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProcessorTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22882,7 +22801,6 @@ impl std::fmt::Debug for GetProcessorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProcessorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23028,7 +22946,6 @@ impl std::fmt::Debug for GetProcessorVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProcessorVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23245,7 +23162,6 @@ impl std::fmt::Debug for ListProcessorVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23439,7 +23355,6 @@ impl std::fmt::Debug for ListProcessorVersionsResponse {
         let mut debug_struct = f.debug_struct("ListProcessorVersionsResponse");
         debug_struct.field("processor_versions", &self.processor_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23585,7 +23500,6 @@ impl std::fmt::Debug for DeleteProcessorVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProcessorVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23743,7 +23657,6 @@ impl std::fmt::Debug for DeleteProcessorVersionMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProcessorVersionMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23889,7 +23802,6 @@ impl std::fmt::Debug for DeployProcessorVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployProcessorVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24007,7 +23919,6 @@ impl serde::ser::Serialize for DeployProcessorVersionResponse {
 impl std::fmt::Debug for DeployProcessorVersionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployProcessorVersionResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24165,7 +24076,6 @@ impl std::fmt::Debug for DeployProcessorVersionMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeployProcessorVersionMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24311,7 +24221,6 @@ impl std::fmt::Debug for UndeployProcessorVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployProcessorVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24429,7 +24338,6 @@ impl serde::ser::Serialize for UndeployProcessorVersionResponse {
 impl std::fmt::Debug for UndeployProcessorVersionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployProcessorVersionResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24587,7 +24495,6 @@ impl std::fmt::Debug for UndeployProcessorVersionMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeployProcessorVersionMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24782,7 +24689,6 @@ impl std::fmt::Debug for CreateProcessorRequest {
         let mut debug_struct = f.debug_struct("CreateProcessorRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("processor", &self.processor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24928,7 +24834,6 @@ impl std::fmt::Debug for DeleteProcessorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProcessorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25086,7 +24991,6 @@ impl std::fmt::Debug for DeleteProcessorMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProcessorMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25232,7 +25136,6 @@ impl std::fmt::Debug for EnableProcessorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableProcessorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25350,7 +25253,6 @@ impl serde::ser::Serialize for EnableProcessorResponse {
 impl std::fmt::Debug for EnableProcessorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableProcessorResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25508,7 +25410,6 @@ impl std::fmt::Debug for EnableProcessorMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableProcessorMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25654,7 +25555,6 @@ impl std::fmt::Debug for DisableProcessorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableProcessorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25772,7 +25672,6 @@ impl serde::ser::Serialize for DisableProcessorResponse {
 impl std::fmt::Debug for DisableProcessorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableProcessorResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25930,7 +25829,6 @@ impl std::fmt::Debug for DisableProcessorMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableProcessorMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26118,7 +26016,6 @@ impl std::fmt::Debug for SetDefaultProcessorVersionRequest {
         let mut debug_struct = f.debug_struct("SetDefaultProcessorVersionRequest");
         debug_struct.field("processor", &self.processor);
         debug_struct.field("default_processor_version", &self.default_processor_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26236,7 +26133,6 @@ impl serde::ser::Serialize for SetDefaultProcessorVersionResponse {
 impl std::fmt::Debug for SetDefaultProcessorVersionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SetDefaultProcessorVersionResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26394,7 +26290,6 @@ impl std::fmt::Debug for SetDefaultProcessorVersionMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SetDefaultProcessorVersionMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26844,7 +26739,6 @@ impl std::fmt::Debug for TrainProcessorVersionRequest {
         debug_struct.field("input_data", &self.input_data);
         debug_struct.field("base_processor_version", &self.base_processor_version);
         debug_struct.field("processor_flags", &self.processor_flags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27050,7 +26944,6 @@ pub mod train_processor_version_request {
             let mut debug_struct = f.debug_struct("InputData");
             debug_struct.field("training_documents", &self.training_documents);
             debug_struct.field("test_documents", &self.test_documents);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27196,7 +27089,6 @@ pub mod train_processor_version_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CustomDocumentExtractionOptions");
             debug_struct.field("training_method", &self.training_method);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27554,7 +27446,6 @@ pub mod train_processor_version_request {
             let mut debug_struct = f.debug_struct("FoundationModelTuningOptions");
             debug_struct.field("train_steps", &self.train_steps);
             debug_struct.field("learning_rate_multiplier", &self.learning_rate_multiplier);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27721,7 +27612,6 @@ impl std::fmt::Debug for TrainProcessorVersionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TrainProcessorVersionResponse");
         debug_struct.field("processor_version", &self.processor_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27965,7 +27855,6 @@ impl std::fmt::Debug for TrainProcessorVersionMetadata {
             &self.training_dataset_validation,
         );
         debug_struct.field("test_dataset_validation", &self.test_dataset_validation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28243,7 +28132,6 @@ pub mod train_processor_version_metadata {
             debug_struct.field("dataset_error_count", &self.dataset_error_count);
             debug_struct.field("document_errors", &self.document_errors);
             debug_struct.field("dataset_errors", &self.dataset_errors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28564,7 +28452,6 @@ impl std::fmt::Debug for ReviewDocumentRequest {
         debug_struct.field("priority", &self.priority);
         debug_struct.field("document_schema", &self.document_schema);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28911,7 +28798,6 @@ impl std::fmt::Debug for ReviewDocumentResponse {
         debug_struct.field("gcs_destination", &self.gcs_destination);
         debug_struct.field("state", &self.state);
         debug_struct.field("rejection_reason", &self.rejection_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29233,7 +29119,6 @@ impl std::fmt::Debug for ReviewDocumentOperationMetadata {
         let mut debug_struct = f.debug_struct("ReviewDocumentOperationMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
         debug_struct.field("question_id", &self.question_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29426,7 +29311,6 @@ impl std::fmt::Debug for EvaluateProcessorVersionRequest {
         let mut debug_struct = f.debug_struct("EvaluateProcessorVersionRequest");
         debug_struct.field("processor_version", &self.processor_version);
         debug_struct.field("evaluation_documents", &self.evaluation_documents);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29584,7 +29468,6 @@ impl std::fmt::Debug for EvaluateProcessorVersionMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EvaluateProcessorVersionMetadata");
         debug_struct.field("common_metadata", &self.common_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29730,7 +29613,6 @@ impl std::fmt::Debug for EvaluateProcessorVersionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EvaluateProcessorVersionResponse");
         debug_struct.field("evaluation", &self.evaluation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29876,7 +29758,6 @@ impl std::fmt::Debug for GetEvaluationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEvaluationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30099,7 +29980,6 @@ impl std::fmt::Debug for ListEvaluationsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30285,7 +30165,6 @@ impl std::fmt::Debug for ListEvaluationsResponse {
         let mut debug_struct = f.debug_struct("ListEvaluationsResponse");
         debug_struct.field("evaluations", &self.evaluations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30522,7 +30401,6 @@ impl std::fmt::Debug for DocumentSchema {
         debug_struct.field("description", &self.description);
         debug_struct.field("entity_types", &self.entity_types);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30858,7 +30736,6 @@ pub mod document_schema {
             debug_struct.field("base_types", &self.base_types);
             debug_struct.field("properties", &self.properties);
             debug_struct.field("value_source", &self.value_source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31014,7 +30891,6 @@ pub mod document_schema {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("EnumValues");
                 debug_struct.field("values", &self.values);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -31261,7 +31137,6 @@ pub mod document_schema {
                 debug_struct.field("display_name", &self.display_name);
                 debug_struct.field("value_type", &self.value_type);
                 debug_struct.field("occurrence_type", &self.occurrence_type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -31696,7 +31571,6 @@ pub mod document_schema {
                 &self.prefixed_naming_on_properties,
             );
             debug_struct.field("skip_naming_validation", &self.skip_naming_validation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31938,7 +31812,6 @@ impl std::fmt::Debug for EvaluationReference {
         debug_struct.field("evaluation", &self.evaluation);
         debug_struct.field("aggregate_metrics", &self.aggregate_metrics);
         debug_struct.field("aggregate_metrics_exact", &self.aggregate_metrics_exact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32289,7 +32162,6 @@ impl std::fmt::Debug for Evaluation {
         debug_struct.field("entity_metrics", &self.entity_metrics);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32616,7 +32488,6 @@ pub mod evaluation {
             debug_struct.field("invalid_documents_count", &self.invalid_documents_count);
             debug_struct.field("failed_documents_count", &self.failed_documents_count);
             debug_struct.field("evaluated_documents_count", &self.evaluated_documents_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33270,7 +33141,6 @@ pub mod evaluation {
             debug_struct.field("false_positives_count", &self.false_positives_count);
             debug_struct.field("false_negatives_count", &self.false_negatives_count);
             debug_struct.field("total_documents_count", &self.total_documents_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33471,7 +33341,6 @@ pub mod evaluation {
             let mut debug_struct = f.debug_struct("ConfidenceLevelMetrics");
             debug_struct.field("confidence_level", &self.confidence_level);
             debug_struct.field("metrics", &self.metrics);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33911,7 +33780,6 @@ pub mod evaluation {
                 &self.estimated_calibration_error_exact,
             );
             debug_struct.field("metrics_type", &self.metrics_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34256,7 +34124,6 @@ impl std::fmt::Debug for Vertex {
         let mut debug_struct = f.debug_struct("Vertex");
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34461,7 +34328,6 @@ impl std::fmt::Debug for NormalizedVertex {
         let mut debug_struct = f.debug_struct("NormalizedVertex");
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34639,7 +34505,6 @@ impl std::fmt::Debug for BoundingPoly {
         let mut debug_struct = f.debug_struct("BoundingPoly");
         debug_struct.field("vertices", &self.vertices);
         debug_struct.field("normalized_vertices", &self.normalized_vertices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34911,7 +34776,6 @@ impl std::fmt::Debug for CommonOperationMetadata {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35618,7 +35482,6 @@ impl std::fmt::Debug for ProcessorVersion {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("gen_ai_model_info", &self.gen_ai_model_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35819,7 +35682,6 @@ pub mod processor_version {
                 "replacement_processor_version",
                 &self.replacement_processor_version,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36088,7 +35950,6 @@ pub mod processor_version {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GenAiModelInfo");
             debug_struct.field("model_info", &self.model_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36308,7 +36169,6 @@ pub mod processor_version {
                     "min_train_labeled_documents",
                     &self.min_train_labeled_documents,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -36498,7 +36358,6 @@ pub mod processor_version {
                 let mut debug_struct = f.debug_struct("CustomGenAiModelInfo");
                 debug_struct.field("custom_model_type", &self.custom_model_type);
                 debug_struct.field("base_processor_version_id", &self.base_processor_version_id);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -37140,7 +36999,6 @@ impl std::fmt::Debug for ProcessorVersionAlias {
         let mut debug_struct = f.debug_struct("ProcessorVersionAlias");
         debug_struct.field("alias", &self.alias);
         debug_struct.field("processor_version", &self.processor_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37584,7 +37442,6 @@ impl std::fmt::Debug for Processor {
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38077,7 +37934,6 @@ impl std::fmt::Debug for ProcessorType {
         debug_struct.field("allow_creation", &self.allow_creation);
         debug_struct.field("launch_stage", &self.launch_stage);
         debug_struct.field("sample_document_uris", &self.sample_document_uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38229,7 +38085,6 @@ pub mod processor_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LocationInfo");
             debug_struct.field("location_id", &self.location_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -576,7 +576,6 @@ impl std::fmt::Debug for Registration {
         debug_struct.field("contact_settings", &self.contact_settings);
         debug_struct.field("pending_contact_settings", &self.pending_contact_settings);
         debug_struct.field("supported_privacy", &self.supported_privacy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1077,7 +1076,6 @@ impl std::fmt::Debug for ManagementSettings {
         let mut debug_struct = f.debug_struct("ManagementSettings");
         debug_struct.field("renewal_method", &self.renewal_method);
         debug_struct.field("transfer_lock_state", &self.transfer_lock_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1507,7 +1505,6 @@ impl std::fmt::Debug for DnsSettings {
         let mut debug_struct = f.debug_struct("DnsSettings");
         debug_struct.field("glue_records", &self.glue_records);
         debug_struct.field("dns_provider", &self.dns_provider);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1698,7 +1695,6 @@ pub mod dns_settings {
             let mut debug_struct = f.debug_struct("CustomDns");
             debug_struct.field("name_servers", &self.name_servers);
             debug_struct.field("ds_records", &self.ds_records);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1916,7 +1912,6 @@ pub mod dns_settings {
             debug_struct.field("name_servers", &self.name_servers);
             debug_struct.field("ds_state", &self.ds_state);
             debug_struct.field("ds_records", &self.ds_records);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2172,7 +2167,6 @@ pub mod dns_settings {
             debug_struct.field("algorithm", &self.algorithm);
             debug_struct.field("digest_type", &self.digest_type);
             debug_struct.field("digest", &self.digest);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2782,7 +2776,6 @@ pub mod dns_settings {
             debug_struct.field("host_name", &self.host_name);
             debug_struct.field("ipv4_addresses", &self.ipv4_addresses);
             debug_struct.field("ipv6_addresses", &self.ipv6_addresses);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3197,7 +3190,6 @@ impl std::fmt::Debug for ContactSettings {
         debug_struct.field("registrant_contact", &self.registrant_contact);
         debug_struct.field("admin_contact", &self.admin_contact);
         debug_struct.field("technical_contact", &self.technical_contact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3442,7 +3434,6 @@ pub mod contact_settings {
             debug_struct.field("email", &self.email);
             debug_struct.field("phone_number", &self.phone_number);
             debug_struct.field("fax_number", &self.fax_number);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3610,7 +3601,6 @@ impl std::fmt::Debug for SearchDomainsRequest {
         let mut debug_struct = f.debug_struct("SearchDomainsRequest");
         debug_struct.field("query", &self.query);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3760,7 +3750,6 @@ impl std::fmt::Debug for SearchDomainsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SearchDomainsResponse");
         debug_struct.field("register_parameters", &self.register_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3928,7 +3917,6 @@ impl std::fmt::Debug for RetrieveRegisterParametersRequest {
         let mut debug_struct = f.debug_struct("RetrieveRegisterParametersRequest");
         debug_struct.field("domain_name", &self.domain_name);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4082,7 +4070,6 @@ impl std::fmt::Debug for RetrieveRegisterParametersResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveRegisterParametersResponse");
         debug_struct.field("register_parameters", &self.register_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4389,7 +4376,6 @@ impl std::fmt::Debug for RegisterDomainRequest {
         debug_struct.field("contact_notices", &self.contact_notices);
         debug_struct.field("yearly_price", &self.yearly_price);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4557,7 +4543,6 @@ impl std::fmt::Debug for RetrieveTransferParametersRequest {
         let mut debug_struct = f.debug_struct("RetrieveTransferParametersRequest");
         debug_struct.field("domain_name", &self.domain_name);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4711,7 +4696,6 @@ impl std::fmt::Debug for RetrieveTransferParametersResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveTransferParametersResponse");
         debug_struct.field("transfer_parameters", &self.transfer_parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5031,7 +5015,6 @@ impl std::fmt::Debug for TransferDomainRequest {
         debug_struct.field("yearly_price", &self.yearly_price);
         debug_struct.field("authorization_code", &self.authorization_code);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5285,7 +5268,6 @@ impl std::fmt::Debug for ListRegistrationsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5471,7 +5453,6 @@ impl std::fmt::Debug for ListRegistrationsResponse {
         let mut debug_struct = f.debug_struct("ListRegistrationsResponse");
         debug_struct.field("registrations", &self.registrations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5614,7 +5595,6 @@ impl std::fmt::Debug for GetRegistrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRegistrationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5806,7 +5786,6 @@ impl std::fmt::Debug for UpdateRegistrationRequest {
         let mut debug_struct = f.debug_struct("UpdateRegistrationRequest");
         debug_struct.field("registration", &self.registration);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6025,7 +6004,6 @@ impl std::fmt::Debug for ConfigureManagementSettingsRequest {
         debug_struct.field("registration", &self.registration);
         debug_struct.field("management_settings", &self.management_settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6276,7 +6254,6 @@ impl std::fmt::Debug for ConfigureDnsSettingsRequest {
         debug_struct.field("dns_settings", &self.dns_settings);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6552,7 +6529,6 @@ impl std::fmt::Debug for ConfigureContactSettingsRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("contact_notices", &self.contact_notices);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6695,7 +6671,6 @@ impl std::fmt::Debug for ExportRegistrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportRegistrationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6838,7 +6813,6 @@ impl std::fmt::Debug for DeleteRegistrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteRegistrationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6981,7 +6955,6 @@ impl std::fmt::Debug for RetrieveAuthorizationCodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveAuthorizationCodeRequest");
         debug_struct.field("registration", &self.registration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7124,7 +7097,6 @@ impl std::fmt::Debug for ResetAuthorizationCodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetAuthorizationCodeRequest");
         debug_struct.field("registration", &self.registration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7400,7 +7372,6 @@ impl std::fmt::Debug for RegisterParameters {
         debug_struct.field("supported_privacy", &self.supported_privacy);
         debug_struct.field("domain_notices", &self.domain_notices);
         debug_struct.field("yearly_price", &self.yearly_price);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7858,7 +7829,6 @@ impl std::fmt::Debug for TransferParameters {
         debug_struct.field("transfer_lock_state", &self.transfer_lock_state);
         debug_struct.field("supported_privacy", &self.supported_privacy);
         debug_struct.field("yearly_price", &self.yearly_price);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8001,7 +7971,6 @@ impl std::fmt::Debug for AuthorizationCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AuthorizationCode");
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8294,7 +8263,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("verb", &self.verb);
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -1023,7 +1023,6 @@ impl std::fmt::Debug for Cluster {
             &self.external_load_balancer_ipv6_address_pools,
         );
         debug_struct.field("connection_state", &self.connection_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1285,7 +1284,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ControlPlane");
             debug_struct.field("config", &self.config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1410,7 +1408,6 @@ pub mod cluster {
         impl std::fmt::Debug for Remote {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Remote");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1742,7 +1739,6 @@ pub mod cluster {
                     "control_plane_node_storage_schema",
                     &self.control_plane_node_storage_schema,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2094,7 +2090,6 @@ pub mod cluster {
             let mut debug_struct = f.debug_struct("SystemAddonsConfig");
             debug_struct.field("ingress", &self.ingress);
             debug_struct.field("vm_service_config", &self.vm_service_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2282,7 +2277,6 @@ pub mod cluster {
                 let mut debug_struct = f.debug_struct("Ingress");
                 debug_struct.field("disabled", &self.disabled);
                 debug_struct.field("ipv4_vip", &self.ipv4_vip);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2433,7 +2427,6 @@ pub mod cluster {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("VMServiceConfig");
                 debug_struct.field("vmm_enabled", &self.vmm_enabled);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2717,7 +2710,6 @@ pub mod cluster {
             debug_struct.field("kms_key_state", &self.kms_key_state);
             debug_struct.field("kms_status", &self.kms_status);
             debug_struct.field("resource_state", &self.resource_state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3164,7 +3156,6 @@ pub mod cluster {
             debug_struct.field("start_time", &self.start_time);
             debug_struct.field("end_time", &self.end_time);
             debug_struct.field("update_time", &self.update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3737,7 +3728,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SurvivabilityConfig");
             debug_struct.field("offline_reboot_ttl", &self.offline_reboot_ttl);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3925,7 +3915,6 @@ pub mod cluster {
             let mut debug_struct = f.debug_struct("ConnectionState");
             debug_struct.field("state", &self.state);
             debug_struct.field("update_time", &self.update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4544,7 +4533,6 @@ impl std::fmt::Debug for ClusterNetworking {
         let mut debug_struct = f.debug_struct("ClusterNetworking");
         debug_struct.field("cluster_ipv4_cidr_blocks", &self.cluster_ipv4_cidr_blocks);
         debug_struct.field("services_ipv4_cidr_blocks", &self.services_ipv4_cidr_blocks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4723,7 +4711,6 @@ impl std::fmt::Debug for Fleet {
         let mut debug_struct = f.debug_struct("Fleet");
         debug_struct.field("project", &self.project);
         debug_struct.field("membership", &self.membership);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4865,7 +4852,6 @@ impl std::fmt::Debug for ClusterUser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ClusterUser");
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5021,7 +5007,6 @@ impl std::fmt::Debug for Authorization {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Authorization");
         debug_struct.field("admin_users", &self.admin_users);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5476,7 +5461,6 @@ impl std::fmt::Debug for NodePool {
         debug_struct.field("local_disk_encryption", &self.local_disk_encryption);
         debug_struct.field("node_version", &self.node_version);
         debug_struct.field("node_config", &self.node_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5764,7 +5748,6 @@ pub mod node_pool {
             debug_struct.field("kms_key_state", &self.kms_key_state);
             debug_struct.field("kms_status", &self.kms_status);
             debug_struct.field("resource_state", &self.resource_state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5953,7 +5936,6 @@ pub mod node_pool {
             let mut debug_struct = f.debug_struct("NodeConfig");
             debug_struct.field("labels", &self.labels);
             debug_struct.field("node_storage_schema", &self.node_storage_schema);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6316,7 +6298,6 @@ impl std::fmt::Debug for Machine {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("version", &self.version);
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6810,7 +6791,6 @@ impl std::fmt::Debug for VpnConnection {
         debug_struct.field("enable_high_availability", &self.enable_high_availability);
         debug_struct.field("router", &self.router);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6993,7 +6973,6 @@ pub mod vpn_connection {
             let mut debug_struct = f.debug_struct("VpcProject");
             debug_struct.field("project_id", &self.project_id);
             debug_struct.field("service_account", &self.service_account);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7241,7 +7220,6 @@ pub mod vpn_connection {
             debug_struct.field("error", &self.error);
             debug_struct.field("cloud_router", &self.cloud_router);
             debug_struct.field("cloud_vpns", &self.cloud_vpns);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7394,7 +7372,6 @@ pub mod vpn_connection {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CloudRouter");
                 debug_struct.field("name", &self.name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -7544,7 +7521,6 @@ pub mod vpn_connection {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CloudVpn");
                 debug_struct.field("gateway", &self.gateway);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -7978,7 +7954,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("available_zones", &self.available_zones);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8198,7 +8173,6 @@ impl std::fmt::Debug for ZoneMetadata {
         debug_struct.field("quota", &self.quota);
         debug_struct.field("rack_types", &self.rack_types);
         debug_struct.field("config_data", &self.config_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8533,7 +8507,6 @@ impl std::fmt::Debug for ConfigData {
             "available_external_lb_pools_ipv6",
             &self.available_external_lb_pools_ipv6,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8761,7 +8734,6 @@ impl std::fmt::Debug for Quota {
         debug_struct.field("metric", &self.metric);
         debug_struct.field("limit", &self.limit);
         debug_struct.field("usage", &self.usage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8951,7 +8923,6 @@ impl std::fmt::Debug for MaintenancePolicy {
         let mut debug_struct = f.debug_struct("MaintenancePolicy");
         debug_struct.field("window", &self.window);
         debug_struct.field("maintenance_exclusions", &self.maintenance_exclusions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9105,7 +9076,6 @@ impl std::fmt::Debug for MaintenanceWindow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaintenanceWindow");
         debug_struct.field("recurring_window", &self.recurring_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9285,7 +9255,6 @@ impl std::fmt::Debug for RecurringTimeWindow {
         let mut debug_struct = f.debug_struct("RecurringTimeWindow");
         debug_struct.field("window", &self.window);
         debug_struct.field("recurrence", &self.recurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9463,7 +9432,6 @@ impl std::fmt::Debug for MaintenanceExclusionWindow {
         let mut debug_struct = f.debug_struct("MaintenanceExclusionWindow");
         debug_struct.field("window", &self.window);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9655,7 +9623,6 @@ impl std::fmt::Debug for TimeWindow {
         let mut debug_struct = f.debug_struct("TimeWindow");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9862,7 +9829,6 @@ impl std::fmt::Debug for ServerConfig {
         debug_struct.field("channels", &self.channels);
         debug_struct.field("versions", &self.versions);
         debug_struct.field("default_version", &self.default_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10005,7 +9971,6 @@ impl std::fmt::Debug for ChannelConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ChannelConfig");
         debug_struct.field("default_version", &self.default_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10147,7 +10112,6 @@ impl std::fmt::Debug for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Version");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10533,7 +10497,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("warnings", &self.warnings);
         debug_struct.field("status_reason", &self.status_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10928,7 +10891,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11141,7 +11103,6 @@ impl std::fmt::Debug for ListClustersResponse {
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11283,7 +11244,6 @@ impl std::fmt::Debug for GetClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11515,7 +11475,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11737,7 +11696,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11963,7 +11921,6 @@ impl std::fmt::Debug for UpgradeClusterRequest {
         debug_struct.field("target_version", &self.target_version);
         debug_struct.field("schedule", &self.schedule);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12266,7 +12223,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         let mut debug_struct = f.debug_struct("DeleteClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12408,7 +12364,6 @@ impl std::fmt::Debug for GenerateAccessTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateAccessTokenRequest");
         debug_struct.field("cluster", &self.cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12588,7 +12543,6 @@ impl std::fmt::Debug for GenerateAccessTokenResponse {
         let mut debug_struct = f.debug_struct("GenerateAccessTokenResponse");
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12730,7 +12684,6 @@ impl std::fmt::Debug for GenerateOfflineCredentialRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateOfflineCredentialRequest");
         debug_struct.field("cluster", &self.cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12965,7 +12918,6 @@ impl std::fmt::Debug for GenerateOfflineCredentialResponse {
         debug_struct.field("client_key", &self.client_key);
         debug_struct.field("user_id", &self.user_id);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13228,7 +13180,6 @@ impl std::fmt::Debug for ListNodePoolsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13442,7 +13393,6 @@ impl std::fmt::Debug for ListNodePoolsResponse {
         debug_struct.field("node_pools", &self.node_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13584,7 +13534,6 @@ impl std::fmt::Debug for GetNodePoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNodePoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13817,7 +13766,6 @@ impl std::fmt::Debug for CreateNodePoolRequest {
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("node_pool", &self.node_pool);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14040,7 +13988,6 @@ impl std::fmt::Debug for UpdateNodePoolRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("node_pool", &self.node_pool);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14210,7 +14157,6 @@ impl std::fmt::Debug for DeleteNodePoolRequest {
         let mut debug_struct = f.debug_struct("DeleteNodePoolRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14473,7 +14419,6 @@ impl std::fmt::Debug for ListMachinesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14686,7 +14631,6 @@ impl std::fmt::Debug for ListMachinesResponse {
         debug_struct.field("machines", &self.machines);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14828,7 +14772,6 @@ impl std::fmt::Debug for GetMachineRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMachineRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15092,7 +15035,6 @@ impl std::fmt::Debug for ListVpnConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15306,7 +15248,6 @@ impl std::fmt::Debug for ListVpnConnectionsResponse {
         debug_struct.field("vpn_connections", &self.vpn_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15448,7 +15389,6 @@ impl std::fmt::Debug for GetVpnConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVpnConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15684,7 +15624,6 @@ impl std::fmt::Debug for CreateVpnConnectionRequest {
         debug_struct.field("vpn_connection_id", &self.vpn_connection_id);
         debug_struct.field("vpn_connection", &self.vpn_connection);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15854,7 +15793,6 @@ impl std::fmt::Debug for DeleteVpnConnectionRequest {
         let mut debug_struct = f.debug_struct("DeleteVpnConnectionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15997,7 +15935,6 @@ impl std::fmt::Debug for GetServerConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServerConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -309,7 +309,6 @@ impl std::fmt::Debug for Zone {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("layout_name", &self.layout_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -632,7 +631,6 @@ impl std::fmt::Debug for Network {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
         debug_struct.field("mtu", &self.mtu);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1094,7 +1092,6 @@ impl std::fmt::Debug for Subnet {
         debug_struct.field("vlan_id", &self.vlan_id);
         debug_struct.field("bonding_type", &self.bonding_type);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1639,7 +1636,6 @@ impl std::fmt::Debug for Interconnect {
             &self.device_cloud_resource_name,
         );
         debug_struct.field("physical_ports", &self.physical_ports);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2215,7 +2211,6 @@ impl std::fmt::Debug for InterconnectAttachment {
         debug_struct.field("vlan_id", &self.vlan_id);
         debug_struct.field("mtu", &self.mtu);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2676,7 +2671,6 @@ impl std::fmt::Debug for Router {
         debug_struct.field("bgp", &self.bgp);
         debug_struct.field("state", &self.state);
         debug_struct.field("route_advertisements", &self.route_advertisements);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2974,7 +2968,6 @@ pub mod router {
             );
             debug_struct.field("subnetwork", &self.subnetwork);
             debug_struct.field("loopback_ip_addresses", &self.loopback_ip_addresses);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3353,7 +3346,6 @@ pub mod router {
             debug_struct.field("peer_ipv6_cidr", &self.peer_ipv6_cidr);
             debug_struct.field("peer_asn", &self.peer_asn);
             debug_struct.field("local_asn", &self.local_asn);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3575,7 +3567,6 @@ pub mod router {
                 "keepalive_interval_in_seconds",
                 &self.keepalive_interval_in_seconds,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3745,7 +3736,6 @@ impl std::fmt::Debug for LinkLayerAddress {
         let mut debug_struct = f.debug_struct("LinkLayerAddress");
         debug_struct.field("mac_address", &self.mac_address);
         debug_struct.field("ip_address", &self.ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3948,7 +3938,6 @@ impl std::fmt::Debug for SubnetStatus {
         debug_struct.field("name", &self.name);
         debug_struct.field("mac_address", &self.mac_address);
         debug_struct.field("link_layer_addresses", &self.link_layer_addresses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4161,7 +4150,6 @@ impl std::fmt::Debug for InterconnectDiagnostics {
         debug_struct.field("mac_address", &self.mac_address);
         debug_struct.field("link_layer_addresses", &self.link_layer_addresses);
         debug_struct.field("links", &self.links);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4426,7 +4414,6 @@ pub mod interconnect_diagnostics {
             debug_struct.field("lacp_status", &self.lacp_status);
             debug_struct.field("lldp_statuses", &self.lldp_statuses);
             debug_struct.field("packet_counts", &self.packet_counts);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4819,7 +4806,6 @@ pub mod interconnect_diagnostics {
             debug_struct.field("outbound_unicast", &self.outbound_unicast);
             debug_struct.field("outbound_errors", &self.outbound_errors);
             debug_struct.field("outbound_discards", &self.outbound_discards);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5104,7 +5090,6 @@ pub mod interconnect_diagnostics {
             debug_struct.field("aggregatable", &self.aggregatable);
             debug_struct.field("collecting", &self.collecting);
             debug_struct.field("distributing", &self.distributing);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5547,7 +5532,6 @@ pub mod interconnect_diagnostics {
             debug_struct.field("peer_chassis_id_type", &self.peer_chassis_id_type);
             debug_struct.field("peer_port_id", &self.peer_port_id);
             debug_struct.field("peer_port_id_type", &self.peer_port_id_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5724,7 +5708,6 @@ impl std::fmt::Debug for RouterStatus {
         let mut debug_struct = f.debug_struct("RouterStatus");
         debug_struct.field("network", &self.network);
         debug_struct.field("bgp_peer_status", &self.bgp_peer_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6096,7 +6079,6 @@ pub mod router_status {
             debug_struct.field("uptime", &self.uptime);
             debug_struct.field("uptime_seconds", &self.uptime_seconds);
             debug_struct.field("prefix_counter", &self.prefix_counter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6618,7 +6600,6 @@ pub mod router_status {
             debug_struct.field("sent", &self.sent);
             debug_struct.field("suppressed", &self.suppressed);
             debug_struct.field("withdrawn", &self.withdrawn);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6885,7 +6866,6 @@ impl std::fmt::Debug for ListZonesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7100,7 +7080,6 @@ impl std::fmt::Debug for ListZonesResponse {
         debug_struct.field("zones", &self.zones);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7244,7 +7223,6 @@ impl std::fmt::Debug for GetZoneRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetZoneRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7508,7 +7486,6 @@ impl std::fmt::Debug for ListNetworksRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7721,7 +7698,6 @@ impl std::fmt::Debug for ListNetworksResponse {
         debug_struct.field("networks", &self.networks);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7863,7 +7839,6 @@ impl std::fmt::Debug for GetNetworkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNetworkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8107,7 +8082,6 @@ impl std::fmt::Debug for CreateNetworkRequest {
         debug_struct.field("network_id", &self.network_id);
         debug_struct.field("network", &self.network);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8287,7 +8261,6 @@ impl std::fmt::Debug for DeleteNetworkRequest {
         let mut debug_struct = f.debug_struct("DeleteNetworkRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8551,7 +8524,6 @@ impl std::fmt::Debug for ListSubnetsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8764,7 +8736,6 @@ impl std::fmt::Debug for ListSubnetsResponse {
         debug_struct.field("subnets", &self.subnets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8906,7 +8877,6 @@ impl std::fmt::Debug for GetSubnetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSubnetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9150,7 +9120,6 @@ impl std::fmt::Debug for CreateSubnetRequest {
         debug_struct.field("subnet_id", &self.subnet_id);
         debug_struct.field("subnet", &self.subnet);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9382,7 +9351,6 @@ impl std::fmt::Debug for UpdateSubnetRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("subnet", &self.subnet);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9562,7 +9530,6 @@ impl std::fmt::Debug for DeleteSubnetRequest {
         let mut debug_struct = f.debug_struct("DeleteSubnetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9826,7 +9793,6 @@ impl std::fmt::Debug for ListInterconnectsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10039,7 +10005,6 @@ impl std::fmt::Debug for ListInterconnectsResponse {
         debug_struct.field("interconnects", &self.interconnects);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10181,7 +10146,6 @@ impl std::fmt::Debug for GetInterconnectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInterconnectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10445,7 +10409,6 @@ impl std::fmt::Debug for ListInterconnectAttachmentsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10665,7 +10628,6 @@ impl std::fmt::Debug for ListInterconnectAttachmentsResponse {
         debug_struct.field("interconnect_attachments", &self.interconnect_attachments);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10807,7 +10769,6 @@ impl std::fmt::Debug for GetInterconnectAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInterconnectAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11062,7 +11023,6 @@ impl std::fmt::Debug for CreateInterconnectAttachmentRequest {
         );
         debug_struct.field("interconnect_attachment", &self.interconnect_attachment);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11242,7 +11202,6 @@ impl std::fmt::Debug for DeleteInterconnectAttachmentRequest {
         let mut debug_struct = f.debug_struct("DeleteInterconnectAttachmentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11506,7 +11465,6 @@ impl std::fmt::Debug for ListRoutersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11719,7 +11677,6 @@ impl std::fmt::Debug for ListRoutersResponse {
         debug_struct.field("routers", &self.routers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11861,7 +11818,6 @@ impl std::fmt::Debug for GetRouterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRouterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12105,7 +12061,6 @@ impl std::fmt::Debug for CreateRouterRequest {
         debug_struct.field("router_id", &self.router_id);
         debug_struct.field("router", &self.router);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12337,7 +12292,6 @@ impl std::fmt::Debug for UpdateRouterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("router", &self.router);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12517,7 +12471,6 @@ impl std::fmt::Debug for DeleteRouterRequest {
         let mut debug_struct = f.debug_struct("DeleteRouterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12842,7 +12795,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12984,7 +12936,6 @@ impl std::fmt::Debug for DiagnoseNetworkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiagnoseNetworkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13175,7 +13126,6 @@ impl std::fmt::Debug for DiagnoseNetworkResponse {
         let mut debug_struct = f.debug_struct("DiagnoseNetworkResponse");
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13376,7 +13326,6 @@ pub mod diagnose_network_response {
                 "macsec_status_internal_links",
                 &self.macsec_status_internal_links,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13660,7 +13609,6 @@ impl std::fmt::Debug for DiagnoseInterconnectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiagnoseInterconnectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13851,7 +13799,6 @@ impl std::fmt::Debug for DiagnoseInterconnectResponse {
         let mut debug_struct = f.debug_struct("DiagnoseInterconnectResponse");
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13993,7 +13940,6 @@ impl std::fmt::Debug for DiagnoseRouterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiagnoseRouterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14183,7 +14129,6 @@ impl std::fmt::Debug for DiagnoseRouterResponse {
         let mut debug_struct = f.debug_struct("DiagnoseRouterResponse");
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14325,7 +14270,6 @@ impl std::fmt::Debug for InitializeZoneRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeZoneRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14439,7 +14383,6 @@ impl serde::ser::Serialize for InitializeZoneResponse {
 impl std::fmt::Debug for InitializeZoneResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializeZoneResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/essentialcontacts/v1/src/model.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/model.rs
@@ -333,7 +333,6 @@ impl std::fmt::Debug for Contact {
         debug_struct.field("language_tag", &self.language_tag);
         debug_struct.field("validation_state", &self.validation_state);
         debug_struct.field("validate_time", &self.validate_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -553,7 +552,6 @@ impl std::fmt::Debug for ListContactsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -741,7 +739,6 @@ impl std::fmt::Debug for ListContactsResponse {
         let mut debug_struct = f.debug_struct("ListContactsResponse");
         debug_struct.field("contacts", &self.contacts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -886,7 +883,6 @@ impl std::fmt::Debug for GetContactRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetContactRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1031,7 +1027,6 @@ impl std::fmt::Debug for DeleteContactRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteContactRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1212,7 +1207,6 @@ impl std::fmt::Debug for CreateContactRequest {
         let mut debug_struct = f.debug_struct("CreateContactRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("contact", &self.contact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1405,7 +1399,6 @@ impl std::fmt::Debug for UpdateContactRequest {
         let mut debug_struct = f.debug_struct("UpdateContactRequest");
         debug_struct.field("contact", &self.contact);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1660,7 +1653,6 @@ impl std::fmt::Debug for ComputeContactsRequest {
         debug_struct.field("notification_categories", &self.notification_categories);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1850,7 +1842,6 @@ impl std::fmt::Debug for ComputeContactsResponse {
         let mut debug_struct = f.debug_struct("ComputeContactsResponse");
         debug_struct.field("contacts", &self.contacts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2055,7 +2046,6 @@ impl std::fmt::Debug for SendTestMessageRequest {
         debug_struct.field("contacts", &self.contacts);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("notification_category", &self.notification_category);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -478,7 +478,6 @@ impl std::fmt::Debug for Channel {
         debug_struct.field("crypto_key_name", &self.crypto_key_name);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("transport", &self.transport);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -949,7 +948,6 @@ impl std::fmt::Debug for ChannelConnection {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("activation_token", &self.activation_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1148,7 +1146,6 @@ impl std::fmt::Debug for Provider {
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("event_types", &self.event_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1385,7 +1382,6 @@ impl std::fmt::Debug for EventType {
         debug_struct.field("description", &self.description);
         debug_struct.field("filtering_attributes", &self.filtering_attributes);
         debug_struct.field("event_schema_uri", &self.event_schema_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1606,7 +1602,6 @@ impl std::fmt::Debug for FilteringAttribute {
         debug_struct.field("description", &self.description);
         debug_struct.field("required", &self.required);
         debug_struct.field("path_pattern_supported", &self.path_pattern_supported);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2059,7 +2054,6 @@ impl std::fmt::Debug for Enrollment {
         debug_struct.field("cel_match", &self.cel_match);
         debug_struct.field("message_bus", &self.message_bus);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2201,7 +2195,6 @@ impl std::fmt::Debug for GetTriggerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTriggerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2475,7 +2468,6 @@ impl std::fmt::Debug for ListTriggersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2689,7 +2681,6 @@ impl std::fmt::Debug for ListTriggersResponse {
         debug_struct.field("triggers", &self.triggers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2920,7 +2911,6 @@ impl std::fmt::Debug for CreateTriggerRequest {
         debug_struct.field("trigger", &self.trigger);
         debug_struct.field("trigger_id", &self.trigger_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3166,7 +3156,6 @@ impl std::fmt::Debug for UpdateTriggerRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3388,7 +3377,6 @@ impl std::fmt::Debug for DeleteTriggerRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3530,7 +3518,6 @@ impl std::fmt::Debug for GetChannelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetChannelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3777,7 +3764,6 @@ impl std::fmt::Debug for ListChannelsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3991,7 +3977,6 @@ impl std::fmt::Debug for ListChannelsResponse {
         debug_struct.field("channels", &self.channels);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4222,7 +4207,6 @@ impl std::fmt::Debug for CreateChannelRequest {
         debug_struct.field("channel", &self.channel);
         debug_struct.field("channel_id", &self.channel_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4441,7 +4425,6 @@ impl std::fmt::Debug for UpdateChannelRequest {
         debug_struct.field("channel", &self.channel);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4610,7 +4593,6 @@ impl std::fmt::Debug for DeleteChannelRequest {
         let mut debug_struct = f.debug_struct("DeleteChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4752,7 +4734,6 @@ impl std::fmt::Debug for GetProviderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProviderRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5022,7 +5003,6 @@ impl std::fmt::Debug for ListProvidersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5236,7 +5216,6 @@ impl std::fmt::Debug for ListProvidersResponse {
         debug_struct.field("providers", &self.providers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5378,7 +5357,6 @@ impl std::fmt::Debug for GetChannelConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetChannelConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5596,7 +5574,6 @@ impl std::fmt::Debug for ListChannelConnectionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5817,7 +5794,6 @@ impl std::fmt::Debug for ListChannelConnectionsResponse {
         debug_struct.field("channel_connections", &self.channel_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6026,7 +6002,6 @@ impl std::fmt::Debug for CreateChannelConnectionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("channel_connection", &self.channel_connection);
         debug_struct.field("channel_connection_id", &self.channel_connection_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6168,7 +6143,6 @@ impl std::fmt::Debug for DeleteChannelConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteChannelConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6361,7 +6335,6 @@ impl std::fmt::Debug for UpdateGoogleChannelConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateGoogleChannelConfigRequest");
         debug_struct.field("google_channel_config", &self.google_channel_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6503,7 +6476,6 @@ impl std::fmt::Debug for GetGoogleChannelConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGoogleChannelConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6645,7 +6617,6 @@ impl std::fmt::Debug for GetMessageBusRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMessageBusRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6918,7 +6889,6 @@ impl std::fmt::Debug for ListMessageBusesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7133,7 +7103,6 @@ impl std::fmt::Debug for ListMessageBusesResponse {
         debug_struct.field("message_buses", &self.message_buses);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7351,7 +7320,6 @@ impl std::fmt::Debug for ListMessageBusEnrollmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7551,7 +7519,6 @@ impl std::fmt::Debug for ListMessageBusEnrollmentsResponse {
         debug_struct.field("enrollments", &self.enrollments);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7784,7 +7751,6 @@ impl std::fmt::Debug for CreateMessageBusRequest {
         debug_struct.field("message_bus", &self.message_bus);
         debug_struct.field("message_bus_id", &self.message_bus_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8031,7 +7997,6 @@ impl std::fmt::Debug for UpdateMessageBusRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8253,7 +8218,6 @@ impl std::fmt::Debug for DeleteMessageBusRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8395,7 +8359,6 @@ impl std::fmt::Debug for GetEnrollmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEnrollmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8668,7 +8631,6 @@ impl std::fmt::Debug for ListEnrollmentsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8882,7 +8844,6 @@ impl std::fmt::Debug for ListEnrollmentsResponse {
         debug_struct.field("enrollments", &self.enrollments);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9114,7 +9075,6 @@ impl std::fmt::Debug for CreateEnrollmentRequest {
         debug_struct.field("enrollment", &self.enrollment);
         debug_struct.field("enrollment_id", &self.enrollment_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9360,7 +9320,6 @@ impl std::fmt::Debug for UpdateEnrollmentRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9582,7 +9541,6 @@ impl std::fmt::Debug for DeleteEnrollmentRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9724,7 +9682,6 @@ impl std::fmt::Debug for GetPipelineRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPipelineRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9997,7 +9954,6 @@ impl std::fmt::Debug for ListPipelinesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10211,7 +10167,6 @@ impl std::fmt::Debug for ListPipelinesResponse {
         debug_struct.field("pipelines", &self.pipelines);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10442,7 +10397,6 @@ impl std::fmt::Debug for CreatePipelineRequest {
         debug_struct.field("pipeline", &self.pipeline);
         debug_struct.field("pipeline_id", &self.pipeline_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10688,7 +10642,6 @@ impl std::fmt::Debug for UpdatePipelineRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10910,7 +10863,6 @@ impl std::fmt::Debug for DeletePipelineRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11052,7 +11004,6 @@ impl std::fmt::Debug for GetGoogleApiSourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGoogleApiSourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11325,7 +11276,6 @@ impl std::fmt::Debug for ListGoogleApiSourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11544,7 +11494,6 @@ impl std::fmt::Debug for ListGoogleApiSourcesResponse {
         debug_struct.field("google_api_sources", &self.google_api_sources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11781,7 +11730,6 @@ impl std::fmt::Debug for CreateGoogleApiSourceRequest {
         debug_struct.field("google_api_source", &self.google_api_source);
         debug_struct.field("google_api_source_id", &self.google_api_source_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12030,7 +11978,6 @@ impl std::fmt::Debug for UpdateGoogleApiSourceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12252,7 +12199,6 @@ impl std::fmt::Debug for DeleteGoogleApiSourceRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12577,7 +12523,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13041,7 +12986,6 @@ impl std::fmt::Debug for GoogleApiSource {
         debug_struct.field("destination", &self.destination);
         debug_struct.field("crypto_key_name", &self.crypto_key_name);
         debug_struct.field("logging_config", &self.logging_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13255,7 +13199,6 @@ impl std::fmt::Debug for GoogleChannelConfig {
         debug_struct.field("name", &self.name);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("crypto_key_name", &self.crypto_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13402,7 +13345,6 @@ impl std::fmt::Debug for LoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingConfig");
         debug_struct.field("log_severity", &self.log_severity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14037,7 +13979,6 @@ impl std::fmt::Debug for MessageBus {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("crypto_key_name", &self.crypto_key_name);
         debug_struct.field("logging_config", &self.logging_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14185,7 +14126,6 @@ impl std::fmt::Debug for NetworkConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkConfig");
         debug_struct.field("network_attachment", &self.network_attachment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14779,7 +14719,6 @@ impl std::fmt::Debug for Pipeline {
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("retry_policy", &self.retry_policy);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15101,7 +15040,6 @@ pub mod pipeline {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MessagePayloadFormat");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15226,7 +15164,6 @@ pub mod pipeline {
         impl std::fmt::Debug for JsonFormat {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("JsonFormat");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -15380,7 +15317,6 @@ pub mod pipeline {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ProtobufFormat");
                 debug_struct.field("schema_definition", &self.schema_definition);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -15534,7 +15470,6 @@ pub mod pipeline {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("AvroFormat");
                 debug_struct.field("schema_definition", &self.schema_definition);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16017,7 +15952,6 @@ pub mod pipeline {
             debug_struct.field("authentication_config", &self.authentication_config);
             debug_struct.field("output_payload_format", &self.output_payload_format);
             debug_struct.field("destination_descriptor", &self.destination_descriptor);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16179,7 +16113,6 @@ pub mod pipeline {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("NetworkConfig");
                 debug_struct.field("network_attachment", &self.network_attachment);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16537,7 +16470,6 @@ pub mod pipeline {
                 let mut debug_struct = f.debug_struct("HttpEndpoint");
                 debug_struct.field("uri", &self.uri);
                 debug_struct.field("message_binding_template", &self.message_binding_template);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16812,7 +16744,6 @@ pub mod pipeline {
                     "authentication_method_descriptor",
                     &self.authentication_method_descriptor,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17020,7 +16951,6 @@ pub mod pipeline {
                     let mut debug_struct = f.debug_struct("OidcToken");
                     debug_struct.field("service_account", &self.service_account);
                     debug_struct.field("audience", &self.audience);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -17224,7 +17154,6 @@ pub mod pipeline {
                     let mut debug_struct = f.debug_struct("OAuthToken");
                     debug_struct.field("service_account", &self.service_account);
                     debug_struct.field("scope", &self.scope);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -17473,7 +17402,6 @@ pub mod pipeline {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Mediation");
             debug_struct.field("mediation_descriptor", &self.mediation_descriptor);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17713,7 +17641,6 @@ pub mod pipeline {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Transformation");
                 debug_struct.field("transformation_template", &self.transformation_template);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17973,7 +17900,6 @@ pub mod pipeline {
             debug_struct.field("max_attempts", &self.max_attempts);
             debug_struct.field("min_retry_delay", &self.min_retry_delay);
             debug_struct.field("max_retry_delay", &self.max_retry_delay);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18543,7 +18469,6 @@ impl std::fmt::Debug for Trigger {
         debug_struct.field("event_data_content_type", &self.event_data_content_type);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18744,7 +18669,6 @@ impl std::fmt::Debug for EventFilter {
         debug_struct.field("attribute", &self.attribute);
         debug_struct.field("value", &self.value);
         debug_struct.field("operator", &self.operator);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18911,7 +18835,6 @@ impl std::fmt::Debug for StateCondition {
         let mut debug_struct = f.debug_struct("StateCondition");
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19328,7 +19251,6 @@ impl std::fmt::Debug for Destination {
         let mut debug_struct = f.debug_struct("Destination");
         debug_struct.field("network_config", &self.network_config);
         debug_struct.field("descriptor", &self.descriptor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19546,7 +19468,6 @@ impl std::fmt::Debug for Transport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Transport");
         debug_struct.field("intermediary", &self.intermediary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19760,7 +19681,6 @@ impl std::fmt::Debug for CloudRun {
         debug_struct.field("service", &self.service);
         debug_struct.field("path", &self.path);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20010,7 +19930,6 @@ impl std::fmt::Debug for Gke {
         debug_struct.field("namespace", &self.namespace);
         debug_struct.field("service", &self.service);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20185,7 +20104,6 @@ impl std::fmt::Debug for Pubsub {
         let mut debug_struct = f.debug_struct("Pubsub");
         debug_struct.field("topic", &self.topic);
         debug_struct.field("subscription", &self.subscription);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20334,7 +20252,6 @@ impl std::fmt::Debug for HttpEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HttpEndpoint");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -309,7 +309,6 @@ impl std::fmt::Debug for NetworkConfig {
         debug_struct.field("reserved_ip_range", &self.reserved_ip_range);
         debug_struct.field("ip_addresses", &self.ip_addresses);
         debug_struct.field("connect_mode", &self.connect_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -866,7 +865,6 @@ impl std::fmt::Debug for FileShareConfig {
         debug_struct.field("capacity_gb", &self.capacity_gb);
         debug_struct.field("nfs_export_options", &self.nfs_export_options);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1196,7 +1194,6 @@ impl std::fmt::Debug for NfsExportOptions {
         debug_struct.field("squash_mode", &self.squash_mode);
         debug_struct.field("anon_uid", &self.anon_uid);
         debug_struct.field("anon_gid", &self.anon_gid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1707,7 +1704,6 @@ impl std::fmt::Debug for ReplicaConfig {
         debug_struct.field("state_reasons", &self.state_reasons);
         debug_struct.field("peer_instance", &self.peer_instance);
         debug_struct.field("last_active_sync_time", &self.last_active_sync_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2170,7 +2166,6 @@ impl std::fmt::Debug for Replication {
         let mut debug_struct = f.debug_struct("Replication");
         debug_struct.field("role", &self.role);
         debug_struct.field("replicas", &self.replicas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3133,7 +3128,6 @@ impl std::fmt::Debug for Instance {
             "deletion_protection_reason",
             &self.deletion_protection_reason,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3304,7 +3298,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IOPSPerTB");
             debug_struct.field("max_iops_per_tb", &self.max_iops_per_tb);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3468,7 +3461,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FixedIOPS");
             debug_struct.field("max_iops", &self.max_iops);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3729,7 +3721,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PerformanceConfig");
             debug_struct.field("mode", &self.mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4119,7 +4110,6 @@ pub mod instance {
             debug_struct.field("max_write_iops", &self.max_write_iops);
             debug_struct.field("max_read_throughput_bps", &self.max_read_throughput_bps);
             debug_struct.field("max_write_throughput_bps", &self.max_write_throughput_bps);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4969,7 +4959,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5112,7 +5101,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5311,7 +5299,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("UpdateInstanceRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5548,7 +5535,6 @@ impl std::fmt::Debug for RestoreInstanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("file_share", &self.file_share);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5737,7 +5723,6 @@ impl std::fmt::Debug for RevertInstanceRequest {
         let mut debug_struct = f.debug_struct("RevertInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("target_snapshot_id", &self.target_snapshot_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5906,7 +5891,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6175,7 +6159,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6394,7 +6377,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6753,7 +6735,6 @@ impl std::fmt::Debug for Snapshot {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("filesystem_used_bytes", &self.filesystem_used_bytes);
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7107,7 +7088,6 @@ impl std::fmt::Debug for CreateSnapshotRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("snapshot_id", &self.snapshot_id);
         debug_struct.field("snapshot", &self.snapshot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7250,7 +7230,6 @@ impl std::fmt::Debug for GetSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7393,7 +7372,6 @@ impl std::fmt::Debug for DeleteSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7584,7 +7562,6 @@ impl std::fmt::Debug for UpdateSnapshotRequest {
         let mut debug_struct = f.debug_struct("UpdateSnapshotRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("snapshot", &self.snapshot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7877,7 +7854,6 @@ impl std::fmt::Debug for ListSnapshotsRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8091,7 +8067,6 @@ impl std::fmt::Debug for ListSnapshotsResponse {
         debug_struct.field("snapshots", &self.snapshots);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8746,7 +8721,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("tags", &self.tags);
         debug_struct.field("file_system_protocol", &self.file_system_protocol);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9121,7 +9095,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup", &self.backup);
         debug_struct.field("backup_id", &self.backup_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9264,7 +9237,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9457,7 +9429,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupRequest");
         debug_struct.field("backup", &self.backup);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9629,7 +9600,6 @@ impl std::fmt::Debug for PromoteReplicaRequest {
         let mut debug_struct = f.debug_struct("PromoteReplicaRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("peer_instance", &self.peer_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9772,7 +9742,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10041,7 +10010,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10261,7 +10229,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -515,7 +515,6 @@ impl std::fmt::Debug for BacktestResult {
         debug_struct.field("backtest_periods", &self.backtest_periods);
         debug_struct.field("performance_target", &self.performance_target);
         debug_struct.field("line_of_business", &self.line_of_business);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -706,7 +705,6 @@ pub mod backtest_result {
                 "party_investigations_per_period_hint",
                 &self.party_investigations_per_period_hint,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1123,7 +1121,6 @@ impl std::fmt::Debug for ListBacktestResultsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1343,7 +1340,6 @@ impl std::fmt::Debug for ListBacktestResultsResponse {
         debug_struct.field("backtest_results", &self.backtest_results);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1485,7 +1481,6 @@ impl std::fmt::Debug for GetBacktestResultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBacktestResultRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1732,7 +1727,6 @@ impl std::fmt::Debug for CreateBacktestResultRequest {
         debug_struct.field("backtest_result_id", &self.backtest_result_id);
         debug_struct.field("backtest_result", &self.backtest_result);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1967,7 +1961,6 @@ impl std::fmt::Debug for UpdateBacktestResultRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("backtest_result", &self.backtest_result);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2147,7 +2140,6 @@ impl std::fmt::Debug for DeleteBacktestResultRequest {
         let mut debug_struct = f.debug_struct("DeleteBacktestResultRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2340,7 +2332,6 @@ impl std::fmt::Debug for ExportBacktestResultMetadataRequest {
             "structured_metadata_destination",
             &self.structured_metadata_destination,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2454,7 +2445,6 @@ impl serde::ser::Serialize for ExportBacktestResultMetadataResponse {
 impl std::fmt::Debug for ExportBacktestResultMetadataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportBacktestResultMetadataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2635,7 +2625,6 @@ impl std::fmt::Debug for BigQueryDestination {
         let mut debug_struct = f.debug_struct("BigQueryDestination");
         debug_struct.field("table_uri", &self.table_uri);
         debug_struct.field("write_disposition", &self.write_disposition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3174,7 +3163,6 @@ impl std::fmt::Debug for Dataset {
         debug_struct.field("state", &self.state);
         debug_struct.field("date_range", &self.date_range);
         debug_struct.field("time_zone", &self.time_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3595,7 +3583,6 @@ impl std::fmt::Debug for ListDatasetsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3809,7 +3796,6 @@ impl std::fmt::Debug for ListDatasetsResponse {
         debug_struct.field("datasets", &self.datasets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3951,7 +3937,6 @@ impl std::fmt::Debug for GetDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4193,7 +4178,6 @@ impl std::fmt::Debug for CreateDatasetRequest {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4426,7 +4410,6 @@ impl std::fmt::Debug for UpdateDatasetRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4606,7 +4589,6 @@ impl std::fmt::Debug for DeleteDatasetRequest {
         let mut debug_struct = f.debug_struct("DeleteDatasetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5104,7 +5086,6 @@ impl std::fmt::Debug for EngineConfig {
             &self.hyperparameter_source_type,
         );
         debug_struct.field("hyperparameter_source", &self.hyperparameter_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5301,7 +5282,6 @@ pub mod engine_config {
             let mut debug_struct = f.debug_struct("Tuning");
             debug_struct.field("primary_dataset", &self.primary_dataset);
             debug_struct.field("end_time", &self.end_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5487,7 +5467,6 @@ pub mod engine_config {
                 "party_investigations_per_period_hint",
                 &self.party_investigations_per_period_hint,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5670,7 +5649,6 @@ pub mod engine_config {
             let mut debug_struct = f.debug_struct("HyperparameterSource");
             debug_struct.field("source_engine_config", &self.source_engine_config);
             debug_struct.field("source_engine_version", &self.source_engine_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6224,7 +6202,6 @@ impl std::fmt::Debug for ListEngineConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6439,7 +6416,6 @@ impl std::fmt::Debug for ListEngineConfigsResponse {
         debug_struct.field("engine_configs", &self.engine_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6581,7 +6557,6 @@ impl std::fmt::Debug for GetEngineConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEngineConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6827,7 +6802,6 @@ impl std::fmt::Debug for CreateEngineConfigRequest {
         debug_struct.field("engine_config_id", &self.engine_config_id);
         debug_struct.field("engine_config", &self.engine_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7061,7 +7035,6 @@ impl std::fmt::Debug for UpdateEngineConfigRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("engine_config", &self.engine_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7241,7 +7214,6 @@ impl std::fmt::Debug for DeleteEngineConfigRequest {
         let mut debug_struct = f.debug_struct("DeleteEngineConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7434,7 +7406,6 @@ impl std::fmt::Debug for ExportEngineConfigMetadataRequest {
             "structured_metadata_destination",
             &self.structured_metadata_destination,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7548,7 +7519,6 @@ impl serde::ser::Serialize for ExportEngineConfigMetadataResponse {
 impl std::fmt::Debug for ExportEngineConfigMetadataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportEngineConfigMetadataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7846,7 +7816,6 @@ impl std::fmt::Debug for EngineVersion {
             &self.expected_decommission_time,
         );
         debug_struct.field("line_of_business", &self.line_of_business);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8265,7 +8234,6 @@ impl std::fmt::Debug for ListEngineVersionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8480,7 +8448,6 @@ impl std::fmt::Debug for ListEngineVersionsResponse {
         debug_struct.field("engine_versions", &self.engine_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8622,7 +8589,6 @@ impl std::fmt::Debug for GetEngineVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEngineVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8936,7 +8902,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("state", &self.state);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9358,7 +9323,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9572,7 +9536,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9714,7 +9677,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9957,7 +9919,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10190,7 +10151,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10370,7 +10330,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10636,7 +10595,6 @@ impl std::fmt::Debug for ImportRegisteredPartiesRequest {
         debug_struct.field("mode", &self.mode);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("line_of_business", &self.line_of_business);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11221,7 +11179,6 @@ impl std::fmt::Debug for ImportRegisteredPartiesResponse {
             "parties_failed_to_downtier",
             &self.parties_failed_to_downtier,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11429,7 +11386,6 @@ impl std::fmt::Debug for ExportRegisteredPartiesRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("line_of_business", &self.line_of_business);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11543,7 +11499,6 @@ impl serde::ser::Serialize for ExportRegisteredPartiesResponse {
 impl std::fmt::Debug for ExportRegisteredPartiesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportRegisteredPartiesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11975,7 +11930,6 @@ impl std::fmt::Debug for Model {
         debug_struct.field("primary_dataset", &self.primary_dataset);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("line_of_business", &self.line_of_business);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12396,7 +12350,6 @@ impl std::fmt::Debug for ListModelsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12610,7 +12563,6 @@ impl std::fmt::Debug for ListModelsResponse {
         debug_struct.field("models", &self.models);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12752,7 +12704,6 @@ impl std::fmt::Debug for GetModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12994,7 +12945,6 @@ impl std::fmt::Debug for CreateModelRequest {
         debug_struct.field("model_id", &self.model_id);
         debug_struct.field("model", &self.model);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13227,7 +13177,6 @@ impl std::fmt::Debug for UpdateModelRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("model", &self.model);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13407,7 +13356,6 @@ impl std::fmt::Debug for DeleteModelRequest {
         let mut debug_struct = f.debug_struct("DeleteModelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13599,7 +13547,6 @@ impl std::fmt::Debug for ExportModelMetadataRequest {
             "structured_metadata_destination",
             &self.structured_metadata_destination,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13713,7 +13660,6 @@ impl serde::ser::Serialize for ExportModelMetadataResponse {
 impl std::fmt::Debug for ExportModelMetadataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportModelMetadataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14206,7 +14152,6 @@ impl std::fmt::Debug for PredictionResult {
         debug_struct.field("prediction_periods", &self.prediction_periods);
         debug_struct.field("outputs", &self.outputs);
         debug_struct.field("line_of_business", &self.line_of_business);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14421,7 +14366,6 @@ pub mod prediction_result {
                 "explainability_destination",
                 &self.explainability_destination,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14838,7 +14782,6 @@ impl std::fmt::Debug for ListPredictionResultsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15058,7 +15001,6 @@ impl std::fmt::Debug for ListPredictionResultsResponse {
         debug_struct.field("prediction_results", &self.prediction_results);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15200,7 +15142,6 @@ impl std::fmt::Debug for GetPredictionResultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPredictionResultRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15447,7 +15388,6 @@ impl std::fmt::Debug for CreatePredictionResultRequest {
         debug_struct.field("prediction_result_id", &self.prediction_result_id);
         debug_struct.field("prediction_result", &self.prediction_result);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15682,7 +15622,6 @@ impl std::fmt::Debug for UpdatePredictionResultRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("prediction_result", &self.prediction_result);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15862,7 +15801,6 @@ impl std::fmt::Debug for DeletePredictionResultRequest {
         let mut debug_struct = f.debug_struct("DeletePredictionResultRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16059,7 +15997,6 @@ impl std::fmt::Debug for ExportPredictionResultMetadataRequest {
             "structured_metadata_destination",
             &self.structured_metadata_destination,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16174,7 +16111,6 @@ impl serde::ser::Serialize for ExportPredictionResultMetadataResponse {
 impl std::fmt::Debug for ExportPredictionResultMetadataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportPredictionResultMetadataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16502,7 +16438,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -584,7 +584,6 @@ impl std::fmt::Debug for Function {
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -937,7 +936,6 @@ impl std::fmt::Debug for StateMessage {
         debug_struct.field("severity", &self.severity);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1329,7 +1327,6 @@ impl std::fmt::Debug for StorageSource {
         debug_struct.field("object", &self.object);
         debug_struct.field("generation", &self.generation);
         debug_struct.field("source_upload_url", &self.source_upload_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1712,7 +1709,6 @@ impl std::fmt::Debug for RepoSource {
         debug_struct.field("dir", &self.dir);
         debug_struct.field("invert_regex", &self.invert_regex);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2020,7 +2016,6 @@ impl std::fmt::Debug for Source {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Source");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2263,7 +2258,6 @@ impl std::fmt::Debug for SourceProvenance {
         debug_struct.field("resolved_storage_source", &self.resolved_storage_source);
         debug_struct.field("resolved_repo_source", &self.resolved_repo_source);
         debug_struct.field("git_uri", &self.git_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2848,7 +2842,6 @@ impl std::fmt::Debug for BuildConfig {
         debug_struct.field("docker_repository", &self.docker_repository);
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("runtime_update_policy", &self.runtime_update_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3829,7 +3822,6 @@ impl std::fmt::Debug for ServiceConfig {
             "binary_authorization_policy",
             &self.binary_authorization_policy,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4484,7 +4476,6 @@ impl std::fmt::Debug for SecretEnvVar {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4720,7 +4711,6 @@ impl std::fmt::Debug for SecretVolume {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("versions", &self.versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4900,7 +4890,6 @@ pub mod secret_volume {
             let mut debug_struct = f.debug_struct("SecretVersion");
             debug_struct.field("version", &self.version);
             debug_struct.field("path", &self.path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5283,7 +5272,6 @@ impl std::fmt::Debug for EventTrigger {
         debug_struct.field("retry_policy", &self.retry_policy);
         debug_struct.field("channel", &self.channel);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5618,7 +5606,6 @@ impl std::fmt::Debug for EventFilter {
         debug_struct.field("attribute", &self.attribute);
         debug_struct.field("value", &self.value);
         debug_struct.field("operator", &self.operator);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5790,7 +5777,6 @@ impl std::fmt::Debug for GetFunctionRequest {
         let mut debug_struct = f.debug_struct("GetFunctionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6067,7 +6053,6 @@ impl std::fmt::Debug for ListFunctionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6282,7 +6267,6 @@ impl std::fmt::Debug for ListFunctionsResponse {
         debug_struct.field("functions", &self.functions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6491,7 +6475,6 @@ impl std::fmt::Debug for CreateFunctionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("function", &self.function);
         debug_struct.field("function_id", &self.function_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6682,7 +6665,6 @@ impl std::fmt::Debug for UpdateFunctionRequest {
         let mut debug_struct = f.debug_struct("UpdateFunctionRequest");
         debug_struct.field("function", &self.function);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6824,7 +6806,6 @@ impl std::fmt::Debug for DeleteFunctionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFunctionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7038,7 +7019,6 @@ impl std::fmt::Debug for GenerateUploadUrlRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7227,7 +7207,6 @@ impl std::fmt::Debug for GenerateUploadUrlResponse {
         let mut debug_struct = f.debug_struct("GenerateUploadUrlResponse");
         debug_struct.field("upload_url", &self.upload_url);
         debug_struct.field("storage_source", &self.storage_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7370,7 +7349,6 @@ impl std::fmt::Debug for GenerateDownloadUrlRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateDownloadUrlRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7514,7 +7492,6 @@ impl std::fmt::Debug for GenerateDownloadUrlResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateDownloadUrlResponse");
         debug_struct.field("download_url", &self.download_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7683,7 +7660,6 @@ impl std::fmt::Debug for ListRuntimesRequest {
         let mut debug_struct = f.debug_struct("ListRuntimesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7832,7 +7808,6 @@ impl std::fmt::Debug for ListRuntimesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListRuntimesResponse");
         debug_struct.field("runtimes", &self.runtimes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8174,7 +8149,6 @@ pub mod list_runtimes_response {
             debug_struct.field("environment", &self.environment);
             debug_struct.field("deprecation_date", &self.deprecation_date);
             debug_struct.field("decommission_date", &self.decommission_date);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8450,7 +8424,6 @@ impl serde::ser::Serialize for AutomaticUpdatePolicy {
 impl std::fmt::Debug for AutomaticUpdatePolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutomaticUpdatePolicy");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8594,7 +8567,6 @@ impl std::fmt::Debug for OnDeployUpdatePolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OnDeployUpdatePolicy");
         debug_struct.field("runtime_version", &self.runtime_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9068,7 +9040,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("source_token", &self.source_token);
         debug_struct.field("build_name", &self.build_name);
         debug_struct.field("operation_type", &self.operation_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9213,7 +9184,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("environments", &self.environments);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9485,7 +9455,6 @@ impl std::fmt::Debug for Stage {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("resource_uri", &self.resource_uri);
         debug_struct.field("state_messages", &self.state_messages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -1323,7 +1323,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("backup_scope", &self.backup_scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1667,7 +1666,6 @@ pub mod backup {
             debug_struct.field("k8s_version", &self.k8s_version);
             debug_struct.field("backup_crd_versions", &self.backup_crd_versions);
             debug_struct.field("platform_version", &self.platform_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2263,7 +2261,6 @@ impl std::fmt::Debug for BackupChannel {
         debug_struct.field("description", &self.description);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("destination_project_id", &self.destination_project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3029,7 +3026,6 @@ impl std::fmt::Debug for BackupPlan {
             "last_successful_backup_time",
             &self.last_successful_backup_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3308,7 +3304,6 @@ pub mod backup_plan {
             debug_struct.field("backup_delete_lock_days", &self.backup_delete_lock_days);
             debug_struct.field("backup_retain_days", &self.backup_retain_days);
             debug_struct.field("locked", &self.locked);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3595,7 +3590,6 @@ pub mod backup_plan {
                 "next_scheduled_backup_time",
                 &self.next_scheduled_backup_time,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4029,7 +4023,6 @@ pub mod backup_plan {
             debug_struct.field("encryption_key", &self.encryption_key);
             debug_struct.field("permissive_mode", &self.permissive_mode);
             debug_struct.field("backup_scope", &self.backup_scope);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4419,7 +4412,6 @@ impl std::fmt::Debug for RpoConfig {
         let mut debug_struct = f.debug_struct("RpoConfig");
         debug_struct.field("target_rpo_minutes", &self.target_rpo_minutes);
         debug_struct.field("exclusion_windows", &self.exclusion_windows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4800,7 +4792,6 @@ impl std::fmt::Debug for ExclusionWindow {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("duration", &self.duration);
         debug_struct.field("recurrence", &self.recurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4954,7 +4945,6 @@ pub mod exclusion_window {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DayOfWeekList");
             debug_struct.field("days_of_week", &self.days_of_week);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5345,7 +5335,6 @@ impl std::fmt::Debug for BackupPlanBinding {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("backup_plan_details", &self.backup_plan_details);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5816,7 +5805,6 @@ pub mod backup_plan_binding {
             debug_struct.field("last_successful_backup", &self.last_successful_backup);
             debug_struct.field("backup_config_details", &self.backup_config_details);
             debug_struct.field("retention_policy_details", &self.retention_policy_details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6241,7 +6229,6 @@ pub mod backup_plan_binding {
                 debug_struct.field("include_secrets", &self.include_secrets);
                 debug_struct.field("encryption_key", &self.encryption_key);
                 debug_struct.field("backup_scope", &self.backup_scope);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6508,7 +6495,6 @@ pub mod backup_plan_binding {
                 let mut debug_struct = f.debug_struct("RetentionPolicyDetails");
                 debug_struct.field("backup_delete_lock_days", &self.backup_delete_lock_days);
                 debug_struct.field("backup_retain_days", &self.backup_retain_days);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6818,7 +6804,6 @@ impl std::fmt::Debug for Namespaces {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Namespaces");
         debug_struct.field("namespaces", &self.namespaces);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6985,7 +6970,6 @@ impl std::fmt::Debug for NamespacedName {
         let mut debug_struct = f.debug_struct("NamespacedName");
         debug_struct.field("namespace", &self.namespace);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7135,7 +7119,6 @@ impl std::fmt::Debug for NamespacedNames {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NamespacedNames");
         debug_struct.field("namespaced_names", &self.namespaced_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7283,7 +7266,6 @@ impl std::fmt::Debug for EncryptionKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptionKey");
         debug_struct.field("gcp_kms_encryption_key", &self.gcp_kms_encryption_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7397,7 +7379,6 @@ impl serde::ser::Serialize for VolumeTypeEnum {
 impl std::fmt::Debug for VolumeTypeEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VolumeTypeEnum");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7855,7 +7836,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8068,7 +8048,6 @@ impl std::fmt::Debug for CreateBackupPlanRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_plan", &self.backup_plan);
         debug_struct.field("backup_plan_id", &self.backup_plan_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8346,7 +8325,6 @@ impl std::fmt::Debug for ListBackupPlansRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8566,7 +8544,6 @@ impl std::fmt::Debug for ListBackupPlansResponse {
         debug_struct.field("backup_plans", &self.backup_plans);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8709,7 +8686,6 @@ impl std::fmt::Debug for GetBackupPlanRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupPlanRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8909,7 +8885,6 @@ impl std::fmt::Debug for UpdateBackupPlanRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupPlanRequest");
         debug_struct.field("backup_plan", &self.backup_plan);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9081,7 +9056,6 @@ impl std::fmt::Debug for DeleteBackupPlanRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupPlanRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9298,7 +9272,6 @@ impl std::fmt::Debug for CreateBackupChannelRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_channel", &self.backup_channel);
         debug_struct.field("backup_channel_id", &self.backup_channel_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9577,7 +9550,6 @@ impl std::fmt::Debug for ListBackupChannelsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9797,7 +9769,6 @@ impl std::fmt::Debug for ListBackupChannelsResponse {
         debug_struct.field("backup_channels", &self.backup_channels);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9940,7 +9911,6 @@ impl std::fmt::Debug for GetBackupChannelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupChannelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10140,7 +10110,6 @@ impl std::fmt::Debug for UpdateBackupChannelRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupChannelRequest");
         debug_struct.field("backup_channel", &self.backup_channel);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10339,7 +10308,6 @@ impl std::fmt::Debug for DeleteBackupChannelRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10618,7 +10586,6 @@ impl std::fmt::Debug for ListBackupPlanBindingsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10842,7 +10809,6 @@ impl std::fmt::Debug for ListBackupPlanBindingsResponse {
         debug_struct.field("backup_plan_bindings", &self.backup_plan_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10986,7 +10952,6 @@ impl std::fmt::Debug for GetBackupPlanBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupPlanBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11198,7 +11163,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup", &self.backup);
         debug_struct.field("backup_id", &self.backup_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11503,7 +11467,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11721,7 +11684,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11864,7 +11826,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12062,7 +12023,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupRequest");
         debug_struct.field("backup", &self.backup);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12261,7 +12221,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12539,7 +12498,6 @@ impl std::fmt::Debug for ListVolumeBackupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12731,7 +12689,6 @@ impl std::fmt::Debug for ListVolumeBackupsResponse {
         let mut debug_struct = f.debug_struct("ListVolumeBackupsResponse");
         debug_struct.field("volume_backups", &self.volume_backups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12874,7 +12831,6 @@ impl std::fmt::Debug for GetVolumeBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVolumeBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13087,7 +13043,6 @@ impl std::fmt::Debug for CreateRestorePlanRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("restore_plan", &self.restore_plan);
         debug_struct.field("restore_plan_id", &self.restore_plan_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13365,7 +13320,6 @@ impl std::fmt::Debug for ListRestorePlansRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13585,7 +13539,6 @@ impl std::fmt::Debug for ListRestorePlansResponse {
         debug_struct.field("restore_plans", &self.restore_plans);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13728,7 +13681,6 @@ impl std::fmt::Debug for GetRestorePlanRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRestorePlanRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13927,7 +13879,6 @@ impl std::fmt::Debug for UpdateRestorePlanRequest {
         let mut debug_struct = f.debug_struct("UpdateRestorePlanRequest");
         debug_struct.field("restore_plan", &self.restore_plan);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14126,7 +14077,6 @@ impl std::fmt::Debug for DeleteRestorePlanRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14344,7 +14294,6 @@ impl std::fmt::Debug for CreateRestoreChannelRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("restore_channel", &self.restore_channel);
         debug_struct.field("restore_channel_id", &self.restore_channel_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14623,7 +14572,6 @@ impl std::fmt::Debug for ListRestoreChannelsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14847,7 +14795,6 @@ impl std::fmt::Debug for ListRestoreChannelsResponse {
         debug_struct.field("restore_channels", &self.restore_channels);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14990,7 +14937,6 @@ impl std::fmt::Debug for GetRestoreChannelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRestoreChannelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15192,7 +15138,6 @@ impl std::fmt::Debug for UpdateRestoreChannelRequest {
         let mut debug_struct = f.debug_struct("UpdateRestoreChannelRequest");
         debug_struct.field("restore_channel", &self.restore_channel);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15365,7 +15310,6 @@ impl std::fmt::Debug for DeleteRestoreChannelRequest {
         let mut debug_struct = f.debug_struct("DeleteRestoreChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15644,7 +15588,6 @@ impl std::fmt::Debug for ListRestorePlanBindingsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15868,7 +15811,6 @@ impl std::fmt::Debug for ListRestorePlanBindingsResponse {
         debug_struct.field("restore_plan_bindings", &self.restore_plan_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16012,7 +15954,6 @@ impl std::fmt::Debug for GetRestorePlanBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRestorePlanBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16224,7 +16165,6 @@ impl std::fmt::Debug for CreateRestoreRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("restore", &self.restore);
         debug_struct.field("restore_id", &self.restore_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16502,7 +16442,6 @@ impl std::fmt::Debug for ListRestoresRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16720,7 +16659,6 @@ impl std::fmt::Debug for ListRestoresResponse {
         debug_struct.field("restores", &self.restores);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16863,7 +16801,6 @@ impl std::fmt::Debug for GetRestoreRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRestoreRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17061,7 +16998,6 @@ impl std::fmt::Debug for UpdateRestoreRequest {
         let mut debug_struct = f.debug_struct("UpdateRestoreRequest");
         debug_struct.field("restore", &self.restore);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17260,7 +17196,6 @@ impl std::fmt::Debug for DeleteRestoreRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17538,7 +17473,6 @@ impl std::fmt::Debug for ListVolumeRestoresRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17730,7 +17664,6 @@ impl std::fmt::Debug for ListVolumeRestoresResponse {
         let mut debug_struct = f.debug_struct("ListVolumeRestoresResponse");
         debug_struct.field("volume_restores", &self.volume_restores);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17873,7 +17806,6 @@ impl std::fmt::Debug for GetVolumeRestoreRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVolumeRestoreRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18017,7 +17949,6 @@ impl std::fmt::Debug for GetBackupIndexDownloadUrlRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupIndexDownloadUrlRequest");
         debug_struct.field("backup", &self.backup);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18160,7 +18091,6 @@ impl std::fmt::Debug for GetBackupIndexDownloadUrlResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupIndexDownloadUrlResponse");
         debug_struct.field("signed_url", &self.signed_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18985,7 +18915,6 @@ impl std::fmt::Debug for Restore {
             "volume_data_restore_policy_overrides",
             &self.volume_data_restore_policy_overrides,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19185,7 +19114,6 @@ pub mod restore {
             let mut debug_struct = f.debug_struct("Filter");
             debug_struct.field("inclusion_filters", &self.inclusion_filters);
             debug_struct.field("exclusion_filters", &self.exclusion_filters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20113,7 +20041,6 @@ impl std::fmt::Debug for RestoreConfig {
             "namespaced_resource_restore_scope",
             &self.namespaced_resource_restore_scope,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20302,7 +20229,6 @@ pub mod restore_config {
             let mut debug_struct = f.debug_struct("GroupKind");
             debug_struct.field("resource_group", &self.resource_group);
             debug_struct.field("resource_kind", &self.resource_kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20569,7 +20495,6 @@ pub mod restore_config {
             debug_struct.field("excluded_group_kinds", &self.excluded_group_kinds);
             debug_struct.field("all_group_kinds", &self.all_group_kinds);
             debug_struct.field("no_group_kinds", &self.no_group_kinds);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20865,7 +20790,6 @@ pub mod restore_config {
             debug_struct.field("target_json_path", &self.target_json_path);
             debug_struct.field("original_value_pattern", &self.original_value_pattern);
             debug_struct.field("new_value", &self.new_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21093,7 +21017,6 @@ pub mod restore_config {
             debug_struct.field("from_path", &self.from_path);
             debug_struct.field("path", &self.path);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21496,7 +21419,6 @@ pub mod restore_config {
             debug_struct.field("namespaces", &self.namespaces);
             debug_struct.field("group_kinds", &self.group_kinds);
             debug_struct.field("json_path", &self.json_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21723,7 +21645,6 @@ pub mod restore_config {
             debug_struct.field("field_actions", &self.field_actions);
             debug_struct.field("resource_filter", &self.resource_filter);
             debug_struct.field("description", &self.description);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21954,7 +21875,6 @@ pub mod restore_config {
             let mut debug_struct = f.debug_struct("VolumeDataRestorePolicyBinding");
             debug_struct.field("policy", &self.policy);
             debug_struct.field("scope", &self.scope);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22125,7 +22045,6 @@ pub mod restore_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RestoreOrder");
             debug_struct.field("group_kind_dependencies", &self.group_kind_dependencies);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22335,7 +22254,6 @@ pub mod restore_config {
                 let mut debug_struct = f.debug_struct("GroupKindDependency");
                 debug_struct.field("satisfying", &self.satisfying);
                 debug_struct.field("requiring", &self.requiring);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -23119,7 +23037,6 @@ impl std::fmt::Debug for ResourceSelector {
         debug_struct.field("name", &self.name);
         debug_struct.field("namespace", &self.namespace);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23343,7 +23260,6 @@ impl std::fmt::Debug for VolumeDataRestorePolicyOverride {
         let mut debug_struct = f.debug_struct("VolumeDataRestorePolicyOverride");
         debug_struct.field("policy", &self.policy);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23758,7 +23674,6 @@ impl std::fmt::Debug for RestoreChannel {
         debug_struct.field("description", &self.description);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("destination_project_id", &self.destination_project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24281,7 +24196,6 @@ impl std::fmt::Debug for RestorePlan {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_reason", &self.state_reason);
         debug_struct.field("restore_channel", &self.restore_channel);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24766,7 +24680,6 @@ impl std::fmt::Debug for RestorePlanBinding {
         debug_struct.field("restore_plan", &self.restore_plan);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("backup_plan", &self.backup_plan);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25381,7 +25294,6 @@ impl std::fmt::Debug for VolumeBackup {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26171,7 +26083,6 @@ impl std::fmt::Debug for VolumeRestore {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_message", &self.state_message);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
@@ -288,7 +288,6 @@ impl std::fmt::Debug for GenerateCredentialsRequest {
         debug_struct.field("version", &self.version);
         debug_struct.field("kubernetes_namespace", &self.kubernetes_namespace);
         debug_struct.field("operating_system", &self.operating_system);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -607,7 +606,6 @@ impl std::fmt::Debug for GenerateCredentialsResponse {
         let mut debug_struct = f.debug_struct("GenerateCredentialsResponse");
         debug_struct.field("kubeconfig", &self.kubeconfig);
         debug_struct.field("endpoint", &self.endpoint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -356,7 +356,6 @@ impl std::fmt::Debug for MembershipState {
             "hierarchy_controller_state",
             &self.hierarchy_controller_state,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -668,7 +667,6 @@ impl std::fmt::Debug for MembershipSpec {
         debug_struct.field("version", &self.version);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("management", &self.management);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1135,7 +1133,6 @@ impl std::fmt::Debug for ConfigSync {
             "metrics_gcp_service_account_email",
             &self.metrics_gcp_service_account_email,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1488,7 +1485,6 @@ impl std::fmt::Debug for GitConfig {
         debug_struct.field("secret_type", &self.secret_type);
         debug_struct.field("https_proxy", &self.https_proxy);
         debug_struct.field("gcp_service_account_email", &self.gcp_service_account_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1762,7 +1758,6 @@ impl std::fmt::Debug for OciConfig {
         debug_struct.field("sync_wait_secs", &self.sync_wait_secs);
         debug_struct.field("secret_type", &self.secret_type);
         debug_struct.field("gcp_service_account_email", &self.gcp_service_account_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2099,7 +2094,6 @@ impl std::fmt::Debug for PolicyController {
         debug_struct.field("exemptable_namespaces", &self.exemptable_namespaces);
         debug_struct.field("referential_rules_enabled", &self.referential_rules_enabled);
         debug_struct.field("log_denies_enabled", &self.log_denies_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2306,7 +2300,6 @@ impl std::fmt::Debug for HierarchyControllerConfig {
             "enable_hierarchical_resource_quota",
             &self.enable_hierarchical_resource_quota,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2476,7 +2469,6 @@ impl std::fmt::Debug for HierarchyControllerDeploymentState {
         let mut debug_struct = f.debug_struct("HierarchyControllerDeploymentState");
         debug_struct.field("hnc", &self.hnc);
         debug_struct.field("extension", &self.extension);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2643,7 +2635,6 @@ impl std::fmt::Debug for HierarchyControllerVersion {
         let mut debug_struct = f.debug_struct("HierarchyControllerVersion");
         debug_struct.field("hnc", &self.hnc);
         debug_struct.field("extension", &self.extension);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2833,7 +2824,6 @@ impl std::fmt::Debug for HierarchyControllerState {
         let mut debug_struct = f.debug_struct("HierarchyControllerState");
         debug_struct.field("version", &self.version);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3032,7 +3022,6 @@ impl std::fmt::Debug for OperatorState {
         debug_struct.field("version", &self.version);
         debug_struct.field("deployment_state", &self.deployment_state);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3175,7 +3164,6 @@ impl std::fmt::Debug for InstallError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstallError");
         debug_struct.field("error_message", &self.error_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3517,7 +3505,6 @@ impl std::fmt::Debug for ConfigSyncState {
         debug_struct.field("rootsync_crd", &self.rootsync_crd);
         debug_struct.field("reposync_crd", &self.reposync_crd);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3959,7 +3946,6 @@ impl std::fmt::Debug for ConfigSyncError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConfigSyncError");
         debug_struct.field("error_message", &self.error_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4261,7 +4247,6 @@ impl std::fmt::Debug for ConfigSyncVersion {
         debug_struct.field("reconciler_manager", &self.reconciler_manager);
         debug_struct.field("root_reconciler", &self.root_reconciler);
         debug_struct.field("admission_webhook", &self.admission_webhook);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4578,7 +4563,6 @@ impl std::fmt::Debug for ConfigSyncDeploymentState {
         debug_struct.field("reconciler_manager", &self.reconciler_manager);
         debug_struct.field("root_reconciler", &self.root_reconciler);
         debug_struct.field("admission_webhook", &self.admission_webhook);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4896,7 +4880,6 @@ impl std::fmt::Debug for SyncState {
         debug_struct.field("last_sync_time", &self.last_sync_time);
         debug_struct.field("code", &self.code);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5266,7 +5249,6 @@ impl std::fmt::Debug for SyncError {
         debug_struct.field("code", &self.code);
         debug_struct.field("error_message", &self.error_message);
         debug_struct.field("error_resources", &self.error_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5502,7 +5484,6 @@ impl std::fmt::Debug for ErrorResource {
         debug_struct.field("resource_name", &self.resource_name);
         debug_struct.field("resource_namespace", &self.resource_namespace);
         debug_struct.field("resource_gvk", &self.resource_gvk);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5694,7 +5675,6 @@ impl std::fmt::Debug for GroupVersionKind {
         debug_struct.field("group", &self.group);
         debug_struct.field("version", &self.version);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5884,7 +5864,6 @@ impl std::fmt::Debug for PolicyControllerState {
         let mut debug_struct = f.debug_struct("PolicyControllerState");
         debug_struct.field("version", &self.version);
         debug_struct.field("deployment_state", &self.deployment_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6027,7 +6006,6 @@ impl std::fmt::Debug for PolicyControllerVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PolicyControllerVersion");
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6214,7 +6192,6 @@ impl std::fmt::Debug for GatekeeperDeploymentState {
             &self.gatekeeper_controller_manager_state,
         );
         debug_struct.field("gatekeeper_audit", &self.gatekeeper_audit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gkehub/multiclusteringress/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/multiclusteringress/v1/src/model.rs
@@ -164,7 +164,6 @@ impl std::fmt::Debug for FeatureSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FeatureSpec");
         debug_struct.field("config_membership", &self.config_membership);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -532,7 +532,6 @@ impl std::fmt::Debug for Feature {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("delete_time", &self.delete_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -681,7 +680,6 @@ impl std::fmt::Debug for FeatureResourceState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FeatureResourceState");
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1050,7 +1048,6 @@ impl std::fmt::Debug for FeatureState {
         debug_struct.field("code", &self.code);
         debug_struct.field("description", &self.description);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1395,7 +1392,6 @@ impl std::fmt::Debug for CommonFeatureSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CommonFeatureSpec");
         debug_struct.field("feature_spec", &self.feature_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1561,7 +1557,6 @@ impl std::fmt::Debug for CommonFeatureState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CommonFeatureState");
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1751,7 +1746,6 @@ impl std::fmt::Debug for MembershipFeatureSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MembershipFeatureSpec");
         debug_struct.field("feature_spec", &self.feature_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1992,7 +1986,6 @@ impl std::fmt::Debug for MembershipFeatureState {
         let mut debug_struct = f.debug_struct("MembershipFeatureState");
         debug_struct.field("state", &self.state);
         debug_struct.field("feature_state", &self.feature_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2616,7 +2609,6 @@ impl std::fmt::Debug for Membership {
         debug_struct.field("authority", &self.authority);
         debug_struct.field("monitoring_config", &self.monitoring_config);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2893,7 +2885,6 @@ impl std::fmt::Debug for MembershipEndpoint {
         debug_struct.field("kubernetes_metadata", &self.kubernetes_metadata);
         debug_struct.field("kubernetes_resource", &self.kubernetes_resource);
         debug_struct.field("google_managed", &self.google_managed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3164,7 +3155,6 @@ impl std::fmt::Debug for KubernetesResource {
         debug_struct.field("membership_resources", &self.membership_resources);
         debug_struct.field("connect_resources", &self.connect_resources);
         debug_struct.field("resource_options", &self.resource_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3366,7 +3356,6 @@ impl std::fmt::Debug for ResourceOptions {
         debug_struct.field("connect_version", &self.connect_version);
         debug_struct.field("v1beta1_crd", &self.v1beta1_crd);
         debug_struct.field("k8s_version", &self.k8s_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3539,7 +3528,6 @@ impl std::fmt::Debug for ResourceManifest {
         let mut debug_struct = f.debug_struct("ResourceManifest");
         debug_struct.field("manifest", &self.manifest);
         debug_struct.field("cluster_scoped", &self.cluster_scoped);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3714,7 +3702,6 @@ impl std::fmt::Debug for GkeCluster {
         let mut debug_struct = f.debug_struct("GkeCluster");
         debug_struct.field("resource_link", &self.resource_link);
         debug_struct.field("cluster_missing", &self.cluster_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4076,7 +4063,6 @@ impl std::fmt::Debug for KubernetesMetadata {
         debug_struct.field("vcpu_count", &self.vcpu_count);
         debug_struct.field("memory_mb", &self.memory_mb);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4339,7 +4325,6 @@ impl std::fmt::Debug for MonitoringConfig {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("kubernetes_metrics_prefix", &self.kubernetes_metrics_prefix);
         debug_struct.field("cluster_hash", &self.cluster_hash);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4482,7 +4467,6 @@ impl std::fmt::Debug for MembershipState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MembershipState");
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4907,7 +4891,6 @@ impl std::fmt::Debug for Authority {
         debug_struct.field("workload_identity_pool", &self.workload_identity_pool);
         debug_struct.field("identity_provider", &self.identity_provider);
         debug_struct.field("oidc_jwks", &self.oidc_jwks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5197,7 +5180,6 @@ impl std::fmt::Debug for ListMembershipsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5412,7 +5394,6 @@ impl std::fmt::Debug for ListMembershipsResponse {
         debug_struct.field("resources", &self.resources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5555,7 +5536,6 @@ impl std::fmt::Debug for GetMembershipRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMembershipRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5806,7 +5786,6 @@ impl std::fmt::Debug for CreateMembershipRequest {
         debug_struct.field("membership_id", &self.membership_id);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6014,7 +5993,6 @@ impl std::fmt::Debug for DeleteMembershipRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6275,7 +6253,6 @@ impl std::fmt::Debug for UpdateMembershipRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6629,7 +6606,6 @@ impl std::fmt::Debug for GenerateConnectManifestRequest {
         debug_struct.field("is_upgrade", &self.is_upgrade);
         debug_struct.field("registry", &self.registry);
         debug_struct.field("image_pull_secret_content", &self.image_pull_secret_content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6780,7 +6756,6 @@ impl std::fmt::Debug for GenerateConnectManifestResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateConnectManifestResponse");
         debug_struct.field("manifest", &self.manifest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6959,7 +6934,6 @@ impl std::fmt::Debug for ConnectAgentResource {
         let mut debug_struct = f.debug_struct("ConnectAgentResource");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("manifest", &self.manifest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7128,7 +7102,6 @@ impl std::fmt::Debug for TypeMeta {
         let mut debug_struct = f.debug_struct("TypeMeta");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7413,7 +7386,6 @@ impl std::fmt::Debug for ListFeaturesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7600,7 +7572,6 @@ impl std::fmt::Debug for ListFeaturesResponse {
         let mut debug_struct = f.debug_struct("ListFeaturesResponse");
         debug_struct.field("resources", &self.resources);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7743,7 +7714,6 @@ impl std::fmt::Debug for GetFeatureRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFeatureRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7986,7 +7956,6 @@ impl std::fmt::Debug for CreateFeatureRequest {
         debug_struct.field("feature_id", &self.feature_id);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8194,7 +8163,6 @@ impl std::fmt::Debug for DeleteFeatureRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8455,7 +8423,6 @@ impl std::fmt::Debug for UpdateFeatureRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8779,7 +8746,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("cancel_requested", &self.cancel_requested);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -958,7 +958,6 @@ impl std::fmt::Debug for AttachedCluster {
         debug_struct.field("binary_authorization", &self.binary_authorization);
         debug_struct.field("security_posture_config", &self.security_posture_config);
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1321,7 +1320,6 @@ impl std::fmt::Debug for AttachedClustersAuthorization {
         let mut debug_struct = f.debug_struct("AttachedClustersAuthorization");
         debug_struct.field("admin_users", &self.admin_users);
         debug_struct.field("admin_groups", &self.admin_groups);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1463,7 +1461,6 @@ impl std::fmt::Debug for AttachedClusterUser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttachedClusterUser");
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1605,7 +1602,6 @@ impl std::fmt::Debug for AttachedClusterGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttachedClusterGroup");
         debug_struct.field("group", &self.group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1807,7 +1803,6 @@ impl std::fmt::Debug for AttachedOidcConfig {
         let mut debug_struct = f.debug_struct("AttachedOidcConfig");
         debug_struct.field("issuer_url", &self.issuer_url);
         debug_struct.field("jwks", &self.jwks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1983,7 +1978,6 @@ impl std::fmt::Debug for AttachedServerConfig {
         let mut debug_struct = f.debug_struct("AttachedServerConfig");
         debug_struct.field("name", &self.name);
         debug_struct.field("valid_versions", &self.valid_versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2125,7 +2119,6 @@ impl std::fmt::Debug for AttachedPlatformVersionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttachedPlatformVersionInfo");
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2267,7 +2260,6 @@ impl std::fmt::Debug for AttachedClusterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttachedClusterError");
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2428,7 +2420,6 @@ impl std::fmt::Debug for AttachedProxyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttachedProxyConfig");
         debug_struct.field("kubernetes_secret", &self.kubernetes_secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2595,7 +2586,6 @@ impl std::fmt::Debug for KubernetesSecret {
         let mut debug_struct = f.debug_struct("KubernetesSecret");
         debug_struct.field("name", &self.name);
         debug_struct.field("namespace", &self.namespace);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2866,7 +2856,6 @@ impl std::fmt::Debug for GenerateAttachedClusterInstallManifestRequest {
         debug_struct.field("attached_cluster_id", &self.attached_cluster_id);
         debug_struct.field("platform_version", &self.platform_version);
         debug_struct.field("proxy_config", &self.proxy_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3012,7 +3001,6 @@ impl std::fmt::Debug for GenerateAttachedClusterInstallManifestResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateAttachedClusterInstallManifestResponse");
         debug_struct.field("manifest", &self.manifest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3269,7 +3257,6 @@ impl std::fmt::Debug for CreateAttachedClusterRequest {
         debug_struct.field("attached_cluster", &self.attached_cluster);
         debug_struct.field("attached_cluster_id", &self.attached_cluster_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3574,7 +3561,6 @@ impl std::fmt::Debug for ImportAttachedClusterRequest {
         debug_struct.field("platform_version", &self.platform_version);
         debug_struct.field("distribution", &self.distribution);
         debug_struct.field("proxy_config", &self.proxy_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3814,7 +3800,6 @@ impl std::fmt::Debug for UpdateAttachedClusterRequest {
         debug_struct.field("attached_cluster", &self.attached_cluster);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3966,7 +3951,6 @@ impl std::fmt::Debug for GetAttachedClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAttachedClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4198,7 +4182,6 @@ impl std::fmt::Debug for ListAttachedClustersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4392,7 +4375,6 @@ impl std::fmt::Debug for ListAttachedClustersResponse {
         let mut debug_struct = f.debug_struct("ListAttachedClustersResponse");
         debug_struct.field("attached_clusters", &self.attached_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4668,7 +4650,6 @@ impl std::fmt::Debug for DeleteAttachedClusterRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("ignore_errors", &self.ignore_errors);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4821,7 +4802,6 @@ impl std::fmt::Debug for GetAttachedServerConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAttachedServerConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5177,7 +5157,6 @@ impl std::fmt::Debug for GenerateAttachedClusterAgentTokenRequest {
         debug_struct.field("scope", &self.scope);
         debug_struct.field("requested_token_type", &self.requested_token_type);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5387,7 +5366,6 @@ impl std::fmt::Debug for GenerateAttachedClusterAgentTokenResponse {
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expires_in", &self.expires_in);
         debug_struct.field("token_type", &self.token_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6201,7 +6179,6 @@ impl std::fmt::Debug for AwsCluster {
         debug_struct.field("errors", &self.errors);
         debug_struct.field("monitoring_config", &self.monitoring_config);
         debug_struct.field("binary_authorization", &self.binary_authorization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7006,7 +6983,6 @@ impl std::fmt::Debug for AwsControlPlane {
         debug_struct.field("proxy_config", &self.proxy_config);
         debug_struct.field("config_encryption", &self.config_encryption);
         debug_struct.field("instance_placement", &self.instance_placement);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7181,7 +7157,6 @@ impl std::fmt::Debug for AwsServicesAuthentication {
         let mut debug_struct = f.debug_struct("AwsServicesAuthentication");
         debug_struct.field("role_arn", &self.role_arn);
         debug_struct.field("role_session_name", &self.role_session_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7374,7 +7349,6 @@ impl std::fmt::Debug for AwsAuthorization {
         let mut debug_struct = f.debug_struct("AwsAuthorization");
         debug_struct.field("admin_users", &self.admin_users);
         debug_struct.field("admin_groups", &self.admin_groups);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7516,7 +7490,6 @@ impl std::fmt::Debug for AwsClusterUser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsClusterUser");
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7658,7 +7631,6 @@ impl std::fmt::Debug for AwsClusterGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsClusterGroup");
         debug_struct.field("group", &self.group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7801,7 +7773,6 @@ impl std::fmt::Debug for AwsDatabaseEncryption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsDatabaseEncryption");
         debug_struct.field("kms_key_arn", &self.kms_key_arn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8118,7 +8089,6 @@ impl std::fmt::Debug for AwsVolumeTemplate {
         debug_struct.field("iops", &self.iops);
         debug_struct.field("throughput", &self.throughput);
         debug_struct.field("kms_key_arn", &self.kms_key_arn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8523,7 +8493,6 @@ impl std::fmt::Debug for AwsClusterNetworking {
             "per_node_pool_sg_rules_disabled",
             &self.per_node_pool_sg_rules_disabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9209,7 +9178,6 @@ impl std::fmt::Debug for AwsNodePool {
         debug_struct.field("management", &self.management);
         debug_struct.field("kubelet_config", &self.kubelet_config);
         debug_struct.field("update_settings", &self.update_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9555,7 +9523,6 @@ impl std::fmt::Debug for UpdateSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateSettings");
         debug_struct.field("surge_settings", &self.surge_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9764,7 +9731,6 @@ impl std::fmt::Debug for SurgeSettings {
         let mut debug_struct = f.debug_struct("SurgeSettings");
         debug_struct.field("max_surge", &self.max_surge);
         debug_struct.field("max_unavailable", &self.max_unavailable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9911,7 +9877,6 @@ impl std::fmt::Debug for AwsNodeManagement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsNodeManagement");
         debug_struct.field("auto_repair", &self.auto_repair);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10541,7 +10506,6 @@ impl std::fmt::Debug for AwsNodeConfig {
             &self.autoscaling_metrics_collection,
         );
         debug_struct.field("spot_config", &self.spot_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10751,7 +10715,6 @@ impl std::fmt::Debug for AwsNodePoolAutoscaling {
         let mut debug_struct = f.debug_struct("AwsNodePoolAutoscaling");
         debug_struct.field("min_node_count", &self.min_node_count);
         debug_struct.field("max_node_count", &self.max_node_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11077,7 +11040,6 @@ impl std::fmt::Debug for AwsOpenIdConfig {
         );
         debug_struct.field("claims_supported", &self.claims_supported);
         debug_struct.field("grant_types", &self.grant_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11223,7 +11185,6 @@ impl std::fmt::Debug for AwsJsonWebKeys {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsJsonWebKeys");
         debug_struct.field("keys", &self.keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11430,7 +11391,6 @@ impl std::fmt::Debug for AwsServerConfig {
         debug_struct.field("name", &self.name);
         debug_struct.field("valid_versions", &self.valid_versions);
         debug_struct.field("supported_aws_regions", &self.supported_aws_regions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11705,7 +11665,6 @@ impl std::fmt::Debug for AwsK8sVersionInfo {
         debug_struct.field("end_of_life", &self.end_of_life);
         debug_struct.field("end_of_life_date", &self.end_of_life_date);
         debug_struct.field("release_date", &self.release_date);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11848,7 +11807,6 @@ impl std::fmt::Debug for AwsSshConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsSshConfig");
         debug_struct.field("ec2_key_pair", &self.ec2_key_pair);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12023,7 +11981,6 @@ impl std::fmt::Debug for AwsProxyConfig {
         let mut debug_struct = f.debug_struct("AwsProxyConfig");
         debug_struct.field("secret_arn", &self.secret_arn);
         debug_struct.field("secret_version", &self.secret_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12166,7 +12123,6 @@ impl std::fmt::Debug for AwsConfigEncryption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsConfigEncryption");
         debug_struct.field("kms_key_arn", &self.kms_key_arn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12317,7 +12273,6 @@ impl std::fmt::Debug for AwsInstancePlacement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsInstancePlacement");
         debug_struct.field("tenancy", &self.tenancy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12637,7 +12592,6 @@ impl std::fmt::Debug for AwsAutoscalingGroupMetricsCollection {
         let mut debug_struct = f.debug_struct("AwsAutoscalingGroupMetricsCollection");
         debug_struct.field("granularity", &self.granularity);
         debug_struct.field("metrics", &self.metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12783,7 +12737,6 @@ impl std::fmt::Debug for SpotConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SpotConfig");
         debug_struct.field("instance_types", &self.instance_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12925,7 +12878,6 @@ impl std::fmt::Debug for AwsClusterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsClusterError");
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13067,7 +13019,6 @@ impl std::fmt::Debug for AwsNodePoolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsNodePoolError");
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13320,7 +13271,6 @@ impl std::fmt::Debug for CreateAwsClusterRequest {
         debug_struct.field("aws_cluster", &self.aws_cluster);
         debug_struct.field("aws_cluster_id", &self.aws_cluster_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13572,7 +13522,6 @@ impl std::fmt::Debug for UpdateAwsClusterRequest {
         debug_struct.field("aws_cluster", &self.aws_cluster);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13724,7 +13673,6 @@ impl std::fmt::Debug for GetAwsClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAwsClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13956,7 +13904,6 @@ impl std::fmt::Debug for ListAwsClustersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14146,7 +14093,6 @@ impl std::fmt::Debug for ListAwsClustersResponse {
         let mut debug_struct = f.debug_struct("ListAwsClustersResponse");
         debug_struct.field("aws_clusters", &self.aws_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14421,7 +14367,6 @@ impl std::fmt::Debug for DeleteAwsClusterRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("ignore_errors", &self.ignore_errors);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14678,7 +14623,6 @@ impl std::fmt::Debug for CreateAwsNodePoolRequest {
         debug_struct.field("aws_node_pool", &self.aws_node_pool);
         debug_struct.field("aws_node_pool_id", &self.aws_node_pool_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14933,7 +14877,6 @@ impl std::fmt::Debug for UpdateAwsNodePoolRequest {
         debug_struct.field("aws_node_pool", &self.aws_node_pool);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15112,7 +15055,6 @@ impl std::fmt::Debug for RollbackAwsNodePoolUpdateRequest {
         let mut debug_struct = f.debug_struct("RollbackAwsNodePoolUpdateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("respect_pdb", &self.respect_pdb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15264,7 +15206,6 @@ impl std::fmt::Debug for GetAwsNodePoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAwsNodePoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15497,7 +15438,6 @@ impl std::fmt::Debug for ListAwsNodePoolsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15687,7 +15627,6 @@ impl std::fmt::Debug for ListAwsNodePoolsResponse {
         let mut debug_struct = f.debug_struct("ListAwsNodePoolsResponse");
         debug_struct.field("aws_node_pools", &self.aws_node_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15963,7 +15902,6 @@ impl std::fmt::Debug for DeleteAwsNodePoolRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("ignore_errors", &self.ignore_errors);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16109,7 +16047,6 @@ impl std::fmt::Debug for GetAwsOpenIdConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAwsOpenIdConfigRequest");
         debug_struct.field("aws_cluster", &self.aws_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16257,7 +16194,6 @@ impl std::fmt::Debug for GetAwsJsonWebKeysRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAwsJsonWebKeysRequest");
         debug_struct.field("aws_cluster", &self.aws_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16409,7 +16345,6 @@ impl std::fmt::Debug for GetAwsServerConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAwsServerConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16562,7 +16497,6 @@ impl std::fmt::Debug for GenerateAwsAccessTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateAwsAccessTokenRequest");
         debug_struct.field("aws_cluster", &self.aws_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16742,7 +16676,6 @@ impl std::fmt::Debug for GenerateAwsAccessTokenResponse {
         let mut debug_struct = f.debug_struct("GenerateAwsAccessTokenResponse");
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expiration_time", &self.expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17120,7 +17053,6 @@ impl std::fmt::Debug for GenerateAwsClusterAgentTokenRequest {
         debug_struct.field("scope", &self.scope);
         debug_struct.field("requested_token_type", &self.requested_token_type);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17329,7 +17261,6 @@ impl std::fmt::Debug for GenerateAwsClusterAgentTokenResponse {
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expires_in", &self.expires_in);
         debug_struct.field("token_type", &self.token_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18268,7 +18199,6 @@ impl std::fmt::Debug for AzureCluster {
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("monitoring_config", &self.monitoring_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18717,7 +18647,6 @@ impl std::fmt::Debug for AzureClusterNetworking {
             "service_load_balancer_subnet_id",
             &self.service_load_balancer_subnet_id,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19273,7 +19202,6 @@ impl std::fmt::Debug for AzureControlPlane {
         debug_struct.field("tags", &self.tags);
         debug_struct.field("replica_placements", &self.replica_placements);
         debug_struct.field("endpoint_subnet_id", &self.endpoint_subnet_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19448,7 +19376,6 @@ impl std::fmt::Debug for ReplicaPlacement {
         let mut debug_struct = f.debug_struct("ReplicaPlacement");
         debug_struct.field("subnet_id", &self.subnet_id);
         debug_struct.field("azure_availability_zone", &self.azure_availability_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19630,7 +19557,6 @@ impl std::fmt::Debug for AzureProxyConfig {
         let mut debug_struct = f.debug_struct("AzureProxyConfig");
         debug_struct.field("resource_group_id", &self.resource_group_id);
         debug_struct.field("secret_id", &self.secret_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19781,7 +19707,6 @@ impl std::fmt::Debug for AzureDatabaseEncryption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureDatabaseEncryption");
         debug_struct.field("key_id", &self.key_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19962,7 +19887,6 @@ impl std::fmt::Debug for AzureConfigEncryption {
         let mut debug_struct = f.debug_struct("AzureConfigEncryption");
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("public_key", &self.public_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20126,7 +20050,6 @@ impl std::fmt::Debug for AzureDiskTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureDiskTemplate");
         debug_struct.field("size_gib", &self.size_gib);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20533,7 +20456,6 @@ impl std::fmt::Debug for AzureClient {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20726,7 +20648,6 @@ impl std::fmt::Debug for AzureAuthorization {
         let mut debug_struct = f.debug_struct("AzureAuthorization");
         debug_struct.field("admin_users", &self.admin_users);
         debug_struct.field("admin_groups", &self.admin_groups);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20895,7 +20816,6 @@ impl std::fmt::Debug for AzureServicesAuthentication {
         let mut debug_struct = f.debug_struct("AzureServicesAuthentication");
         debug_struct.field("tenant_id", &self.tenant_id);
         debug_struct.field("application_id", &self.application_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21037,7 +20957,6 @@ impl std::fmt::Debug for AzureClusterUser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureClusterUser");
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21179,7 +21098,6 @@ impl std::fmt::Debug for AzureClusterGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureClusterGroup");
         debug_struct.field("group", &self.group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21815,7 +21733,6 @@ impl std::fmt::Debug for AzureNodePool {
         debug_struct.field("azure_availability_zone", &self.azure_availability_zone);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("management", &self.management);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22131,7 +22048,6 @@ impl std::fmt::Debug for AzureNodeManagement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureNodeManagement");
         debug_struct.field("auto_repair", &self.auto_repair);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22570,7 +22486,6 @@ impl std::fmt::Debug for AzureNodeConfig {
         debug_struct.field("config_encryption", &self.config_encryption);
         debug_struct.field("taints", &self.taints);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22782,7 +22697,6 @@ impl std::fmt::Debug for AzureNodePoolAutoscaling {
         let mut debug_struct = f.debug_struct("AzureNodePoolAutoscaling");
         debug_struct.field("min_node_count", &self.min_node_count);
         debug_struct.field("max_node_count", &self.max_node_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23108,7 +23022,6 @@ impl std::fmt::Debug for AzureOpenIdConfig {
         );
         debug_struct.field("claims_supported", &self.claims_supported);
         debug_struct.field("grant_types", &self.grant_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23254,7 +23167,6 @@ impl std::fmt::Debug for AzureJsonWebKeys {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureJsonWebKeys");
         debug_struct.field("keys", &self.keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23468,7 +23380,6 @@ impl std::fmt::Debug for AzureServerConfig {
         debug_struct.field("name", &self.name);
         debug_struct.field("valid_versions", &self.valid_versions);
         debug_struct.field("supported_azure_regions", &self.supported_azure_regions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23743,7 +23654,6 @@ impl std::fmt::Debug for AzureK8sVersionInfo {
         debug_struct.field("end_of_life", &self.end_of_life);
         debug_struct.field("end_of_life_date", &self.end_of_life_date);
         debug_struct.field("release_date", &self.release_date);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23888,7 +23798,6 @@ impl std::fmt::Debug for AzureSshConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureSshConfig");
         debug_struct.field("authorized_key", &self.authorized_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24081,7 +23990,6 @@ impl std::fmt::Debug for AzureClusterResources {
             "control_plane_application_security_group_id",
             &self.control_plane_application_security_group_id,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24223,7 +24131,6 @@ impl std::fmt::Debug for AzureClusterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureClusterError");
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24365,7 +24272,6 @@ impl std::fmt::Debug for AzureNodePoolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureNodePoolError");
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24621,7 +24527,6 @@ impl std::fmt::Debug for CreateAzureClusterRequest {
         debug_struct.field("azure_cluster", &self.azure_cluster);
         debug_struct.field("azure_cluster_id", &self.azure_cluster_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24863,7 +24768,6 @@ impl std::fmt::Debug for UpdateAzureClusterRequest {
         debug_struct.field("azure_cluster", &self.azure_cluster);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25015,7 +24919,6 @@ impl std::fmt::Debug for GetAzureClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAzureClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25247,7 +25150,6 @@ impl std::fmt::Debug for ListAzureClustersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25437,7 +25339,6 @@ impl std::fmt::Debug for ListAzureClustersResponse {
         let mut debug_struct = f.debug_struct("ListAzureClustersResponse");
         debug_struct.field("azure_clusters", &self.azure_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25712,7 +25613,6 @@ impl std::fmt::Debug for DeleteAzureClusterRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("ignore_errors", &self.ignore_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25969,7 +25869,6 @@ impl std::fmt::Debug for CreateAzureNodePoolRequest {
         debug_struct.field("azure_node_pool", &self.azure_node_pool);
         debug_struct.field("azure_node_pool_id", &self.azure_node_pool_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26202,7 +26101,6 @@ impl std::fmt::Debug for UpdateAzureNodePoolRequest {
         debug_struct.field("azure_node_pool", &self.azure_node_pool);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26354,7 +26252,6 @@ impl std::fmt::Debug for GetAzureNodePoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAzureNodePoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26587,7 +26484,6 @@ impl std::fmt::Debug for ListAzureNodePoolsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26777,7 +26673,6 @@ impl std::fmt::Debug for ListAzureNodePoolsResponse {
         let mut debug_struct = f.debug_struct("ListAzureNodePoolsResponse");
         debug_struct.field("azure_node_pools", &self.azure_node_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27054,7 +26949,6 @@ impl std::fmt::Debug for DeleteAzureNodePoolRequest {
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("ignore_errors", &self.ignore_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27200,7 +27094,6 @@ impl std::fmt::Debug for GetAzureOpenIdConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAzureOpenIdConfigRequest");
         debug_struct.field("azure_cluster", &self.azure_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27348,7 +27241,6 @@ impl std::fmt::Debug for GetAzureJsonWebKeysRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAzureJsonWebKeysRequest");
         debug_struct.field("azure_cluster", &self.azure_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27500,7 +27392,6 @@ impl std::fmt::Debug for GetAzureServerConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAzureServerConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27753,7 +27644,6 @@ impl std::fmt::Debug for CreateAzureClientRequest {
         debug_struct.field("azure_client", &self.azure_client);
         debug_struct.field("azure_client_id", &self.azure_client_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27906,7 +27796,6 @@ impl std::fmt::Debug for GetAzureClientRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAzureClientRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28138,7 +28027,6 @@ impl std::fmt::Debug for ListAzureClientsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28328,7 +28216,6 @@ impl std::fmt::Debug for ListAzureClientsResponse {
         let mut debug_struct = f.debug_struct("ListAzureClientsResponse");
         debug_struct.field("azure_clients", &self.azure_clients);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28540,7 +28427,6 @@ impl std::fmt::Debug for DeleteAzureClientRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28693,7 +28579,6 @@ impl std::fmt::Debug for GenerateAzureAccessTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateAzureAccessTokenRequest");
         debug_struct.field("azure_cluster", &self.azure_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28873,7 +28758,6 @@ impl std::fmt::Debug for GenerateAzureAccessTokenResponse {
         let mut debug_struct = f.debug_struct("GenerateAzureAccessTokenResponse");
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expiration_time", &self.expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29252,7 +29136,6 @@ impl std::fmt::Debug for GenerateAzureClusterAgentTokenRequest {
         debug_struct.field("scope", &self.scope);
         debug_struct.field("requested_token_type", &self.requested_token_type);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29462,7 +29345,6 @@ impl std::fmt::Debug for GenerateAzureClusterAgentTokenResponse {
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expires_in", &self.expires_in);
         debug_struct.field("token_type", &self.token_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29804,7 +29686,6 @@ impl std::fmt::Debug for Jwk {
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
         debug_struct.field("crv", &self.crv);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30003,7 +29884,6 @@ impl std::fmt::Debug for WorkloadIdentityConfig {
         debug_struct.field("issuer_uri", &self.issuer_uri);
         debug_struct.field("workload_pool", &self.workload_pool);
         debug_struct.field("identity_provider", &self.identity_provider);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30165,7 +30045,6 @@ impl std::fmt::Debug for MaxPodsConstraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaxPodsConstraint");
         debug_struct.field("max_pods_per_node", &self.max_pods_per_node);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30494,7 +30373,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("error_detail", &self.error_detail);
         debug_struct.field("verb", &self.verb);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30687,7 +30565,6 @@ impl std::fmt::Debug for NodeTaint {
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
         debug_struct.field("effect", &self.effect);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31194,7 +31071,6 @@ impl std::fmt::Debug for NodeKubeletConfig {
         debug_struct.field("cpu_cfs_quota", &self.cpu_cfs_quota);
         debug_struct.field("cpu_cfs_quota_period", &self.cpu_cfs_quota_period);
         debug_struct.field("pod_pids_limit", &self.pod_pids_limit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31377,7 +31253,6 @@ impl std::fmt::Debug for Fleet {
         let mut debug_struct = f.debug_struct("Fleet");
         debug_struct.field("project", &self.project);
         debug_struct.field("membership", &self.membership);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31531,7 +31406,6 @@ impl std::fmt::Debug for LoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingConfig");
         debug_struct.field("component_config", &self.component_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31683,7 +31557,6 @@ impl std::fmt::Debug for LoggingComponentConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingComponentConfig");
         debug_struct.field("enable_components", &self.enable_components);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32017,7 +31890,6 @@ impl std::fmt::Debug for MonitoringConfig {
         let mut debug_struct = f.debug_struct("MonitoringConfig");
         debug_struct.field("managed_prometheus_config", &self.managed_prometheus_config);
         debug_struct.field("cloud_monitoring_config", &self.cloud_monitoring_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32160,7 +32032,6 @@ impl std::fmt::Debug for ManagedPrometheusConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ManagedPrometheusConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32315,7 +32186,6 @@ impl std::fmt::Debug for CloudMonitoringConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudMonitoringConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32466,7 +32336,6 @@ impl std::fmt::Debug for BinaryAuthorization {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BinaryAuthorization");
         debug_struct.field("evaluation_mode", &self.evaluation_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32758,7 +32627,6 @@ impl std::fmt::Debug for SecurityPostureConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecurityPostureConfig");
         debug_struct.field("vulnerability_mode", &self.vulnerability_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/gsuiteaddons/v1/src/model.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/model.rs
@@ -174,7 +174,6 @@ impl std::fmt::Debug for GetAuthorizationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAuthorizationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -374,7 +373,6 @@ impl std::fmt::Debug for Authorization {
         debug_struct.field("name", &self.name);
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("oauth_client_id", &self.oauth_client_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -581,7 +579,6 @@ impl std::fmt::Debug for CreateDeploymentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("deployment_id", &self.deployment_id);
         debug_struct.field("deployment", &self.deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -734,7 +731,6 @@ impl std::fmt::Debug for ReplaceDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplaceDeploymentRequest");
         debug_struct.field("deployment", &self.deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -878,7 +874,6 @@ impl std::fmt::Debug for GetDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1099,7 +1094,6 @@ impl std::fmt::Debug for ListDeploymentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1285,7 +1279,6 @@ impl std::fmt::Debug for ListDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListDeploymentsResponse");
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1455,7 +1448,6 @@ impl std::fmt::Debug for DeleteDeploymentRequest {
         let mut debug_struct = f.debug_struct("DeleteDeploymentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1599,7 +1591,6 @@ impl std::fmt::Debug for InstallDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstallDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1743,7 +1734,6 @@ impl std::fmt::Debug for UninstallDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UninstallDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1887,7 +1877,6 @@ impl std::fmt::Debug for GetInstallStatusRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstallStatusRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2067,7 +2056,6 @@ impl std::fmt::Debug for InstallStatus {
         let mut debug_struct = f.debug_struct("InstallStatus");
         debug_struct.field("name", &self.name);
         debug_struct.field("installed", &self.installed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2304,7 +2292,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("oauth_scopes", &self.oauth_scopes);
         debug_struct.field("add_ons", &self.add_ons);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2719,7 +2706,6 @@ impl std::fmt::Debug for AddOns {
         debug_struct.field("sheets", &self.sheets);
         debug_struct.field("slides", &self.slides);
         debug_struct.field("http_options", &self.http_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -246,7 +246,6 @@ impl std::fmt::Debug for ListTunnelDestGroupsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -437,7 +436,6 @@ impl std::fmt::Debug for ListTunnelDestGroupsResponse {
         let mut debug_struct = f.debug_struct("ListTunnelDestGroupsResponse");
         debug_struct.field("tunnel_dest_groups", &self.tunnel_dest_groups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -652,7 +650,6 @@ impl std::fmt::Debug for CreateTunnelDestGroupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tunnel_dest_group", &self.tunnel_dest_group);
         debug_struct.field("tunnel_dest_group_id", &self.tunnel_dest_group_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -796,7 +793,6 @@ impl std::fmt::Debug for GetTunnelDestGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTunnelDestGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -940,7 +936,6 @@ impl std::fmt::Debug for DeleteTunnelDestGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTunnelDestGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1134,7 +1129,6 @@ impl std::fmt::Debug for UpdateTunnelDestGroupRequest {
         let mut debug_struct = f.debug_struct("UpdateTunnelDestGroupRequest");
         debug_struct.field("tunnel_dest_group", &self.tunnel_dest_group);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1333,7 +1327,6 @@ impl std::fmt::Debug for TunnelDestGroup {
         debug_struct.field("name", &self.name);
         debug_struct.field("cidrs", &self.cidrs);
         debug_struct.field("fqdns", &self.fqdns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1477,7 +1470,6 @@ impl std::fmt::Debug for GetIapSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetIapSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1675,7 +1667,6 @@ impl std::fmt::Debug for UpdateIapSettingsRequest {
         let mut debug_struct = f.debug_struct("UpdateIapSettingsRequest");
         debug_struct.field("iap_settings", &self.iap_settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1892,7 +1883,6 @@ impl std::fmt::Debug for IapSettings {
         debug_struct.field("name", &self.name);
         debug_struct.field("access_settings", &self.access_settings);
         debug_struct.field("application_settings", &self.application_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2280,7 +2270,6 @@ impl std::fmt::Debug for AccessSettings {
             &self.workforce_identity_settings,
         );
         debug_struct.field("identity_sources", &self.identity_sources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2609,7 +2598,6 @@ impl std::fmt::Debug for GcipSettings {
         let mut debug_struct = f.debug_struct("GcipSettings");
         debug_struct.field("tenant_ids", &self.tenant_ids);
         debug_struct.field("login_page_uri", &self.login_page_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2766,7 +2754,6 @@ impl std::fmt::Debug for CorsSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CorsSettings");
         debug_struct.field("allow_http_options", &self.allow_http_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2954,7 +2941,6 @@ impl std::fmt::Debug for OAuthSettings {
         let mut debug_struct = f.debug_struct("OAuthSettings");
         debug_struct.field("login_hint", &self.login_hint);
         debug_struct.field("programmatic_clients", &self.programmatic_clients);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3139,7 +3125,6 @@ impl std::fmt::Debug for WorkforceIdentitySettings {
         let mut debug_struct = f.debug_struct("WorkforceIdentitySettings");
         debug_struct.field("workforce_pools", &self.workforce_pools);
         debug_struct.field("oauth2", &self.oauth2);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3340,7 +3325,6 @@ impl std::fmt::Debug for OAuth2 {
         debug_struct.field("client_id", &self.client_id);
         debug_struct.field("client_secret", &self.client_secret);
         debug_struct.field("client_secret_sha256", &self.client_secret_sha256);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3550,7 +3534,6 @@ impl std::fmt::Debug for ReauthSettings {
         debug_struct.field("method", &self.method);
         debug_struct.field("max_age", &self.max_age);
         debug_struct.field("policy_type", &self.policy_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4016,7 +3999,6 @@ impl std::fmt::Debug for AllowedDomainsSettings {
         let mut debug_struct = f.debug_struct("AllowedDomainsSettings");
         debug_struct.field("enable", &self.enable);
         debug_struct.field("domains", &self.domains);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4306,7 +4288,6 @@ impl std::fmt::Debug for ApplicationSettings {
             "attribute_propagation_settings",
             &self.attribute_propagation_settings,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4464,7 +4445,6 @@ impl std::fmt::Debug for CsmSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CsmSettings");
         debug_struct.field("rctoken_aud", &self.rctoken_aud);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4720,7 +4700,6 @@ impl std::fmt::Debug for AccessDeniedPageSettings {
             "remediation_token_generation_enabled",
             &self.remediation_token_generation_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4971,7 +4950,6 @@ impl std::fmt::Debug for AttributePropagationSettings {
         debug_struct.field("expression", &self.expression);
         debug_struct.field("output_credentials", &self.output_credentials);
         debug_struct.field("enable", &self.enable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5290,7 +5268,6 @@ impl std::fmt::Debug for ValidateIapAttributeExpressionRequest {
         let mut debug_struct = f.debug_struct("ValidateIapAttributeExpressionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("expression", &self.expression);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5405,7 +5382,6 @@ impl serde::ser::Serialize for ValidateIapAttributeExpressionResponse {
 impl std::fmt::Debug for ValidateIapAttributeExpressionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ValidateIapAttributeExpressionResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5548,7 +5524,6 @@ impl std::fmt::Debug for ListBrandsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListBrandsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5693,7 +5668,6 @@ impl std::fmt::Debug for ListBrandsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListBrandsResponse");
         debug_struct.field("brands", &self.brands);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5872,7 +5846,6 @@ impl std::fmt::Debug for CreateBrandRequest {
         let mut debug_struct = f.debug_struct("CreateBrandRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("brand", &self.brand);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6015,7 +5988,6 @@ impl std::fmt::Debug for GetBrandRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBrandRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6236,7 +6208,6 @@ impl std::fmt::Debug for ListIdentityAwareProxyClientsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6438,7 +6409,6 @@ impl std::fmt::Debug for ListIdentityAwareProxyClientsResponse {
             &self.identity_aware_proxy_clients,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6631,7 +6601,6 @@ impl std::fmt::Debug for CreateIdentityAwareProxyClientRequest {
             "identity_aware_proxy_client",
             &self.identity_aware_proxy_client,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6775,7 +6744,6 @@ impl std::fmt::Debug for GetIdentityAwareProxyClientRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetIdentityAwareProxyClientRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6921,7 +6889,6 @@ impl std::fmt::Debug for ResetIdentityAwareProxyClientSecretRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetIdentityAwareProxyClientSecretRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7066,7 +7033,6 @@ impl std::fmt::Debug for DeleteIdentityAwareProxyClientRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIdentityAwareProxyClientRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7293,7 +7259,6 @@ impl std::fmt::Debug for Brand {
         debug_struct.field("support_email", &self.support_email);
         debug_struct.field("application_title", &self.application_title);
         debug_struct.field("org_internal_only", &self.org_internal_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7486,7 +7451,6 @@ impl std::fmt::Debug for IdentityAwareProxyClient {
         debug_struct.field("name", &self.name);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -462,7 +462,6 @@ impl std::fmt::Debug for Endpoint {
         debug_struct.field("severity", &self.severity);
         debug_struct.field("state", &self.state);
         debug_struct.field("traffic_logs", &self.traffic_logs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1029,7 +1028,6 @@ impl std::fmt::Debug for ListEndpointsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1242,7 +1240,6 @@ impl std::fmt::Debug for ListEndpointsResponse {
         debug_struct.field("endpoints", &self.endpoints);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1384,7 +1381,6 @@ impl std::fmt::Debug for GetEndpointRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEndpointRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1630,7 +1626,6 @@ impl std::fmt::Debug for CreateEndpointRequest {
         debug_struct.field("endpoint_id", &self.endpoint_id);
         debug_struct.field("endpoint", &self.endpoint);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1809,7 +1804,6 @@ impl std::fmt::Debug for DeleteEndpointRequest {
         let mut debug_struct = f.debug_struct("DeleteEndpointRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2133,7 +2127,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/kms/inventory/v1/src/model.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/model.rs
@@ -242,7 +242,6 @@ impl std::fmt::Debug for ListCryptoKeysRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -434,7 +433,6 @@ impl std::fmt::Debug for ListCryptoKeysResponse {
         let mut debug_struct = f.debug_struct("ListCryptoKeysResponse");
         debug_struct.field("crypto_keys", &self.crypto_keys);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -582,7 +580,6 @@ impl std::fmt::Debug for GetProtectedResourcesSummaryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProtectedResourcesSummaryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1006,7 +1003,6 @@ impl std::fmt::Debug for ProtectedResourcesSummary {
         debug_struct.field("resource_types", &self.resource_types);
         debug_struct.field("cloud_products", &self.cloud_products);
         debug_struct.field("locations", &self.locations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1304,7 +1300,6 @@ impl std::fmt::Debug for SearchProtectedResourcesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("resource_types", &self.resource_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1498,7 +1493,6 @@ impl std::fmt::Debug for SearchProtectedResourcesResponse {
         let mut debug_struct = f.debug_struct("SearchProtectedResourcesResponse");
         debug_struct.field("protected_resources", &self.protected_resources);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1915,7 +1909,6 @@ impl std::fmt::Debug for ProtectedResource {
         debug_struct.field("crypto_key_version", &self.crypto_key_version);
         debug_struct.field("crypto_key_versions", &self.crypto_key_versions);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -244,7 +244,6 @@ impl std::fmt::Debug for CreateKeyHandleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("key_handle_id", &self.key_handle_id);
         debug_struct.field("key_handle", &self.key_handle);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -392,7 +391,6 @@ impl std::fmt::Debug for GetKeyHandleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKeyHandleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -615,7 +613,6 @@ impl std::fmt::Debug for KeyHandle {
         debug_struct.field("name", &self.name);
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("resource_type_selector", &self.resource_type_selector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -733,7 +730,6 @@ impl serde::ser::Serialize for CreateKeyHandleMetadata {
 impl std::fmt::Debug for CreateKeyHandleMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateKeyHandleMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -994,7 +990,6 @@ impl std::fmt::Debug for ListKeyHandlesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1189,7 +1184,6 @@ impl std::fmt::Debug for ListKeyHandlesResponse {
         let mut debug_struct = f.debug_struct("ListKeyHandlesResponse");
         debug_struct.field("key_handles", &self.key_handles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1390,7 +1384,6 @@ impl std::fmt::Debug for UpdateAutokeyConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateAutokeyConfigRequest");
         debug_struct.field("autokey_config", &self.autokey_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1538,7 +1531,6 @@ impl std::fmt::Debug for GetAutokeyConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAutokeyConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1777,7 +1769,6 @@ impl std::fmt::Debug for AutokeyConfig {
         debug_struct.field("key_project", &self.key_project);
         debug_struct.field("state", &self.state);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2071,7 +2062,6 @@ impl std::fmt::Debug for ShowEffectiveAutokeyConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShowEffectiveAutokeyConfigRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2218,7 +2208,6 @@ impl std::fmt::Debug for ShowEffectiveAutokeyConfigResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShowEffectiveAutokeyConfigResponse");
         debug_struct.field("key_project", &self.key_project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2506,7 +2495,6 @@ impl std::fmt::Debug for ListEkmConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2753,7 +2741,6 @@ impl std::fmt::Debug for ListEkmConnectionsResponse {
         debug_struct.field("ekm_connections", &self.ekm_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2902,7 +2889,6 @@ impl std::fmt::Debug for GetEkmConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEkmConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3121,7 +3107,6 @@ impl std::fmt::Debug for CreateEkmConnectionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("ekm_connection_id", &self.ekm_connection_id);
         debug_struct.field("ekm_connection", &self.ekm_connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3318,7 +3303,6 @@ impl std::fmt::Debug for UpdateEkmConnectionRequest {
         let mut debug_struct = f.debug_struct("UpdateEkmConnectionRequest");
         debug_struct.field("ekm_connection", &self.ekm_connection);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3467,7 +3451,6 @@ impl std::fmt::Debug for GetEkmConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEkmConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3663,7 +3646,6 @@ impl std::fmt::Debug for UpdateEkmConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateEkmConfigRequest");
         debug_struct.field("ekm_config", &self.ekm_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4091,7 +4073,6 @@ impl std::fmt::Debug for Certificate {
         debug_struct.field("not_after_time", &self.not_after_time);
         debug_struct.field("serial_number", &self.serial_number);
         debug_struct.field("sha256_fingerprint", &self.sha256_fingerprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4432,7 +4413,6 @@ impl std::fmt::Debug for EkmConnection {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("key_management_mode", &self.key_management_mode);
         debug_struct.field("crypto_space_path", &self.crypto_space_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4694,7 +4674,6 @@ pub mod ekm_connection {
             debug_struct.field("endpoint_filter", &self.endpoint_filter);
             debug_struct.field("hostname", &self.hostname);
             debug_struct.field("server_certificates", &self.server_certificates);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5059,7 +5038,6 @@ impl std::fmt::Debug for EkmConfig {
         let mut debug_struct = f.debug_struct("EkmConfig");
         debug_struct.field("name", &self.name);
         debug_struct.field("default_ekm_connection", &self.default_ekm_connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5208,7 +5186,6 @@ impl std::fmt::Debug for VerifyConnectivityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerifyConnectivityRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5325,7 +5302,6 @@ impl serde::ser::Serialize for VerifyConnectivityResponse {
 impl std::fmt::Debug for VerifyConnectivityResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerifyConnectivityResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5515,7 +5491,6 @@ impl std::fmt::Debug for KeyRing {
         let mut debug_struct = f.debug_struct("KeyRing");
         debug_struct.field("name", &self.name);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6185,7 +6160,6 @@ impl std::fmt::Debug for CryptoKey {
             &self.key_access_justifications_policy,
         );
         debug_struct.field("rotation_schedule", &self.rotation_schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6617,7 +6591,6 @@ impl std::fmt::Debug for CryptoKeyVersionTemplate {
         let mut debug_struct = f.debug_struct("CryptoKeyVersionTemplate");
         debug_struct.field("protection_level", &self.protection_level);
         debug_struct.field("algorithm", &self.algorithm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6851,7 +6824,6 @@ impl std::fmt::Debug for KeyOperationAttestation {
         debug_struct.field("format", &self.format);
         debug_struct.field("content", &self.content);
         debug_struct.field("cert_chains", &self.cert_chains);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7067,7 +7039,6 @@ pub mod key_operation_attestation {
             debug_struct.field("cavium_certs", &self.cavium_certs);
             debug_struct.field("google_card_certs", &self.google_card_certs);
             debug_struct.field("google_partition_certs", &self.google_partition_certs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7965,7 +7936,6 @@ impl std::fmt::Debug for CryptoKeyVersion {
             &self.external_protection_level_options,
         );
         debug_struct.field("reimport_eligible", &self.reimport_eligible);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9075,7 +9045,6 @@ impl std::fmt::Debug for ChecksummedData {
         let mut debug_struct = f.debug_struct("ChecksummedData");
         debug_struct.field("data", &self.data);
         debug_struct.field("crc32c_checksum", &self.crc32c_checksum);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9477,7 +9446,6 @@ impl std::fmt::Debug for PublicKey {
         debug_struct.field("protection_level", &self.protection_level);
         debug_struct.field("public_key_format", &self.public_key_format);
         debug_struct.field("public_key", &self.public_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10172,7 +10140,6 @@ impl std::fmt::Debug for ImportJob {
         debug_struct.field("state", &self.state);
         debug_struct.field("public_key", &self.public_key);
         debug_struct.field("attestation", &self.attestation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10330,7 +10297,6 @@ pub mod import_job {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("WrappingPublicKey");
             debug_struct.field("pem", &self.pem);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10876,7 +10842,6 @@ impl std::fmt::Debug for ExternalProtectionLevelOptions {
         let mut debug_struct = f.debug_struct("ExternalProtectionLevelOptions");
         debug_struct.field("external_key_uri", &self.external_key_uri);
         debug_struct.field("ekm_connection_key_path", &self.ekm_connection_key_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11036,7 +11001,6 @@ impl std::fmt::Debug for KeyAccessJustificationsPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("KeyAccessJustificationsPolicy");
         debug_struct.field("allowed_access_reasons", &self.allowed_access_reasons);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11324,7 +11288,6 @@ impl std::fmt::Debug for ListKeyRingsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11644,7 +11607,6 @@ impl std::fmt::Debug for ListCryptoKeysRequest {
         debug_struct.field("version_view", &self.version_view);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11964,7 +11926,6 @@ impl std::fmt::Debug for ListCryptoKeyVersionsRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12251,7 +12212,6 @@ impl std::fmt::Debug for ListImportJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12498,7 +12458,6 @@ impl std::fmt::Debug for ListKeyRingsResponse {
         debug_struct.field("key_rings", &self.key_rings);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12745,7 +12704,6 @@ impl std::fmt::Debug for ListCryptoKeysResponse {
         debug_struct.field("crypto_keys", &self.crypto_keys);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12997,7 +12955,6 @@ impl std::fmt::Debug for ListCryptoKeyVersionsResponse {
         debug_struct.field("crypto_key_versions", &self.crypto_key_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13244,7 +13201,6 @@ impl std::fmt::Debug for ListImportJobsResponse {
         debug_struct.field("import_jobs", &self.import_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13393,7 +13349,6 @@ impl std::fmt::Debug for GetKeyRingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKeyRingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13542,7 +13497,6 @@ impl std::fmt::Debug for GetCryptoKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCryptoKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13691,7 +13645,6 @@ impl std::fmt::Debug for GetCryptoKeyVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCryptoKeyVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13879,7 +13832,6 @@ impl std::fmt::Debug for GetPublicKeyRequest {
         let mut debug_struct = f.debug_struct("GetPublicKeyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("public_key_format", &self.public_key_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14028,7 +13980,6 @@ impl std::fmt::Debug for GetImportJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetImportJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14244,7 +14195,6 @@ impl std::fmt::Debug for CreateKeyRingRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("key_ring_id", &self.key_ring_id);
         debug_struct.field("key_ring", &self.key_ring);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14508,7 +14458,6 @@ impl std::fmt::Debug for CreateCryptoKeyRequest {
             "skip_initial_version_creation",
             &self.skip_initial_version_creation,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14700,7 +14649,6 @@ impl std::fmt::Debug for CreateCryptoKeyVersionRequest {
         let mut debug_struct = f.debug_struct("CreateCryptoKeyVersionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("crypto_key_version", &self.crypto_key_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15156,7 +15104,6 @@ impl std::fmt::Debug for ImportCryptoKeyVersionRequest {
         debug_struct.field("import_job", &self.import_job);
         debug_struct.field("wrapped_key", &self.wrapped_key);
         debug_struct.field("wrapped_key_material", &self.wrapped_key_material);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15397,7 +15344,6 @@ impl std::fmt::Debug for CreateImportJobRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("import_job_id", &self.import_job_id);
         debug_struct.field("import_job", &self.import_job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15593,7 +15539,6 @@ impl std::fmt::Debug for UpdateCryptoKeyRequest {
         let mut debug_struct = f.debug_struct("UpdateCryptoKeyRequest");
         debug_struct.field("crypto_key", &self.crypto_key);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15791,7 +15736,6 @@ impl std::fmt::Debug for UpdateCryptoKeyVersionRequest {
         let mut debug_struct = f.debug_struct("UpdateCryptoKeyVersionRequest");
         debug_struct.field("crypto_key_version", &self.crypto_key_version);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15971,7 +15915,6 @@ impl std::fmt::Debug for UpdateCryptoKeyPrimaryVersionRequest {
         let mut debug_struct = f.debug_struct("UpdateCryptoKeyPrimaryVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("crypto_key_version_id", &self.crypto_key_version_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16119,7 +16062,6 @@ impl std::fmt::Debug for DestroyCryptoKeyVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DestroyCryptoKeyVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16267,7 +16209,6 @@ impl std::fmt::Debug for RestoreCryptoKeyVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestoreCryptoKeyVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16732,7 +16673,6 @@ impl std::fmt::Debug for EncryptRequest {
             "additional_authenticated_data_crc32c",
             &self.additional_authenticated_data_crc32c,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17162,7 +17102,6 @@ impl std::fmt::Debug for DecryptRequest {
             "additional_authenticated_data_crc32c",
             &self.additional_authenticated_data_crc32c,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17748,7 +17687,6 @@ impl std::fmt::Debug for RawEncryptRequest {
             "initialization_vector_crc32c",
             &self.initialization_vector_crc32c,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18352,7 +18290,6 @@ impl std::fmt::Debug for RawDecryptRequest {
             "initialization_vector_crc32c",
             &self.initialization_vector_crc32c,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18754,7 +18691,6 @@ impl std::fmt::Debug for AsymmetricSignRequest {
         debug_struct.field("digest_crc32c", &self.digest_crc32c);
         debug_struct.field("data", &self.data);
         debug_struct.field("data_crc32c", &self.data_crc32c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19030,7 +18966,6 @@ impl std::fmt::Debug for AsymmetricDecryptRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("ciphertext", &self.ciphertext);
         debug_struct.field("ciphertext_crc32c", &self.ciphertext_crc32c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19301,7 +19236,6 @@ impl std::fmt::Debug for MacSignRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("data", &self.data);
         debug_struct.field("data_crc32c", &self.data_crc32c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19697,7 +19631,6 @@ impl std::fmt::Debug for MacVerifyRequest {
         debug_struct.field("data_crc32c", &self.data_crc32c);
         debug_struct.field("mac", &self.mac);
         debug_struct.field("mac_crc32c", &self.mac_crc32c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19923,7 +19856,6 @@ impl std::fmt::Debug for GenerateRandomBytesRequest {
         debug_struct.field("location", &self.location);
         debug_struct.field("length_bytes", &self.length_bytes);
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20327,7 +20259,6 @@ impl std::fmt::Debug for EncryptResponse {
             &self.verified_additional_authenticated_data_crc32c,
         );
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20631,7 +20562,6 @@ impl std::fmt::Debug for DecryptResponse {
         debug_struct.field("plaintext_crc32c", &self.plaintext_crc32c);
         debug_struct.field("used_primary", &self.used_primary);
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21263,7 +21193,6 @@ impl std::fmt::Debug for RawEncryptResponse {
         );
         debug_struct.field("name", &self.name);
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21694,7 +21623,6 @@ impl std::fmt::Debug for RawDecryptResponse {
             "verified_initialization_vector_crc32c",
             &self.verified_initialization_vector_crc32c,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22077,7 +22005,6 @@ impl std::fmt::Debug for AsymmetricSignResponse {
         debug_struct.field("name", &self.name);
         debug_struct.field("verified_data_crc32c", &self.verified_data_crc32c);
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22396,7 +22323,6 @@ impl std::fmt::Debug for AsymmetricDecryptResponse {
             &self.verified_ciphertext_crc32c,
         );
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22736,7 +22662,6 @@ impl std::fmt::Debug for MacSignResponse {
         debug_struct.field("mac_crc32c", &self.mac_crc32c);
         debug_struct.field("verified_data_crc32c", &self.verified_data_crc32c);
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23073,7 +22998,6 @@ impl std::fmt::Debug for MacVerifyResponse {
             &self.verified_success_integrity,
         );
         debug_struct.field("protection_level", &self.protection_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23308,7 +23232,6 @@ impl std::fmt::Debug for GenerateRandomBytesResponse {
         let mut debug_struct = f.debug_struct("GenerateRandomBytesResponse");
         debug_struct.field("data", &self.data);
         debug_struct.field("data_crc32c", &self.data_crc32c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23629,7 +23552,6 @@ impl std::fmt::Debug for Digest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Digest");
         debug_struct.field("digest", &self.digest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23833,7 +23755,6 @@ impl std::fmt::Debug for LocationMetadata {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("hsm_available", &self.hsm_available);
         debug_struct.field("ekm_available", &self.ekm_available);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -306,7 +306,6 @@ impl std::fmt::Debug for Document {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -652,7 +651,6 @@ impl std::fmt::Debug for Sentence {
         let mut debug_struct = f.debug_struct("Sentence");
         debug_struct.field("text", &self.text);
         debug_struct.field("sentiment", &self.sentiment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -928,7 +926,6 @@ impl std::fmt::Debug for Entity {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("mentions", &self.mentions);
         debug_struct.field("sentiment", &self.sentiment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1379,7 +1376,6 @@ impl std::fmt::Debug for Sentiment {
         let mut debug_struct = f.debug_struct("Sentiment");
         debug_struct.field("magnitude", &self.magnitude);
         debug_struct.field("score", &self.score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1644,7 +1640,6 @@ impl std::fmt::Debug for EntityMention {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("sentiment", &self.sentiment);
         debug_struct.field("probability", &self.probability);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1973,7 +1968,6 @@ impl std::fmt::Debug for TextSpan {
         let mut debug_struct = f.debug_struct("TextSpan");
         debug_struct.field("content", &self.content);
         debug_struct.field("begin_offset", &self.begin_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2204,7 +2198,6 @@ impl std::fmt::Debug for ClassificationCategory {
         debug_struct.field("name", &self.name);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("severity", &self.severity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2386,7 +2379,6 @@ impl std::fmt::Debug for AnalyzeSentimentRequest {
         let mut debug_struct = f.debug_struct("AnalyzeSentimentRequest");
         debug_struct.field("document", &self.document);
         debug_struct.field("encoding_type", &self.encoding_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2624,7 +2616,6 @@ impl std::fmt::Debug for AnalyzeSentimentResponse {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("sentences", &self.sentences);
         debug_struct.field("language_supported", &self.language_supported);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2806,7 +2797,6 @@ impl std::fmt::Debug for AnalyzeEntitiesRequest {
         let mut debug_struct = f.debug_struct("AnalyzeEntitiesRequest");
         debug_struct.field("document", &self.document);
         debug_struct.field("encoding_type", &self.encoding_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3007,7 +2997,6 @@ impl std::fmt::Debug for AnalyzeEntitiesResponse {
         debug_struct.field("entities", &self.entities);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("language_supported", &self.language_supported);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3160,7 +3149,6 @@ impl std::fmt::Debug for ClassifyTextRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ClassifyTextRequest");
         debug_struct.field("document", &self.document);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3365,7 +3353,6 @@ impl std::fmt::Debug for ClassifyTextResponse {
         debug_struct.field("categories", &self.categories);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("language_supported", &self.language_supported);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3551,7 +3538,6 @@ impl std::fmt::Debug for ModerateTextRequest {
         let mut debug_struct = f.debug_struct("ModerateTextRequest");
         debug_struct.field("document", &self.document);
         debug_struct.field("model_version", &self.model_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3899,7 +3885,6 @@ impl std::fmt::Debug for ModerateTextResponse {
         debug_struct.field("moderation_categories", &self.moderation_categories);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("language_supported", &self.language_supported);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4119,7 +4104,6 @@ impl std::fmt::Debug for AnnotateTextRequest {
         debug_struct.field("document", &self.document);
         debug_struct.field("features", &self.features);
         debug_struct.field("encoding_type", &self.encoding_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4359,7 +4343,6 @@ pub mod annotate_text_request {
             );
             debug_struct.field("classify_text", &self.classify_text);
             debug_struct.field("moderate_text", &self.moderate_text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4703,7 +4686,6 @@ impl std::fmt::Debug for AnnotateTextResponse {
         debug_struct.field("categories", &self.categories);
         debug_struct.field("moderation_categories", &self.moderation_categories);
         debug_struct.field("language_supported", &self.language_supported);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/licensemanager/v1/src/model.rs
+++ b/src/generated/cloud/licensemanager/v1/src/model.rs
@@ -457,7 +457,6 @@ impl std::fmt::Debug for Configuration {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -868,7 +867,6 @@ impl std::fmt::Debug for BillingInfo {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("current_billing_info", &self.current_billing_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1043,7 +1041,6 @@ impl std::fmt::Debug for UserCountBillingInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserCountBillingInfo");
         debug_struct.field("user_count", &self.user_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1206,7 +1203,6 @@ impl std::fmt::Debug for UserCountUsage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserCountUsage");
         debug_struct.field("unique_user_count", &self.unique_user_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1501,7 +1497,6 @@ impl std::fmt::Debug for Product {
         debug_struct.field("sku", &self.sku);
         debug_struct.field("description", &self.description);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2052,7 +2047,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("product_activation", &self.product_activation);
         debug_struct.field("license_version_id", &self.license_version_id);
         debug_struct.field("compute_instance", &self.compute_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2414,7 +2408,6 @@ impl std::fmt::Debug for Usage {
         let mut debug_struct = f.debug_struct("Usage");
         debug_struct.field("lima_instance", &self.lima_instance);
         debug_struct.field("users", &self.users);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2678,7 +2671,6 @@ impl std::fmt::Debug for ListConfigurationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2891,7 +2883,6 @@ impl std::fmt::Debug for ListConfigurationsResponse {
         debug_struct.field("configurations", &self.configurations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3033,7 +3024,6 @@ impl std::fmt::Debug for GetConfigurationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConfigurationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3278,7 +3268,6 @@ impl std::fmt::Debug for CreateConfigurationRequest {
         debug_struct.field("configuration_id", &self.configuration_id);
         debug_struct.field("configuration", &self.configuration);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3510,7 +3499,6 @@ impl std::fmt::Debug for UpdateConfigurationRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("configuration", &self.configuration);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3690,7 +3678,6 @@ impl std::fmt::Debug for DeleteConfigurationRequest {
         let mut debug_struct = f.debug_struct("DeleteConfigurationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3954,7 +3941,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4167,7 +4153,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4309,7 +4294,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4528,7 +4512,6 @@ impl std::fmt::Debug for QueryConfigurationLicenseUsageRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4727,7 +4710,6 @@ impl std::fmt::Debug for QueryConfigurationLicenseUsageResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryConfigurationLicenseUsageResponse");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4922,7 +4904,6 @@ impl std::fmt::Debug for DeactivateConfigurationRequest {
         let mut debug_struct = f.debug_struct("DeactivateConfigurationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5102,7 +5083,6 @@ impl std::fmt::Debug for ReactivateConfigurationRequest {
         let mut debug_struct = f.debug_struct("ReactivateConfigurationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5442,7 +5422,6 @@ impl std::fmt::Debug for AggregateUsageRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5655,7 +5634,6 @@ impl std::fmt::Debug for AggregateUsageResponse {
         debug_struct.field("usages", &self.usages);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5919,7 +5897,6 @@ impl std::fmt::Debug for ListProductsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6132,7 +6109,6 @@ impl std::fmt::Debug for ListProductsResponse {
         debug_struct.field("products", &self.products);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6274,7 +6250,6 @@ impl std::fmt::Debug for GetProductRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProductRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6601,7 +6576,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/location/src/model.rs
+++ b/src/generated/cloud/location/src/model.rs
@@ -261,7 +261,6 @@ impl std::fmt::Debug for ListLocationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -448,7 +447,6 @@ impl std::fmt::Debug for ListLocationsResponse {
         let mut debug_struct = f.debug_struct("ListLocationsResponse");
         debug_struct.field("locations", &self.locations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -592,7 +590,6 @@ impl std::fmt::Debug for GetLocationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLocationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -864,7 +861,6 @@ impl std::fmt::Debug for Location {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/lustre/v1/src/model.rs
+++ b/src/generated/cloud/lustre/v1/src/model.rs
@@ -540,7 +540,6 @@ impl std::fmt::Debug for Instance {
             &self.per_unit_storage_throughput,
         );
         debug_struct.field("gke_support_enabled", &self.gke_support_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -981,7 +980,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1196,7 +1194,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1339,7 +1336,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1588,7 +1584,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1823,7 +1818,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2004,7 +1998,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2329,7 +2322,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2668,7 +2660,6 @@ impl std::fmt::Debug for ImportDataRequest {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("source", &self.source);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3034,7 +3025,6 @@ impl std::fmt::Debug for ExportDataRequest {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("source", &self.source);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3174,7 +3164,6 @@ impl serde::ser::Serialize for ExportDataResponse {
 impl std::fmt::Debug for ExportDataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportDataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3288,7 +3277,6 @@ impl serde::ser::Serialize for ImportDataResponse {
 impl std::fmt::Debug for ImportDataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportDataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3652,7 +3640,6 @@ impl std::fmt::Debug for ExportDataMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3991,7 +3978,6 @@ impl std::fmt::Debug for ImportDataMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4136,7 +4122,6 @@ impl std::fmt::Debug for GcsPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsPath");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4281,7 +4266,6 @@ impl std::fmt::Debug for LustrePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LustrePath");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4764,7 +4748,6 @@ impl std::fmt::Debug for TransferCounters {
         debug_struct.field("bytes_copied_count", &self.bytes_copied_count);
         debug_struct.field("objects_failed_count", &self.objects_failed_count);
         debug_struct.field("bytes_failed_count", &self.bytes_failed_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4936,7 +4919,6 @@ impl std::fmt::Debug for ErrorLogEntry {
         let mut debug_struct = f.debug_struct("ErrorLogEntry");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("error_details", &self.error_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5156,7 +5138,6 @@ impl std::fmt::Debug for ErrorSummary {
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("error_count", &self.error_count);
         debug_struct.field("error_log_entries", &self.error_log_entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5625,7 +5606,6 @@ impl std::fmt::Debug for TransferOperationMetadata {
         debug_struct.field("error_summaries", &self.error_summaries);
         debug_struct.field("source", &self.source);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -322,7 +322,6 @@ impl std::fmt::Debug for OpMetadata {
         debug_struct.field("verb", &self.verb);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -539,7 +538,6 @@ impl std::fmt::Debug for CreateMicrosoftAdDomainRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("domain_name", &self.domain_name);
         debug_struct.field("domain", &self.domain);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -683,7 +681,6 @@ impl std::fmt::Debug for ResetAdminPasswordRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetAdminPasswordRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -828,7 +825,6 @@ impl std::fmt::Debug for ResetAdminPasswordResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetAdminPasswordResponse");
         debug_struct.field("password", &self.password);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1105,7 +1101,6 @@ impl std::fmt::Debug for ListDomainsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1320,7 +1315,6 @@ impl std::fmt::Debug for ListDomainsResponse {
         debug_struct.field("domains", &self.domains);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1463,7 +1457,6 @@ impl std::fmt::Debug for GetDomainRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDomainRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1663,7 +1656,6 @@ impl std::fmt::Debug for UpdateDomainRequest {
         let mut debug_struct = f.debug_struct("UpdateDomainRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("domain", &self.domain);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1807,7 +1799,6 @@ impl std::fmt::Debug for DeleteDomainRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDomainRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1987,7 +1978,6 @@ impl std::fmt::Debug for AttachTrustRequest {
         let mut debug_struct = f.debug_struct("AttachTrustRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("trust", &self.trust);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2191,7 +2181,6 @@ impl std::fmt::Debug for ReconfigureTrustRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("target_domain_name", &self.target_domain_name);
         debug_struct.field("target_dns_ip_addresses", &self.target_dns_ip_addresses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2371,7 +2360,6 @@ impl std::fmt::Debug for DetachTrustRequest {
         let mut debug_struct = f.debug_struct("DetachTrustRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("trust", &self.trust);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2551,7 +2539,6 @@ impl std::fmt::Debug for ValidateTrustRequest {
         let mut debug_struct = f.debug_struct("ValidateTrustRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("trust", &self.trust);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3034,7 +3021,6 @@ impl std::fmt::Debug for Domain {
         debug_struct.field("state", &self.state);
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("trusts", &self.trusts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3671,7 +3657,6 @@ impl std::fmt::Debug for Trust {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_description", &self.state_description);
         debug_struct.field("last_trust_heartbeat_time", &self.last_trust_heartbeat_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/src/model.rs
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/src/model.rs
@@ -169,7 +169,6 @@ impl std::fmt::Debug for GetSchemaRegistryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSchemaRegistryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -312,7 +311,6 @@ impl std::fmt::Debug for ListSchemaRegistriesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListSchemaRegistriesRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -462,7 +460,6 @@ impl std::fmt::Debug for ListSchemaRegistriesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListSchemaRegistriesResponse");
         debug_struct.field("schema_registries", &self.schema_registries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -676,7 +673,6 @@ impl std::fmt::Debug for CreateSchemaRegistryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("schema_registry_id", &self.schema_registry_id);
         debug_struct.field("schema_registry", &self.schema_registry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -820,7 +816,6 @@ impl std::fmt::Debug for DeleteSchemaRegistryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSchemaRegistryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -963,7 +958,6 @@ impl std::fmt::Debug for GetContextRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetContextRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1106,7 +1100,6 @@ impl std::fmt::Debug for ListContextsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListContextsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1287,7 +1280,6 @@ impl std::fmt::Debug for GetSchemaRequest {
         let mut debug_struct = f.debug_struct("GetSchemaRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("subject", &self.subject);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1431,7 +1423,6 @@ impl std::fmt::Debug for ListSchemaTypesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListSchemaTypesRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1649,7 +1640,6 @@ impl std::fmt::Debug for ListSchemaVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("subject", &self.subject);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1872,7 +1862,6 @@ impl std::fmt::Debug for ListSubjectsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("subject_prefix", &self.subject_prefix);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2090,7 +2079,6 @@ impl std::fmt::Debug for ListSubjectsBySchemaIdRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("subject", &self.subject);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2271,7 +2259,6 @@ impl std::fmt::Debug for ListVersionsRequest {
         let mut debug_struct = f.debug_struct("ListVersionsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2455,7 +2442,6 @@ impl std::fmt::Debug for DeleteSubjectRequest {
         let mut debug_struct = f.debug_struct("DeleteSubjectRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("permanent", &self.permanent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2637,7 +2623,6 @@ impl std::fmt::Debug for GetVersionRequest {
         let mut debug_struct = f.debug_struct("GetVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3032,7 +3017,6 @@ impl std::fmt::Debug for CreateVersionRequest {
         debug_struct.field("schema", &self.schema);
         debug_struct.field("references", &self.references);
         debug_struct.field("normalize", &self.normalize);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3192,7 +3176,6 @@ impl std::fmt::Debug for CreateVersionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateVersionResponse");
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3504,7 +3487,6 @@ impl std::fmt::Debug for LookupVersionRequest {
         debug_struct.field("references", &self.references);
         debug_struct.field("normalize", &self.normalize);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3688,7 +3670,6 @@ impl std::fmt::Debug for DeleteVersionRequest {
         let mut debug_struct = f.debug_struct("DeleteVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("permanent", &self.permanent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3833,7 +3814,6 @@ impl std::fmt::Debug for ListReferencedSchemasRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListReferencedSchemasRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4111,7 +4091,6 @@ impl std::fmt::Debug for CheckCompatibilityRequest {
         debug_struct.field("schema", &self.schema);
         debug_struct.field("references", &self.references);
         debug_struct.field("verbose", &self.verbose);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4282,7 +4261,6 @@ impl std::fmt::Debug for CheckCompatibilityResponse {
         let mut debug_struct = f.debug_struct("CheckCompatibilityResponse");
         debug_struct.field("is_compatible", &self.is_compatible);
         debug_struct.field("messages", &self.messages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4466,7 +4444,6 @@ impl std::fmt::Debug for GetSchemaConfigRequest {
         let mut debug_struct = f.debug_struct("GetSchemaConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("default_to_global", &self.default_to_global);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4692,7 +4669,6 @@ impl std::fmt::Debug for UpdateSchemaConfigRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("compatibility", &self.compatibility);
         debug_struct.field("normalize", &self.normalize);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4837,7 +4813,6 @@ impl std::fmt::Debug for DeleteSchemaConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSchemaConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4982,7 +4957,6 @@ impl std::fmt::Debug for GetSchemaModeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSchemaModeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5153,7 +5127,6 @@ impl std::fmt::Debug for UpdateSchemaModeRequest {
         let mut debug_struct = f.debug_struct("UpdateSchemaModeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5299,7 +5272,6 @@ impl std::fmt::Debug for DeleteSchemaModeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSchemaModeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5474,7 +5446,6 @@ impl std::fmt::Debug for SchemaRegistry {
         let mut debug_struct = f.debug_struct("SchemaRegistry");
         debug_struct.field("name", &self.name);
         debug_struct.field("contexts", &self.contexts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5651,7 +5622,6 @@ impl std::fmt::Debug for Context {
         let mut debug_struct = f.debug_struct("Context");
         debug_struct.field("name", &self.name);
         debug_struct.field("subjects", &self.subjects);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5853,7 +5823,6 @@ impl std::fmt::Debug for Schema {
         debug_struct.field("schema_type", &self.schema_type);
         debug_struct.field("schema_payload", &self.schema_payload);
         debug_struct.field("references", &self.references);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6071,7 +6040,6 @@ pub mod schema {
             debug_struct.field("name", &self.name);
             debug_struct.field("subject", &self.subject);
             debug_struct.field("version", &self.version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6391,7 +6359,6 @@ impl std::fmt::Debug for SchemaSubject {
         let mut debug_struct = f.debug_struct("SchemaSubject");
         debug_struct.field("name", &self.name);
         debug_struct.field("versions", &self.versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6706,7 +6673,6 @@ impl std::fmt::Debug for SchemaVersion {
         debug_struct.field("schema_type", &self.schema_type);
         debug_struct.field("schema_payload", &self.schema_payload);
         debug_struct.field("references", &self.references);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6929,7 +6895,6 @@ impl std::fmt::Debug for SchemaConfig {
         debug_struct.field("compatibility", &self.compatibility);
         debug_struct.field("normalize", &self.normalize);
         debug_struct.field("alias", &self.alias);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7249,7 +7214,6 @@ impl std::fmt::Debug for SchemaMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SchemaMode");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/managedkafka/v1/src/model.rs
+++ b/src/generated/cloud/managedkafka/v1/src/model.rs
@@ -295,7 +295,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -509,7 +508,6 @@ impl std::fmt::Debug for ListClustersResponse {
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -651,7 +649,6 @@ impl std::fmt::Debug for GetClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -901,7 +898,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1134,7 +1130,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1315,7 +1310,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         let mut debug_struct = f.debug_struct("DeleteClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1534,7 +1528,6 @@ impl std::fmt::Debug for ListTopicsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1721,7 +1714,6 @@ impl std::fmt::Debug for ListTopicsResponse {
         let mut debug_struct = f.debug_struct("ListTopicsResponse");
         debug_struct.field("topics", &self.topics);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1865,7 +1857,6 @@ impl std::fmt::Debug for GetTopicRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTopicRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2075,7 +2066,6 @@ impl std::fmt::Debug for CreateTopicRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("topic_id", &self.topic_id);
         debug_struct.field("topic", &self.topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2269,7 +2259,6 @@ impl std::fmt::Debug for UpdateTopicRequest {
         let mut debug_struct = f.debug_struct("UpdateTopicRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("topic", &self.topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2412,7 +2401,6 @@ impl std::fmt::Debug for DeleteTopicRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTopicRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2632,7 +2620,6 @@ impl std::fmt::Debug for ListConsumerGroupsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2820,7 +2807,6 @@ impl std::fmt::Debug for ListConsumerGroupsResponse {
         let mut debug_struct = f.debug_struct("ListConsumerGroupsResponse");
         debug_struct.field("consumer_groups", &self.consumer_groups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2963,7 +2949,6 @@ impl std::fmt::Debug for GetConsumerGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConsumerGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3158,7 +3143,6 @@ impl std::fmt::Debug for UpdateConsumerGroupRequest {
         let mut debug_struct = f.debug_struct("UpdateConsumerGroupRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("consumer_group", &self.consumer_group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3301,7 +3285,6 @@ impl std::fmt::Debug for DeleteConsumerGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConsumerGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3521,7 +3504,6 @@ impl std::fmt::Debug for ListAclsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3708,7 +3690,6 @@ impl std::fmt::Debug for ListAclsResponse {
         let mut debug_struct = f.debug_struct("ListAclsResponse");
         debug_struct.field("acls", &self.acls);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3856,7 +3837,6 @@ impl std::fmt::Debug for GetAclRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAclRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4083,7 +4063,6 @@ impl std::fmt::Debug for CreateAclRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("acl_id", &self.acl_id);
         debug_struct.field("acl", &self.acl);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4278,7 +4257,6 @@ impl std::fmt::Debug for UpdateAclRequest {
         let mut debug_struct = f.debug_struct("UpdateAclRequest");
         debug_struct.field("acl", &self.acl);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4425,7 +4403,6 @@ impl std::fmt::Debug for DeleteAclRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAclRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4610,7 +4587,6 @@ impl std::fmt::Debug for AddAclEntryRequest {
         let mut debug_struct = f.debug_struct("AddAclEntryRequest");
         debug_struct.field("acl", &self.acl);
         debug_struct.field("acl_entry", &self.acl_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4789,7 +4765,6 @@ impl std::fmt::Debug for AddAclEntryResponse {
         let mut debug_struct = f.debug_struct("AddAclEntryResponse");
         debug_struct.field("acl", &self.acl);
         debug_struct.field("acl_created", &self.acl_created);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4974,7 +4949,6 @@ impl std::fmt::Debug for RemoveAclEntryRequest {
         let mut debug_struct = f.debug_struct("RemoveAclEntryRequest");
         debug_struct.field("acl", &self.acl);
         debug_struct.field("acl_entry", &self.acl_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5207,7 +5181,6 @@ impl std::fmt::Debug for RemoveAclEntryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveAclEntryResponse");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5370,7 +5343,6 @@ impl std::fmt::Debug for GetConnectClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5626,7 +5598,6 @@ impl std::fmt::Debug for CreateConnectClusterRequest {
         debug_struct.field("connect_cluster_id", &self.connect_cluster_id);
         debug_struct.field("connect_cluster", &self.connect_cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5862,7 +5833,6 @@ impl std::fmt::Debug for UpdateConnectClusterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("connect_cluster", &self.connect_cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6045,7 +6015,6 @@ impl std::fmt::Debug for DeleteConnectClusterRequest {
         let mut debug_struct = f.debug_struct("DeleteConnectClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6315,7 +6284,6 @@ impl std::fmt::Debug for ListConnectClustersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6534,7 +6502,6 @@ impl std::fmt::Debug for ListConnectClustersResponse {
         debug_struct.field("connect_clusters", &self.connect_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6678,7 +6645,6 @@ impl std::fmt::Debug for GetConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6889,7 +6855,6 @@ impl std::fmt::Debug for CreateConnectorRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("connector_id", &self.connector_id);
         debug_struct.field("connector", &self.connector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7083,7 +7048,6 @@ impl std::fmt::Debug for UpdateConnectorRequest {
         let mut debug_struct = f.debug_struct("UpdateConnectorRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("connector", &self.connector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7227,7 +7191,6 @@ impl std::fmt::Debug for DeleteConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7447,7 +7410,6 @@ impl std::fmt::Debug for ListConnectorsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7633,7 +7595,6 @@ impl std::fmt::Debug for ListConnectorsResponse {
         let mut debug_struct = f.debug_struct("ListConnectorsResponse");
         debug_struct.field("connectors", &self.connectors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7777,7 +7738,6 @@ impl std::fmt::Debug for PauseConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7891,7 +7851,6 @@ impl serde::ser::Serialize for PauseConnectorResponse {
 impl std::fmt::Debug for PauseConnectorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseConnectorResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8035,7 +7994,6 @@ impl std::fmt::Debug for ResumeConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8149,7 +8107,6 @@ impl serde::ser::Serialize for ResumeConnectorResponse {
 impl std::fmt::Debug for ResumeConnectorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeConnectorResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8293,7 +8250,6 @@ impl std::fmt::Debug for RestartConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestartConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8407,7 +8363,6 @@ impl serde::ser::Serialize for RestartConnectorResponse {
 impl std::fmt::Debug for RestartConnectorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestartConnectorResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8551,7 +8506,6 @@ impl std::fmt::Debug for StopConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8665,7 +8619,6 @@ impl serde::ser::Serialize for StopConnectorResponse {
 impl std::fmt::Debug for StopConnectorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopConnectorResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9197,7 +9150,6 @@ impl std::fmt::Debug for Cluster {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("tls_config", &self.tls_config);
         debug_struct.field("platform_config", &self.platform_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9558,7 +9510,6 @@ impl std::fmt::Debug for CapacityConfig {
         let mut debug_struct = f.debug_struct("CapacityConfig");
         debug_struct.field("vcpu_count", &self.vcpu_count);
         debug_struct.field("memory_bytes", &self.memory_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9702,7 +9653,6 @@ impl std::fmt::Debug for RebalanceConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RebalanceConfig");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9992,7 +9942,6 @@ impl std::fmt::Debug for NetworkConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkConfig");
         debug_struct.field("subnet", &self.subnet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10140,7 +10089,6 @@ impl std::fmt::Debug for AccessConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccessConfig");
         debug_struct.field("network_configs", &self.network_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10324,7 +10272,6 @@ impl std::fmt::Debug for GcpConfig {
         let mut debug_struct = f.debug_struct("GcpConfig");
         debug_struct.field("access_config", &self.access_config);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10526,7 +10473,6 @@ impl std::fmt::Debug for TlsConfig {
             "ssl_principal_mapping_rules",
             &self.ssl_principal_mapping_rules,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10673,7 +10619,6 @@ impl std::fmt::Debug for TrustConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TrustConfig");
         debug_struct.field("cas_configs", &self.cas_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10829,7 +10774,6 @@ pub mod trust_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CertificateAuthorityServiceConfig");
             debug_struct.field("ca_pool", &self.ca_pool);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11106,7 +11050,6 @@ impl std::fmt::Debug for Topic {
         debug_struct.field("partition_count", &self.partition_count);
         debug_struct.field("replication_factor", &self.replication_factor);
         debug_struct.field("configs", &self.configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11290,7 +11233,6 @@ impl std::fmt::Debug for ConsumerTopicMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConsumerTopicMetadata");
         debug_struct.field("partitions", &self.partitions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11477,7 +11419,6 @@ impl std::fmt::Debug for ConsumerPartitionMetadata {
         let mut debug_struct = f.debug_struct("ConsumerPartitionMetadata");
         debug_struct.field("offset", &self.offset);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11659,7 +11600,6 @@ impl std::fmt::Debug for ConsumerGroup {
         let mut debug_struct = f.debug_struct("ConsumerGroup");
         debug_struct.field("name", &self.name);
         debug_struct.field("topics", &self.topics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11984,7 +11924,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12443,7 +12382,6 @@ impl std::fmt::Debug for ConnectCluster {
         debug_struct.field("state", &self.state);
         debug_struct.field("config", &self.config);
         debug_struct.field("platform_config", &self.platform_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12816,7 +12754,6 @@ impl std::fmt::Debug for ConnectNetworkConfig {
         debug_struct.field("primary_subnet", &self.primary_subnet);
         debug_struct.field("additional_subnets", &self.additional_subnets);
         debug_struct.field("dns_domain_names", &self.dns_domain_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12969,7 +12906,6 @@ impl std::fmt::Debug for ConnectAccessConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConnectAccessConfig");
         debug_struct.field("network_configs", &self.network_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13156,7 +13092,6 @@ impl std::fmt::Debug for ConnectGcpConfig {
         let mut debug_struct = f.debug_struct("ConnectGcpConfig");
         debug_struct.field("access_config", &self.access_config);
         debug_struct.field("secret_paths", &self.secret_paths);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13445,7 +13380,6 @@ impl std::fmt::Debug for Connector {
         debug_struct.field("configs", &self.configs);
         debug_struct.field("state", &self.state);
         debug_struct.field("restart_policy", &self.restart_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13822,7 +13756,6 @@ impl std::fmt::Debug for TaskRetryPolicy {
         let mut debug_struct = f.debug_struct("TaskRetryPolicy");
         debug_struct.field("minimum_backoff", &self.minimum_backoff);
         debug_struct.field("maximum_backoff", &self.maximum_backoff);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14133,7 +14066,6 @@ impl std::fmt::Debug for Acl {
         debug_struct.field("resource_type", &self.resource_type);
         debug_struct.field("resource_name", &self.resource_name);
         debug_struct.field("pattern_type", &self.pattern_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14361,7 +14293,6 @@ impl std::fmt::Debug for AclEntry {
         debug_struct.field("permission_type", &self.permission_type);
         debug_struct.field("operation", &self.operation);
         debug_struct.field("host", &self.host);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -762,7 +762,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("discovery_endpoint", &self.discovery_endpoint);
         debug_struct.field("maintenance_policy", &self.maintenance_policy);
         debug_struct.field("maintenance_schedule", &self.maintenance_schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -977,7 +976,6 @@ pub mod instance {
             let mut debug_struct = f.debug_struct("NodeConfig");
             debug_struct.field("cpu_count", &self.cpu_count);
             debug_struct.field("memory_size_mb", &self.memory_size_mb);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1279,7 +1277,6 @@ pub mod instance {
             debug_struct.field("host", &self.host);
             debug_struct.field("port", &self.port);
             debug_struct.field("parameters", &self.parameters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1608,7 +1605,6 @@ pub mod instance {
             let mut debug_struct = f.debug_struct("InstanceMessage");
             debug_struct.field("code", &self.code);
             debug_struct.field("message", &self.message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2154,7 +2150,6 @@ impl std::fmt::Debug for MaintenancePolicy {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("description", &self.description);
         debug_struct.field("weekly_maintenance_window", &self.weekly_maintenance_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2369,7 +2364,6 @@ impl std::fmt::Debug for WeeklyMaintenanceWindow {
         debug_struct.field("day", &self.day);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2598,7 +2592,6 @@ impl std::fmt::Debug for MaintenanceSchedule {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("schedule_deadline_time", &self.schedule_deadline_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2816,7 +2809,6 @@ impl std::fmt::Debug for RescheduleMaintenanceRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("reschedule_type", &self.reschedule_type);
         debug_struct.field("schedule_time", &self.schedule_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3238,7 +3230,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3458,7 +3449,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3604,7 +3594,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3821,7 +3810,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4016,7 +4004,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("UpdateInstanceRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4162,7 +4149,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4364,7 +4350,6 @@ impl std::fmt::Debug for ApplyParametersRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("node_ids", &self.node_ids);
         debug_struct.field("apply_all", &self.apply_all);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4582,7 +4567,6 @@ impl std::fmt::Debug for UpdateParametersRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4763,7 +4747,6 @@ impl std::fmt::Debug for MemcacheParameters {
         let mut debug_struct = f.debug_struct("MemcacheParameters");
         debug_struct.field("id", &self.id);
         debug_struct.field("params", &self.params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5087,7 +5070,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("cancel_requested", &self.cancel_requested);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5245,7 +5227,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("available_zones", &self.available_zones);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5358,7 +5339,6 @@ impl serde::ser::Serialize for ZoneMetadata {
 impl std::fmt::Debug for ZoneMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ZoneMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -1375,7 +1375,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("backup_collection", &self.backup_collection);
         debug_struct.field("automated_backup_config", &self.automated_backup_config);
         debug_struct.field("import_sources", &self.import_sources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1578,7 +1577,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StateInfo");
             debug_struct.field("info", &self.info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1922,7 +1920,6 @@ pub mod instance {
                 debug_struct.field("target_replica_count", &self.target_replica_count);
                 debug_struct.field("target_engine_version", &self.target_engine_version);
                 debug_struct.field("target_node_type", &self.target_node_type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2079,7 +2076,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GcsBackupSource");
             debug_struct.field("uris", &self.uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2229,7 +2225,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ManagedBackupSource");
             debug_struct.field("backup", &self.backup);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2384,7 +2379,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InstanceEndpoint");
             debug_struct.field("connections", &self.connections);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2636,7 +2630,6 @@ pub mod instance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConnectionDetail");
             debug_struct.field("connection", &self.connection);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3640,7 +3633,6 @@ impl std::fmt::Debug for AutomatedBackupConfig {
         debug_struct.field("automated_backup_mode", &self.automated_backup_mode);
         debug_struct.field("retention", &self.retention);
         debug_struct.field("schedule", &self.schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3804,7 +3796,6 @@ pub mod automated_backup_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FixedFrequencySchedule");
             debug_struct.field("start_time", &self.start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4231,7 +4222,6 @@ impl std::fmt::Debug for BackupCollection {
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4794,7 +4784,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("backup_type", &self.backup_type);
         debug_struct.field("state", &self.state);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5303,7 +5292,6 @@ impl std::fmt::Debug for BackupFile {
         debug_struct.field("file_name", &self.file_name);
         debug_struct.field("size_bytes", &self.size_bytes);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5613,7 +5601,6 @@ impl std::fmt::Debug for CrossInstanceReplicationConfig {
         debug_struct.field("secondary_instances", &self.secondary_instances);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("membership", &self.membership);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5790,7 +5777,6 @@ pub mod cross_instance_replication_config {
             let mut debug_struct = f.debug_struct("RemoteInstance");
             debug_struct.field("instance", &self.instance);
             debug_struct.field("uid", &self.uid);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5983,7 +5969,6 @@ pub mod cross_instance_replication_config {
             let mut debug_struct = f.debug_struct("Membership");
             debug_struct.field("primary_instance", &self.primary_instance);
             debug_struct.field("secondary_instances", &self.secondary_instances);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6358,7 +6343,6 @@ impl std::fmt::Debug for MaintenancePolicy {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("weekly_maintenance_window", &self.weekly_maintenance_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6537,7 +6521,6 @@ impl std::fmt::Debug for WeeklyMaintenanceWindow {
         let mut debug_struct = f.debug_struct("WeeklyMaintenanceWindow");
         debug_struct.field("day", &self.day);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6730,7 +6713,6 @@ impl std::fmt::Debug for MaintenanceSchedule {
         let mut debug_struct = f.debug_struct("MaintenanceSchedule");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6907,7 +6889,6 @@ impl std::fmt::Debug for PscAttachmentDetail {
         let mut debug_struct = f.debug_struct("PscAttachmentDetail");
         debug_struct.field("service_attachment", &self.service_attachment);
         debug_struct.field("connection_type", &self.connection_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7334,7 +7315,6 @@ impl std::fmt::Debug for PscAutoConnection {
         debug_struct.field("psc_connection_status", &self.psc_connection_status);
         debug_struct.field("connection_type", &self.connection_type);
         debug_struct.field("ports", &self.ports);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7774,7 +7754,6 @@ impl std::fmt::Debug for PscConnection {
         debug_struct.field("psc_connection_status", &self.psc_connection_status);
         debug_struct.field("connection_type", &self.connection_type);
         debug_struct.field("ports", &self.ports);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8000,7 +7979,6 @@ impl std::fmt::Debug for DiscoveryEndpoint {
         debug_struct.field("address", &self.address);
         debug_struct.field("port", &self.port);
         debug_struct.field("network", &self.network);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8225,7 +8203,6 @@ impl std::fmt::Debug for PersistenceConfig {
         debug_struct.field("mode", &self.mode);
         debug_struct.field("rdb_config", &self.rdb_config);
         debug_struct.field("aof_config", &self.aof_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8420,7 +8397,6 @@ pub mod persistence_config {
             let mut debug_struct = f.debug_struct("RDBConfig");
             debug_struct.field("rdb_snapshot_period", &self.rdb_snapshot_period);
             debug_struct.field("rdb_snapshot_start_time", &self.rdb_snapshot_start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8728,7 +8704,6 @@ pub mod persistence_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AOFConfig");
             debug_struct.field("append_fsync", &self.append_fsync);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9180,7 +9155,6 @@ impl std::fmt::Debug for NodeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodeConfig");
         debug_struct.field("size_gb", &self.size_gb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9355,7 +9329,6 @@ impl std::fmt::Debug for ZoneDistributionConfig {
         let mut debug_struct = f.debug_struct("ZoneDistributionConfig");
         debug_struct.field("zone", &self.zone);
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9711,7 +9684,6 @@ impl std::fmt::Debug for RescheduleMaintenanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("reschedule_type", &self.reschedule_type);
         debug_struct.field("schedule_time", &self.schedule_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10115,7 +10087,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10331,7 +10302,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10474,7 +10444,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10726,7 +10695,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10955,7 +10923,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11136,7 +11103,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11360,7 +11326,6 @@ impl std::fmt::Debug for ListBackupCollectionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11588,7 +11553,6 @@ impl std::fmt::Debug for ListBackupCollectionsResponse {
         debug_struct.field("backup_collections", &self.backup_collections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11732,7 +11696,6 @@ impl std::fmt::Debug for GetBackupCollectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupCollectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11954,7 +11917,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12168,7 +12130,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12311,7 +12272,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12480,7 +12440,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12690,7 +12649,6 @@ impl std::fmt::Debug for ExportBackupRequest {
         let mut debug_struct = f.debug_struct("ExportBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12922,7 +12880,6 @@ impl std::fmt::Debug for BackupInstanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("ttl", &self.ttl);
         debug_struct.field("backup_id", &self.backup_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13066,7 +13023,6 @@ impl std::fmt::Debug for GetCertificateAuthorityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateAuthorityRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13287,7 +13243,6 @@ impl std::fmt::Debug for CertificateAuthority {
         let mut debug_struct = f.debug_struct("CertificateAuthority");
         debug_struct.field("name", &self.name);
         debug_struct.field("server_ca", &self.server_ca);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13445,7 +13400,6 @@ pub mod certificate_authority {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ManagedCertificateAuthority");
             debug_struct.field("ca_certs", &self.ca_certs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13603,7 +13557,6 @@ pub mod certificate_authority {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CertChain");
                 debug_struct.field("certificates", &self.certificates);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -13940,7 +13893,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -885,7 +885,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("telemetry_config", &self.telemetry_config);
         debug_struct.field("scaling_config", &self.scaling_config);
         debug_struct.field("metastore_config", &self.metastore_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1676,7 +1675,6 @@ impl std::fmt::Debug for MaintenanceWindow {
         let mut debug_struct = f.debug_struct("MaintenanceWindow");
         debug_struct.field("hour_of_day", &self.hour_of_day);
         debug_struct.field("day_of_week", &self.day_of_week);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1981,7 +1979,6 @@ impl std::fmt::Debug for HiveMetastoreConfig {
         debug_struct.field("kerberos_config", &self.kerberos_config);
         debug_struct.field("endpoint_protocol", &self.endpoint_protocol);
         debug_struct.field("auxiliary_versions", &self.auxiliary_versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2331,7 +2328,6 @@ impl std::fmt::Debug for KerberosConfig {
         debug_struct.field("keytab", &self.keytab);
         debug_struct.field("principal", &self.principal);
         debug_struct.field("krb5_config_gcs_uri", &self.krb5_config_gcs_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2508,7 +2504,6 @@ impl std::fmt::Debug for Secret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Secret");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2670,7 +2665,6 @@ impl std::fmt::Debug for EncryptionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptionConfig");
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2892,7 +2886,6 @@ impl std::fmt::Debug for AuxiliaryVersionConfig {
         debug_struct.field("version", &self.version);
         debug_struct.field("config_overrides", &self.config_overrides);
         debug_struct.field("network_config", &self.network_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3044,7 +3037,6 @@ impl std::fmt::Debug for NetworkConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkConfig");
         debug_struct.field("consumers", &self.consumers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3299,7 +3291,6 @@ pub mod network_config {
             debug_struct.field("endpoint_uri", &self.endpoint_uri);
             debug_struct.field("endpoint_location", &self.endpoint_location);
             debug_struct.field("vpc_resource", &self.vpc_resource);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3464,7 +3455,6 @@ impl std::fmt::Debug for TelemetryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TelemetryConfig");
         debug_struct.field("log_format", &self.log_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3779,7 +3769,6 @@ impl std::fmt::Debug for MetadataManagementActivity {
         let mut debug_struct = f.debug_struct("MetadataManagementActivity");
         debug_struct.field("metadata_exports", &self.metadata_exports);
         debug_struct.field("restores", &self.restores);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4163,7 +4152,6 @@ impl std::fmt::Debug for MetadataImport {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("state", &self.state);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4409,7 +4397,6 @@ pub mod metadata_import {
             debug_struct.field("gcs_uri", &self.gcs_uri);
             debug_struct.field("source_database", &self.source_database);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5012,7 +4999,6 @@ impl std::fmt::Debug for MetadataExport {
         debug_struct.field("state", &self.state);
         debug_struct.field("database_dump_type", &self.database_dump_type);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5508,7 +5494,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("service_revision", &self.service_revision);
         debug_struct.field("description", &self.description);
         debug_struct.field("restoring_services", &self.restoring_services);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5963,7 +5948,6 @@ impl std::fmt::Debug for Restore {
         debug_struct.field("backup", &self.backup);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6507,7 +6491,6 @@ impl std::fmt::Debug for ScalingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScalingConfig");
         debug_struct.field("scaling_model", &self.scaling_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6963,7 +6946,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7180,7 +7162,6 @@ impl std::fmt::Debug for ListServicesResponse {
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7328,7 +7309,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7582,7 +7562,6 @@ impl std::fmt::Debug for CreateServiceRequest {
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("service", &self.service);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7819,7 +7798,6 @@ impl std::fmt::Debug for UpdateServiceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service", &self.service);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8004,7 +7982,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
         let mut debug_struct = f.debug_struct("DeleteServiceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8287,7 +8264,6 @@ impl std::fmt::Debug for ListMetadataImportsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8509,7 +8485,6 @@ impl std::fmt::Debug for ListMetadataImportsResponse {
         debug_struct.field("metadata_imports", &self.metadata_imports);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8657,7 +8632,6 @@ impl std::fmt::Debug for GetMetadataImportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMetadataImportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8916,7 +8890,6 @@ impl std::fmt::Debug for CreateMetadataImportRequest {
         debug_struct.field("metadata_import_id", &self.metadata_import_id);
         debug_struct.field("metadata_import", &self.metadata_import);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9155,7 +9128,6 @@ impl std::fmt::Debug for UpdateMetadataImportRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("metadata_import", &self.metadata_import);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9438,7 +9410,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9655,7 +9626,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9803,7 +9773,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10056,7 +10025,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("backup_id", &self.backup_id);
         debug_struct.field("backup", &self.backup);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10241,7 +10209,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10523,7 +10490,6 @@ impl std::fmt::Debug for ExportMetadataRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("database_dump_type", &self.database_dump_type);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10776,7 +10742,6 @@ impl std::fmt::Debug for RestoreServiceRequest {
         debug_struct.field("backup", &self.backup);
         debug_struct.field("restore_type", &self.restore_type);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11101,7 +11066,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11266,7 +11230,6 @@ impl std::fmt::Debug for LocationMetadata {
             "supported_hive_metastore_versions",
             &self.supported_hive_metastore_versions,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11443,7 +11406,6 @@ pub mod location_metadata {
             let mut debug_struct = f.debug_struct("HiveMetastoreVersion");
             debug_struct.field("version", &self.version);
             debug_struct.field("is_default", &self.is_default);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11558,7 +11520,6 @@ impl serde::ser::Serialize for DatabaseDumpSpec {
 impl std::fmt::Debug for DatabaseDumpSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseDumpSpec");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11870,7 +11831,6 @@ impl std::fmt::Debug for QueryMetadataRequest {
         let mut debug_struct = f.debug_struct("QueryMetadataRequest");
         debug_struct.field("service", &self.service);
         debug_struct.field("query", &self.query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12022,7 +11982,6 @@ impl std::fmt::Debug for QueryMetadataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryMetadataResponse");
         debug_struct.field("result_manifest_uri", &self.result_manifest_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12181,7 +12140,6 @@ impl std::fmt::Debug for ErrorDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ErrorDetails");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12410,7 +12368,6 @@ impl std::fmt::Debug for MoveTableToDatabaseRequest {
         debug_struct.field("table_name", &self.table_name);
         debug_struct.field("db_name", &self.db_name);
         debug_struct.field("destination_db_name", &self.destination_db_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12527,7 +12484,6 @@ impl serde::ser::Serialize for MoveTableToDatabaseResponse {
 impl std::fmt::Debug for MoveTableToDatabaseResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MoveTableToDatabaseResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12733,7 +12689,6 @@ impl std::fmt::Debug for AlterMetadataResourceLocationRequest {
         debug_struct.field("service", &self.service);
         debug_struct.field("resource_name", &self.resource_name);
         debug_struct.field("location_uri", &self.location_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12851,7 +12806,6 @@ impl serde::ser::Serialize for AlterMetadataResourceLocationResponse {
 impl std::fmt::Debug for AlterMetadataResourceLocationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AlterMetadataResourceLocationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13307,7 +13261,6 @@ impl std::fmt::Debug for Federation {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_message", &self.state_message);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13650,7 +13603,6 @@ impl std::fmt::Debug for BackendMetastore {
         let mut debug_struct = f.debug_struct("BackendMetastore");
         debug_struct.field("name", &self.name);
         debug_struct.field("metastore_type", &self.metastore_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14065,7 +14017,6 @@ impl std::fmt::Debug for ListFederationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14279,7 +14230,6 @@ impl std::fmt::Debug for ListFederationsResponse {
         debug_struct.field("federations", &self.federations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14424,7 +14374,6 @@ impl std::fmt::Debug for GetFederationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFederationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14675,7 +14624,6 @@ impl std::fmt::Debug for CreateFederationRequest {
         debug_struct.field("federation_id", &self.federation_id);
         debug_struct.field("federation", &self.federation);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14909,7 +14857,6 @@ impl std::fmt::Debug for UpdateFederationRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("federation", &self.federation);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15091,7 +15038,6 @@ impl std::fmt::Debug for DeleteFederationRequest {
         let mut debug_struct = f.debug_struct("DeleteFederationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -520,7 +520,6 @@ impl std::fmt::Debug for Asset {
         debug_struct.field("sources", &self.sources);
         debug_struct.field("assigned_groups", &self.assigned_groups);
         debug_struct.field("asset_details", &self.asset_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -850,7 +849,6 @@ impl std::fmt::Debug for PreferenceSet {
             "virtual_machine_preferences",
             &self.virtual_machine_preferences,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1345,7 +1343,6 @@ impl std::fmt::Debug for ImportJob {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("asset_source", &self.asset_source);
         debug_struct.field("report", &self.report);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1864,7 +1861,6 @@ impl std::fmt::Debug for ImportDataFile {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("state", &self.state);
         debug_struct.field("file_info", &self.file_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2315,7 +2311,6 @@ impl std::fmt::Debug for Group {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2563,7 +2558,6 @@ impl std::fmt::Debug for ErrorFrame {
         debug_struct.field("violations", &self.violations);
         debug_struct.field("original_frame", &self.original_frame);
         debug_struct.field("ingestion_time", &self.ingestion_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3042,7 +3036,6 @@ impl std::fmt::Debug for Source {
         debug_struct.field("pending_frame_count", &self.pending_frame_count);
         debug_struct.field("error_frame_count", &self.error_frame_count);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3647,7 +3640,6 @@ impl std::fmt::Debug for ReportConfig {
             "group_preferenceset_assignments",
             &self.group_preferenceset_assignments,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3826,7 +3818,6 @@ pub mod report_config {
             let mut debug_struct = f.debug_struct("GroupPreferenceSetAssignment");
             debug_struct.field("group", &self.group);
             debug_struct.field("preference_set", &self.preference_set);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4180,7 +4171,6 @@ impl std::fmt::Debug for Report {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("state", &self.state);
         debug_struct.field("summary", &self.summary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4775,7 +4765,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5064,7 +5053,6 @@ impl std::fmt::Debug for ListAssetsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5277,7 +5265,6 @@ impl std::fmt::Debug for ListAssetsResponse {
         debug_struct.field("assets", &self.assets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5444,7 +5431,6 @@ impl std::fmt::Debug for GetAssetRequest {
         let mut debug_struct = f.debug_struct("GetAssetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5677,7 +5663,6 @@ impl std::fmt::Debug for UpdateAssetRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("asset", &self.asset);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5852,7 +5837,6 @@ impl std::fmt::Debug for BatchUpdateAssetsRequest {
         let mut debug_struct = f.debug_struct("BatchUpdateAssetsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("requests", &self.requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5998,7 +5982,6 @@ impl std::fmt::Debug for BatchUpdateAssetsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchUpdateAssetsResponse");
         debug_struct.field("assets", &self.assets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6178,7 +6161,6 @@ impl std::fmt::Debug for DeleteAssetRequest {
         let mut debug_struct = f.debug_struct("DeleteAssetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6378,7 +6360,6 @@ impl std::fmt::Debug for BatchDeleteAssetsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("names", &self.names);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6581,7 +6562,6 @@ impl std::fmt::Debug for ReportAssetFramesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("frames", &self.frames);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6695,7 +6675,6 @@ impl serde::ser::Serialize for ReportAssetFramesResponse {
 impl std::fmt::Debug for ReportAssetFramesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReportAssetFramesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6891,7 +6870,6 @@ impl std::fmt::Debug for AggregateAssetsValuesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("aggregations", &self.aggregations);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7040,7 +7018,6 @@ impl std::fmt::Debug for AggregateAssetsValuesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AggregateAssetsValuesResponse");
         debug_struct.field("results", &self.results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7283,7 +7260,6 @@ impl std::fmt::Debug for CreateImportJobRequest {
         debug_struct.field("import_job_id", &self.import_job_id);
         debug_struct.field("import_job", &self.import_job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7573,7 +7549,6 @@ impl std::fmt::Debug for ListImportJobsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7787,7 +7762,6 @@ impl std::fmt::Debug for ListImportJobsResponse {
         debug_struct.field("import_jobs", &self.import_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7955,7 +7929,6 @@ impl std::fmt::Debug for GetImportJobRequest {
         let mut debug_struct = f.debug_struct("GetImportJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8162,7 +8135,6 @@ impl std::fmt::Debug for DeleteImportJobRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8396,7 +8368,6 @@ impl std::fmt::Debug for UpdateImportJobRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("import_job", &self.import_job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8576,7 +8547,6 @@ impl std::fmt::Debug for ValidateImportJobRequest {
         let mut debug_struct = f.debug_struct("ValidateImportJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8756,7 +8726,6 @@ impl std::fmt::Debug for RunImportJobRequest {
         let mut debug_struct = f.debug_struct("RunImportJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8898,7 +8867,6 @@ impl std::fmt::Debug for GetImportDataFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetImportDataFileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9168,7 +9136,6 @@ impl std::fmt::Debug for ListImportDataFilesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9387,7 +9354,6 @@ impl std::fmt::Debug for ListImportDataFilesResponse {
         debug_struct.field("import_data_files", &self.import_data_files);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9634,7 +9600,6 @@ impl std::fmt::Debug for CreateImportDataFileRequest {
         debug_struct.field("import_data_file_id", &self.import_data_file_id);
         debug_struct.field("import_data_file", &self.import_data_file);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9814,7 +9779,6 @@ impl std::fmt::Debug for DeleteImportDataFileRequest {
         let mut debug_struct = f.debug_struct("DeleteImportDataFileRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10078,7 +10042,6 @@ impl std::fmt::Debug for ListGroupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10291,7 +10254,6 @@ impl std::fmt::Debug for ListGroupsResponse {
         debug_struct.field("groups", &self.groups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10433,7 +10395,6 @@ impl std::fmt::Debug for GetGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10679,7 +10640,6 @@ impl std::fmt::Debug for CreateGroupRequest {
         debug_struct.field("group_id", &self.group_id);
         debug_struct.field("group", &self.group);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10911,7 +10871,6 @@ impl std::fmt::Debug for UpdateGroupRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("group", &self.group);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11091,7 +11050,6 @@ impl std::fmt::Debug for DeleteGroupRequest {
         let mut debug_struct = f.debug_struct("DeleteGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11340,7 +11298,6 @@ impl std::fmt::Debug for AddAssetsToGroupRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("assets", &self.assets);
         debug_struct.field("allow_existing", &self.allow_existing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11588,7 +11545,6 @@ impl std::fmt::Debug for RemoveAssetsFromGroupRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("assets", &self.assets);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11827,7 +11783,6 @@ impl std::fmt::Debug for ListErrorFramesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12041,7 +11996,6 @@ impl std::fmt::Debug for ListErrorFramesResponse {
         debug_struct.field("error_frames", &self.error_frames);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12210,7 +12164,6 @@ impl std::fmt::Debug for GetErrorFrameRequest {
         let mut debug_struct = f.debug_struct("GetErrorFrameRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12474,7 +12427,6 @@ impl std::fmt::Debug for ListSourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12687,7 +12639,6 @@ impl std::fmt::Debug for ListSourcesResponse {
         debug_struct.field("sources", &self.sources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12829,7 +12780,6 @@ impl std::fmt::Debug for GetSourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13075,7 +13025,6 @@ impl std::fmt::Debug for CreateSourceRequest {
         debug_struct.field("source_id", &self.source_id);
         debug_struct.field("source", &self.source);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13308,7 +13257,6 @@ impl std::fmt::Debug for UpdateSourceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("source", &self.source);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13488,7 +13436,6 @@ impl std::fmt::Debug for DeleteSourceRequest {
         let mut debug_struct = f.debug_struct("DeleteSourceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13728,7 +13675,6 @@ impl std::fmt::Debug for ListPreferenceSetsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13942,7 +13888,6 @@ impl std::fmt::Debug for ListPreferenceSetsResponse {
         debug_struct.field("preference_sets", &self.preference_sets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14084,7 +14029,6 @@ impl std::fmt::Debug for GetPreferenceSetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPreferenceSetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14335,7 +14279,6 @@ impl std::fmt::Debug for CreatePreferenceSetRequest {
         debug_struct.field("preference_set_id", &self.preference_set_id);
         debug_struct.field("preference_set", &self.preference_set);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14569,7 +14512,6 @@ impl std::fmt::Debug for UpdatePreferenceSetRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("preference_set", &self.preference_set);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14749,7 +14691,6 @@ impl std::fmt::Debug for DeletePreferenceSetRequest {
         let mut debug_struct = f.debug_struct("DeletePreferenceSetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14891,7 +14832,6 @@ impl std::fmt::Debug for GetSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15124,7 +15064,6 @@ impl std::fmt::Debug for UpdateSettingsRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("settings", &self.settings);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15374,7 +15313,6 @@ impl std::fmt::Debug for CreateReportConfigRequest {
         debug_struct.field("report_config_id", &self.report_config_id);
         debug_struct.field("report_config", &self.report_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15581,7 +15519,6 @@ impl std::fmt::Debug for DeleteReportConfigRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15748,7 +15685,6 @@ impl std::fmt::Debug for GetReportRequest {
         let mut debug_struct = f.debug_struct("GetReportRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16037,7 +15973,6 @@ impl std::fmt::Debug for ListReportsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16250,7 +16185,6 @@ impl std::fmt::Debug for ListReportsResponse {
         debug_struct.field("reports", &self.reports);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16430,7 +16364,6 @@ impl std::fmt::Debug for DeleteReportRequest {
         let mut debug_struct = f.debug_struct("DeleteReportRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16572,7 +16505,6 @@ impl std::fmt::Debug for GetReportConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReportConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16836,7 +16768,6 @@ impl std::fmt::Debug for ListReportConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17050,7 +16981,6 @@ impl std::fmt::Debug for ListReportConfigsResponse {
         debug_struct.field("report_configs", &self.report_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17296,7 +17226,6 @@ impl std::fmt::Debug for CreateReportRequest {
         debug_struct.field("report_id", &self.report_id);
         debug_struct.field("report", &self.report);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17442,7 +17371,6 @@ impl std::fmt::Debug for Frames {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Frames");
         debug_struct.field("frames_data", &self.frames_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17804,7 +17732,6 @@ impl std::fmt::Debug for AssetFrame {
         debug_struct.field("performance_samples", &self.performance_samples);
         debug_struct.field("trace_token", &self.trace_token);
         debug_struct.field("frame_data", &self.frame_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18322,7 +18249,6 @@ impl std::fmt::Debug for MachineDetails {
         debug_struct.field("network", &self.network);
         debug_struct.field("disks", &self.disks);
         debug_struct.field("platform", &self.platform);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18878,7 +18804,6 @@ impl std::fmt::Debug for MachineArchitectureDetails {
         debug_struct.field("bios", &self.bios);
         debug_struct.field("firmware_type", &self.firmware_type);
         debug_struct.field("hyperthreading", &self.hyperthreading);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19432,7 +19357,6 @@ impl std::fmt::Debug for BiosDetails {
         debug_struct.field("version", &self.version);
         debug_struct.field("release_date", &self.release_date);
         debug_struct.field("smbios_uuid", &self.smbios_uuid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19673,7 +19597,6 @@ impl std::fmt::Debug for MachineNetworkDetails {
         debug_struct.field("public_ip_address", &self.public_ip_address);
         debug_struct.field("primary_mac_address", &self.primary_mac_address);
         debug_struct.field("adapters", &self.adapters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19822,7 +19745,6 @@ impl std::fmt::Debug for NetworkAdapterList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkAdapterList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20027,7 +19949,6 @@ impl std::fmt::Debug for NetworkAdapterDetails {
         debug_struct.field("adapter_type", &self.adapter_type);
         debug_struct.field("mac_address", &self.mac_address);
         debug_struct.field("addresses", &self.addresses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20176,7 +20097,6 @@ impl std::fmt::Debug for NetworkAddressList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkAddressList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20427,7 +20347,6 @@ impl std::fmt::Debug for NetworkAddress {
         debug_struct.field("bcast", &self.bcast);
         debug_struct.field("fqdn", &self.fqdn);
         debug_struct.field("assignment", &self.assignment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20808,7 +20727,6 @@ impl std::fmt::Debug for MachineDiskDetails {
         debug_struct.field("total_capacity_bytes", &self.total_capacity_bytes);
         debug_struct.field("total_free_bytes", &self.total_free_bytes);
         debug_struct.field("disks", &self.disks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20953,7 +20871,6 @@ impl std::fmt::Debug for DiskEntryList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiskEntryList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21369,7 +21286,6 @@ impl std::fmt::Debug for DiskEntry {
         debug_struct.field("partitions", &self.partitions);
         debug_struct.field("hw_address", &self.hw_address);
         debug_struct.field("platform_specific", &self.platform_specific);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21695,7 +21611,6 @@ impl std::fmt::Debug for DiskPartitionList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiskPartitionList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22041,7 +21956,6 @@ impl std::fmt::Debug for DiskPartition {
         debug_struct.field("free_bytes", &self.free_bytes);
         debug_struct.field("uuid", &self.uuid);
         debug_struct.field("sub_partitions", &self.sub_partitions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22276,7 +22190,6 @@ impl std::fmt::Debug for VmwareDiskConfig {
         debug_struct.field("shared", &self.shared);
         debug_struct.field("vmdk_mode", &self.vmdk_mode);
         debug_struct.field("rdm_compatibility", &self.rdm_compatibility);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22995,7 +22908,6 @@ impl std::fmt::Debug for GuestOsDetails {
         debug_struct.field("version", &self.version);
         debug_struct.field("config", &self.config);
         debug_struct.field("runtime", &self.runtime);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23281,7 +23193,6 @@ impl std::fmt::Debug for GuestConfigDetails {
         debug_struct.field("hosts", &self.hosts);
         debug_struct.field("nfs_exports", &self.nfs_exports);
         debug_struct.field("selinux_mode", &self.selinux_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23571,7 +23482,6 @@ impl std::fmt::Debug for FstabEntryList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FstabEntryList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23875,7 +23785,6 @@ impl std::fmt::Debug for FstabEntry {
         debug_struct.field("mntops", &self.mntops);
         debug_struct.field("freq", &self.freq);
         debug_struct.field("passno", &self.passno);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24020,7 +23929,6 @@ impl std::fmt::Debug for HostsEntryList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HostsEntryList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24191,7 +24099,6 @@ impl std::fmt::Debug for HostsEntry {
         let mut debug_struct = f.debug_struct("HostsEntry");
         debug_struct.field("ip", &self.ip);
         debug_struct.field("host_names", &self.host_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24336,7 +24243,6 @@ impl std::fmt::Debug for NfsExportList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NfsExportList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24510,7 +24416,6 @@ impl std::fmt::Debug for NfsExport {
         let mut debug_struct = f.debug_struct("NfsExport");
         debug_struct.field("export_directory", &self.export_directory);
         debug_struct.field("hosts", &self.hosts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24899,7 +24804,6 @@ impl std::fmt::Debug for GuestRuntimeDetails {
         debug_struct.field("machine_name", &self.machine_name);
         debug_struct.field("installed_apps", &self.installed_apps);
         debug_struct.field("open_file_list", &self.open_file_list);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25048,7 +24952,6 @@ impl std::fmt::Debug for RunningServiceList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunningServiceList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25338,7 +25241,6 @@ impl std::fmt::Debug for RunningService {
         debug_struct.field("exe_path", &self.exe_path);
         debug_struct.field("cmdline", &self.cmdline);
         debug_struct.field("pid", &self.pid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25785,7 +25687,6 @@ impl std::fmt::Debug for RunningProcessList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunningProcessList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26057,7 +25958,6 @@ impl std::fmt::Debug for RunningProcess {
         debug_struct.field("cmdline", &self.cmdline);
         debug_struct.field("user", &self.user);
         debug_struct.field("attributes", &self.attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26247,7 +26147,6 @@ impl std::fmt::Debug for RuntimeNetworkInfo {
         let mut debug_struct = f.debug_struct("RuntimeNetworkInfo");
         debug_struct.field("scan_time", &self.scan_time);
         debug_struct.field("connections", &self.connections);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26396,7 +26295,6 @@ impl std::fmt::Debug for NetworkConnectionList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkConnectionList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26778,7 +26676,6 @@ impl std::fmt::Debug for NetworkConnection {
         debug_struct.field("state", &self.state);
         debug_struct.field("pid", &self.pid);
         debug_struct.field("process_name", &self.process_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27086,7 +26983,6 @@ impl std::fmt::Debug for GuestInstalledApplicationList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GuestInstalledApplicationList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27344,7 +27240,6 @@ impl std::fmt::Debug for GuestInstalledApplication {
         debug_struct.field("install_time", &self.install_time);
         debug_struct.field("path", &self.path);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27493,7 +27388,6 @@ impl std::fmt::Debug for OpenFileList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OpenFileList");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27712,7 +27606,6 @@ impl std::fmt::Debug for OpenFileDetails {
         debug_struct.field("user", &self.user);
         debug_struct.field("file_type", &self.file_type);
         debug_struct.field("file_path", &self.file_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28136,7 +28029,6 @@ impl std::fmt::Debug for PlatformDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PlatformDetails");
         debug_struct.field("vendor_details", &self.vendor_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28430,7 +28322,6 @@ impl std::fmt::Debug for VmwarePlatformDetails {
         debug_struct.field("vcenter_folder", &self.vcenter_folder);
         debug_struct.field("vcenter_uri", &self.vcenter_uri);
         debug_struct.field("vcenter_vm_id", &self.vcenter_vm_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28601,7 +28492,6 @@ impl std::fmt::Debug for AwsEc2PlatformDetails {
         let mut debug_struct = f.debug_struct("AwsEc2PlatformDetails");
         debug_struct.field("machine_type_label", &self.machine_type_label);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28801,7 +28691,6 @@ impl std::fmt::Debug for AzureVmPlatformDetails {
         debug_struct.field("machine_type_label", &self.machine_type_label);
         debug_struct.field("location", &self.location);
         debug_struct.field("provisioning_state", &self.provisioning_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28945,7 +28834,6 @@ impl std::fmt::Debug for GenericPlatformDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenericPlatformDetails");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29089,7 +28977,6 @@ impl std::fmt::Debug for PhysicalPlatformDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PhysicalPlatformDetails");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29251,7 +29138,6 @@ impl std::fmt::Debug for MemoryUsageSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MemoryUsageSample");
         debug_struct.field("utilized_percentage", &self.utilized_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29414,7 +29300,6 @@ impl std::fmt::Debug for CpuUsageSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CpuUsageSample");
         debug_struct.field("utilized_percentage", &self.utilized_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29623,7 +29508,6 @@ impl std::fmt::Debug for NetworkUsageSample {
         let mut debug_struct = f.debug_struct("NetworkUsageSample");
         debug_struct.field("average_ingress_bps", &self.average_ingress_bps);
         debug_struct.field("average_egress_bps", &self.average_egress_bps);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29784,7 +29668,6 @@ impl std::fmt::Debug for DiskUsageSample {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiskUsageSample");
         debug_struct.field("average_iops", &self.average_iops);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30086,7 +29969,6 @@ impl std::fmt::Debug for PerformanceSample {
         debug_struct.field("cpu", &self.cpu);
         debug_struct.field("network", &self.network);
         debug_struct.field("disk", &self.disk);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30249,7 +30131,6 @@ impl std::fmt::Debug for AssetPerformanceData {
             "daily_resource_usage_aggregations",
             &self.daily_resource_usage_aggregations,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30550,7 +30431,6 @@ impl std::fmt::Debug for DailyResourceUsageAggregation {
         debug_struct.field("memory", &self.memory);
         debug_struct.field("network", &self.network);
         debug_struct.field("disk", &self.disk);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30856,7 +30736,6 @@ pub mod daily_resource_usage_aggregation {
             debug_struct.field("median", &self.median);
             debug_struct.field("nintey_fifth_percentile", &self.nintey_fifth_percentile);
             debug_struct.field("peak", &self.peak);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31018,7 +30897,6 @@ pub mod daily_resource_usage_aggregation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Cpu");
             debug_struct.field("utilization_percentage", &self.utilization_percentage);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31180,7 +31058,6 @@ pub mod daily_resource_usage_aggregation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Memory");
             debug_struct.field("utilization_percentage", &self.utilization_percentage);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31376,7 +31253,6 @@ pub mod daily_resource_usage_aggregation {
             let mut debug_struct = f.debug_struct("Network");
             debug_struct.field("ingress_bps", &self.ingress_bps);
             debug_struct.field("egress_bps", &self.egress_bps);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31533,7 +31409,6 @@ pub mod daily_resource_usage_aggregation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Disk");
             debug_struct.field("iops", &self.iops);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31716,7 +31591,6 @@ impl std::fmt::Debug for InsightList {
         let mut debug_struct = f.debug_struct("InsightList");
         debug_struct.field("insights", &self.insights);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31960,7 +31834,6 @@ impl std::fmt::Debug for Insight {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Insight");
         debug_struct.field("insight", &self.insight);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32196,7 +32069,6 @@ impl std::fmt::Debug for GenericInsight {
         debug_struct.field("message_id", &self.message_id);
         debug_struct.field("default_message", &self.default_message);
         debug_struct.field("additional_information", &self.additional_information);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32423,7 +32295,6 @@ impl std::fmt::Debug for MigrationInsight {
         let mut debug_struct = f.debug_struct("MigrationInsight");
         debug_struct.field("fit", &self.fit);
         debug_struct.field("migration_target", &self.migration_target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32590,7 +32461,6 @@ impl std::fmt::Debug for ComputeEngineMigrationTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ComputeEngineMigrationTarget");
         debug_struct.field("shape", &self.shape);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32924,7 +32794,6 @@ impl std::fmt::Debug for ComputeEngineShapeDescriptor {
         debug_struct.field("series", &self.series);
         debug_struct.field("machine_type", &self.machine_type);
         debug_struct.field("storage", &self.storage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33111,7 +32980,6 @@ impl std::fmt::Debug for ComputeStorageDescriptor {
         let mut debug_struct = f.debug_struct("ComputeStorageDescriptor");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("size_gb", &self.size_gb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33255,7 +33123,6 @@ impl std::fmt::Debug for FitDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FitDescriptor");
         debug_struct.field("fit_level", &self.fit_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33778,7 +33645,6 @@ impl std::fmt::Debug for Aggregation {
         let mut debug_struct = f.debug_struct("Aggregation");
         debug_struct.field("field", &self.field);
         debug_struct.field("aggregation_function", &self.aggregation_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33900,7 +33766,6 @@ pub mod aggregation {
     impl std::fmt::Debug for Count {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Count");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34017,7 +33882,6 @@ pub mod aggregation {
     impl std::fmt::Debug for Sum {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Sum");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34202,7 +34066,6 @@ pub mod aggregation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Histogram");
             debug_struct.field("lower_bounds", &self.lower_bounds);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34319,7 +34182,6 @@ pub mod aggregation {
     impl std::fmt::Debug for Frequency {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Frequency");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34713,7 +34575,6 @@ impl std::fmt::Debug for AggregationResult {
         let mut debug_struct = f.debug_struct("AggregationResult");
         debug_struct.field("field", &self.field);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34880,7 +34741,6 @@ pub mod aggregation_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Count");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35042,7 +34902,6 @@ pub mod aggregation_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Sum");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35200,7 +35059,6 @@ pub mod aggregation_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Histogram");
             debug_struct.field("buckets", &self.buckets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35478,7 +35336,6 @@ pub mod aggregation_result {
                 debug_struct.field("lower_bound", &self.lower_bound);
                 debug_struct.field("upper_bound", &self.upper_bound);
                 debug_struct.field("count", &self.count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35663,7 +35520,6 @@ pub mod aggregation_result {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Frequency");
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35905,7 +35761,6 @@ impl std::fmt::Debug for FileValidationReport {
         debug_struct.field("row_errors", &self.row_errors);
         debug_struct.field("partial_report", &self.partial_report);
         debug_struct.field("file_errors", &self.file_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36084,7 +35939,6 @@ impl std::fmt::Debug for ValidationReport {
         let mut debug_struct = f.debug_struct("ValidationReport");
         debug_struct.field("file_validations", &self.file_validations);
         debug_struct.field("job_errors", &self.job_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36329,7 +36183,6 @@ impl std::fmt::Debug for ExecutionReport {
         debug_struct.field("frames_reported", &self.frames_reported);
         debug_struct.field("execution_errors", &self.execution_errors);
         debug_struct.field("total_rows_count", &self.total_rows_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36499,7 +36352,6 @@ impl std::fmt::Debug for ImportError {
         let mut debug_struct = f.debug_struct("ImportError");
         debug_struct.field("error_details", &self.error_details);
         debug_struct.field("severity", &self.severity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36883,7 +36735,6 @@ impl std::fmt::Debug for ImportRowError {
         debug_struct.field("vm_name", &self.vm_name);
         debug_struct.field("vm_uuid", &self.vm_uuid);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37099,7 +36950,6 @@ impl std::fmt::Debug for UploadFileInfo {
         debug_struct.field("signed_uri", &self.signed_uri);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("uri_expiration_time", &self.uri_expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37245,7 +37095,6 @@ impl std::fmt::Debug for AssetList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AssetList");
         debug_struct.field("asset_ids", &self.asset_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37413,7 +37262,6 @@ impl std::fmt::Debug for FrameViolationEntry {
         let mut debug_struct = f.debug_struct("FrameViolationEntry");
         debug_struct.field("field", &self.field);
         debug_struct.field("violation", &self.violation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37809,7 +37657,6 @@ impl std::fmt::Debug for VirtualMachinePreferences {
         );
         debug_struct.field("vmware_engine_preferences", &self.vmware_engine_preferences);
         debug_struct.field("sole_tenancy_preferences", &self.sole_tenancy_preferences);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37994,7 +37841,6 @@ impl std::fmt::Debug for ComputeEnginePreferences {
         let mut debug_struct = f.debug_struct("ComputeEnginePreferences");
         debug_struct.field("machine_preferences", &self.machine_preferences);
         debug_struct.field("license_type", &self.license_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38143,7 +37989,6 @@ impl std::fmt::Debug for MachinePreferences {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MachinePreferences");
         debug_struct.field("allowed_machine_series", &self.allowed_machine_series);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38287,7 +38132,6 @@ impl std::fmt::Debug for MachineSeries {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MachineSeries");
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38601,7 +38445,6 @@ impl std::fmt::Debug for VmwareEnginePreferences {
             &self.storage_deduplication_compression_ratio,
         );
         debug_struct.field("commitment_plan", &self.commitment_plan);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39034,7 +38877,6 @@ impl std::fmt::Debug for SoleTenancyPreferences {
         debug_struct.field("host_maintenance_policy", &self.host_maintenance_policy);
         debug_struct.field("commitment_plan", &self.commitment_plan);
         debug_struct.field("node_types", &self.node_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39468,7 +39310,6 @@ impl std::fmt::Debug for SoleTenantNodeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SoleTenantNodeType");
         debug_struct.field("node_name", &self.node_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39618,7 +39459,6 @@ impl std::fmt::Debug for RegionPreferences {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RegionPreferences");
         debug_struct.field("preferred_regions", &self.preferred_regions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39786,7 +39626,6 @@ impl std::fmt::Debug for Settings {
         let mut debug_struct = f.debug_struct("Settings");
         debug_struct.field("name", &self.name);
         debug_struct.field("preference_set", &self.preference_set);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39975,7 +39814,6 @@ impl std::fmt::Debug for ReportSummary {
         let mut debug_struct = f.debug_struct("ReportSummary");
         debug_struct.field("all_assets_stats", &self.all_assets_stats);
         debug_struct.field("group_findings", &self.group_findings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40137,7 +39975,6 @@ pub mod report_summary {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ChartData");
             debug_struct.field("data_points", &self.data_points);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40337,7 +40174,6 @@ pub mod report_summary {
                 let mut debug_struct = f.debug_struct("DataPoint");
                 debug_struct.field("label", &self.label);
                 debug_struct.field("value", &self.value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -40545,7 +40381,6 @@ pub mod report_summary {
             let mut debug_struct = f.debug_struct("UtilizationChartData");
             debug_struct.field("used", &self.used);
             debug_struct.field("free", &self.free);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40698,7 +40533,6 @@ pub mod report_summary {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("HistogramChartData");
             debug_struct.field("buckets", &self.buckets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40976,7 +40810,6 @@ pub mod report_summary {
                 debug_struct.field("lower_bound", &self.lower_bound);
                 debug_struct.field("upper_bound", &self.upper_bound);
                 debug_struct.field("count", &self.count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -41534,7 +41367,6 @@ pub mod report_summary {
             debug_struct.field("core_count_histogram", &self.core_count_histogram);
             debug_struct.field("memory_bytes_histogram", &self.memory_bytes_histogram);
             debug_struct.field("storage_bytes_histogram", &self.storage_bytes_histogram);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -41739,7 +41571,6 @@ pub mod report_summary {
             let mut debug_struct = f.debug_struct("MachineSeriesAllocation");
             debug_struct.field("machine_series", &self.machine_series);
             debug_struct.field("allocated_asset_count", &self.allocated_asset_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42013,7 +41844,6 @@ pub mod report_summary {
                 &self.machine_series_allocations,
             );
             debug_struct.field("allocated_disk_types", &self.allocated_disk_types);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42243,7 +42073,6 @@ pub mod report_summary {
             debug_struct.field("allocated_regions", &self.allocated_regions);
             debug_struct.field("allocated_asset_count", &self.allocated_asset_count);
             debug_struct.field("node_allocations", &self.node_allocations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42493,7 +42322,6 @@ pub mod report_summary {
             debug_struct.field("vmware_node", &self.vmware_node);
             debug_struct.field("node_count", &self.node_count);
             debug_struct.field("allocated_asset_count", &self.allocated_asset_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42640,7 +42468,6 @@ pub mod report_summary {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("VmwareNode");
             debug_struct.field("code", &self.code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42870,7 +42697,6 @@ pub mod report_summary {
             debug_struct.field("allocated_regions", &self.allocated_regions);
             debug_struct.field("allocated_asset_count", &self.allocated_asset_count);
             debug_struct.field("node_allocations", &self.node_allocations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43117,7 +42943,6 @@ pub mod report_summary {
             debug_struct.field("node", &self.node);
             debug_struct.field("node_count", &self.node_count);
             debug_struct.field("allocated_asset_count", &self.allocated_asset_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43689,7 +43514,6 @@ pub mod report_summary {
             debug_struct.field("compute_engine_finding", &self.compute_engine_finding);
             debug_struct.field("vmware_engine_finding", &self.vmware_engine_finding);
             debug_struct.field("sole_tenant_finding", &self.sole_tenant_finding);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43997,7 +43821,6 @@ pub mod report_summary {
             debug_struct.field("asset_aggregate_stats", &self.asset_aggregate_stats);
             debug_struct.field("overlapping_asset_count", &self.overlapping_asset_count);
             debug_struct.field("preference_set_findings", &self.preference_set_findings);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -349,7 +349,6 @@ impl std::fmt::Debug for Template {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("filter_config", &self.filter_config);
         debug_struct.field("template_metadata", &self.template_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -828,7 +827,6 @@ pub mod template {
             debug_struct.field("log_template_operations", &self.log_template_operations);
             debug_struct.field("log_sanitize_operations", &self.log_sanitize_operations);
             debug_struct.field("multi_language_detection", &self.multi_language_detection);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -998,7 +996,6 @@ pub mod template {
                     "enable_multi_language_detection",
                     &self.enable_multi_language_detection,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1303,7 +1300,6 @@ impl std::fmt::Debug for FloorSetting {
             "enable_floor_setting_enforcement",
             &self.enable_floor_setting_enforcement,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1567,7 +1563,6 @@ impl std::fmt::Debug for ListTemplatesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1780,7 +1775,6 @@ impl std::fmt::Debug for ListTemplatesResponse {
         debug_struct.field("templates", &self.templates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1922,7 +1916,6 @@ impl std::fmt::Debug for GetTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2166,7 +2159,6 @@ impl std::fmt::Debug for CreateTemplateRequest {
         debug_struct.field("template_id", &self.template_id);
         debug_struct.field("template", &self.template);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2398,7 +2390,6 @@ impl std::fmt::Debug for UpdateTemplateRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("template", &self.template);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2578,7 +2569,6 @@ impl std::fmt::Debug for DeleteTemplateRequest {
         let mut debug_struct = f.debug_struct("DeleteTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2721,7 +2711,6 @@ impl std::fmt::Debug for GetFloorSettingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFloorSettingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2916,7 +2905,6 @@ impl std::fmt::Debug for UpdateFloorSettingRequest {
         let mut debug_struct = f.debug_struct("UpdateFloorSettingRequest");
         debug_struct.field("floor_setting", &self.floor_setting);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3211,7 +3199,6 @@ impl std::fmt::Debug for FilterConfig {
             "malicious_uri_filter_settings",
             &self.malicious_uri_filter_settings,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3392,7 +3379,6 @@ impl std::fmt::Debug for PiAndJailbreakFilterSettings {
         let mut debug_struct = f.debug_struct("PiAndJailbreakFilterSettings");
         debug_struct.field("filter_enforcement", &self.filter_enforcement);
         debug_struct.field("confidence_level", &self.confidence_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3681,7 +3667,6 @@ impl std::fmt::Debug for MaliciousUriFilterSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaliciousUriFilterSettings");
         debug_struct.field("filter_enforcement", &self.filter_enforcement);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3970,7 +3955,6 @@ impl std::fmt::Debug for RaiFilterSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RaiFilterSettings");
         debug_struct.field("rai_filters", &self.rai_filters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4158,7 +4142,6 @@ pub mod rai_filter_settings {
             let mut debug_struct = f.debug_struct("RaiFilter");
             debug_struct.field("filter_type", &self.filter_type);
             debug_struct.field("confidence_level", &self.confidence_level);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4412,7 +4395,6 @@ impl std::fmt::Debug for SdpFilterSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SdpFilterSettings");
         debug_struct.field("sdp_configuration", &self.sdp_configuration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4585,7 +4567,6 @@ impl std::fmt::Debug for SdpBasicConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SdpBasicConfig");
         debug_struct.field("filter_enforcement", &self.filter_enforcement);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4921,7 +4902,6 @@ impl std::fmt::Debug for SdpAdvancedConfig {
         let mut debug_struct = f.debug_struct("SdpAdvancedConfig");
         debug_struct.field("inspect_template", &self.inspect_template);
         debug_struct.field("deidentify_template", &self.deidentify_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5154,7 +5134,6 @@ impl std::fmt::Debug for SanitizeUserPromptRequest {
             "multi_language_detection_metadata",
             &self.multi_language_detection_metadata,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5413,7 +5392,6 @@ impl std::fmt::Debug for SanitizeModelResponseRequest {
             "multi_language_detection_metadata",
             &self.multi_language_detection_metadata,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5567,7 +5545,6 @@ impl std::fmt::Debug for SanitizeUserPromptResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SanitizeUserPromptResponse");
         debug_struct.field("sanitization_result", &self.sanitization_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5721,7 +5698,6 @@ impl std::fmt::Debug for SanitizeModelResponseResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SanitizeModelResponseResponse");
         debug_struct.field("sanitization_result", &self.sanitization_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5986,7 +5962,6 @@ impl std::fmt::Debug for SanitizationResult {
         debug_struct.field("filter_results", &self.filter_results);
         debug_struct.field("invocation_result", &self.invocation_result);
         debug_struct.field("sanitization_metadata", &self.sanitization_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6226,7 +6201,6 @@ pub mod sanitization_result {
                 "ignore_partial_invocation_failures",
                 &self.ignore_partial_invocation_failures,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6412,7 +6386,6 @@ impl std::fmt::Debug for MultiLanguageDetectionMetadata {
             "enable_multi_language_detection",
             &self.enable_multi_language_detection,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6906,7 +6879,6 @@ impl std::fmt::Debug for FilterResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FilterResult");
         debug_struct.field("filter_result", &self.filter_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7182,7 +7154,6 @@ impl std::fmt::Debug for RaiFilterResult {
         debug_struct.field("message_items", &self.message_items);
         debug_struct.field("match_state", &self.match_state);
         debug_struct.field("rai_filter_type_results", &self.rai_filter_type_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7393,7 +7364,6 @@ pub mod rai_filter_result {
             debug_struct.field("filter_type", &self.filter_type);
             debug_struct.field("confidence_level", &self.confidence_level);
             debug_struct.field("match_state", &self.match_state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7645,7 +7615,6 @@ impl std::fmt::Debug for SdpFilterResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SdpFilterResult");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7929,7 +7898,6 @@ impl std::fmt::Debug for SdpInspectResult {
         debug_struct.field("match_state", &self.match_state);
         debug_struct.field("findings", &self.findings);
         debug_struct.field("findings_truncated", &self.findings_truncated);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8159,7 +8127,6 @@ impl std::fmt::Debug for DataItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataItem");
         debug_struct.field("data_item", &self.data_item);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8363,7 +8330,6 @@ impl std::fmt::Debug for ByteDataItem {
         let mut debug_struct = f.debug_struct("ByteDataItem");
         debug_struct.field("byte_data_type", &self.byte_data_type);
         debug_struct.field("byte_data", &self.byte_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8854,7 +8820,6 @@ impl std::fmt::Debug for SdpDeidentifyResult {
         debug_struct.field("data", &self.data);
         debug_struct.field("transformed_bytes", &self.transformed_bytes);
         debug_struct.field("info_types", &self.info_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9060,7 +9025,6 @@ impl std::fmt::Debug for SdpFinding {
         debug_struct.field("info_type", &self.info_type);
         debug_struct.field("likelihood", &self.likelihood);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9264,7 +9228,6 @@ pub mod sdp_finding {
             let mut debug_struct = f.debug_struct("SdpFindingLocation");
             debug_struct.field("byte_range", &self.byte_range);
             debug_struct.field("codepoint_range", &self.codepoint_range);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9499,7 +9462,6 @@ impl std::fmt::Debug for PiAndJailbreakFilterResult {
         debug_struct.field("message_items", &self.message_items);
         debug_struct.field("match_state", &self.match_state);
         debug_struct.field("confidence_level", &self.confidence_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9747,7 +9709,6 @@ impl std::fmt::Debug for MaliciousUriFilterResult {
             "malicious_uri_matched_items",
             &self.malicious_uri_matched_items,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9928,7 +9889,6 @@ pub mod malicious_uri_filter_result {
             let mut debug_struct = f.debug_struct("MaliciousUriMatchedItem");
             debug_struct.field("uri", &self.uri);
             debug_struct.field("locations", &self.locations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10257,7 +10217,6 @@ impl std::fmt::Debug for VirusScanFilterResult {
         debug_struct.field("scanned_content_type", &self.scanned_content_type);
         debug_struct.field("scanned_size", &self.scanned_size);
         debug_struct.field("virus_details", &self.virus_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10600,7 +10559,6 @@ impl std::fmt::Debug for VirusDetail {
         debug_struct.field("vendor", &self.vendor);
         debug_struct.field("names", &self.names);
         debug_struct.field("threat_type", &self.threat_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10970,7 +10928,6 @@ impl std::fmt::Debug for CsamFilterResult {
         debug_struct.field("execution_state", &self.execution_state);
         debug_struct.field("message_items", &self.message_items);
         debug_struct.field("match_state", &self.match_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11139,7 +11096,6 @@ impl std::fmt::Debug for MessageItem {
         let mut debug_struct = f.debug_struct("MessageItem");
         debug_struct.field("message_type", &self.message_type);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11517,7 +11473,6 @@ impl std::fmt::Debug for RangeInfo {
         let mut debug_struct = f.debug_struct("RangeInfo");
         debug_struct.field("start", &self.start);
         debug_struct.field("end", &self.end);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -289,7 +289,6 @@ impl std::fmt::Debug for ListActiveDirectoriesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -507,7 +506,6 @@ impl std::fmt::Debug for ListActiveDirectoriesResponse {
         debug_struct.field("active_directories", &self.active_directories);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -649,7 +647,6 @@ impl std::fmt::Debug for GetActiveDirectoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetActiveDirectoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -861,7 +858,6 @@ impl std::fmt::Debug for CreateActiveDirectoryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("active_directory", &self.active_directory);
         debug_struct.field("active_directory_id", &self.active_directory_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1057,7 +1053,6 @@ impl std::fmt::Debug for UpdateActiveDirectoryRequest {
         let mut debug_struct = f.debug_struct("UpdateActiveDirectoryRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("active_directory", &self.active_directory);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1199,7 +1194,6 @@ impl std::fmt::Debug for DeleteActiveDirectoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteActiveDirectoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1922,7 +1916,6 @@ impl std::fmt::Debug for ActiveDirectory {
         debug_struct.field("encrypt_dc_connections", &self.encrypt_dc_connections);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("state_details", &self.state_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2707,7 +2700,6 @@ impl std::fmt::Debug for Backup {
             "enforced_retention_end_time",
             &self.enforced_retention_end_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3286,7 +3278,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3500,7 +3491,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3643,7 +3633,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3852,7 +3841,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_id", &self.backup_id);
         debug_struct.field("backup", &self.backup);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3995,7 +3983,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4189,7 +4176,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("backup", &self.backup);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4740,7 +4726,6 @@ impl std::fmt::Debug for BackupPolicy {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5111,7 +5096,6 @@ impl std::fmt::Debug for CreateBackupPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_policy", &self.backup_policy);
         debug_struct.field("backup_policy_id", &self.backup_policy_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5254,7 +5238,6 @@ impl std::fmt::Debug for GetBackupPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5518,7 +5501,6 @@ impl std::fmt::Debug for ListBackupPoliciesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5732,7 +5714,6 @@ impl std::fmt::Debug for ListBackupPoliciesResponse {
         debug_struct.field("backup_policies", &self.backup_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5927,7 +5908,6 @@ impl std::fmt::Debug for UpdateBackupPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("backup_policy", &self.backup_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6070,7 +6050,6 @@ impl std::fmt::Debug for DeleteBackupPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6529,7 +6508,6 @@ impl std::fmt::Debug for BackupVault {
         debug_struct.field("source_backup_vault", &self.source_backup_vault);
         debug_struct.field("destination_backup_vault", &self.destination_backup_vault);
         debug_struct.field("backup_retention_policy", &self.backup_retention_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6841,7 +6819,6 @@ pub mod backup_vault {
             debug_struct.field("weekly_backup_immutable", &self.weekly_backup_immutable);
             debug_struct.field("monthly_backup_immutable", &self.monthly_backup_immutable);
             debug_struct.field("manual_backup_immutable", &self.manual_backup_immutable);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7270,7 +7247,6 @@ impl std::fmt::Debug for GetBackupVaultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupVaultRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7536,7 +7512,6 @@ impl std::fmt::Debug for ListBackupVaultsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7751,7 +7726,6 @@ impl std::fmt::Debug for ListBackupVaultsResponse {
         debug_struct.field("backup_vaults", &self.backup_vaults);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7961,7 +7935,6 @@ impl std::fmt::Debug for CreateBackupVaultRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_vault_id", &self.backup_vault_id);
         debug_struct.field("backup_vault", &self.backup_vault);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8104,7 +8077,6 @@ impl std::fmt::Debug for DeleteBackupVaultRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupVaultRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8299,7 +8271,6 @@ impl std::fmt::Debug for UpdateBackupVaultRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupVaultRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("backup_vault", &self.backup_vault);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8624,7 +8595,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8815,7 +8785,6 @@ impl std::fmt::Debug for LocationMetadata {
             "supported_flex_performance",
             &self.supported_flex_performance,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8957,7 +8926,6 @@ impl std::fmt::Debug for GetKmsConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKmsConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9221,7 +9189,6 @@ impl std::fmt::Debug for ListKmsConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9435,7 +9402,6 @@ impl std::fmt::Debug for ListKmsConfigsResponse {
         debug_struct.field("kms_configs", &self.kms_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9643,7 +9609,6 @@ impl std::fmt::Debug for CreateKmsConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("kms_config_id", &self.kms_config_id);
         debug_struct.field("kms_config", &self.kms_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9838,7 +9803,6 @@ impl std::fmt::Debug for UpdateKmsConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateKmsConfigRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("kms_config", &self.kms_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9980,7 +9944,6 @@ impl std::fmt::Debug for DeleteKmsConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteKmsConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10122,7 +10085,6 @@ impl std::fmt::Debug for EncryptVolumesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptVolumesRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10264,7 +10226,6 @@ impl std::fmt::Debug for VerifyKmsConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerifyKmsConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10460,7 +10421,6 @@ impl std::fmt::Debug for VerifyKmsConfigResponse {
         debug_struct.field("healthy", &self.healthy);
         debug_struct.field("health_error", &self.health_error);
         debug_struct.field("instructions", &self.instructions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10835,7 +10795,6 @@ impl std::fmt::Debug for KmsConfig {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("instructions", &self.instructions);
         debug_struct.field("service_account", &self.service_account);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11302,7 +11261,6 @@ impl std::fmt::Debug for ListQuotaRulesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11516,7 +11474,6 @@ impl std::fmt::Debug for ListQuotaRulesResponse {
         debug_struct.field("quota_rules", &self.quota_rules);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11658,7 +11615,6 @@ impl std::fmt::Debug for GetQuotaRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQuotaRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11866,7 +11822,6 @@ impl std::fmt::Debug for CreateQuotaRuleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("quota_rule", &self.quota_rule);
         debug_struct.field("quota_rule_id", &self.quota_rule_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12061,7 +12016,6 @@ impl std::fmt::Debug for UpdateQuotaRuleRequest {
         let mut debug_struct = f.debug_struct("UpdateQuotaRuleRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("quota_rule", &self.quota_rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12203,7 +12157,6 @@ impl std::fmt::Debug for DeleteQuotaRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteQuotaRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12598,7 +12551,6 @@ impl std::fmt::Debug for QuotaRule {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13360,7 +13312,6 @@ impl std::fmt::Debug for TransferStats {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("last_transfer_end_time", &self.last_transfer_end_time);
         debug_struct.field("last_transfer_error", &self.last_transfer_error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14037,7 +13988,6 @@ impl std::fmt::Debug for Replication {
         debug_struct.field("hybrid_peering_details", &self.hybrid_peering_details);
         debug_struct.field("cluster_location", &self.cluster_location);
         debug_struct.field("hybrid_replication_type", &self.hybrid_replication_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15100,7 +15050,6 @@ impl std::fmt::Debug for HybridPeeringDetails {
         debug_struct.field("peer_volume_name", &self.peer_volume_name);
         debug_struct.field("peer_cluster_name", &self.peer_cluster_name);
         debug_struct.field("peer_svm_name", &self.peer_svm_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15366,7 +15315,6 @@ impl std::fmt::Debug for ListReplicationsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15580,7 +15528,6 @@ impl std::fmt::Debug for ListReplicationsResponse {
         debug_struct.field("replications", &self.replications);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15723,7 +15670,6 @@ impl std::fmt::Debug for GetReplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15996,7 +15942,6 @@ impl std::fmt::Debug for DestinationVolumeParameters {
         debug_struct.field("share_name", &self.share_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("tiering_policy", &self.tiering_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16204,7 +16149,6 @@ impl std::fmt::Debug for CreateReplicationRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("replication", &self.replication);
         debug_struct.field("replication_id", &self.replication_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16347,7 +16291,6 @@ impl std::fmt::Debug for DeleteReplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteReplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16538,7 +16481,6 @@ impl std::fmt::Debug for UpdateReplicationRequest {
         let mut debug_struct = f.debug_struct("UpdateReplicationRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("replication", &self.replication);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16711,7 +16653,6 @@ impl std::fmt::Debug for StopReplicationRequest {
         let mut debug_struct = f.debug_struct("StopReplicationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16854,7 +16795,6 @@ impl std::fmt::Debug for ResumeReplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeReplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16998,7 +16938,6 @@ impl std::fmt::Debug for ReverseReplicationDirectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReverseReplicationDirectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17258,7 +17197,6 @@ impl std::fmt::Debug for EstablishPeeringRequest {
         debug_struct.field("peer_svm_name", &self.peer_svm_name);
         debug_struct.field("peer_ip_addresses", &self.peer_ip_addresses);
         debug_struct.field("peer_volume_name", &self.peer_volume_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17401,7 +17339,6 @@ impl std::fmt::Debug for SyncReplicationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SyncReplicationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17667,7 +17604,6 @@ impl std::fmt::Debug for ListSnapshotsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17881,7 +17817,6 @@ impl std::fmt::Debug for ListSnapshotsResponse {
         debug_struct.field("snapshots", &self.snapshots);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18024,7 +17959,6 @@ impl std::fmt::Debug for GetSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18232,7 +18166,6 @@ impl std::fmt::Debug for CreateSnapshotRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("snapshot", &self.snapshot);
         debug_struct.field("snapshot_id", &self.snapshot_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18375,7 +18308,6 @@ impl std::fmt::Debug for DeleteSnapshotRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSnapshotRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18566,7 +18498,6 @@ impl std::fmt::Debug for UpdateSnapshotRequest {
         let mut debug_struct = f.debug_struct("UpdateSnapshotRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("snapshot", &self.snapshot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18904,7 +18835,6 @@ impl std::fmt::Debug for Snapshot {
         debug_struct.field("used_bytes", &self.used_bytes);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19212,7 +19142,6 @@ impl std::fmt::Debug for GetStoragePoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStoragePoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19477,7 +19406,6 @@ impl std::fmt::Debug for ListStoragePoolsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19691,7 +19619,6 @@ impl std::fmt::Debug for ListStoragePoolsResponse {
         debug_struct.field("storage_pools", &self.storage_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19899,7 +19826,6 @@ impl std::fmt::Debug for CreateStoragePoolRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("storage_pool_id", &self.storage_pool_id);
         debug_struct.field("storage_pool", &self.storage_pool);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20094,7 +20020,6 @@ impl std::fmt::Debug for UpdateStoragePoolRequest {
         let mut debug_struct = f.debug_struct("UpdateStoragePoolRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("storage_pool", &self.storage_pool);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20236,7 +20161,6 @@ impl std::fmt::Debug for DeleteStoragePoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteStoragePoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20379,7 +20303,6 @@ impl std::fmt::Debug for SwitchActiveReplicaZoneRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SwitchActiveReplicaZoneRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21298,7 +21221,6 @@ impl std::fmt::Debug for StoragePool {
         );
         debug_struct.field("total_throughput_mibps", &self.total_throughput_mibps);
         debug_struct.field("total_iops", &self.total_iops);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21641,7 +21563,6 @@ impl std::fmt::Debug for ValidateDirectoryServiceRequest {
         let mut debug_struct = f.debug_struct("ValidateDirectoryServiceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("directory_service_type", &self.directory_service_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21905,7 +21826,6 @@ impl std::fmt::Debug for ListVolumesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22118,7 +22038,6 @@ impl std::fmt::Debug for ListVolumesResponse {
         debug_struct.field("volumes", &self.volumes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22260,7 +22179,6 @@ impl std::fmt::Debug for GetVolumeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVolumeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22467,7 +22385,6 @@ impl std::fmt::Debug for CreateVolumeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("volume_id", &self.volume_id);
         debug_struct.field("volume", &self.volume);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22661,7 +22578,6 @@ impl std::fmt::Debug for UpdateVolumeRequest {
         let mut debug_struct = f.debug_struct("UpdateVolumeRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("volume", &self.volume);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22830,7 +22746,6 @@ impl std::fmt::Debug for DeleteVolumeRequest {
         let mut debug_struct = f.debug_struct("DeleteVolumeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23001,7 +22916,6 @@ impl std::fmt::Debug for RevertVolumeRequest {
         let mut debug_struct = f.debug_struct("RevertVolumeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("snapshot_id", &self.snapshot_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24319,7 +24233,6 @@ impl std::fmt::Debug for Volume {
             "hybrid_replication_parameters",
             &self.hybrid_replication_parameters,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24657,7 +24570,6 @@ impl std::fmt::Debug for ExportPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportPolicy");
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25192,7 +25104,6 @@ impl std::fmt::Debug for SimpleExportPolicyRule {
         debug_struct.field("kerberos_5i_read_write", &self.kerberos_5i_read_write);
         debug_struct.field("kerberos_5p_read_only", &self.kerberos_5p_read_only);
         debug_struct.field("kerberos_5p_read_write", &self.kerberos_5p_read_write);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25496,7 +25407,6 @@ impl std::fmt::Debug for SnapshotPolicy {
         debug_struct.field("daily_schedule", &self.daily_schedule);
         debug_struct.field("weekly_schedule", &self.weekly_schedule);
         debug_struct.field("monthly_schedule", &self.monthly_schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25729,7 +25639,6 @@ impl std::fmt::Debug for HourlySchedule {
         let mut debug_struct = f.debug_struct("HourlySchedule");
         debug_struct.field("snapshots_to_keep", &self.snapshots_to_keep);
         debug_struct.field("minute", &self.minute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26019,7 +25928,6 @@ impl std::fmt::Debug for DailySchedule {
         debug_struct.field("snapshots_to_keep", &self.snapshots_to_keep);
         debug_struct.field("minute", &self.minute);
         debug_struct.field("hour", &self.hour);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26347,7 +26255,6 @@ impl std::fmt::Debug for WeeklySchedule {
         debug_struct.field("minute", &self.minute);
         debug_struct.field("hour", &self.hour);
         debug_struct.field("day", &self.day);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26675,7 +26582,6 @@ impl std::fmt::Debug for MonthlySchedule {
         debug_struct.field("minute", &self.minute);
         debug_struct.field("hour", &self.hour);
         debug_struct.field("days_of_month", &self.days_of_month);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26919,7 +26825,6 @@ impl std::fmt::Debug for MountOption {
         debug_struct.field("protocol", &self.protocol);
         debug_struct.field("instructions", &self.instructions);
         debug_struct.field("ip_address", &self.ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27152,7 +27057,6 @@ impl std::fmt::Debug for RestoreParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestoreParameters");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27446,7 +27350,6 @@ impl std::fmt::Debug for BackupConfig {
         debug_struct.field("backup_vault", &self.backup_vault);
         debug_struct.field("scheduled_backup_enabled", &self.scheduled_backup_enabled);
         debug_struct.field("backup_chain_bytes", &self.backup_chain_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27663,7 +27566,6 @@ impl std::fmt::Debug for TieringPolicy {
         let mut debug_struct = f.debug_struct("TieringPolicy");
         debug_struct.field("tier_action", &self.tier_action);
         debug_struct.field("cooling_threshold_days", &self.cooling_threshold_days);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28151,7 +28053,6 @@ impl std::fmt::Debug for HybridReplicationParameters {
         debug_struct.field("cluster_location", &self.cluster_location);
         debug_struct.field("description", &self.description);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -354,7 +354,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -895,7 +894,6 @@ impl std::fmt::Debug for ServiceConnectionMap {
         debug_struct.field("consumer_psc_connections", &self.consumer_psc_connections);
         debug_struct.field("token", &self.token);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1053,7 +1051,6 @@ pub mod service_connection_map {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ProducerPscConfig");
             debug_struct.field("service_attachment_uri", &self.service_attachment_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1491,7 +1488,6 @@ pub mod service_connection_map {
                 &self.producer_instance_metadata,
             );
             debug_struct.field("ip_version", &self.ip_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2264,7 +2260,6 @@ pub mod service_connection_map {
                 &self.producer_instance_metadata,
             );
             debug_struct.field("ip_version", &self.ip_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2702,7 +2697,6 @@ impl std::fmt::Debug for ListServiceConnectionMapsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2921,7 +2915,6 @@ impl std::fmt::Debug for ListServiceConnectionMapsResponse {
         debug_struct.field("service_connection_maps", &self.service_connection_maps);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3063,7 +3056,6 @@ impl std::fmt::Debug for GetServiceConnectionMapRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceConnectionMapRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3316,7 +3308,6 @@ impl std::fmt::Debug for CreateServiceConnectionMapRequest {
         debug_struct.field("service_connection_map_id", &self.service_connection_map_id);
         debug_struct.field("service_connection_map", &self.service_connection_map);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3549,7 +3540,6 @@ impl std::fmt::Debug for UpdateServiceConnectionMapRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service_connection_map", &self.service_connection_map);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3767,7 +3757,6 @@ impl std::fmt::Debug for DeleteServiceConnectionMapRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4248,7 +4237,6 @@ impl std::fmt::Debug for ServiceConnectionPolicy {
         debug_struct.field("psc_config", &self.psc_config);
         debug_struct.field("psc_connections", &self.psc_connections);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4564,7 +4552,6 @@ pub mod service_connection_policy {
                 "allowed_google_producers_resource_hierarchy_level",
                 &self.allowed_google_producers_resource_hierarchy_level,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5299,7 +5286,6 @@ pub mod service_connection_policy {
             );
             debug_struct.field("service_class", &self.service_class);
             debug_struct.field("ip_version", &self.ip_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5729,7 +5715,6 @@ impl std::fmt::Debug for ListServiceConnectionPoliciesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5959,7 +5944,6 @@ impl std::fmt::Debug for ListServiceConnectionPoliciesResponse {
         );
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6101,7 +6085,6 @@ impl std::fmt::Debug for GetServiceConnectionPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceConnectionPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6365,7 +6348,6 @@ impl std::fmt::Debug for CreateServiceConnectionPolicyRequest {
         );
         debug_struct.field("service_connection_policy", &self.service_connection_policy);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6602,7 +6584,6 @@ impl std::fmt::Debug for UpdateServiceConnectionPolicyRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service_connection_policy", &self.service_connection_policy);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6820,7 +6801,6 @@ impl std::fmt::Debug for DeleteServiceConnectionPolicyRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7166,7 +7146,6 @@ impl std::fmt::Debug for ServiceClass {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7429,7 +7408,6 @@ impl std::fmt::Debug for ListServiceClassesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7644,7 +7622,6 @@ impl std::fmt::Debug for ListServiceClassesResponse {
         debug_struct.field("service_classes", &self.service_classes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7786,7 +7763,6 @@ impl std::fmt::Debug for GetServiceClassRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceClassRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8019,7 +7995,6 @@ impl std::fmt::Debug for UpdateServiceClassRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service_class", &self.service_class);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8237,7 +8212,6 @@ impl std::fmt::Debug for DeleteServiceClassRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8644,7 +8618,6 @@ impl std::fmt::Debug for ServiceConnectionToken {
         debug_struct.field("token", &self.token);
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8907,7 +8880,6 @@ impl std::fmt::Debug for ListServiceConnectionTokensRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9130,7 +9102,6 @@ impl std::fmt::Debug for ListServiceConnectionTokensResponse {
         debug_struct.field("service_connection_tokens", &self.service_connection_tokens);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9272,7 +9243,6 @@ impl std::fmt::Debug for GetServiceConnectionTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceConnectionTokenRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9535,7 +9505,6 @@ impl std::fmt::Debug for CreateServiceConnectionTokenRequest {
         );
         debug_struct.field("service_connection_token", &self.service_connection_token);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9753,7 +9722,6 @@ impl std::fmt::Debug for DeleteServiceConnectionTokenRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10302,7 +10270,6 @@ impl std::fmt::Debug for Hub {
         debug_struct.field("policy_mode", &self.policy_mode);
         debug_struct.field("preset_topology", &self.preset_topology);
         debug_struct.field("export_psc", &self.export_psc);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10490,7 +10457,6 @@ impl std::fmt::Debug for RoutingVPC {
             "required_for_new_site_to_site_data_transfer_spokes",
             &self.required_for_new_site_to_site_data_transfer_spokes,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11233,7 +11199,6 @@ impl std::fmt::Debug for Spoke {
             "field_paths_pending_update",
             &self.field_paths_pending_update,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11442,7 +11407,6 @@ pub mod spoke {
             debug_struct.field("code", &self.code);
             debug_struct.field("message", &self.message);
             debug_struct.field("user_details", &self.user_details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11954,7 +11918,6 @@ impl std::fmt::Debug for RouteTable {
         debug_struct.field("description", &self.description);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12622,7 +12585,6 @@ impl std::fmt::Debug for Route {
             "next_hop_interconnect_attachment",
             &self.next_hop_interconnect_attachment,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13021,7 +12983,6 @@ impl std::fmt::Debug for Group {
         debug_struct.field("state", &self.state);
         debug_struct.field("auto_accept", &self.auto_accept);
         debug_struct.field("route_table", &self.route_table);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13175,7 +13136,6 @@ impl std::fmt::Debug for AutoAccept {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutoAccept");
         debug_struct.field("auto_accept_projects", &self.auto_accept_projects);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13442,7 +13402,6 @@ impl std::fmt::Debug for ListHubsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13661,7 +13620,6 @@ impl std::fmt::Debug for ListHubsResponse {
         debug_struct.field("hubs", &self.hubs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13807,7 +13765,6 @@ impl std::fmt::Debug for GetHubRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetHubRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14054,7 +14011,6 @@ impl std::fmt::Debug for CreateHubRequest {
         debug_struct.field("hub_id", &self.hub_id);
         debug_struct.field("hub", &self.hub);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14291,7 +14247,6 @@ impl std::fmt::Debug for UpdateHubRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("hub", &self.hub);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14475,7 +14430,6 @@ impl std::fmt::Debug for DeleteHubRequest {
         let mut debug_struct = f.debug_struct("DeleteHubRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14809,7 +14763,6 @@ impl std::fmt::Debug for ListHubSpokesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15171,7 +15124,6 @@ impl std::fmt::Debug for ListHubSpokesResponse {
         debug_struct.field("spokes", &self.spokes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15490,7 +15442,6 @@ impl std::fmt::Debug for QueryHubStatusRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("group_by", &self.group_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15685,7 +15636,6 @@ impl std::fmt::Debug for QueryHubStatusResponse {
         let mut debug_struct = f.debug_struct("QueryHubStatusResponse");
         debug_struct.field("hub_status_entries", &self.hub_status_entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15912,7 +15862,6 @@ impl std::fmt::Debug for HubStatusEntry {
         debug_struct.field("count", &self.count);
         debug_struct.field("group_by", &self.group_by);
         debug_struct.field("psc_propagation_status", &self.psc_propagation_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16215,7 +16164,6 @@ impl std::fmt::Debug for PscPropagationStatus {
         debug_struct.field("target_group", &self.target_group);
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16670,7 +16618,6 @@ impl std::fmt::Debug for ListSpokesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16888,7 +16835,6 @@ impl std::fmt::Debug for ListSpokesResponse {
         debug_struct.field("spokes", &self.spokes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17033,7 +16979,6 @@ impl std::fmt::Debug for GetSpokeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSpokeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17279,7 +17224,6 @@ impl std::fmt::Debug for CreateSpokeRequest {
         debug_struct.field("spoke_id", &self.spoke_id);
         debug_struct.field("spoke", &self.spoke);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17516,7 +17460,6 @@ impl std::fmt::Debug for UpdateSpokeRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("spoke", &self.spoke);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17700,7 +17643,6 @@ impl std::fmt::Debug for DeleteSpokeRequest {
         let mut debug_struct = f.debug_struct("DeleteSpokeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17910,7 +17852,6 @@ impl std::fmt::Debug for AcceptHubSpokeRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("spoke_uri", &self.spoke_uri);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18066,7 +18007,6 @@ impl std::fmt::Debug for AcceptHubSpokeResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AcceptHubSpokeResponse");
         debug_struct.field("spoke", &self.spoke);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18301,7 +18241,6 @@ impl std::fmt::Debug for RejectHubSpokeRequest {
         debug_struct.field("spoke_uri", &self.spoke_uri);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18457,7 +18396,6 @@ impl std::fmt::Debug for RejectHubSpokeResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RejectHubSpokeResponse");
         debug_struct.field("spoke", &self.spoke);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18693,7 +18631,6 @@ impl std::fmt::Debug for AcceptSpokeUpdateRequest {
         debug_struct.field("spoke_uri", &self.spoke_uri);
         debug_struct.field("spoke_etag", &self.spoke_etag);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18849,7 +18786,6 @@ impl std::fmt::Debug for AcceptSpokeUpdateResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AcceptSpokeUpdateResponse");
         debug_struct.field("spoke", &self.spoke);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19110,7 +19046,6 @@ impl std::fmt::Debug for RejectSpokeUpdateRequest {
         debug_struct.field("spoke_etag", &self.spoke_etag);
         debug_struct.field("details", &self.details);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19266,7 +19201,6 @@ impl std::fmt::Debug for RejectSpokeUpdateResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RejectSpokeUpdateResponse");
         debug_struct.field("spoke", &self.spoke);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19411,7 +19345,6 @@ impl std::fmt::Debug for GetRouteTableRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRouteTableRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19556,7 +19489,6 @@ impl std::fmt::Debug for GetRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19823,7 +19755,6 @@ impl std::fmt::Debug for ListRoutesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20042,7 +19973,6 @@ impl std::fmt::Debug for ListRoutesResponse {
         debug_struct.field("routes", &self.routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20309,7 +20239,6 @@ impl std::fmt::Debug for ListRouteTablesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20529,7 +20458,6 @@ impl std::fmt::Debug for ListRouteTablesResponse {
         debug_struct.field("route_tables", &self.route_tables);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20796,7 +20724,6 @@ impl std::fmt::Debug for ListGroupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21015,7 +20942,6 @@ impl std::fmt::Debug for ListGroupsResponse {
         debug_struct.field("groups", &self.groups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21255,7 +21181,6 @@ impl std::fmt::Debug for LinkedVpnTunnels {
         );
         debug_struct.field("vpc_network", &self.vpc_network);
         debug_struct.field("include_import_ranges", &self.include_import_ranges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21495,7 +21420,6 @@ impl std::fmt::Debug for LinkedInterconnectAttachments {
         );
         debug_struct.field("vpc_network", &self.vpc_network);
         debug_struct.field("include_import_ranges", &self.include_import_ranges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21740,7 +21664,6 @@ impl std::fmt::Debug for LinkedRouterApplianceInstances {
         );
         debug_struct.field("vpc_network", &self.vpc_network);
         debug_struct.field("include_import_ranges", &self.include_import_ranges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22055,7 +21978,6 @@ impl std::fmt::Debug for LinkedVpcNetwork {
             &self.proposed_exclude_export_ranges,
         );
         debug_struct.field("producer_vpc_spokes", &self.producer_vpc_spokes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22427,7 +22349,6 @@ impl std::fmt::Debug for LinkedProducerVpcNetwork {
             "proposed_exclude_export_ranges",
             &self.proposed_exclude_export_ranges,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22599,7 +22520,6 @@ impl std::fmt::Debug for RouterApplianceInstance {
         let mut debug_struct = f.debug_struct("RouterApplianceInstance");
         debug_struct.field("virtual_machine", &self.virtual_machine);
         debug_struct.field("ip_address", &self.ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22749,7 +22669,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("location_features", &self.location_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22890,7 +22809,6 @@ impl std::fmt::Debug for NextHopVpcNetwork {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NextHopVpcNetwork");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23093,7 +23011,6 @@ impl std::fmt::Debug for NextHopVPNTunnel {
             "site_to_site_data_transfer",
             &self.site_to_site_data_transfer,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23296,7 +23213,6 @@ impl std::fmt::Debug for NextHopRouterApplianceInstance {
             "site_to_site_data_transfer",
             &self.site_to_site_data_transfer,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23500,7 +23416,6 @@ impl std::fmt::Debug for NextHopInterconnectAttachment {
             "site_to_site_data_transfer",
             &self.site_to_site_data_transfer,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23728,7 +23643,6 @@ impl std::fmt::Debug for SpokeSummary {
         debug_struct.field("spoke_type_counts", &self.spoke_type_counts);
         debug_struct.field("spoke_state_counts", &self.spoke_state_counts);
         debug_struct.field("spoke_state_reason_counts", &self.spoke_state_reason_counts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23928,7 +23842,6 @@ pub mod spoke_summary {
             let mut debug_struct = f.debug_struct("SpokeTypeCount");
             debug_struct.field("spoke_type", &self.spoke_type);
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24118,7 +24031,6 @@ pub mod spoke_summary {
             let mut debug_struct = f.debug_struct("SpokeStateCount");
             debug_struct.field("state", &self.state);
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24315,7 +24227,6 @@ pub mod spoke_summary {
             let mut debug_struct = f.debug_struct("SpokeStateReasonCount");
             debug_struct.field("state_reason_code", &self.state_reason_code);
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24461,7 +24372,6 @@ impl std::fmt::Debug for GetGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24698,7 +24608,6 @@ impl std::fmt::Debug for UpdateGroupRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("group", &self.group);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25379,7 +25288,6 @@ impl std::fmt::Debug for InternalRange {
         debug_struct.field("immutable", &self.immutable);
         debug_struct.field("allocation_options", &self.allocation_options);
         debug_struct.field("exclude_cidr_ranges", &self.exclude_cidr_ranges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25560,7 +25468,6 @@ pub mod internal_range {
             let mut debug_struct = f.debug_struct("Migration");
             debug_struct.field("source", &self.source);
             debug_struct.field("target", &self.target);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25777,7 +25684,6 @@ pub mod internal_range {
                 "first_available_ranges_lookup_size",
                 &self.first_available_ranges_lookup_size,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26638,7 +26544,6 @@ impl std::fmt::Debug for ListInternalRangesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26853,7 +26758,6 @@ impl std::fmt::Debug for ListInternalRangesResponse {
         debug_struct.field("internal_ranges", &self.internal_ranges);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26995,7 +26899,6 @@ impl std::fmt::Debug for GetInternalRangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInternalRangeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27244,7 +27147,6 @@ impl std::fmt::Debug for CreateInternalRangeRequest {
         debug_struct.field("internal_range_id", &self.internal_range_id);
         debug_struct.field("internal_range", &self.internal_range);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27477,7 +27379,6 @@ impl std::fmt::Debug for UpdateInternalRangeRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("internal_range", &self.internal_range);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27657,7 +27558,6 @@ impl std::fmt::Debug for DeleteInternalRangeRequest {
         let mut debug_struct = f.debug_struct("DeleteInternalRangeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28397,7 +28297,6 @@ impl std::fmt::Debug for PolicyBasedRoute {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("target", &self.target);
         debug_struct.field("next_hop", &self.next_hop);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28551,7 +28450,6 @@ pub mod policy_based_route {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("VirtualMachine");
             debug_struct.field("tags", &self.tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28697,7 +28595,6 @@ pub mod policy_based_route {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InterconnectAttachment");
             debug_struct.field("region", &self.region);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28933,7 +28830,6 @@ pub mod policy_based_route {
             debug_struct.field("src_range", &self.src_range);
             debug_struct.field("dest_range", &self.dest_range);
             debug_struct.field("protocol_version", &self.protocol_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29287,7 +29183,6 @@ pub mod policy_based_route {
             debug_struct.field("code", &self.code);
             debug_struct.field("data", &self.data);
             debug_struct.field("warning_message", &self.warning_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29857,7 +29752,6 @@ impl std::fmt::Debug for ListPolicyBasedRoutesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30080,7 +29974,6 @@ impl std::fmt::Debug for ListPolicyBasedRoutesResponse {
         debug_struct.field("policy_based_routes", &self.policy_based_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30226,7 +30119,6 @@ impl std::fmt::Debug for GetPolicyBasedRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyBasedRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30484,7 +30376,6 @@ impl std::fmt::Debug for CreatePolicyBasedRouteRequest {
         debug_struct.field("policy_based_route_id", &self.policy_based_route_id);
         debug_struct.field("policy_based_route", &self.policy_based_route);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30668,7 +30559,6 @@ impl std::fmt::Debug for DeletePolicyBasedRouteRequest {
         let mut debug_struct = f.debug_struct("DeletePolicyBasedRouteRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -656,7 +656,6 @@ impl std::fmt::Debug for ConnectivityTest {
             &self.return_reachability_details,
         );
         debug_struct.field("bypass_firewall_checks", &self.bypass_firewall_checks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1364,7 +1363,6 @@ impl std::fmt::Debug for Endpoint {
         debug_struct.field("network", &self.network);
         debug_struct.field("network_type", &self.network_type);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1514,7 +1512,6 @@ pub mod endpoint {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudFunctionEndpoint");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1661,7 +1658,6 @@ pub mod endpoint {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AppEngineVersionEndpoint");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1809,7 +1805,6 @@ pub mod endpoint {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudRunRevisionEndpoint");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2342,7 +2337,6 @@ impl std::fmt::Debug for ReachabilityDetails {
         debug_struct.field("verify_time", &self.verify_time);
         debug_struct.field("error", &self.error);
         debug_struct.field("traces", &self.traces);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2719,7 +2713,6 @@ impl std::fmt::Debug for LatencyPercentile {
         let mut debug_struct = f.debug_struct("LatencyPercentile");
         debug_struct.field("percent", &self.percent);
         debug_struct.field("latency_micros", &self.latency_micros);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2869,7 +2862,6 @@ impl std::fmt::Debug for LatencyDistribution {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LatencyDistribution");
         debug_struct.field("latency_percentiles", &self.latency_percentiles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3346,7 +3338,6 @@ impl std::fmt::Debug for ProbingDetails {
             "destination_egress_location",
             &self.destination_egress_location,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3501,7 +3492,6 @@ pub mod probing_details {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EdgeLocation");
             debug_struct.field("metropolitan_area", &self.metropolitan_area);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4071,7 +4061,6 @@ impl std::fmt::Debug for ListConnectivityTestsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4288,7 +4277,6 @@ impl std::fmt::Debug for ListConnectivityTestsResponse {
         debug_struct.field("resources", &self.resources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4431,7 +4419,6 @@ impl std::fmt::Debug for GetConnectivityTestRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectivityTestRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4644,7 +4631,6 @@ impl std::fmt::Debug for CreateConnectivityTestRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("test_id", &self.test_id);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4836,7 +4822,6 @@ impl std::fmt::Debug for UpdateConnectivityTestRequest {
         let mut debug_struct = f.debug_struct("UpdateConnectivityTestRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4979,7 +4964,6 @@ impl std::fmt::Debug for DeleteConnectivityTestRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConnectivityTestRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5122,7 +5106,6 @@ impl std::fmt::Debug for RerunConnectivityTestRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RerunConnectivityTestRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5444,7 +5427,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("cancel_requested", &self.cancel_requested);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5692,7 +5674,6 @@ impl std::fmt::Debug for Trace {
         debug_struct.field("endpoint_info", &self.endpoint_info);
         debug_struct.field("steps", &self.steps);
         debug_struct.field("forward_trace_id", &self.forward_trace_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7479,7 +7460,6 @@ impl std::fmt::Debug for Step {
         debug_struct.field("causes_drop", &self.causes_drop);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("step_info", &self.step_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8357,7 +8337,6 @@ impl std::fmt::Debug for InstanceInfo {
             "psc_network_attachment_uri",
             &self.psc_network_attachment_uri,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8609,7 +8588,6 @@ impl std::fmt::Debug for NetworkInfo {
         debug_struct.field("matched_subnet_uri", &self.matched_subnet_uri);
         debug_struct.field("matched_ip_range", &self.matched_ip_range);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9047,7 +9025,6 @@ impl std::fmt::Debug for FirewallInfo {
         debug_struct.field("policy", &self.policy);
         debug_struct.field("policy_uri", &self.policy_uri);
         debug_struct.field("firewall_rule_type", &self.firewall_rule_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10153,7 +10130,6 @@ impl std::fmt::Debug for RouteInfo {
             &self.originating_route_display_name,
         );
         debug_struct.field("ncc_hub_route_uri", &self.ncc_hub_route_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10862,7 +10838,6 @@ impl std::fmt::Debug for GoogleServiceInfo {
         let mut debug_struct = f.debug_struct("GoogleServiceInfo");
         debug_struct.field("source_ip", &self.source_ip);
         debug_struct.field("google_service_type", &self.google_service_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11471,7 +11446,6 @@ impl std::fmt::Debug for ForwardingRuleInfo {
             &self.psc_service_attachment_uri,
         );
         debug_struct.field("psc_google_api_target", &self.psc_google_api_target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11745,7 +11719,6 @@ impl std::fmt::Debug for LoadBalancerInfo {
         debug_struct.field("backends", &self.backends);
         debug_struct.field("backend_type", &self.backend_type);
         debug_struct.field("backend_uri", &self.backend_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12332,7 +12305,6 @@ impl std::fmt::Debug for LoadBalancerBackend {
             "health_check_blocking_firewall_rules",
             &self.health_check_blocking_firewall_rules,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12749,7 +12721,6 @@ impl std::fmt::Debug for VpnGatewayInfo {
         debug_struct.field("ip_address", &self.ip_address);
         debug_struct.field("vpn_tunnel_uri", &self.vpn_tunnel_uri);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13105,7 +13076,6 @@ impl std::fmt::Debug for VpnTunnelInfo {
         debug_struct.field("network_uri", &self.network_uri);
         debug_struct.field("region", &self.region);
         debug_struct.field("routing_type", &self.routing_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13623,7 +13593,6 @@ impl std::fmt::Debug for EndpointInfo {
         debug_struct.field("source_network_uri", &self.source_network_uri);
         debug_struct.field("destination_network_uri", &self.destination_network_uri);
         debug_struct.field("source_agent_uri", &self.source_agent_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13874,7 +13843,6 @@ impl std::fmt::Debug for DeliverInfo {
         debug_struct.field("ip_address", &self.ip_address);
         debug_struct.field("storage_bucket", &self.storage_bucket);
         debug_struct.field("psc_google_api_target", &self.psc_google_api_target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14315,7 +14283,6 @@ impl std::fmt::Debug for ForwardInfo {
         debug_struct.field("target", &self.target);
         debug_struct.field("resource_uri", &self.resource_uri);
         debug_struct.field("ip_address", &self.ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14744,7 +14711,6 @@ impl std::fmt::Debug for AbortInfo {
             "projects_missing_permission",
             &self.projects_missing_permission,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15465,7 +15431,6 @@ impl std::fmt::Debug for DropInfo {
         debug_struct.field("source_ip", &self.source_ip);
         debug_struct.field("destination_ip", &self.destination_ip);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16746,7 +16711,6 @@ impl std::fmt::Debug for GKEMasterInfo {
         debug_struct.field("internal_ip", &self.internal_ip);
         debug_struct.field("external_ip", &self.external_ip);
         debug_struct.field("dns_endpoint", &self.dns_endpoint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17018,7 +16982,6 @@ impl std::fmt::Debug for CloudSQLInstanceInfo {
         debug_struct.field("internal_ip", &self.internal_ip);
         debug_struct.field("external_ip", &self.external_ip);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17295,7 +17258,6 @@ impl std::fmt::Debug for RedisInstanceInfo {
         debug_struct.field("primary_endpoint_ip", &self.primary_endpoint_ip);
         debug_struct.field("read_endpoint_ip", &self.read_endpoint_ip);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17595,7 +17557,6 @@ impl std::fmt::Debug for RedisClusterInfo {
             &self.secondary_endpoint_ip_address,
         );
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17832,7 +17793,6 @@ impl std::fmt::Debug for CloudFunctionInfo {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("location", &self.location);
         debug_struct.field("version_id", &self.version_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18051,7 +18011,6 @@ impl std::fmt::Debug for CloudRunRevisionInfo {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("location", &self.location);
         debug_struct.field("service_uri", &self.service_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18269,7 +18228,6 @@ impl std::fmt::Debug for AppEngineVersionInfo {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("runtime", &self.runtime);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18462,7 +18420,6 @@ impl std::fmt::Debug for VpcConnectorInfo {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("uri", &self.uri);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18715,7 +18672,6 @@ impl std::fmt::Debug for DirectVpcEgressConnectionInfo {
         debug_struct.field("selected_ip_range", &self.selected_ip_range);
         debug_struct.field("selected_ip_address", &self.selected_ip_address);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18861,7 +18817,6 @@ impl std::fmt::Debug for ServerlessExternalConnectionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServerlessExternalConnectionInfo");
         debug_struct.field("selected_ip_address", &self.selected_ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19401,7 +19356,6 @@ impl std::fmt::Debug for NatInfo {
         debug_struct.field("new_destination_port", &self.new_destination_port);
         debug_struct.field("router_uri", &self.router_uri);
         debug_struct.field("nat_gateway_name", &self.nat_gateway_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20040,7 +19994,6 @@ impl std::fmt::Debug for ProxyConnectionInfo {
         debug_struct.field("new_destination_port", &self.new_destination_port);
         debug_struct.field("subnet_uri", &self.subnet_uri);
         debug_struct.field("network_uri", &self.network_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20476,7 +20429,6 @@ impl std::fmt::Debug for LoadBalancerBackendInfo {
             "health_check_firewalls_config_state",
             &self.health_check_firewalls_config_state,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20783,7 +20735,6 @@ impl std::fmt::Debug for StorageBucketInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StorageBucketInfo");
         debug_struct.field("bucket", &self.bucket);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20927,7 +20878,6 @@ impl std::fmt::Debug for ServerlessNegInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServerlessNegInfo");
         debug_struct.field("neg_uri", &self.neg_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21194,7 +21144,6 @@ impl std::fmt::Debug for ListVpcFlowLogsConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21412,7 +21361,6 @@ impl std::fmt::Debug for ListVpcFlowLogsConfigsResponse {
         debug_struct.field("vpc_flow_logs_configs", &self.vpc_flow_logs_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21555,7 +21503,6 @@ impl std::fmt::Debug for GetVpcFlowLogsConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVpcFlowLogsConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21765,7 +21712,6 @@ impl std::fmt::Debug for CreateVpcFlowLogsConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("vpc_flow_logs_config_id", &self.vpc_flow_logs_config_id);
         debug_struct.field("vpc_flow_logs_config", &self.vpc_flow_logs_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21958,7 +21904,6 @@ impl std::fmt::Debug for UpdateVpcFlowLogsConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateVpcFlowLogsConfigRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("vpc_flow_logs_config", &self.vpc_flow_logs_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22101,7 +22046,6 @@ impl std::fmt::Debug for DeleteVpcFlowLogsConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteVpcFlowLogsConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22797,7 +22741,6 @@ impl std::fmt::Debug for VpcFlowLogsConfig {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("target_resource", &self.target_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -369,7 +369,6 @@ impl std::fmt::Debug for AuthorizationPolicy {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("action", &self.action);
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -569,7 +568,6 @@ pub mod authorization_policy {
             let mut debug_struct = f.debug_struct("Rule");
             debug_struct.field("sources", &self.sources);
             debug_struct.field("destinations", &self.destinations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -767,7 +765,6 @@ pub mod authorization_policy {
                 let mut debug_struct = f.debug_struct("Source");
                 debug_struct.field("principals", &self.principals);
                 debug_struct.field("ip_blocks", &self.ip_blocks);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1062,7 +1059,6 @@ pub mod authorization_policy {
                 debug_struct.field("ports", &self.ports);
                 debug_struct.field("methods", &self.methods);
                 debug_struct.field("http_header_match", &self.http_header_match);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1301,7 +1297,6 @@ pub mod authorization_policy {
                     let mut debug_struct = f.debug_struct("HttpHeaderMatch");
                     debug_struct.field("header_name", &self.header_name);
                     debug_struct.field("r#type", &self.r#type);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -1674,7 +1669,6 @@ impl std::fmt::Debug for ListAuthorizationPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1866,7 +1860,6 @@ impl std::fmt::Debug for ListAuthorizationPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListAuthorizationPoliciesResponse");
         debug_struct.field("authorization_policies", &self.authorization_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2009,7 +2002,6 @@ impl std::fmt::Debug for GetAuthorizationPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAuthorizationPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2221,7 +2213,6 @@ impl std::fmt::Debug for CreateAuthorizationPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("authorization_policy_id", &self.authorization_policy_id);
         debug_struct.field("authorization_policy", &self.authorization_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2416,7 +2407,6 @@ impl std::fmt::Debug for UpdateAuthorizationPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateAuthorizationPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("authorization_policy", &self.authorization_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2559,7 +2549,6 @@ impl std::fmt::Debug for DeleteAuthorizationPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAuthorizationPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2934,7 +2923,6 @@ impl std::fmt::Debug for ClientTlsPolicy {
         debug_struct.field("sni", &self.sni);
         debug_struct.field("client_certificate", &self.client_certificate);
         debug_struct.field("server_validation_ca", &self.server_validation_ca);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3150,7 +3138,6 @@ impl std::fmt::Debug for ListClientTlsPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3342,7 +3329,6 @@ impl std::fmt::Debug for ListClientTlsPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListClientTlsPoliciesResponse");
         debug_struct.field("client_tls_policies", &self.client_tls_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3485,7 +3471,6 @@ impl std::fmt::Debug for GetClientTlsPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClientTlsPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3697,7 +3682,6 @@ impl std::fmt::Debug for CreateClientTlsPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("client_tls_policy_id", &self.client_tls_policy_id);
         debug_struct.field("client_tls_policy", &self.client_tls_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3894,7 +3878,6 @@ impl std::fmt::Debug for UpdateClientTlsPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateClientTlsPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("client_tls_policy", &self.client_tls_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4037,7 +4020,6 @@ impl std::fmt::Debug for DeleteClientTlsPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteClientTlsPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4361,7 +4343,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4757,7 +4738,6 @@ impl std::fmt::Debug for ServerTlsPolicy {
         debug_struct.field("allow_open", &self.allow_open);
         debug_struct.field("server_certificate", &self.server_certificate);
         debug_struct.field("mtls_policy", &self.mtls_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4916,7 +4896,6 @@ pub mod server_tls_policy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MTLSPolicy");
             debug_struct.field("client_validation_ca", &self.client_validation_ca);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5133,7 +5112,6 @@ impl std::fmt::Debug for ListServerTlsPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5325,7 +5303,6 @@ impl std::fmt::Debug for ListServerTlsPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListServerTlsPoliciesResponse");
         debug_struct.field("server_tls_policies", &self.server_tls_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5468,7 +5445,6 @@ impl std::fmt::Debug for GetServerTlsPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServerTlsPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5680,7 +5656,6 @@ impl std::fmt::Debug for CreateServerTlsPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("server_tls_policy_id", &self.server_tls_policy_id);
         debug_struct.field("server_tls_policy", &self.server_tls_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5877,7 +5852,6 @@ impl std::fmt::Debug for UpdateServerTlsPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateServerTlsPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("server_tls_policy", &self.server_tls_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6020,7 +5994,6 @@ impl std::fmt::Debug for DeleteServerTlsPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServerTlsPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6164,7 +6137,6 @@ impl std::fmt::Debug for GrpcEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GrpcEndpoint");
         debug_struct.field("target_uri", &self.target_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6415,7 +6387,6 @@ impl std::fmt::Debug for ValidationCA {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ValidationCA");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6582,7 +6553,6 @@ impl std::fmt::Debug for CertificateProviderInstance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CertificateProviderInstance");
         debug_struct.field("plugin_instance", &self.plugin_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6834,7 +6804,6 @@ impl std::fmt::Debug for CertificateProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CertificateProvider");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -351,7 +351,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -499,7 +498,6 @@ impl std::fmt::Debug for TrafficPortSelector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TrafficPortSelector");
         debug_struct.field("ports", &self.ports);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -696,7 +694,6 @@ impl std::fmt::Debug for EndpointMatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EndpointMatcher");
         debug_struct.field("matcher_type", &self.matcher_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -917,7 +914,6 @@ pub mod endpoint_matcher {
                 &self.metadata_label_match_criteria,
             );
             debug_struct.field("metadata_labels", &self.metadata_labels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1108,7 +1104,6 @@ pub mod endpoint_matcher {
                 let mut debug_struct = f.debug_struct("MetadataLabels");
                 debug_struct.field("label_name", &self.label_name);
                 debug_struct.field("label_value", &self.label_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1479,7 +1474,6 @@ impl std::fmt::Debug for ExtensionChain {
         debug_struct.field("name", &self.name);
         debug_struct.field("match_condition", &self.match_condition);
         debug_struct.field("extensions", &self.extensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1637,7 +1631,6 @@ pub mod extension_chain {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MatchCondition");
             debug_struct.field("cel_expression", &self.cel_expression);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2076,7 +2069,6 @@ pub mod extension_chain {
             debug_struct.field("fail_open", &self.fail_open);
             debug_struct.field("forward_headers", &self.forward_headers);
             debug_struct.field("metadata", &self.metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2520,7 +2512,6 @@ impl std::fmt::Debug for LbTrafficExtension {
         debug_struct.field("extension_chains", &self.extension_chains);
         debug_struct.field("load_balancing_scheme", &self.load_balancing_scheme);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2786,7 +2777,6 @@ impl std::fmt::Debug for ListLbTrafficExtensionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3004,7 +2994,6 @@ impl std::fmt::Debug for ListLbTrafficExtensionsResponse {
         debug_struct.field("lb_traffic_extensions", &self.lb_traffic_extensions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3148,7 +3137,6 @@ impl std::fmt::Debug for GetLbTrafficExtensionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLbTrafficExtensionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3395,7 +3383,6 @@ impl std::fmt::Debug for CreateLbTrafficExtensionRequest {
         debug_struct.field("lb_traffic_extension_id", &self.lb_traffic_extension_id);
         debug_struct.field("lb_traffic_extension", &self.lb_traffic_extension);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3627,7 +3614,6 @@ impl std::fmt::Debug for UpdateLbTrafficExtensionRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("lb_traffic_extension", &self.lb_traffic_extension);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3808,7 +3794,6 @@ impl std::fmt::Debug for DeleteLbTrafficExtensionRequest {
         let mut debug_struct = f.debug_struct("DeleteLbTrafficExtensionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4249,7 +4234,6 @@ impl std::fmt::Debug for LbRouteExtension {
         debug_struct.field("extension_chains", &self.extension_chains);
         debug_struct.field("load_balancing_scheme", &self.load_balancing_scheme);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4515,7 +4499,6 @@ impl std::fmt::Debug for ListLbRouteExtensionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4733,7 +4716,6 @@ impl std::fmt::Debug for ListLbRouteExtensionsResponse {
         debug_struct.field("lb_route_extensions", &self.lb_route_extensions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4877,7 +4859,6 @@ impl std::fmt::Debug for GetLbRouteExtensionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLbRouteExtensionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5125,7 +5106,6 @@ impl std::fmt::Debug for CreateLbRouteExtensionRequest {
         debug_struct.field("lb_route_extension_id", &self.lb_route_extension_id);
         debug_struct.field("lb_route_extension", &self.lb_route_extension);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5358,7 +5338,6 @@ impl std::fmt::Debug for UpdateLbRouteExtensionRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("lb_route_extension", &self.lb_route_extension);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5539,7 +5518,6 @@ impl std::fmt::Debug for DeleteLbRouteExtensionRequest {
         let mut debug_struct = f.debug_struct("DeleteLbRouteExtensionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6097,7 +6075,6 @@ impl std::fmt::Debug for AuthzExtension {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("forward_headers", &self.forward_headers);
         debug_struct.field("wire_format", &self.wire_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6363,7 +6340,6 @@ impl std::fmt::Debug for ListAuthzExtensionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6581,7 +6557,6 @@ impl std::fmt::Debug for ListAuthzExtensionsResponse {
         debug_struct.field("authz_extensions", &self.authz_extensions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6725,7 +6700,6 @@ impl std::fmt::Debug for GetAuthzExtensionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAuthzExtensionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6973,7 +6947,6 @@ impl std::fmt::Debug for CreateAuthzExtensionRequest {
         debug_struct.field("authz_extension_id", &self.authz_extension_id);
         debug_struct.field("authz_extension", &self.authz_extension);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7206,7 +7179,6 @@ impl std::fmt::Debug for UpdateAuthzExtensionRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("authz_extension", &self.authz_extension);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7387,7 +7359,6 @@ impl std::fmt::Debug for DeleteAuthzExtensionRequest {
         let mut debug_struct = f.debug_struct("DeleteAuthzExtensionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7878,7 +7849,6 @@ impl std::fmt::Debug for EndpointPolicy {
         debug_struct.field("description", &self.description);
         debug_struct.field("server_tls_policy", &self.server_tls_policy);
         debug_struct.field("client_tls_policy", &self.client_tls_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8260,7 +8230,6 @@ impl std::fmt::Debug for ListEndpointPoliciesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8485,7 +8454,6 @@ impl std::fmt::Debug for ListEndpointPoliciesResponse {
         debug_struct.field("endpoint_policies", &self.endpoint_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8628,7 +8596,6 @@ impl std::fmt::Debug for GetEndpointPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEndpointPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8839,7 +8806,6 @@ impl std::fmt::Debug for CreateEndpointPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("endpoint_policy_id", &self.endpoint_policy_id);
         debug_struct.field("endpoint_policy", &self.endpoint_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9035,7 +9001,6 @@ impl std::fmt::Debug for UpdateEndpointPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateEndpointPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("endpoint_policy", &self.endpoint_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9178,7 +9143,6 @@ impl std::fmt::Debug for DeleteEndpointPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEndpointPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9616,7 +9580,6 @@ impl std::fmt::Debug for WasmPlugin {
         debug_struct.field("log_config", &self.log_config);
         debug_struct.field("versions", &self.versions);
         debug_struct.field("used_by", &self.used_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10124,7 +10087,6 @@ pub mod wasm_plugin {
             debug_struct.field("image_digest", &self.image_digest);
             debug_struct.field("plugin_config_digest", &self.plugin_config_digest);
             debug_struct.field("plugin_config_source", &self.plugin_config_source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10392,7 +10354,6 @@ pub mod wasm_plugin {
             debug_struct.field("enable", &self.enable);
             debug_struct.field("sample_rate", &self.sample_rate);
             debug_struct.field("min_log_level", &self.min_log_level);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10709,7 +10670,6 @@ pub mod wasm_plugin {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UsedBy");
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11222,7 +11182,6 @@ impl std::fmt::Debug for WasmPluginVersion {
         debug_struct.field("image_digest", &self.image_digest);
         debug_struct.field("plugin_config_digest", &self.plugin_config_digest);
         debug_struct.field("plugin_config_source", &self.plugin_config_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11465,7 +11424,6 @@ impl std::fmt::Debug for ListWasmPluginsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11684,7 +11642,6 @@ impl std::fmt::Debug for ListWasmPluginsResponse {
         debug_struct.field("wasm_plugins", &self.wasm_plugins);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11853,7 +11810,6 @@ impl std::fmt::Debug for GetWasmPluginRequest {
         let mut debug_struct = f.debug_struct("GetWasmPluginRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12059,7 +12015,6 @@ impl std::fmt::Debug for CreateWasmPluginRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("wasm_plugin_id", &self.wasm_plugin_id);
         debug_struct.field("wasm_plugin", &self.wasm_plugin);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12259,7 +12214,6 @@ impl std::fmt::Debug for UpdateWasmPluginRequest {
         let mut debug_struct = f.debug_struct("UpdateWasmPluginRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("wasm_plugin", &self.wasm_plugin);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12402,7 +12356,6 @@ impl std::fmt::Debug for DeleteWasmPluginRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteWasmPluginRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12622,7 +12575,6 @@ impl std::fmt::Debug for ListWasmPluginVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12845,7 +12797,6 @@ impl std::fmt::Debug for ListWasmPluginVersionsResponse {
         debug_struct.field("wasm_plugin_versions", &self.wasm_plugin_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12989,7 +12940,6 @@ impl std::fmt::Debug for GetWasmPluginVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWasmPluginVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13201,7 +13151,6 @@ impl std::fmt::Debug for CreateWasmPluginVersionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("wasm_plugin_version_id", &self.wasm_plugin_version_id);
         debug_struct.field("wasm_plugin_version", &self.wasm_plugin_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13345,7 +13294,6 @@ impl std::fmt::Debug for DeleteWasmPluginVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteWasmPluginVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14052,7 +14000,6 @@ impl std::fmt::Debug for Gateway {
         debug_struct.field("ip_version", &self.ip_version);
         debug_struct.field("envoy_headers", &self.envoy_headers);
         debug_struct.field("routing_mode", &self.routing_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14680,7 +14627,6 @@ impl std::fmt::Debug for ListGatewaysRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14895,7 +14841,6 @@ impl std::fmt::Debug for ListGatewaysResponse {
         debug_struct.field("gateways", &self.gateways);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15038,7 +14983,6 @@ impl std::fmt::Debug for GetGatewayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGatewayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15243,7 +15187,6 @@ impl std::fmt::Debug for CreateGatewayRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("gateway_id", &self.gateway_id);
         debug_struct.field("gateway", &self.gateway);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15437,7 +15380,6 @@ impl std::fmt::Debug for UpdateGatewayRequest {
         let mut debug_struct = f.debug_struct("UpdateGatewayRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("gateway", &self.gateway);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15580,7 +15522,6 @@ impl std::fmt::Debug for DeleteGatewayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGatewayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16046,7 +15987,6 @@ impl std::fmt::Debug for GrpcRoute {
         debug_struct.field("meshes", &self.meshes);
         debug_struct.field("gateways", &self.gateways);
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16298,7 +16238,6 @@ pub mod grpc_route {
             debug_struct.field("grpc_service", &self.grpc_service);
             debug_struct.field("grpc_method", &self.grpc_method);
             debug_struct.field("case_sensitive", &self.case_sensitive);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16641,7 +16580,6 @@ pub mod grpc_route {
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("key", &self.key);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16973,7 +16911,6 @@ pub mod grpc_route {
             let mut debug_struct = f.debug_struct("RouteMatch");
             debug_struct.field("method", &self.method);
             debug_struct.field("headers", &self.headers);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17236,7 +17173,6 @@ pub mod grpc_route {
             let mut debug_struct = f.debug_struct("Destination");
             debug_struct.field("weight", &self.weight);
             debug_struct.field("destination_type", &self.destination_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17450,7 +17386,6 @@ pub mod grpc_route {
             let mut debug_struct = f.debug_struct("FaultInjectionPolicy");
             debug_struct.field("delay", &self.delay);
             debug_struct.field("abort", &self.abort);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17682,7 +17617,6 @@ pub mod grpc_route {
                 let mut debug_struct = f.debug_struct("Delay");
                 debug_struct.field("fixed_delay", &self.fixed_delay);
                 debug_struct.field("percentage", &self.percentage);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17935,7 +17869,6 @@ pub mod grpc_route {
                 let mut debug_struct = f.debug_struct("Abort");
                 debug_struct.field("http_status", &self.http_status);
                 debug_struct.field("percentage", &self.percentage);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -18105,7 +18038,6 @@ pub mod grpc_route {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StatefulSessionAffinityPolicy");
             debug_struct.field("cookie_ttl", &self.cookie_ttl);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18317,7 +18249,6 @@ pub mod grpc_route {
             let mut debug_struct = f.debug_struct("RetryPolicy");
             debug_struct.field("retry_conditions", &self.retry_conditions);
             debug_struct.field("num_retries", &self.num_retries);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18686,7 +18617,6 @@ pub mod grpc_route {
             debug_struct.field("retry_policy", &self.retry_policy);
             debug_struct.field("stateful_session_affinity", &self.stateful_session_affinity);
             debug_struct.field("idle_timeout", &self.idle_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18878,7 +18808,6 @@ pub mod grpc_route {
             let mut debug_struct = f.debug_struct("RouteRule");
             debug_struct.field("matches", &self.matches);
             debug_struct.field("action", &self.action);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19122,7 +19051,6 @@ impl std::fmt::Debug for ListGrpcRoutesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19343,7 +19271,6 @@ impl std::fmt::Debug for ListGrpcRoutesResponse {
         debug_struct.field("grpc_routes", &self.grpc_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19486,7 +19413,6 @@ impl std::fmt::Debug for GetGrpcRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGrpcRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19692,7 +19618,6 @@ impl std::fmt::Debug for CreateGrpcRouteRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("grpc_route_id", &self.grpc_route_id);
         debug_struct.field("grpc_route", &self.grpc_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19887,7 +19812,6 @@ impl std::fmt::Debug for UpdateGrpcRouteRequest {
         let mut debug_struct = f.debug_struct("UpdateGrpcRouteRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("grpc_route", &self.grpc_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20030,7 +19954,6 @@ impl std::fmt::Debug for DeleteGrpcRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGrpcRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20489,7 +20412,6 @@ impl std::fmt::Debug for HttpRoute {
         debug_struct.field("gateways", &self.gateways);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20999,7 +20921,6 @@ pub mod http_route {
             debug_struct.field("header", &self.header);
             debug_struct.field("invert_match", &self.invert_match);
             debug_struct.field("match_type", &self.match_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21220,7 +21141,6 @@ pub mod http_route {
                 let mut debug_struct = f.debug_struct("IntegerRange");
                 debug_struct.field("start", &self.start);
                 debug_struct.field("end", &self.end);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -21556,7 +21476,6 @@ pub mod http_route {
             let mut debug_struct = f.debug_struct("QueryParameterMatch");
             debug_struct.field("query_parameter", &self.query_parameter);
             debug_struct.field("match_type", &self.match_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21977,7 +21896,6 @@ pub mod http_route {
             debug_struct.field("headers", &self.headers);
             debug_struct.field("query_parameters", &self.query_parameters);
             debug_struct.field("path_match", &self.path_match);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22306,7 +22224,6 @@ pub mod http_route {
             debug_struct.field("weight", &self.weight);
             debug_struct.field("request_header_modifier", &self.request_header_modifier);
             debug_struct.field("response_header_modifier", &self.response_header_modifier);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22659,7 +22576,6 @@ pub mod http_route {
             debug_struct.field("https_redirect", &self.https_redirect);
             debug_struct.field("strip_query", &self.strip_query);
             debug_struct.field("port_redirect", &self.port_redirect);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23022,7 +22938,6 @@ pub mod http_route {
             let mut debug_struct = f.debug_struct("FaultInjectionPolicy");
             debug_struct.field("delay", &self.delay);
             debug_struct.field("abort", &self.abort);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23241,7 +23156,6 @@ pub mod http_route {
                 let mut debug_struct = f.debug_struct("Delay");
                 debug_struct.field("fixed_delay", &self.fixed_delay);
                 debug_struct.field("percentage", &self.percentage);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -23468,7 +23382,6 @@ pub mod http_route {
                 let mut debug_struct = f.debug_struct("Abort");
                 debug_struct.field("http_status", &self.http_status);
                 debug_struct.field("percentage", &self.percentage);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -23638,7 +23551,6 @@ pub mod http_route {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StatefulSessionAffinityPolicy");
             debug_struct.field("cookie_ttl", &self.cookie_ttl);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23861,7 +23773,6 @@ pub mod http_route {
             debug_struct.field("set", &self.set);
             debug_struct.field("add", &self.add);
             debug_struct.field("remove", &self.remove);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24042,7 +23953,6 @@ pub mod http_route {
             let mut debug_struct = f.debug_struct("URLRewrite");
             debug_struct.field("path_prefix_rewrite", &self.path_prefix_rewrite);
             debug_struct.field("host_rewrite", &self.host_rewrite);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24295,7 +24205,6 @@ pub mod http_route {
             debug_struct.field("retry_conditions", &self.retry_conditions);
             debug_struct.field("num_retries", &self.num_retries);
             debug_struct.field("per_try_timeout", &self.per_try_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24502,7 +24411,6 @@ pub mod http_route {
             let mut debug_struct = f.debug_struct("RequestMirrorPolicy");
             debug_struct.field("destination", &self.destination);
             debug_struct.field("mirror_percent", &self.mirror_percent);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24854,7 +24762,6 @@ pub mod http_route {
             debug_struct.field("max_age", &self.max_age);
             debug_struct.field("allow_credentials", &self.allow_credentials);
             debug_struct.field("disabled", &self.disabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25160,7 +25067,6 @@ pub mod http_route {
             let mut debug_struct = f.debug_struct("HttpDirectResponse");
             debug_struct.field("status", &self.status);
             debug_struct.field("http_body", &self.http_body);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25829,7 +25735,6 @@ pub mod http_route {
             debug_struct.field("stateful_session_affinity", &self.stateful_session_affinity);
             debug_struct.field("direct_response", &self.direct_response);
             debug_struct.field("idle_timeout", &self.idle_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26026,7 +25931,6 @@ pub mod http_route {
             let mut debug_struct = f.debug_struct("RouteRule");
             debug_struct.field("matches", &self.matches);
             debug_struct.field("action", &self.action);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26270,7 +26174,6 @@ impl std::fmt::Debug for ListHttpRoutesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26491,7 +26394,6 @@ impl std::fmt::Debug for ListHttpRoutesResponse {
         debug_struct.field("http_routes", &self.http_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26634,7 +26536,6 @@ impl std::fmt::Debug for GetHttpRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetHttpRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26840,7 +26741,6 @@ impl std::fmt::Debug for CreateHttpRouteRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("http_route_id", &self.http_route_id);
         debug_struct.field("http_route", &self.http_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27035,7 +26935,6 @@ impl std::fmt::Debug for UpdateHttpRouteRequest {
         let mut debug_struct = f.debug_struct("UpdateHttpRouteRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("http_route", &self.http_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27178,7 +27077,6 @@ impl std::fmt::Debug for DeleteHttpRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteHttpRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27574,7 +27472,6 @@ impl std::fmt::Debug for Mesh {
         debug_struct.field("description", &self.description);
         debug_struct.field("interception_port", &self.interception_port);
         debug_struct.field("envoy_headers", &self.envoy_headers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27817,7 +27714,6 @@ impl std::fmt::Debug for ListMeshesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28034,7 +27930,6 @@ impl std::fmt::Debug for ListMeshesResponse {
         debug_struct.field("meshes", &self.meshes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28177,7 +28072,6 @@ impl std::fmt::Debug for GetMeshRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMeshRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28382,7 +28276,6 @@ impl std::fmt::Debug for CreateMeshRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("mesh_id", &self.mesh_id);
         debug_struct.field("mesh", &self.mesh);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28576,7 +28469,6 @@ impl std::fmt::Debug for UpdateMeshRequest {
         let mut debug_struct = f.debug_struct("UpdateMeshRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("mesh", &self.mesh);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28719,7 +28611,6 @@ impl std::fmt::Debug for DeleteMeshRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteMeshRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28986,7 +28877,6 @@ impl std::fmt::Debug for GatewayRouteView {
         debug_struct.field("route_location", &self.route_location);
         debug_struct.field("route_type", &self.route_type);
         debug_struct.field("route_id", &self.route_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29253,7 +29143,6 @@ impl std::fmt::Debug for MeshRouteView {
         debug_struct.field("route_location", &self.route_location);
         debug_struct.field("route_type", &self.route_type);
         debug_struct.field("route_id", &self.route_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29397,7 +29286,6 @@ impl std::fmt::Debug for GetGatewayRouteViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGatewayRouteViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29541,7 +29429,6 @@ impl std::fmt::Debug for GetMeshRouteViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMeshRouteViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29757,7 +29644,6 @@ impl std::fmt::Debug for ListGatewayRouteViewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29973,7 +29859,6 @@ impl std::fmt::Debug for ListMeshRouteViewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30194,7 +30079,6 @@ impl std::fmt::Debug for ListGatewayRouteViewsResponse {
         debug_struct.field("gateway_route_views", &self.gateway_route_views);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30411,7 +30295,6 @@ impl std::fmt::Debug for ListMeshRouteViewsResponse {
         debug_struct.field("mesh_route_views", &self.mesh_route_views);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30759,7 +30642,6 @@ impl std::fmt::Debug for ServiceBinding {
         debug_struct.field("service", &self.service);
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30974,7 +30856,6 @@ impl std::fmt::Debug for ListServiceBindingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31196,7 +31077,6 @@ impl std::fmt::Debug for ListServiceBindingsResponse {
         debug_struct.field("service_bindings", &self.service_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31339,7 +31219,6 @@ impl std::fmt::Debug for GetServiceBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31549,7 +31428,6 @@ impl std::fmt::Debug for CreateServiceBindingRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_binding_id", &self.service_binding_id);
         debug_struct.field("service_binding", &self.service_binding);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31745,7 +31623,6 @@ impl std::fmt::Debug for UpdateServiceBindingRequest {
         let mut debug_struct = f.debug_struct("UpdateServiceBindingRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service_binding", &self.service_binding);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31888,7 +31765,6 @@ impl std::fmt::Debug for DeleteServiceBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32321,7 +32197,6 @@ impl std::fmt::Debug for ServiceLbPolicy {
         debug_struct.field("auto_capacity_drain", &self.auto_capacity_drain);
         debug_struct.field("failover_config", &self.failover_config);
         debug_struct.field("isolation_config", &self.isolation_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32477,7 +32352,6 @@ pub mod service_lb_policy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AutoCapacityDrain");
             debug_struct.field("enable", &self.enable);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32655,7 +32529,6 @@ pub mod service_lb_policy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FailoverConfig");
             debug_struct.field("failover_health_threshold", &self.failover_health_threshold);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32842,7 +32715,6 @@ pub mod service_lb_policy {
             let mut debug_struct = f.debug_struct("IsolationConfig");
             debug_struct.field("isolation_granularity", &self.isolation_granularity);
             debug_struct.field("isolation_mode", &self.isolation_mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33474,7 +33346,6 @@ impl std::fmt::Debug for ListServiceLbPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33696,7 +33567,6 @@ impl std::fmt::Debug for ListServiceLbPoliciesResponse {
         debug_struct.field("service_lb_policies", &self.service_lb_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33839,7 +33709,6 @@ impl std::fmt::Debug for GetServiceLbPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceLbPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34052,7 +33921,6 @@ impl std::fmt::Debug for CreateServiceLbPolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_lb_policy_id", &self.service_lb_policy_id);
         debug_struct.field("service_lb_policy", &self.service_lb_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34248,7 +34116,6 @@ impl std::fmt::Debug for UpdateServiceLbPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateServiceLbPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("service_lb_policy", &self.service_lb_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34391,7 +34258,6 @@ impl std::fmt::Debug for DeleteServiceLbPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceLbPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34797,7 +34663,6 @@ impl std::fmt::Debug for TcpRoute {
         debug_struct.field("meshes", &self.meshes);
         debug_struct.field("gateways", &self.gateways);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34994,7 +34859,6 @@ pub mod tcp_route {
             let mut debug_struct = f.debug_struct("RouteRule");
             debug_struct.field("matches", &self.matches);
             debug_struct.field("action", &self.action);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35174,7 +35038,6 @@ pub mod tcp_route {
             let mut debug_struct = f.debug_struct("RouteMatch");
             debug_struct.field("address", &self.address);
             debug_struct.field("port", &self.port);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35397,7 +35260,6 @@ pub mod tcp_route {
             debug_struct.field("destinations", &self.destinations);
             debug_struct.field("original_destination", &self.original_destination);
             debug_struct.field("idle_timeout", &self.idle_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35603,7 +35465,6 @@ pub mod tcp_route {
             let mut debug_struct = f.debug_struct("RouteDestination");
             debug_struct.field("service_name", &self.service_name);
             debug_struct.field("weight", &self.weight);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35847,7 +35708,6 @@ impl std::fmt::Debug for ListTcpRoutesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36068,7 +35928,6 @@ impl std::fmt::Debug for ListTcpRoutesResponse {
         debug_struct.field("tcp_routes", &self.tcp_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36211,7 +36070,6 @@ impl std::fmt::Debug for GetTcpRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTcpRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36417,7 +36275,6 @@ impl std::fmt::Debug for CreateTcpRouteRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tcp_route_id", &self.tcp_route_id);
         debug_struct.field("tcp_route", &self.tcp_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36612,7 +36469,6 @@ impl std::fmt::Debug for UpdateTcpRouteRequest {
         let mut debug_struct = f.debug_struct("UpdateTcpRouteRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("tcp_route", &self.tcp_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36755,7 +36611,6 @@ impl std::fmt::Debug for DeleteTcpRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTcpRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37161,7 +37016,6 @@ impl std::fmt::Debug for TlsRoute {
         debug_struct.field("meshes", &self.meshes);
         debug_struct.field("gateways", &self.gateways);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37357,7 +37211,6 @@ pub mod tls_route {
             let mut debug_struct = f.debug_struct("RouteRule");
             debug_struct.field("matches", &self.matches);
             debug_struct.field("action", &self.action);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37545,7 +37398,6 @@ pub mod tls_route {
             let mut debug_struct = f.debug_struct("RouteMatch");
             debug_struct.field("sni_host", &self.sni_host);
             debug_struct.field("alpn", &self.alpn);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37739,7 +37591,6 @@ pub mod tls_route {
             let mut debug_struct = f.debug_struct("RouteAction");
             debug_struct.field("destinations", &self.destinations);
             debug_struct.field("idle_timeout", &self.idle_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37935,7 +37786,6 @@ pub mod tls_route {
             let mut debug_struct = f.debug_struct("RouteDestination");
             debug_struct.field("service_name", &self.service_name);
             debug_struct.field("weight", &self.weight);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38179,7 +38029,6 @@ impl std::fmt::Debug for ListTlsRoutesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("return_partial_success", &self.return_partial_success);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38400,7 +38249,6 @@ impl std::fmt::Debug for ListTlsRoutesResponse {
         debug_struct.field("tls_routes", &self.tls_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38543,7 +38391,6 @@ impl std::fmt::Debug for GetTlsRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTlsRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38749,7 +38596,6 @@ impl std::fmt::Debug for CreateTlsRouteRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tls_route_id", &self.tls_route_id);
         debug_struct.field("tls_route", &self.tls_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38944,7 +38790,6 @@ impl std::fmt::Debug for UpdateTlsRouteRequest {
         let mut debug_struct = f.debug_struct("UpdateTlsRouteRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("tls_route", &self.tls_route);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39087,7 +38932,6 @@ impl std::fmt::Debug for DeleteTlsRouteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTlsRouteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -304,7 +304,6 @@ impl std::fmt::Debug for DiagnosticConfig {
             "enable_copy_home_files_flag",
             &self.enable_copy_home_files_flag,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -520,7 +519,6 @@ impl std::fmt::Debug for Event {
         debug_struct.field("report_time", &self.report_time);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -886,7 +884,6 @@ impl std::fmt::Debug for NetworkInterface {
         debug_struct.field("network", &self.network);
         debug_struct.field("subnet", &self.subnet);
         debug_struct.field("nic_type", &self.nic_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1271,7 +1268,6 @@ impl std::fmt::Debug for VmImage {
         let mut debug_struct = f.debug_struct("VmImage");
         debug_struct.field("project", &self.project);
         debug_struct.field("image", &self.image);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1458,7 +1454,6 @@ impl std::fmt::Debug for ContainerImage {
         let mut debug_struct = f.debug_struct("ContainerImage");
         debug_struct.field("repository", &self.repository);
         debug_struct.field("tag", &self.tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1654,7 +1649,6 @@ impl std::fmt::Debug for AcceleratorConfig {
         let mut debug_struct = f.debug_struct("AcceleratorConfig");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("core_count", &self.core_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2067,7 +2061,6 @@ impl std::fmt::Debug for ShieldedInstanceConfig {
             "enable_integrity_monitoring",
             &self.enable_integrity_monitoring,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2243,7 +2236,6 @@ impl std::fmt::Debug for GPUDriverConfig {
         let mut debug_struct = f.debug_struct("GPUDriverConfig");
         debug_struct.field("enable_gpu_driver", &self.enable_gpu_driver);
         debug_struct.field("custom_gpu_driver_path", &self.custom_gpu_driver_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2491,7 +2483,6 @@ impl std::fmt::Debug for DataDisk {
         debug_struct.field("disk_type", &self.disk_type);
         debug_struct.field("disk_encryption", &self.disk_encryption);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2740,7 +2731,6 @@ impl std::fmt::Debug for BootDisk {
         debug_struct.field("disk_type", &self.disk_type);
         debug_struct.field("disk_encryption", &self.disk_encryption);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2911,7 +2901,6 @@ impl std::fmt::Debug for ServiceAccount {
         let mut debug_struct = f.debug_struct("ServiceAccount");
         debug_struct.field("email", &self.email);
         debug_struct.field("scopes", &self.scopes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3547,7 +3536,6 @@ impl std::fmt::Debug for GceSetup {
         debug_struct.field("enable_ip_forwarding", &self.enable_ip_forwarding);
         debug_struct.field("gpu_driver_config", &self.gpu_driver_config);
         debug_struct.field("image", &self.image);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3927,7 +3915,6 @@ impl std::fmt::Debug for UpgradeHistoryEntry {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("action", &self.action);
         debug_struct.field("target_version", &self.target_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4800,7 +4787,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("disable_proxy_access", &self.disable_proxy_access);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("infrastructure", &self.infrastructure);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5165,7 +5151,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("endpoint", &self.endpoint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5431,7 +5416,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5647,7 +5631,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5790,7 +5773,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6021,7 +6003,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6237,7 +6218,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6406,7 +6386,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6549,7 +6528,6 @@ impl std::fmt::Debug for StartInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6692,7 +6670,6 @@ impl std::fmt::Debug for StopInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6835,7 +6812,6 @@ impl std::fmt::Debug for ResetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6982,7 +6958,6 @@ impl std::fmt::Debug for CheckInstanceUpgradabilityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CheckInstanceUpgradabilityRequest");
         debug_struct.field("notebook_instance", &self.notebook_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7205,7 +7180,6 @@ impl std::fmt::Debug for CheckInstanceUpgradabilityResponse {
         debug_struct.field("upgrade_version", &self.upgrade_version);
         debug_struct.field("upgrade_info", &self.upgrade_info);
         debug_struct.field("upgrade_image", &self.upgrade_image);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7348,7 +7322,6 @@ impl std::fmt::Debug for UpgradeInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpgradeInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7544,7 +7517,6 @@ impl std::fmt::Debug for RollbackInstanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("target_snapshot", &self.target_snapshot);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7770,7 +7742,6 @@ impl std::fmt::Debug for DiagnoseInstanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("diagnostic_config", &self.diagnostic_config);
         debug_struct.field("timeout_minutes", &self.timeout_minutes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -241,7 +241,6 @@ impl std::fmt::Debug for InputConfig {
         let mut debug_struct = f.debug_struct("InputConfig");
         debug_struct.field("data_format", &self.data_format);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -480,7 +479,6 @@ impl std::fmt::Debug for OutputConfig {
         let mut debug_struct = f.debug_struct("OutputConfig");
         debug_struct.field("data_format", &self.data_format);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -637,7 +635,6 @@ impl std::fmt::Debug for GcsSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsSource");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -779,7 +776,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1023,7 +1019,6 @@ impl std::fmt::Debug for AsyncModelMetadata {
         debug_struct.field("state_message", &self.state_message);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2134,7 +2129,6 @@ impl std::fmt::Debug for OptimizeToursRequest {
             "populate_travel_step_polylines",
             &self.populate_travel_step_polylines,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2774,7 +2768,6 @@ impl std::fmt::Debug for OptimizeToursResponse {
         debug_struct.field("validation_errors", &self.validation_errors);
         debug_struct.field("metrics", &self.metrics);
         debug_struct.field("total_cost", &self.total_cost);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3267,7 +3260,6 @@ pub mod optimize_tours_response {
             debug_struct.field("latest_vehicle_end_time", &self.latest_vehicle_end_time);
             debug_struct.field("costs", &self.costs);
             debug_struct.field("total_cost", &self.total_cost);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3448,7 +3440,6 @@ impl std::fmt::Debug for BatchOptimizeToursRequest {
         let mut debug_struct = f.debug_struct("BatchOptimizeToursRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("model_configs", &self.model_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3712,7 +3703,6 @@ pub mod batch_optimize_tours_request {
             debug_struct.field("input_config", &self.input_config);
             debug_struct.field("output_config", &self.output_config);
             debug_struct.field("enable_checkpoints", &self.enable_checkpoints);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3828,7 +3818,6 @@ impl serde::ser::Serialize for BatchOptimizeToursResponse {
 impl std::fmt::Debug for BatchOptimizeToursResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchOptimizeToursResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4645,7 +4634,6 @@ impl std::fmt::Debug for ShipmentModel {
         );
         debug_struct.field("precedence_rules", &self.precedence_rules);
         debug_struct.field("break_rules", &self.break_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4840,7 +4828,6 @@ pub mod shipment_model {
             let mut debug_struct = f.debug_struct("DurationDistanceMatrix");
             debug_struct.field("rows", &self.rows);
             debug_struct.field("vehicle_start_tag", &self.vehicle_start_tag);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5064,7 +5051,6 @@ pub mod shipment_model {
                 let mut debug_struct = f.debug_struct("Row");
                 debug_struct.field("durations", &self.durations);
                 debug_struct.field("meters", &self.meters);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5399,7 +5385,6 @@ pub mod shipment_model {
             debug_struct.field("second_index", &self.second_index);
             debug_struct.field("second_is_delivery", &self.second_is_delivery);
             debug_struct.field("offset_duration", &self.offset_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5600,7 +5585,6 @@ pub mod shipment_model {
             let mut debug_struct = f.debug_struct("BreakRule");
             debug_struct.field("break_requests", &self.break_requests);
             debug_struct.field("frequency_constraints", &self.frequency_constraints);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5849,7 +5833,6 @@ pub mod shipment_model {
                 debug_struct.field("earliest_start_time", &self.earliest_start_time);
                 debug_struct.field("latest_start_time", &self.latest_start_time);
                 debug_struct.field("min_duration", &self.min_duration);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6095,7 +6078,6 @@ pub mod shipment_model {
                 let mut debug_struct = f.debug_struct("FrequencyConstraint");
                 debug_struct.field("min_break_duration", &self.min_break_duration);
                 debug_struct.field("max_inter_break_duration", &self.max_inter_break_duration);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6925,7 +6907,6 @@ impl std::fmt::Debug for Shipment {
         debug_struct.field("label", &self.label);
         debug_struct.field("ignore", &self.ignore);
         debug_struct.field("demands", &self.demands);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7522,7 +7503,6 @@ pub mod shipment {
             debug_struct.field("visit_types", &self.visit_types);
             debug_struct.field("label", &self.label);
             debug_struct.field("demands", &self.demands);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7692,7 +7672,6 @@ pub mod shipment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Load");
             debug_struct.field("amount", &self.amount);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7870,7 +7849,6 @@ impl std::fmt::Debug for ShipmentTypeIncompatibility {
         let mut debug_struct = f.debug_struct("ShipmentTypeIncompatibility");
         debug_struct.field("types", &self.types);
         debug_struct.field("incompatibility_mode", &self.incompatibility_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8248,7 +8226,6 @@ impl std::fmt::Debug for ShipmentTypeRequirement {
         );
         debug_struct.field("dependent_shipment_types", &self.dependent_shipment_types);
         debug_struct.field("requirement_mode", &self.requirement_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8642,7 +8619,6 @@ impl std::fmt::Debug for RouteModifiers {
         debug_struct.field("avoid_highways", &self.avoid_highways);
         debug_struct.field("avoid_ferries", &self.avoid_ferries);
         debug_struct.field("avoid_indoor", &self.avoid_indoor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9981,7 +9957,6 @@ impl std::fmt::Debug for Vehicle {
         debug_struct.field("capacities", &self.capacities);
         debug_struct.field("start_load_intervals", &self.start_load_intervals);
         debug_struct.field("end_load_intervals", &self.end_load_intervals);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10364,7 +10339,6 @@ pub mod vehicle {
             );
             debug_struct.field("start_load_interval", &self.start_load_interval);
             debug_struct.field("end_load_interval", &self.end_load_interval);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10613,7 +10587,6 @@ pub mod vehicle {
                 let mut debug_struct = f.debug_struct("Interval");
                 debug_struct.field("min", &self.min);
                 debug_struct.field("max", &self.max);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -11041,7 +11014,6 @@ pub mod vehicle {
                 "cost_per_square_hour_after_quadratic_soft_max",
                 &self.cost_per_square_hour_after_quadratic_soft_max,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11770,7 +11742,6 @@ impl std::fmt::Debug for TimeWindow {
             "cost_per_hour_after_soft_end_time",
             &self.cost_per_hour_after_soft_end_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11958,7 +11929,6 @@ impl std::fmt::Debug for CapacityQuantity {
         let mut debug_struct = f.debug_struct("CapacityQuantity");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12218,7 +12188,6 @@ impl std::fmt::Debug for CapacityQuantityInterval {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("min_value", &self.min_value);
         debug_struct.field("max_value", &self.max_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12622,7 +12591,6 @@ impl std::fmt::Debug for DistanceLimit {
             "cost_per_kilometer_above_soft_max",
             &self.cost_per_kilometer_above_soft_max,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13044,7 +13012,6 @@ impl std::fmt::Debug for TransitionAttributes {
         debug_struct.field("cost_per_kilometer", &self.cost_per_kilometer);
         debug_struct.field("distance_limit", &self.distance_limit);
         debug_struct.field("delay", &self.delay);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13307,7 +13274,6 @@ impl std::fmt::Debug for Waypoint {
         let mut debug_struct = f.debug_struct("Waypoint");
         debug_struct.field("side_of_road", &self.side_of_road);
         debug_struct.field("location_type", &self.location_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13538,7 +13504,6 @@ impl std::fmt::Debug for Location {
         let mut debug_struct = f.debug_struct("Location");
         debug_struct.field("lat_lng", &self.lat_lng);
         debug_struct.field("heading", &self.heading);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13731,7 +13696,6 @@ impl std::fmt::Debug for BreakRule {
         let mut debug_struct = f.debug_struct("BreakRule");
         debug_struct.field("break_requests", &self.break_requests);
         debug_struct.field("frequency_constraints", &self.frequency_constraints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13971,7 +13935,6 @@ pub mod break_rule {
             debug_struct.field("earliest_start_time", &self.earliest_start_time);
             debug_struct.field("latest_start_time", &self.latest_start_time);
             debug_struct.field("min_duration", &self.min_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14206,7 +14169,6 @@ pub mod break_rule {
             let mut debug_struct = f.debug_struct("FrequencyConstraint");
             debug_struct.field("min_break_duration", &self.min_break_duration);
             debug_struct.field("max_inter_break_duration", &self.max_inter_break_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15098,7 +15060,6 @@ impl std::fmt::Debug for ShipmentRoute {
         debug_struct.field("travel_steps", &self.travel_steps);
         debug_struct.field("vehicle_detour", &self.vehicle_detour);
         debug_struct.field("delay_before_vehicle_end", &self.delay_before_vehicle_end);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15303,7 +15264,6 @@ pub mod shipment_route {
             let mut debug_struct = f.debug_struct("Delay");
             debug_struct.field("start_time", &self.start_time);
             debug_struct.field("duration", &self.duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15869,7 +15829,6 @@ pub mod shipment_route {
             debug_struct.field("arrival_loads", &self.arrival_loads);
             debug_struct.field("delay_before_start", &self.delay_before_start);
             debug_struct.field("demands", &self.demands);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16454,7 +16413,6 @@ pub mod shipment_route {
             debug_struct.field("route_polyline", &self.route_polyline);
             debug_struct.field("vehicle_loads", &self.vehicle_loads);
             debug_struct.field("loads", &self.loads);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16625,7 +16583,6 @@ pub mod shipment_route {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("VehicleLoad");
             debug_struct.field("amount", &self.amount);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16773,7 +16730,6 @@ pub mod shipment_route {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EncodedPolyline");
             debug_struct.field("points", &self.points);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16966,7 +16922,6 @@ pub mod shipment_route {
             let mut debug_struct = f.debug_struct("Break");
             debug_struct.field("start_time", &self.start_time);
             debug_struct.field("duration", &self.duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17264,7 +17219,6 @@ pub mod shipment_route {
             debug_struct.field("distance_meters", &self.distance_meters);
             debug_struct.field("traffic_info_unavailable", &self.traffic_info_unavailable);
             debug_struct.field("route_polyline", &self.route_polyline);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17490,7 +17444,6 @@ impl std::fmt::Debug for SkippedShipment {
         debug_struct.field("index", &self.index);
         debug_struct.field("label", &self.label);
         debug_struct.field("reasons", &self.reasons);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17772,7 +17725,6 @@ pub mod skipped_shipment {
                 "example_exceeded_capacity_type",
                 &self.example_exceeded_capacity_type,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18624,7 +18576,6 @@ impl std::fmt::Debug for AggregatedMetrics {
         debug_struct.field("max_loads", &self.max_loads);
         debug_struct.field("costs", &self.costs);
         debug_struct.field("total_cost", &self.total_cost);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18838,7 +18789,6 @@ impl std::fmt::Debug for InjectedSolutionConstraint {
         debug_struct.field("routes", &self.routes);
         debug_struct.field("skipped_shipments", &self.skipped_shipments);
         debug_struct.field("constraint_relaxations", &self.constraint_relaxations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19069,7 +19019,6 @@ pub mod injected_solution_constraint {
             let mut debug_struct = f.debug_struct("ConstraintRelaxation");
             debug_struct.field("relaxations", &self.relaxations);
             debug_struct.field("vehicle_indices", &self.vehicle_indices);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19359,7 +19308,6 @@ pub mod injected_solution_constraint {
                 debug_struct.field("level", &self.level);
                 debug_struct.field("threshold_time", &self.threshold_time);
                 debug_struct.field("threshold_visit_count", &self.threshold_visit_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -20086,7 +20034,6 @@ impl std::fmt::Debug for OptimizeToursValidationError {
         debug_struct.field("fields", &self.fields);
         debug_struct.field("error_message", &self.error_message);
         debug_struct.field("offending_values", &self.offending_values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20424,7 +20371,6 @@ pub mod optimize_tours_validation_error {
             debug_struct.field("name", &self.name);
             debug_struct.field("sub_field", &self.sub_field);
             debug_struct.field("index_or_key", &self.index_or_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -438,7 +438,6 @@ impl std::fmt::Debug for AutonomousDatabase {
         debug_struct.field("network", &self.network);
         debug_struct.field("cidr", &self.cidr);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2694,7 +2693,6 @@ impl std::fmt::Debug for AutonomousDatabaseProperties {
         );
         debug_struct.field("maintenance_begin_time", &self.maintenance_begin_time);
         debug_struct.field("maintenance_end_time", &self.maintenance_end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4398,7 +4396,6 @@ impl std::fmt::Debug for AutonomousDatabaseApex {
         let mut debug_struct = f.debug_struct("AutonomousDatabaseApex");
         debug_struct.field("apex_version", &self.apex_version);
         debug_struct.field("ords_version", &self.ords_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4692,7 +4689,6 @@ impl std::fmt::Debug for AutonomousDatabaseConnectionStrings {
         debug_struct.field("low", &self.low);
         debug_struct.field("medium", &self.medium);
         debug_struct.field("profiles", &self.profiles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5083,7 +5079,6 @@ impl std::fmt::Debug for DatabaseConnectionStringProfile {
         debug_struct.field("syntax_format", &self.syntax_format);
         debug_struct.field("tls_authentication", &self.tls_authentication);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6105,7 +6100,6 @@ impl std::fmt::Debug for AllConnectionStrings {
         debug_struct.field("high", &self.high);
         debug_struct.field("low", &self.low);
         debug_struct.field("medium", &self.medium);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6469,7 +6463,6 @@ impl std::fmt::Debug for AutonomousDatabaseConnectionUrls {
         debug_struct.field("mongo_db_uri", &self.mongo_db_uri);
         debug_struct.field("ords_uri", &self.ords_uri);
         debug_struct.field("sql_dev_web_uri", &self.sql_dev_web_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6779,7 +6772,6 @@ impl std::fmt::Debug for AutonomousDatabaseStandbySummary {
             "disaster_recovery_role_changed_time",
             &self.disaster_recovery_role_changed_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6997,7 +6989,6 @@ impl std::fmt::Debug for ScheduledOperationDetails {
         debug_struct.field("day_of_week", &self.day_of_week);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("stop_time", &self.stop_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7198,7 +7189,6 @@ impl std::fmt::Debug for AutonomousDatabaseCharacterSet {
         debug_struct.field("name", &self.name);
         debug_struct.field("character_set_type", &self.character_set_type);
         debug_struct.field("character_set", &self.character_set);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7612,7 +7602,6 @@ impl std::fmt::Debug for AutonomousDatabaseBackup {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("properties", &self.properties);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8367,7 +8356,6 @@ impl std::fmt::Debug for AutonomousDatabaseBackupProperties {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("vault_id", &self.vault_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8898,7 +8886,6 @@ impl std::fmt::Debug for AutonomousDbVersion {
         debug_struct.field("version", &self.version);
         debug_struct.field("db_workload", &self.db_workload);
         debug_struct.field("workload_uri", &self.workload_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9042,7 +9029,6 @@ impl std::fmt::Debug for CustomerContact {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomerContact");
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9223,7 +9209,6 @@ impl std::fmt::Debug for DbNode {
         let mut debug_struct = f.debug_struct("DbNode");
         debug_struct.field("name", &self.name);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9624,7 +9609,6 @@ impl std::fmt::Debug for DbNodeProperties {
         debug_struct.field("hostname", &self.hostname);
         debug_struct.field("state", &self.state);
         debug_struct.field("total_cpu_core_count", &self.total_cpu_core_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10017,7 +10001,6 @@ impl std::fmt::Debug for DbServer {
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10540,7 +10523,6 @@ impl std::fmt::Debug for DbServerProperties {
         debug_struct.field("vm_count", &self.vm_count);
         debug_struct.field("state", &self.state);
         debug_struct.field("db_node_ids", &self.db_node_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11356,7 +11338,6 @@ impl std::fmt::Debug for DbSystemShape {
             "min_db_node_storage_per_node_gb",
             &self.min_db_node_storage_per_node_gb,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11588,7 +11569,6 @@ impl std::fmt::Debug for Entitlement {
         debug_struct.field("cloud_account_details", &self.cloud_account_details);
         debug_struct.field("entitlement_id", &self.entitlement_id);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11999,7 +11979,6 @@ impl std::fmt::Debug for CloudAccountDetails {
         debug_struct.field("cloud_account_home_region", &self.cloud_account_home_region);
         debug_struct.field("link_existing_account_uri", &self.link_existing_account_uri);
         debug_struct.field("account_creation_uri", &self.account_creation_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12333,7 +12312,6 @@ impl std::fmt::Debug for CloudExadataInfrastructure {
         debug_struct.field("properties", &self.properties);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13541,7 +13519,6 @@ impl std::fmt::Debug for CloudExadataInfrastructureProperties {
             &self.monthly_storage_server_version,
         );
         debug_struct.field("monthly_db_server_version", &self.monthly_db_server_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14217,7 +14194,6 @@ impl std::fmt::Debug for MaintenanceWindow {
             "is_custom_action_timeout_enabled",
             &self.is_custom_action_timeout_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14662,7 +14638,6 @@ impl std::fmt::Debug for GiVersion {
         let mut debug_struct = f.debug_struct("GiVersion");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14810,7 +14785,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("gcp_oracle_zones", &self.gcp_oracle_zones);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15026,7 +15000,6 @@ impl std::fmt::Debug for ListCloudExadataInfrastructuresRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15227,7 +15200,6 @@ impl std::fmt::Debug for ListCloudExadataInfrastructuresResponse {
             &self.cloud_exadata_infrastructures,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15371,7 +15343,6 @@ impl std::fmt::Debug for GetCloudExadataInfrastructureRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCloudExadataInfrastructureRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15637,7 +15608,6 @@ impl std::fmt::Debug for CreateCloudExadataInfrastructureRequest {
             &self.cloud_exadata_infrastructure,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15842,7 +15812,6 @@ impl std::fmt::Debug for DeleteCloudExadataInfrastructureRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16082,7 +16051,6 @@ impl std::fmt::Debug for ListCloudVmClustersRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16272,7 +16240,6 @@ impl std::fmt::Debug for ListCloudVmClustersResponse {
         let mut debug_struct = f.debug_struct("ListCloudVmClustersResponse");
         debug_struct.field("cloud_vm_clusters", &self.cloud_vm_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16415,7 +16382,6 @@ impl std::fmt::Debug for GetCloudVmClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCloudVmClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16661,7 +16627,6 @@ impl std::fmt::Debug for CreateCloudVmClusterRequest {
         debug_struct.field("cloud_vm_cluster_id", &self.cloud_vm_cluster_id);
         debug_struct.field("cloud_vm_cluster", &self.cloud_vm_cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16864,7 +16829,6 @@ impl std::fmt::Debug for DeleteCloudVmClusterRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17079,7 +17043,6 @@ impl std::fmt::Debug for ListEntitlementsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17264,7 +17227,6 @@ impl std::fmt::Debug for ListEntitlementsResponse {
         let mut debug_struct = f.debug_struct("ListEntitlementsResponse");
         debug_struct.field("entitlements", &self.entitlements);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17479,7 +17441,6 @@ impl std::fmt::Debug for ListDbServersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17665,7 +17626,6 @@ impl std::fmt::Debug for ListDbServersResponse {
         let mut debug_struct = f.debug_struct("ListDbServersResponse");
         debug_struct.field("db_servers", &self.db_servers);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17880,7 +17840,6 @@ impl std::fmt::Debug for ListDbNodesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18066,7 +18025,6 @@ impl std::fmt::Debug for ListDbNodesResponse {
         let mut debug_struct = f.debug_struct("ListDbNodesResponse");
         debug_struct.field("db_nodes", &self.db_nodes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18282,7 +18240,6 @@ impl std::fmt::Debug for ListGiVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18468,7 +18425,6 @@ impl std::fmt::Debug for ListGiVersionsResponse {
         let mut debug_struct = f.debug_struct("ListGiVersionsResponse");
         debug_struct.field("gi_versions", &self.gi_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18683,7 +18639,6 @@ impl std::fmt::Debug for ListDbSystemShapesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18869,7 +18824,6 @@ impl std::fmt::Debug for ListDbSystemShapesResponse {
         let mut debug_struct = f.debug_struct("ListDbSystemShapesResponse");
         debug_struct.field("db_system_shapes", &self.db_system_shapes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19240,7 +19194,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("percent_complete", &self.percent_complete);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19506,7 +19459,6 @@ impl std::fmt::Debug for ListAutonomousDatabasesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19696,7 +19648,6 @@ impl std::fmt::Debug for ListAutonomousDatabasesResponse {
         let mut debug_struct = f.debug_struct("ListAutonomousDatabasesResponse");
         debug_struct.field("autonomous_databases", &self.autonomous_databases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19839,7 +19790,6 @@ impl std::fmt::Debug for GetAutonomousDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAutonomousDatabaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20084,7 +20034,6 @@ impl std::fmt::Debug for CreateAutonomousDatabaseRequest {
         debug_struct.field("autonomous_database_id", &self.autonomous_database_id);
         debug_struct.field("autonomous_database", &self.autonomous_database);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20260,7 +20209,6 @@ impl std::fmt::Debug for DeleteAutonomousDatabaseRequest {
         let mut debug_struct = f.debug_struct("DeleteAutonomousDatabaseRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20440,7 +20388,6 @@ impl std::fmt::Debug for RestoreAutonomousDatabaseRequest {
         let mut debug_struct = f.debug_struct("RestoreAutonomousDatabaseRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("restore_time", &self.restore_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20583,7 +20530,6 @@ impl std::fmt::Debug for StopAutonomousDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopAutonomousDatabaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20726,7 +20672,6 @@ impl std::fmt::Debug for StartAutonomousDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartAutonomousDatabaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20869,7 +20814,6 @@ impl std::fmt::Debug for RestartAutonomousDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestartAutonomousDatabaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21092,7 +21036,6 @@ impl std::fmt::Debug for GenerateAutonomousDatabaseWalletRequest {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("is_regional", &self.is_regional);
         debug_struct.field("password", &self.password);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21255,7 +21198,6 @@ impl std::fmt::Debug for GenerateAutonomousDatabaseWalletResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateAutonomousDatabaseWalletResponse");
         debug_struct.field("archive_content", &self.archive_content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21470,7 +21412,6 @@ impl std::fmt::Debug for ListAutonomousDbVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21660,7 +21601,6 @@ impl std::fmt::Debug for ListAutonomousDbVersionsResponse {
         let mut debug_struct = f.debug_struct("ListAutonomousDbVersionsResponse");
         debug_struct.field("autonomous_db_versions", &self.autonomous_db_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21905,7 +21845,6 @@ impl std::fmt::Debug for ListAutonomousDatabaseCharacterSetsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22108,7 +22047,6 @@ impl std::fmt::Debug for ListAutonomousDatabaseCharacterSetsResponse {
             &self.autonomous_database_character_sets,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22354,7 +22292,6 @@ impl std::fmt::Debug for ListAutonomousDatabaseBackupsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22555,7 +22492,6 @@ impl std::fmt::Debug for ListAutonomousDatabaseBackupsResponse {
             &self.autonomous_database_backups,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22972,7 +22908,6 @@ impl std::fmt::Debug for CloudVmCluster {
         debug_struct.field("cidr", &self.cidr);
         debug_struct.field("backup_subnet_cidr", &self.backup_subnet_cidr);
         debug_struct.field("network", &self.network);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24171,7 +24106,6 @@ impl std::fmt::Debug for CloudVmClusterProperties {
         debug_struct.field("compartment_id", &self.compartment_id);
         debug_struct.field("dns_listener_ip", &self.dns_listener_ip);
         debug_struct.field("cluster_name", &self.cluster_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24816,7 +24750,6 @@ impl std::fmt::Debug for DataCollectionOptions {
         );
         debug_struct.field("health_monitoring_enabled", &self.health_monitoring_enabled);
         debug_struct.field("incident_logs_enabled", &self.incident_logs_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -204,7 +204,6 @@ impl std::fmt::Debug for CreateEnvironmentRequest {
         let mut debug_struct = f.debug_struct("CreateEnvironmentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -347,7 +346,6 @@ impl std::fmt::Debug for GetEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -560,7 +558,6 @@ impl std::fmt::Debug for ListEnvironmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -745,7 +742,6 @@ impl std::fmt::Debug for ListEnvironmentsResponse {
         let mut debug_struct = f.debug_struct("ListEnvironmentsResponse");
         debug_struct.field("environments", &self.environments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -888,7 +884,6 @@ impl std::fmt::Debug for DeleteEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1233,7 +1228,6 @@ impl std::fmt::Debug for UpdateEnvironmentRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1457,7 +1451,6 @@ impl std::fmt::Debug for ExecuteAirflowCommandRequest {
         debug_struct.field("command", &self.command);
         debug_struct.field("subcommand", &self.subcommand);
         debug_struct.field("parameters", &self.parameters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1676,7 +1669,6 @@ impl std::fmt::Debug for ExecuteAirflowCommandResponse {
         debug_struct.field("pod", &self.pod);
         debug_struct.field("pod_namespace", &self.pod_namespace);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1922,7 +1914,6 @@ impl std::fmt::Debug for StopAirflowCommandRequest {
         debug_struct.field("pod", &self.pod);
         debug_struct.field("pod_namespace", &self.pod_namespace);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2093,7 +2084,6 @@ impl std::fmt::Debug for StopAirflowCommandResponse {
         let mut debug_struct = f.debug_struct("StopAirflowCommandResponse");
         debug_struct.field("is_done", &self.is_done);
         debug_struct.field("output", &self.output);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2358,7 +2348,6 @@ impl std::fmt::Debug for PollAirflowCommandRequest {
         debug_struct.field("pod", &self.pod);
         debug_struct.field("pod_namespace", &self.pod_namespace);
         debug_struct.field("next_line_number", &self.next_line_number);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2574,7 +2563,6 @@ impl std::fmt::Debug for PollAirflowCommandResponse {
         debug_struct.field("output", &self.output);
         debug_struct.field("output_end", &self.output_end);
         debug_struct.field("exit_info", &self.exit_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2769,7 +2757,6 @@ pub mod poll_airflow_command_response {
             let mut debug_struct = f.debug_struct("Line");
             debug_struct.field("line_number", &self.line_number);
             debug_struct.field("content", &self.content);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2959,7 +2946,6 @@ pub mod poll_airflow_command_response {
             let mut debug_struct = f.debug_struct("ExitInfo");
             debug_struct.field("exit_code", &self.exit_code);
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3140,7 +3126,6 @@ impl std::fmt::Debug for CreateUserWorkloadsSecretRequest {
         let mut debug_struct = f.debug_struct("CreateUserWorkloadsSecretRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("user_workloads_secret", &self.user_workloads_secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3283,7 +3268,6 @@ impl std::fmt::Debug for GetUserWorkloadsSecretRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetUserWorkloadsSecretRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3497,7 +3481,6 @@ impl std::fmt::Debug for ListUserWorkloadsSecretsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3651,7 +3634,6 @@ impl std::fmt::Debug for UpdateUserWorkloadsSecretRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateUserWorkloadsSecretRequest");
         debug_struct.field("user_workloads_secret", &self.user_workloads_secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3794,7 +3776,6 @@ impl std::fmt::Debug for DeleteUserWorkloadsSecretRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteUserWorkloadsSecretRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3976,7 +3957,6 @@ impl std::fmt::Debug for CreateUserWorkloadsConfigMapRequest {
         let mut debug_struct = f.debug_struct("CreateUserWorkloadsConfigMapRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("user_workloads_config_map", &self.user_workloads_config_map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4119,7 +4099,6 @@ impl std::fmt::Debug for GetUserWorkloadsConfigMapRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetUserWorkloadsConfigMapRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4333,7 +4312,6 @@ impl std::fmt::Debug for ListUserWorkloadsConfigMapsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4489,7 +4467,6 @@ impl std::fmt::Debug for UpdateUserWorkloadsConfigMapRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateUserWorkloadsConfigMapRequest");
         debug_struct.field("user_workloads_config_map", &self.user_workloads_config_map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4632,7 +4609,6 @@ impl std::fmt::Debug for DeleteUserWorkloadsConfigMapRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteUserWorkloadsConfigMapRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4822,7 +4798,6 @@ impl std::fmt::Debug for UserWorkloadsSecret {
         let mut debug_struct = f.debug_struct("UserWorkloadsSecret");
         debug_struct.field("name", &self.name);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5012,7 +4987,6 @@ impl std::fmt::Debug for ListUserWorkloadsSecretsResponse {
         let mut debug_struct = f.debug_struct("ListUserWorkloadsSecretsResponse");
         debug_struct.field("user_workloads_secrets", &self.user_workloads_secrets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5201,7 +5175,6 @@ impl std::fmt::Debug for UserWorkloadsConfigMap {
         let mut debug_struct = f.debug_struct("UserWorkloadsConfigMap");
         debug_struct.field("name", &self.name);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5398,7 +5371,6 @@ impl std::fmt::Debug for ListUserWorkloadsConfigMapsResponse {
             &self.user_workloads_config_maps,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5642,7 +5614,6 @@ impl std::fmt::Debug for ListWorkloadsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5833,7 +5804,6 @@ impl std::fmt::Debug for ListWorkloadsResponse {
         let mut debug_struct = f.debug_struct("ListWorkloadsResponse");
         debug_struct.field("workloads", &self.workloads);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6053,7 +6023,6 @@ pub mod list_workloads_response {
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6263,7 +6232,6 @@ pub mod list_workloads_response {
             debug_struct.field("state", &self.state);
             debug_struct.field("status_message", &self.status_message);
             debug_struct.field("detailed_status_message", &self.detailed_status_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6773,7 +6741,6 @@ impl std::fmt::Debug for SaveSnapshotRequest {
         let mut debug_struct = f.debug_struct("SaveSnapshotRequest");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("snapshot_location", &self.snapshot_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6919,7 +6886,6 @@ impl std::fmt::Debug for SaveSnapshotResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SaveSnapshotResponse");
         debug_struct.field("snapshot_path", &self.snapshot_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7233,7 +7199,6 @@ impl std::fmt::Debug for LoadSnapshotRequest {
             &self.skip_airflow_overrides_setting,
         );
         debug_struct.field("skip_gcs_data_copying", &self.skip_gcs_data_copying);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7347,7 +7312,6 @@ impl serde::ser::Serialize for LoadSnapshotResponse {
 impl std::fmt::Debug for LoadSnapshotResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoadSnapshotResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7491,7 +7455,6 @@ impl std::fmt::Debug for DatabaseFailoverRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseFailoverRequest");
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7605,7 +7568,6 @@ impl serde::ser::Serialize for DatabaseFailoverResponse {
 impl std::fmt::Debug for DatabaseFailoverResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseFailoverResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7748,7 +7710,6 @@ impl std::fmt::Debug for FetchDatabasePropertiesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchDatabasePropertiesRequest");
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7962,7 +7923,6 @@ impl std::fmt::Debug for FetchDatabasePropertiesResponse {
             "is_failover_replica_available",
             &self.is_failover_replica_available,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8105,7 +8065,6 @@ impl std::fmt::Debug for StorageConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StorageConfig");
         debug_struct.field("bucket", &self.bucket);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8983,7 +8942,6 @@ impl std::fmt::Debug for EnvironmentConfig {
         debug_struct.field("recovery_config", &self.recovery_config);
         debug_struct.field("resilience_mode", &self.resilience_mode);
         debug_struct.field("data_retention_config", &self.data_retention_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9400,7 +9358,6 @@ impl std::fmt::Debug for WebServerNetworkAccessControl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WebServerNetworkAccessControl");
         debug_struct.field("allowed_ip_ranges", &self.allowed_ip_ranges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9583,7 +9540,6 @@ pub mod web_server_network_access_control {
             let mut debug_struct = f.debug_struct("AllowedIpRange");
             debug_struct.field("value", &self.value);
             debug_struct.field("description", &self.description);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9761,7 +9717,6 @@ impl std::fmt::Debug for DatabaseConfig {
         let mut debug_struct = f.debug_struct("DatabaseConfig");
         debug_struct.field("machine_type", &self.machine_type);
         debug_struct.field("zone", &self.zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9911,7 +9866,6 @@ impl std::fmt::Debug for WebServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WebServerConfig");
         debug_struct.field("machine_type", &self.machine_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10058,7 +10012,6 @@ impl std::fmt::Debug for EncryptionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EncryptionConfig");
         debug_struct.field("kms_key_name", &self.kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10291,7 +10244,6 @@ impl std::fmt::Debug for MaintenanceWindow {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("recurrence", &self.recurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10783,7 +10735,6 @@ impl std::fmt::Debug for SoftwareConfig {
             &self.cloud_data_lineage_integration,
         );
         debug_struct.field("web_server_plugins_mode", &self.web_server_plugins_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11331,7 +11282,6 @@ impl std::fmt::Debug for IPAllocationPolicy {
         debug_struct.field("use_ip_aliases", &self.use_ip_aliases);
         debug_struct.field("cluster_ip_allocation", &self.cluster_ip_allocation);
         debug_struct.field("services_ip_allocation", &self.services_ip_allocation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11976,7 +11926,6 @@ impl std::fmt::Debug for NodeConfig {
             "composer_internal_ipv4_cidr_block",
             &self.composer_internal_ipv4_cidr_block,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12191,7 +12140,6 @@ impl std::fmt::Debug for PrivateClusterConfig {
             "master_ipv4_reserved_range",
             &self.master_ipv4_reserved_range,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12344,7 +12292,6 @@ impl std::fmt::Debug for NetworkingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkingConfig");
         debug_struct.field("connection_type", &self.connection_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13054,7 +13001,6 @@ impl std::fmt::Debug for PrivateEnvironmentConfig {
             &self.cloud_composer_connection_subnetwork,
         );
         debug_struct.field("networking_config", &self.networking_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13363,7 +13309,6 @@ impl std::fmt::Debug for WorkloadsConfig {
         debug_struct.field("worker", &self.worker);
         debug_struct.field("triggerer", &self.triggerer);
         debug_struct.field("dag_processor", &self.dag_processor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13666,7 +13611,6 @@ pub mod workloads_config {
             debug_struct.field("memory_gb", &self.memory_gb);
             debug_struct.field("storage_gb", &self.storage_gb);
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13919,7 +13863,6 @@ pub mod workloads_config {
             debug_struct.field("cpu", &self.cpu);
             debug_struct.field("memory_gb", &self.memory_gb);
             debug_struct.field("storage_gb", &self.storage_gb);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14264,7 +14207,6 @@ pub mod workloads_config {
             debug_struct.field("storage_gb", &self.storage_gb);
             debug_struct.field("min_count", &self.min_count);
             debug_struct.field("max_count", &self.max_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14516,7 +14458,6 @@ pub mod workloads_config {
             debug_struct.field("count", &self.count);
             debug_struct.field("cpu", &self.cpu);
             debug_struct.field("memory_gb", &self.memory_gb);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14819,7 +14760,6 @@ pub mod workloads_config {
             debug_struct.field("memory_gb", &self.memory_gb);
             debug_struct.field("storage_gb", &self.storage_gb);
             debug_struct.field("count", &self.count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14981,7 +14921,6 @@ impl std::fmt::Debug for RecoveryConfig {
             "scheduled_snapshots_config",
             &self.scheduled_snapshots_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15218,7 +15157,6 @@ impl std::fmt::Debug for ScheduledSnapshotsConfig {
             &self.snapshot_creation_schedule,
         );
         debug_struct.field("time_zone", &self.time_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15399,7 +15337,6 @@ impl std::fmt::Debug for MasterAuthorizedNetworksConfig {
         let mut debug_struct = f.debug_struct("MasterAuthorizedNetworksConfig");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("cidr_blocks", &self.cidr_blocks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15579,7 +15516,6 @@ pub mod master_authorized_networks_config {
             let mut debug_struct = f.debug_struct("CidrBlock");
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("cidr_block", &self.cidr_block);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15722,7 +15658,6 @@ impl std::fmt::Debug for CloudDataLineageIntegration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudDataLineageIntegration");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16163,7 +16098,6 @@ impl std::fmt::Debug for Environment {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
         debug_struct.field("storage_config", &self.storage_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16516,7 +16450,6 @@ impl std::fmt::Debug for CheckUpgradeRequest {
         let mut debug_struct = f.debug_struct("CheckUpgradeRequest");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("image_version", &self.image_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16807,7 +16740,6 @@ impl std::fmt::Debug for CheckUpgradeResponse {
         );
         debug_struct.field("image_version", &self.image_version);
         debug_struct.field("pypi_dependencies", &self.pypi_dependencies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17158,7 +17090,6 @@ impl std::fmt::Debug for DataRetentionConfig {
             "task_logs_retention_config",
             &self.task_logs_retention_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17308,7 +17239,6 @@ impl std::fmt::Debug for TaskLogsRetentionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TaskLogsRetentionConfig");
         debug_struct.field("storage_mode", &self.storage_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17641,7 +17571,6 @@ impl std::fmt::Debug for AirflowMetadataRetentionPolicyConfig {
         let mut debug_struct = f.debug_struct("AirflowMetadataRetentionPolicyConfig");
         debug_struct.field("retention_mode", &self.retention_mode);
         debug_struct.field("retention_days", &self.retention_days);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18017,7 +17946,6 @@ impl std::fmt::Debug for ListImageVersionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("include_past_releases", &self.include_past_releases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18203,7 +18131,6 @@ impl std::fmt::Debug for ListImageVersionsResponse {
         let mut debug_struct = f.debug_struct("ListImageVersionsResponse");
         debug_struct.field("image_versions", &self.image_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18500,7 +18427,6 @@ impl std::fmt::Debug for ImageVersion {
         debug_struct.field("release_date", &self.release_date);
         debug_struct.field("creation_disabled", &self.creation_disabled);
         debug_struct.field("upgrade_disabled", &self.upgrade_disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18797,7 +18723,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("resource_uuid", &self.resource_uuid);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -496,7 +496,6 @@ impl std::fmt::Debug for Policy {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("policy_type", &self.policy_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -890,7 +889,6 @@ pub mod policy {
             debug_struct.field("all_values", &self.all_values);
             debug_struct.field("suggested_value", &self.suggested_value);
             debug_struct.field("inherit_from_parent", &self.inherit_from_parent);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1229,7 +1227,6 @@ pub mod policy {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BooleanPolicy");
             debug_struct.field("enforced", &self.enforced);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1357,7 +1354,6 @@ pub mod policy {
     impl std::fmt::Debug for RestoreDefault {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RestoreDefault");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -496,7 +496,6 @@ impl std::fmt::Debug for Constraint {
         debug_struct.field("equivalent_constraint", &self.equivalent_constraint);
         debug_struct.field("supports_simulation", &self.supports_simulation);
         debug_struct.field("constraint_type", &self.constraint_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -682,7 +681,6 @@ pub mod constraint {
             let mut debug_struct = f.debug_struct("ListConstraint");
             debug_struct.field("supports_in", &self.supports_in);
             debug_struct.field("supports_under", &self.supports_under);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -963,7 +961,6 @@ pub mod constraint {
             debug_struct.field("condition", &self.condition);
             debug_struct.field("action_type", &self.action_type);
             debug_struct.field("parameters", &self.parameters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1271,7 +1268,6 @@ pub mod constraint {
                 debug_struct.field("valid_values_expr", &self.valid_values_expr);
                 debug_struct.field("metadata", &self.metadata);
                 debug_struct.field("item", &self.item);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1437,7 +1433,6 @@ pub mod constraint {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Metadata");
                     debug_struct.field("description", &self.description);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -2060,7 +2055,6 @@ pub mod constraint {
                 "custom_constraint_definition",
                 &self.custom_constraint_definition,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2584,7 +2578,6 @@ impl std::fmt::Debug for CustomConstraint {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3181,7 +3174,6 @@ impl std::fmt::Debug for Policy {
         debug_struct.field("alternate", &self.alternate);
         debug_struct.field("dry_run_spec", &self.dry_run_spec);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3362,7 +3354,6 @@ impl std::fmt::Debug for AlternatePolicySpec {
         let mut debug_struct = f.debug_struct("AlternatePolicySpec");
         debug_struct.field("launch", &self.launch);
         debug_struct.field("spec", &self.spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3654,7 +3645,6 @@ impl std::fmt::Debug for PolicySpec {
         debug_struct.field("rules", &self.rules);
         debug_struct.field("inherit_from_parent", &self.inherit_from_parent);
         debug_struct.field("reset", &self.reset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4090,7 +4080,6 @@ pub mod policy_spec {
             debug_struct.field("condition", &self.condition);
             debug_struct.field("parameters", &self.parameters);
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4296,7 +4285,6 @@ pub mod policy_spec {
                 let mut debug_struct = f.debug_struct("StringValues");
                 debug_struct.field("allowed_values", &self.allowed_values);
                 debug_struct.field("denied_values", &self.denied_values);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4538,7 +4526,6 @@ impl std::fmt::Debug for ListConstraintsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4724,7 +4711,6 @@ impl std::fmt::Debug for ListConstraintsResponse {
         let mut debug_struct = f.debug_struct("ListConstraintsResponse");
         debug_struct.field("constraints", &self.constraints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4947,7 +4933,6 @@ impl std::fmt::Debug for ListPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5136,7 +5121,6 @@ impl std::fmt::Debug for ListPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListPoliciesResponse");
         debug_struct.field("policies", &self.policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5282,7 +5266,6 @@ impl std::fmt::Debug for GetPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5428,7 +5411,6 @@ impl std::fmt::Debug for GetEffectivePolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEffectivePolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5613,7 +5595,6 @@ impl std::fmt::Debug for CreatePolicyRequest {
         let mut debug_struct = f.debug_struct("CreatePolicyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5806,7 +5787,6 @@ impl std::fmt::Debug for UpdatePolicyRequest {
         let mut debug_struct = f.debug_struct("UpdatePolicyRequest");
         debug_struct.field("policy", &self.policy);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5977,7 +5957,6 @@ impl std::fmt::Debug for DeletePolicyRequest {
         let mut debug_struct = f.debug_struct("DeletePolicyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6160,7 +6139,6 @@ impl std::fmt::Debug for CreateCustomConstraintRequest {
         let mut debug_struct = f.debug_struct("CreateCustomConstraintRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("custom_constraint", &self.custom_constraint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6304,7 +6282,6 @@ impl std::fmt::Debug for GetCustomConstraintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCustomConstraintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6524,7 +6501,6 @@ impl std::fmt::Debug for ListCustomConstraintsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6719,7 +6695,6 @@ impl std::fmt::Debug for ListCustomConstraintsResponse {
         let mut debug_struct = f.debug_struct("ListCustomConstraintsResponse");
         debug_struct.field("custom_constraints", &self.custom_constraints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6875,7 +6850,6 @@ impl std::fmt::Debug for UpdateCustomConstraintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateCustomConstraintRequest");
         debug_struct.field("custom_constraint", &self.custom_constraint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7019,7 +6993,6 @@ impl std::fmt::Debug for DeleteCustomConstraintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCustomConstraintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -292,7 +292,6 @@ impl std::fmt::Debug for Inventory {
         debug_struct.field("os_info", &self.os_info);
         debug_struct.field("items", &self.items);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -639,7 +638,6 @@ pub mod inventory {
             debug_struct.field("kernel_version", &self.kernel_version);
             debug_struct.field("kernel_release", &self.kernel_release);
             debug_struct.field("osconfig_agent_version", &self.osconfig_agent_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1055,7 +1053,6 @@ pub mod inventory {
             debug_struct.field("update_time", &self.update_time);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("details", &self.details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2004,7 +2001,6 @@ pub mod inventory {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SoftwarePackage");
             debug_struct.field("details", &self.details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2252,7 +2248,6 @@ pub mod inventory {
             debug_struct.field("package_name", &self.package_name);
             debug_struct.field("architecture", &self.architecture);
             debug_struct.field("version", &self.version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2473,7 +2468,6 @@ pub mod inventory {
             debug_struct.field("category", &self.category);
             debug_struct.field("severity", &self.severity);
             debug_struct.field("summary", &self.summary);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2886,7 +2880,6 @@ pub mod inventory {
                 "last_deployment_change_time",
                 &self.last_deployment_change_time,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3064,7 +3057,6 @@ pub mod inventory {
                 let mut debug_struct = f.debug_struct("WindowsUpdateCategory");
                 debug_struct.field("id", &self.id);
                 debug_struct.field("name", &self.name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3302,7 +3294,6 @@ pub mod inventory {
             debug_struct.field("description", &self.description);
             debug_struct.field("hot_fix_id", &self.hot_fix_id);
             debug_struct.field("install_time", &self.install_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3572,7 +3563,6 @@ pub mod inventory {
             debug_struct.field("publisher", &self.publisher);
             debug_struct.field("install_date", &self.install_date);
             debug_struct.field("help_link", &self.help_link);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3748,7 +3738,6 @@ impl std::fmt::Debug for GetInventoryRequest {
         let mut debug_struct = f.debug_struct("GetInventoryRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4019,7 +4008,6 @@ impl std::fmt::Debug for ListInventoriesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4205,7 +4193,6 @@ impl std::fmt::Debug for ListInventoriesResponse {
         let mut debug_struct = f.debug_struct("ListInventoriesResponse");
         debug_struct.field("inventories", &self.inventories);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4483,7 +4470,6 @@ impl std::fmt::Debug for OSPolicy {
             "allow_no_resource_group_match",
             &self.allow_no_resource_group_match,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4669,7 +4655,6 @@ pub mod os_policy {
             let mut debug_struct = f.debug_struct("InventoryFilter");
             debug_struct.field("os_short_name", &self.os_short_name);
             debug_struct.field("os_version", &self.os_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5083,7 +5068,6 @@ pub mod os_policy {
             let mut debug_struct = f.debug_struct("Resource");
             debug_struct.field("id", &self.id);
             debug_struct.field("resource_type", &self.resource_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5445,7 +5429,6 @@ pub mod os_policy {
                 let mut debug_struct = f.debug_struct("File");
                 debug_struct.field("allow_insecure", &self.allow_insecure);
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5640,7 +5623,6 @@ pub mod os_policy {
                     let mut debug_struct = f.debug_struct("Remote");
                     debug_struct.field("uri", &self.uri);
                     debug_struct.field("sha256_checksum", &self.sha256_checksum);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -5885,7 +5867,6 @@ pub mod os_policy {
                     debug_struct.field("bucket", &self.bucket);
                     debug_struct.field("object", &self.object);
                     debug_struct.field("generation", &self.generation);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -6516,7 +6497,6 @@ pub mod os_policy {
                 let mut debug_struct = f.debug_struct("PackageResource");
                 debug_struct.field("desired_state", &self.desired_state);
                 debug_struct.field("system_package", &self.system_package);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6722,7 +6702,6 @@ pub mod os_policy {
                     let mut debug_struct = f.debug_struct("Deb");
                     debug_struct.field("source", &self.source);
                     debug_struct.field("pull_deps", &self.pull_deps);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -6885,7 +6864,6 @@ pub mod os_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Apt");
                     debug_struct.field("name", &self.name);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7086,7 +7064,6 @@ pub mod os_policy {
                     let mut debug_struct = f.debug_struct("Rpm");
                     debug_struct.field("source", &self.source);
                     debug_struct.field("pull_deps", &self.pull_deps);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7249,7 +7226,6 @@ pub mod os_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Yum");
                     debug_struct.field("name", &self.name);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7412,7 +7388,6 @@ pub mod os_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Zypper");
                     debug_struct.field("name", &self.name);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7575,7 +7550,6 @@ pub mod os_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("GooGet");
                     debug_struct.field("name", &self.name);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7781,7 +7755,6 @@ pub mod os_policy {
                     let mut debug_struct = f.debug_struct("Msi");
                     debug_struct.field("source", &self.source);
                     debug_struct.field("properties", &self.properties);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8344,7 +8317,6 @@ pub mod os_policy {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("RepositoryResource");
                 debug_struct.field("repository", &self.repository);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8634,7 +8606,6 @@ pub mod os_policy {
                     debug_struct.field("distribution", &self.distribution);
                     debug_struct.field("components", &self.components);
                     debug_struct.field("gpg_key", &self.gpg_key);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -9035,7 +9006,6 @@ pub mod os_policy {
                     debug_struct.field("display_name", &self.display_name);
                     debug_struct.field("base_url", &self.base_url);
                     debug_struct.field("gpg_keys", &self.gpg_keys);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -9294,7 +9264,6 @@ pub mod os_policy {
                     debug_struct.field("display_name", &self.display_name);
                     debug_struct.field("base_url", &self.base_url);
                     debug_struct.field("gpg_keys", &self.gpg_keys);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -9484,7 +9453,6 @@ pub mod os_policy {
                     let mut debug_struct = f.debug_struct("GooRepository");
                     debug_struct.field("name", &self.name);
                     debug_struct.field("url", &self.url);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -9749,7 +9717,6 @@ pub mod os_policy {
                 let mut debug_struct = f.debug_struct("ExecResource");
                 debug_struct.field("validate", &self.validate);
                 debug_struct.field("enforce", &self.enforce);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -10128,7 +10095,6 @@ pub mod os_policy {
                     debug_struct.field("interpreter", &self.interpreter);
                     debug_struct.field("output_file_path", &self.output_file_path);
                     debug_struct.field("source", &self.source);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -10643,7 +10609,6 @@ pub mod os_policy {
                 debug_struct.field("state", &self.state);
                 debug_struct.field("permissions", &self.permissions);
                 debug_struct.field("source", &self.source);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -11023,7 +10988,6 @@ pub mod os_policy {
             let mut debug_struct = f.debug_struct("ResourceGroup");
             debug_struct.field("inventory_filters", &self.inventory_filters);
             debug_struct.field("resources", &self.resources);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11309,7 +11273,6 @@ impl std::fmt::Debug for GetOSPolicyAssignmentReportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOSPolicyAssignmentReportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11569,7 +11532,6 @@ impl std::fmt::Debug for ListOSPolicyAssignmentReportsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11772,7 +11734,6 @@ impl std::fmt::Debug for ListOSPolicyAssignmentReportsResponse {
             &self.os_policy_assignment_reports,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12074,7 +12035,6 @@ impl std::fmt::Debug for OSPolicyAssignmentReport {
         debug_struct.field("os_policy_compliances", &self.os_policy_compliances);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("last_run_id", &self.last_run_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12345,7 +12305,6 @@ pub mod os_policy_assignment_report {
                 "os_policy_resource_compliances",
                 &self.os_policy_resource_compliances,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12682,7 +12641,6 @@ pub mod os_policy_assignment_report {
                 debug_struct.field("compliance_state", &self.compliance_state);
                 debug_struct.field("compliance_state_reason", &self.compliance_state_reason);
                 debug_struct.field("output", &self.output);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12877,7 +12835,6 @@ pub mod os_policy_assignment_report {
                     let mut debug_struct = f.debug_struct("OSPolicyResourceConfigStep");
                     debug_struct.field("r#type", &self.r#type);
                     debug_struct.field("error_message", &self.error_message);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -13241,7 +13198,6 @@ pub mod os_policy_assignment_report {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("ExecResourceOutput");
                     debug_struct.field("enforcement_output", &self.enforcement_output);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -14061,7 +14017,6 @@ impl std::fmt::Debug for OSPolicyAssignment {
         debug_struct.field("deleted", &self.deleted);
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14233,7 +14188,6 @@ pub mod os_policy_assignment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LabelSet");
             debug_struct.field("labels", &self.labels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14486,7 +14440,6 @@ pub mod os_policy_assignment {
             debug_struct.field("inclusion_labels", &self.inclusion_labels);
             debug_struct.field("exclusion_labels", &self.exclusion_labels);
             debug_struct.field("inventories", &self.inventories);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14682,7 +14635,6 @@ pub mod os_policy_assignment {
                 let mut debug_struct = f.debug_struct("Inventory");
                 debug_struct.field("os_short_name", &self.os_short_name);
                 debug_struct.field("os_version", &self.os_version);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -14883,7 +14835,6 @@ pub mod os_policy_assignment {
             let mut debug_struct = f.debug_struct("Rollout");
             debug_struct.field("disruption_budget", &self.disruption_budget);
             debug_struct.field("min_wait_duration", &self.min_wait_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15312,7 +15263,6 @@ impl std::fmt::Debug for OSPolicyAssignmentOperationMetadata {
         debug_struct.field("rollout_state", &self.rollout_state);
         debug_struct.field("rollout_start_time", &self.rollout_start_time);
         debug_struct.field("rollout_update_time", &self.rollout_update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15819,7 +15769,6 @@ impl std::fmt::Debug for CreateOSPolicyAssignmentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("os_policy_assignment", &self.os_policy_assignment);
         debug_struct.field("os_policy_assignment_id", &self.os_policy_assignment_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16011,7 +15960,6 @@ impl std::fmt::Debug for UpdateOSPolicyAssignmentRequest {
         let mut debug_struct = f.debug_struct("UpdateOSPolicyAssignmentRequest");
         debug_struct.field("os_policy_assignment", &self.os_policy_assignment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16156,7 +16104,6 @@ impl std::fmt::Debug for GetOSPolicyAssignmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOSPolicyAssignmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16370,7 +16317,6 @@ impl std::fmt::Debug for ListOSPolicyAssignmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16560,7 +16506,6 @@ impl std::fmt::Debug for ListOSPolicyAssignmentsResponse {
         let mut debug_struct = f.debug_struct("ListOSPolicyAssignmentsResponse");
         debug_struct.field("os_policy_assignments", &self.os_policy_assignments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16775,7 +16720,6 @@ impl std::fmt::Debug for ListOSPolicyAssignmentRevisionsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16967,7 +16911,6 @@ impl std::fmt::Debug for ListOSPolicyAssignmentRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListOSPolicyAssignmentRevisionsResponse");
         debug_struct.field("os_policy_assignments", &self.os_policy_assignments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17109,7 +17052,6 @@ impl std::fmt::Debug for DeleteOSPolicyAssignmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteOSPolicyAssignmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17373,7 +17315,6 @@ impl std::fmt::Debug for FixedOrPercent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FixedOrPercent");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17987,7 +17928,6 @@ impl std::fmt::Debug for PatchDeployment {
         debug_struct.field("rollout", &self.rollout);
         debug_struct.field("state", &self.state);
         debug_struct.field("schedule", &self.schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18291,7 +18231,6 @@ impl std::fmt::Debug for OneTimeSchedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OneTimeSchedule");
         debug_struct.field("execute_time", &self.execute_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18788,7 +18727,6 @@ impl std::fmt::Debug for RecurringSchedule {
         debug_struct.field("last_execute_time", &self.last_execute_time);
         debug_struct.field("next_execute_time", &self.next_execute_time);
         debug_struct.field("schedule_config", &self.schedule_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19090,7 +19028,6 @@ impl std::fmt::Debug for WeeklySchedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WeeklySchedule");
         debug_struct.field("day_of_week", &self.day_of_week);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19350,7 +19287,6 @@ impl std::fmt::Debug for MonthlySchedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MonthlySchedule");
         debug_struct.field("day_of_month", &self.day_of_month);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19607,7 +19543,6 @@ impl std::fmt::Debug for WeekDayOfMonth {
         debug_struct.field("week_ordinal", &self.week_ordinal);
         debug_struct.field("day_of_week", &self.day_of_week);
         debug_struct.field("day_offset", &self.day_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19824,7 +19759,6 @@ impl std::fmt::Debug for CreatePatchDeploymentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("patch_deployment_id", &self.patch_deployment_id);
         debug_struct.field("patch_deployment", &self.patch_deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19967,7 +19901,6 @@ impl std::fmt::Debug for GetPatchDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPatchDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20182,7 +20115,6 @@ impl std::fmt::Debug for ListPatchDeploymentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20373,7 +20305,6 @@ impl std::fmt::Debug for ListPatchDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListPatchDeploymentsResponse");
         debug_struct.field("patch_deployments", &self.patch_deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20516,7 +20447,6 @@ impl std::fmt::Debug for DeletePatchDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeletePatchDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20709,7 +20639,6 @@ impl std::fmt::Debug for UpdatePatchDeploymentRequest {
         let mut debug_struct = f.debug_struct("UpdatePatchDeploymentRequest");
         debug_struct.field("patch_deployment", &self.patch_deployment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20852,7 +20781,6 @@ impl std::fmt::Debug for PausePatchDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PausePatchDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20995,7 +20923,6 @@ impl std::fmt::Debug for ResumePatchDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumePatchDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21366,7 +21293,6 @@ impl std::fmt::Debug for ExecutePatchJobRequest {
         debug_struct.field("dry_run", &self.dry_run);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("rollout", &self.rollout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21508,7 +21434,6 @@ impl std::fmt::Debug for GetPatchJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPatchJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21749,7 +21674,6 @@ impl std::fmt::Debug for ListPatchJobInstanceDetailsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21946,7 +21870,6 @@ impl std::fmt::Debug for ListPatchJobInstanceDetailsResponse {
             &self.patch_job_instance_details,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22218,7 +22141,6 @@ impl std::fmt::Debug for PatchJobInstanceDetails {
         debug_struct.field("state", &self.state);
         debug_struct.field("failure_reason", &self.failure_reason);
         debug_struct.field("attempt_count", &self.attempt_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22458,7 +22380,6 @@ impl std::fmt::Debug for ListPatchJobsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22644,7 +22565,6 @@ impl std::fmt::Debug for ListPatchJobsResponse {
         let mut debug_struct = f.debug_struct("ListPatchJobsResponse");
         debug_struct.field("patch_jobs", &self.patch_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23268,7 +23188,6 @@ impl std::fmt::Debug for PatchJob {
         debug_struct.field("percent_complete", &self.percent_complete);
         debug_struct.field("patch_deployment", &self.patch_deployment);
         debug_struct.field("rollout", &self.rollout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24200,7 +24119,6 @@ pub mod patch_job {
                 "no_agent_detected_instance_count",
                 &self.no_agent_detected_instance_count,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24800,7 +24718,6 @@ impl std::fmt::Debug for PatchConfig {
         debug_struct.field("pre_step", &self.pre_step);
         debug_struct.field("post_step", &self.post_step);
         debug_struct.field("mig_instances_allowed", &self.mig_instances_allowed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25062,7 +24979,6 @@ impl serde::ser::Serialize for Instance {
 impl std::fmt::Debug for Instance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Instance");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25437,7 +25353,6 @@ impl std::fmt::Debug for CancelPatchJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelPatchJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25642,7 +25557,6 @@ impl std::fmt::Debug for AptSettings {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("excludes", &self.excludes);
         debug_struct.field("exclusive_packages", &self.exclusive_packages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26012,7 +25926,6 @@ impl std::fmt::Debug for YumSettings {
         debug_struct.field("minimal", &self.minimal);
         debug_struct.field("excludes", &self.excludes);
         debug_struct.field("exclusive_packages", &self.exclusive_packages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26126,7 +26039,6 @@ impl serde::ser::Serialize for GooSettings {
 impl std::fmt::Debug for GooSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GooSettings");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26413,7 +26325,6 @@ impl std::fmt::Debug for ZypperSettings {
         debug_struct.field("severities", &self.severities);
         debug_struct.field("excludes", &self.excludes);
         debug_struct.field("exclusive_patches", &self.exclusive_patches);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26624,7 +26535,6 @@ impl std::fmt::Debug for WindowsUpdateSettings {
         debug_struct.field("classifications", &self.classifications);
         debug_struct.field("excludes", &self.excludes);
         debug_struct.field("exclusive_patches", &self.exclusive_patches);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27025,7 +26935,6 @@ impl std::fmt::Debug for ExecStep {
         let mut debug_struct = f.debug_struct("ExecStep");
         debug_struct.field("linux_exec_step_config", &self.linux_exec_step_config);
         debug_struct.field("windows_exec_step_config", &self.windows_exec_step_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27352,7 +27261,6 @@ impl std::fmt::Debug for ExecStepConfig {
         debug_struct.field("allowed_success_codes", &self.allowed_success_codes);
         debug_struct.field("interpreter", &self.interpreter);
         debug_struct.field("executable", &self.executable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27717,7 +27625,6 @@ impl std::fmt::Debug for GcsObject {
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("object", &self.object);
         debug_struct.field("generation_number", &self.generation_number);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27988,7 +27895,6 @@ impl std::fmt::Debug for PatchInstanceFilter {
         debug_struct.field("zones", &self.zones);
         debug_struct.field("instances", &self.instances);
         debug_struct.field("instance_name_prefixes", &self.instance_name_prefixes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28157,7 +28063,6 @@ pub mod patch_instance_filter {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GroupLabel");
             debug_struct.field("labels", &self.labels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28362,7 +28267,6 @@ impl std::fmt::Debug for PatchRollout {
         let mut debug_struct = f.debug_struct("PatchRollout");
         debug_struct.field("mode", &self.mode);
         debug_struct.field("disruption_budget", &self.disruption_budget);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28726,7 +28630,6 @@ impl std::fmt::Debug for VulnerabilityReport {
         debug_struct.field("name", &self.name);
         debug_struct.field("vulnerabilities", &self.vulnerabilities);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29089,7 +28992,6 @@ pub mod vulnerability_report {
             debug_struct.field("create_time", &self.create_time);
             debug_struct.field("update_time", &self.update_time);
             debug_struct.field("items", &self.items);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29430,7 +29332,6 @@ pub mod vulnerability_report {
                 debug_struct.field("severity", &self.severity);
                 debug_struct.field("description", &self.description);
                 debug_struct.field("references", &self.references);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29623,7 +29524,6 @@ pub mod vulnerability_report {
                     let mut debug_struct = f.debug_struct("Reference");
                     debug_struct.field("url", &self.url);
                     debug_struct.field("source", &self.source);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -29902,7 +29802,6 @@ pub mod vulnerability_report {
                 );
                 debug_struct.field("fixed_cpe_uri", &self.fixed_cpe_uri);
                 debug_struct.field("upstream_fix", &self.upstream_fix);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -30053,7 +29952,6 @@ impl std::fmt::Debug for GetVulnerabilityReportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVulnerabilityReportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30298,7 +30196,6 @@ impl std::fmt::Debug for ListVulnerabilityReportsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30490,7 +30387,6 @@ impl std::fmt::Debug for ListVulnerabilityReportsResponse {
         let mut debug_struct = f.debug_struct("ListVulnerabilityReportsResponse");
         debug_struct.field("vulnerability_reports", &self.vulnerability_reports);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30981,7 +30877,6 @@ impl std::fmt::Debug for CVSSv3 {
         debug_struct.field("confidentiality_impact", &self.confidentiality_impact);
         debug_struct.field("integrity_impact", &self.integrity_impact);
         debug_struct.field("availability_impact", &self.availability_impact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/oslogin/v1/src/model.rs
+++ b/src/generated/cloud/oslogin/v1/src/model.rs
@@ -237,7 +237,6 @@ impl std::fmt::Debug for LoginProfile {
         debug_struct.field("name", &self.name);
         debug_struct.field("posix_accounts", &self.posix_accounts);
         debug_struct.field("ssh_public_keys", &self.ssh_public_keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -416,7 +415,6 @@ impl std::fmt::Debug for CreateSshPublicKeyRequest {
         let mut debug_struct = f.debug_struct("CreateSshPublicKeyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("ssh_public_key", &self.ssh_public_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -560,7 +558,6 @@ impl std::fmt::Debug for DeletePosixAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeletePosixAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -704,7 +701,6 @@ impl std::fmt::Debug for DeleteSshPublicKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSshPublicKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -898,7 +894,6 @@ impl std::fmt::Debug for GetLoginProfileRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("system_id", &self.system_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1042,7 +1037,6 @@ impl std::fmt::Debug for GetSshPublicKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSshPublicKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1277,7 +1271,6 @@ impl std::fmt::Debug for ImportSshPublicKeyRequest {
         debug_struct.field("ssh_public_key", &self.ssh_public_key);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("regions", &self.regions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1456,7 +1449,6 @@ impl std::fmt::Debug for ImportSshPublicKeyResponse {
         let mut debug_struct = f.debug_struct("ImportSshPublicKeyResponse");
         debug_struct.field("login_profile", &self.login_profile);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1674,7 +1666,6 @@ impl std::fmt::Debug for UpdateSshPublicKeyRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("ssh_public_key", &self.ssh_public_key);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -638,7 +638,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("file_stripe_level", &self.file_stripe_level);
         debug_struct.field("directory_stripe_level", &self.directory_stripe_level);
         debug_struct.field("deployment_type", &self.deployment_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1073,7 +1072,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1289,7 +1287,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1432,7 +1429,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1682,7 +1678,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1913,7 +1908,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2093,7 +2087,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2419,7 +2412,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2563,7 +2555,6 @@ impl std::fmt::Debug for SourceGcsBucket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceGcsBucket");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2707,7 +2698,6 @@ impl std::fmt::Debug for DestinationGcsBucket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DestinationGcsBucket");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2850,7 +2840,6 @@ impl std::fmt::Debug for SourceParallelstore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceParallelstore");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2993,7 +2982,6 @@ impl std::fmt::Debug for DestinationParallelstore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DestinationParallelstore");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3362,7 +3350,6 @@ impl std::fmt::Debug for ImportDataRequest {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("source", &self.source);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3748,7 +3735,6 @@ impl std::fmt::Debug for ExportDataRequest {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("source", &self.source);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3884,7 +3870,6 @@ impl serde::ser::Serialize for ImportDataResponse {
 impl std::fmt::Debug for ImportDataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportDataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4056,7 +4041,6 @@ impl std::fmt::Debug for TransferErrorLogEntry {
         let mut debug_struct = f.debug_struct("TransferErrorLogEntry");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("error_details", &self.error_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4277,7 +4261,6 @@ impl std::fmt::Debug for TransferErrorSummary {
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("error_count", &self.error_count);
         debug_struct.field("error_log_entries", &self.error_log_entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4640,7 +4623,6 @@ impl std::fmt::Debug for ImportDataMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4754,7 +4736,6 @@ impl serde::ser::Serialize for ExportDataResponse {
 impl std::fmt::Debug for ExportDataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportDataResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5117,7 +5098,6 @@ impl std::fmt::Debug for ExportDataMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5601,7 +5581,6 @@ impl std::fmt::Debug for TransferOperationMetadata {
         debug_struct.field("error_summary", &self.error_summary);
         debug_struct.field("source", &self.source);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6107,7 +6086,6 @@ impl std::fmt::Debug for TransferCounters {
         debug_struct.field("bytes_copied", &self.bytes_copied);
         debug_struct.field("objects_failed", &self.objects_failed);
         debug_struct.field("bytes_failed", &self.bytes_failed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/parametermanager/v1/src/model.rs
+++ b/src/generated/cloud/parametermanager/v1/src/model.rs
@@ -384,7 +384,6 @@ impl std::fmt::Debug for Parameter {
         debug_struct.field("format", &self.format);
         debug_struct.field("policy_member", &self.policy_member);
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -649,7 +648,6 @@ impl std::fmt::Debug for ListParametersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -862,7 +860,6 @@ impl std::fmt::Debug for ListParametersResponse {
         debug_struct.field("parameters", &self.parameters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1005,7 +1002,6 @@ impl std::fmt::Debug for GetParameterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetParameterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1248,7 +1244,6 @@ impl std::fmt::Debug for CreateParameterRequest {
         debug_struct.field("parameter_id", &self.parameter_id);
         debug_struct.field("parameter", &self.parameter);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1481,7 +1476,6 @@ impl std::fmt::Debug for UpdateParameterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("parameter", &self.parameter);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1662,7 +1656,6 @@ impl std::fmt::Debug for DeleteParameterRequest {
         let mut debug_struct = f.debug_struct("DeleteParameterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1986,7 +1979,6 @@ impl std::fmt::Debug for ParameterVersion {
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("payload", &self.payload);
         debug_struct.field("kms_key_version", &self.kms_key_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2146,7 +2138,6 @@ impl std::fmt::Debug for ParameterVersionPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ParameterVersionPayload");
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2411,7 +2402,6 @@ impl std::fmt::Debug for ListParameterVersionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2629,7 +2619,6 @@ impl std::fmt::Debug for ListParameterVersionsResponse {
         debug_struct.field("parameter_versions", &self.parameter_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2799,7 +2788,6 @@ impl std::fmt::Debug for GetParameterVersionRequest {
         let mut debug_struct = f.debug_struct("GetParameterVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2941,7 +2929,6 @@ impl std::fmt::Debug for RenderParameterVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RenderParameterVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3172,7 +3159,6 @@ impl std::fmt::Debug for RenderParameterVersionResponse {
         debug_struct.field("parameter_version", &self.parameter_version);
         debug_struct.field("payload", &self.payload);
         debug_struct.field("rendered_payload", &self.rendered_payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3420,7 +3406,6 @@ impl std::fmt::Debug for CreateParameterVersionRequest {
         debug_struct.field("parameter_version_id", &self.parameter_version_id);
         debug_struct.field("parameter_version", &self.parameter_version);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3655,7 +3640,6 @@ impl std::fmt::Debug for UpdateParameterVersionRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("parameter_version", &self.parameter_version);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3836,7 +3820,6 @@ impl std::fmt::Debug for DeleteParameterVersionRequest {
         let mut debug_struct = f.debug_struct("DeleteParameterVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -241,7 +241,6 @@ impl std::fmt::Debug for AccessTuple {
         debug_struct.field("principal", &self.principal);
         debug_struct.field("full_resource_name", &self.full_resource_name);
         debug_struct.field("permission", &self.permission);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -547,7 +546,6 @@ impl std::fmt::Debug for ExplainedPolicy {
         debug_struct.field("policy", &self.policy);
         debug_struct.field("binding_explanations", &self.binding_explanations);
         debug_struct.field("relevance", &self.relevance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -919,7 +917,6 @@ impl std::fmt::Debug for BindingExplanation {
         debug_struct.field("memberships", &self.memberships);
         debug_struct.field("relevance", &self.relevance);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1103,7 +1100,6 @@ pub mod binding_explanation {
             let mut debug_struct = f.debug_struct("AnnotatedMembership");
             debug_struct.field("membership", &self.membership);
             debug_struct.field("relevance", &self.relevance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1796,7 +1792,6 @@ impl std::fmt::Debug for OrgPolicyViolationsPreview {
         debug_struct.field("resource_counts", &self.resource_counts);
         debug_struct.field("custom_constraints", &self.custom_constraints);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2143,7 +2138,6 @@ pub mod org_policy_violations_preview {
             debug_struct.field("compliant", &self.compliant);
             debug_struct.field("unenforced", &self.unenforced);
             debug_struct.field("errors", &self.errors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2398,7 +2392,6 @@ impl std::fmt::Debug for OrgPolicyViolation {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("custom_constraint", &self.custom_constraint);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2614,7 +2607,6 @@ impl std::fmt::Debug for ResourceContext {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("asset_type", &self.asset_type);
         debug_struct.field("ancestors", &self.ancestors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2812,7 +2804,6 @@ impl std::fmt::Debug for OrgPolicyOverlay {
         let mut debug_struct = f.debug_struct("OrgPolicyOverlay");
         debug_struct.field("policies", &self.policies);
         debug_struct.field("custom_constraints", &self.custom_constraints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3004,7 +2995,6 @@ pub mod org_policy_overlay {
             let mut debug_struct = f.debug_struct("PolicyOverlay");
             debug_struct.field("policy_parent", &self.policy_parent);
             debug_struct.field("policy", &self.policy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3195,7 +3185,6 @@ pub mod org_policy_overlay {
             let mut debug_struct = f.debug_struct("CustomConstraintOverlay");
             debug_struct.field("custom_constraint_parent", &self.custom_constraint_parent);
             debug_struct.field("custom_constraint", &self.custom_constraint);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3552,7 +3541,6 @@ impl std::fmt::Debug for CreateOrgPolicyViolationsPreviewOperationMetadata {
         debug_struct.field("resources_found", &self.resources_found);
         debug_struct.field("resources_scanned", &self.resources_scanned);
         debug_struct.field("resources_pending", &self.resources_pending);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3778,7 +3766,6 @@ impl std::fmt::Debug for ListOrgPolicyViolationsPreviewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3983,7 +3970,6 @@ impl std::fmt::Debug for ListOrgPolicyViolationsPreviewsResponse {
             &self.org_policy_violations_previews,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4128,7 +4114,6 @@ impl std::fmt::Debug for GetOrgPolicyViolationsPreviewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrgPolicyViolationsPreviewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4378,7 +4363,6 @@ impl std::fmt::Debug for CreateOrgPolicyViolationsPreviewRequest {
             "org_policy_violations_preview_id",
             &self.org_policy_violations_preview_id,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4601,7 +4585,6 @@ impl std::fmt::Debug for ListOrgPolicyViolationsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4795,7 +4778,6 @@ impl std::fmt::Debug for ListOrgPolicyViolationsResponse {
         let mut debug_struct = f.debug_struct("ListOrgPolicyViolationsResponse");
         debug_struct.field("org_policy_violations", &self.org_policy_violations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5043,7 +5025,6 @@ impl std::fmt::Debug for Replay {
         debug_struct.field("state", &self.state);
         debug_struct.field("config", &self.config);
         debug_struct.field("results_summary", &self.results_summary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5424,7 +5405,6 @@ pub mod replay {
             debug_struct.field("error_count", &self.error_count);
             debug_struct.field("oldest_date", &self.oldest_date);
             debug_struct.field("newest_date", &self.newest_date);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5947,7 +5927,6 @@ impl std::fmt::Debug for ReplayResult {
         debug_struct.field("access_tuple", &self.access_tuple);
         debug_struct.field("last_seen_date", &self.last_seen_date);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6162,7 +6141,6 @@ impl std::fmt::Debug for CreateReplayRequest {
         let mut debug_struct = f.debug_struct("CreateReplayRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("replay", &self.replay);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6316,7 +6294,6 @@ impl std::fmt::Debug for ReplayOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplayOperationMetadata");
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6471,7 +6448,6 @@ impl std::fmt::Debug for GetReplayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReplayRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6708,7 +6684,6 @@ impl std::fmt::Debug for ListReplayResultsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6903,7 +6878,6 @@ impl std::fmt::Debug for ListReplayResultsResponse {
         let mut debug_struct = f.debug_struct("ListReplayResultsResponse");
         debug_struct.field("replay_results", &self.replay_results);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7105,7 +7079,6 @@ impl std::fmt::Debug for ReplayConfig {
         let mut debug_struct = f.debug_struct("ReplayConfig");
         debug_struct.field("policy_overlay", &self.policy_overlay);
         debug_struct.field("log_source", &self.log_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7410,7 +7383,6 @@ impl std::fmt::Debug for ReplayDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplayDiff");
         debug_struct.field("access_diff", &self.access_diff);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7646,7 +7618,6 @@ impl std::fmt::Debug for AccessStateDiff {
         debug_struct.field("baseline", &self.baseline);
         debug_struct.field("simulated", &self.simulated);
         debug_struct.field("access_change", &self.access_change);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8061,7 +8032,6 @@ impl std::fmt::Debug for ExplainedAccess {
         debug_struct.field("access_state", &self.access_state);
         debug_struct.field("policies", &self.policies);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -184,7 +184,6 @@ impl std::fmt::Debug for TroubleshootIamPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TroubleshootIamPolicyRequest");
         debug_struct.field("access_tuple", &self.access_tuple);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -451,7 +450,6 @@ impl std::fmt::Debug for TroubleshootIamPolicyResponse {
         debug_struct.field("access_tuple", &self.access_tuple);
         debug_struct.field("allow_policy_explanation", &self.allow_policy_explanation);
         debug_struct.field("deny_policy_explanation", &self.deny_policy_explanation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -887,7 +885,6 @@ impl std::fmt::Debug for AccessTuple {
         debug_struct.field("permission", &self.permission);
         debug_struct.field("permission_fqdn", &self.permission_fqdn);
         debug_struct.field("condition_context", &self.condition_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1151,7 +1148,6 @@ impl std::fmt::Debug for ConditionContext {
         debug_struct.field("destination", &self.destination);
         debug_struct.field("request", &self.request);
         debug_struct.field("effective_tags", &self.effective_tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1367,7 +1363,6 @@ pub mod condition_context {
             debug_struct.field("service", &self.service);
             debug_struct.field("name", &self.name);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1558,7 +1553,6 @@ pub mod condition_context {
             let mut debug_struct = f.debug_struct("Peer");
             debug_struct.field("ip", &self.ip);
             debug_struct.field("port", &self.port);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1718,7 +1712,6 @@ pub mod condition_context {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Request");
             debug_struct.field("receive_time", &self.receive_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2018,7 +2011,6 @@ pub mod condition_context {
             debug_struct.field("namespaced_tag_key", &self.namespaced_tag_key);
             debug_struct.field("tag_key_parent_name", &self.tag_key_parent_name);
             debug_struct.field("inherited", &self.inherited);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2236,7 +2228,6 @@ impl std::fmt::Debug for AllowPolicyExplanation {
         debug_struct.field("allow_access_state", &self.allow_access_state);
         debug_struct.field("explained_policies", &self.explained_policies);
         debug_struct.field("relevance", &self.relevance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2538,7 +2529,6 @@ impl std::fmt::Debug for ExplainedAllowPolicy {
         debug_struct.field("binding_explanations", &self.binding_explanations);
         debug_struct.field("relevance", &self.relevance);
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2982,7 +2972,6 @@ impl std::fmt::Debug for AllowBindingExplanation {
         debug_struct.field("relevance", &self.relevance);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("condition_explanation", &self.condition_explanation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3160,7 +3149,6 @@ pub mod allow_binding_explanation {
             let mut debug_struct = f.debug_struct("AnnotatedAllowMembership");
             debug_struct.field("membership", &self.membership);
             debug_struct.field("relevance", &self.relevance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3407,7 +3395,6 @@ impl std::fmt::Debug for DenyPolicyExplanation {
         debug_struct.field("explained_resources", &self.explained_resources);
         debug_struct.field("relevance", &self.relevance);
         debug_struct.field("permission_deniable", &self.permission_deniable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3667,7 +3654,6 @@ impl std::fmt::Debug for ExplainedDenyResource {
         debug_struct.field("full_resource_name", &self.full_resource_name);
         debug_struct.field("explained_policies", &self.explained_policies);
         debug_struct.field("relevance", &self.relevance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3934,7 +3920,6 @@ impl std::fmt::Debug for ExplainedDenyPolicy {
         debug_struct.field("policy", &self.policy);
         debug_struct.field("rule_explanations", &self.rule_explanations);
         debug_struct.field("relevance", &self.relevance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4550,7 +4535,6 @@ impl std::fmt::Debug for DenyRuleExplanation {
         debug_struct.field("relevance", &self.relevance);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("condition_explanation", &self.condition_explanation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4742,7 +4726,6 @@ pub mod deny_rule_explanation {
             let mut debug_struct = f.debug_struct("AnnotatedPermissionMatching");
             debug_struct.field("permission_matching_state", &self.permission_matching_state);
             debug_struct.field("relevance", &self.relevance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4918,7 +4901,6 @@ pub mod deny_rule_explanation {
             let mut debug_struct = f.debug_struct("AnnotatedDenyPrincipalMatching");
             debug_struct.field("membership", &self.membership);
             debug_struct.field("relevance", &self.relevance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5138,7 +5120,6 @@ impl std::fmt::Debug for ConditionExplanation {
         debug_struct.field("value", &self.value);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("evaluation_states", &self.evaluation_states);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5417,7 +5398,6 @@ pub mod condition_explanation {
             debug_struct.field("end", &self.end);
             debug_struct.field("value", &self.value);
             debug_struct.field("errors", &self.errors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/policytroubleshooter/v1/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/model.rs
@@ -183,7 +183,6 @@ impl std::fmt::Debug for TroubleshootIamPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TroubleshootIamPolicyRequest");
         debug_struct.field("access_tuple", &self.access_tuple);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -399,7 +398,6 @@ impl std::fmt::Debug for TroubleshootIamPolicyResponse {
         debug_struct.field("access", &self.access);
         debug_struct.field("explained_policies", &self.explained_policies);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -612,7 +610,6 @@ impl std::fmt::Debug for AccessTuple {
         debug_struct.field("principal", &self.principal);
         debug_struct.field("full_resource_name", &self.full_resource_name);
         debug_struct.field("permission", &self.permission);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -906,7 +903,6 @@ impl std::fmt::Debug for ExplainedPolicy {
         debug_struct.field("policy", &self.policy);
         debug_struct.field("binding_explanations", &self.binding_explanations);
         debug_struct.field("relevance", &self.relevance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1278,7 +1274,6 @@ impl std::fmt::Debug for BindingExplanation {
         debug_struct.field("memberships", &self.memberships);
         debug_struct.field("relevance", &self.relevance);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1462,7 +1457,6 @@ pub mod binding_explanation {
             let mut debug_struct = f.debug_struct("AnnotatedMembership");
             debug_struct.field("membership", &self.membership);
             debug_struct.field("relevance", &self.relevance);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -173,7 +173,6 @@ impl std::fmt::Debug for CheckOnboardingStatusRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CheckOnboardingStatusRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -352,7 +351,6 @@ impl std::fmt::Debug for CheckOnboardingStatusResponse {
         let mut debug_struct = f.debug_struct("CheckOnboardingStatusResponse");
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("findings", &self.findings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -564,7 +562,6 @@ pub mod check_onboarding_status_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Finding");
             debug_struct.field("finding_type", &self.finding_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -726,7 +723,6 @@ pub mod check_onboarding_status_response {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("IAMAccessDenied");
                 debug_struct.field("missing_permissions", &self.missing_permissions);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1274,7 +1270,6 @@ impl std::fmt::Debug for Entitlement {
             &self.additional_notification_targets,
         );
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1542,7 +1537,6 @@ pub mod entitlement {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RequesterJustificationConfig");
             debug_struct.field("justification_type", &self.justification_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1668,7 +1662,6 @@ pub mod entitlement {
         impl std::fmt::Debug for NotMandatory {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("NotMandatory");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1788,7 +1781,6 @@ pub mod entitlement {
         impl std::fmt::Debug for Unstructured {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Unstructured");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2003,7 +1995,6 @@ pub mod entitlement {
                 "requester_email_recipients",
                 &self.requester_email_recipients,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2304,7 +2295,6 @@ impl std::fmt::Debug for AccessControlEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccessControlEntry");
         debug_struct.field("principals", &self.principals);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2497,7 +2487,6 @@ impl std::fmt::Debug for ApprovalWorkflow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApprovalWorkflow");
         debug_struct.field("approval_workflow", &self.approval_workflow);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2712,7 +2701,6 @@ impl std::fmt::Debug for ManualApprovals {
             &self.require_approver_justification,
         );
         debug_struct.field("steps", &self.steps);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2952,7 +2940,6 @@ pub mod manual_approvals {
             debug_struct.field("approvers", &self.approvers);
             debug_struct.field("approvals_needed", &self.approvals_needed);
             debug_struct.field("approver_email_recipients", &self.approver_email_recipients);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3147,7 +3134,6 @@ impl std::fmt::Debug for PrivilegedAccess {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrivilegedAccess");
         debug_struct.field("access_type", &self.access_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3358,7 +3344,6 @@ pub mod privileged_access {
             debug_struct.field("resource_type", &self.resource_type);
             debug_struct.field("resource", &self.resource);
             debug_struct.field("role_bindings", &self.role_bindings);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3552,7 +3537,6 @@ pub mod privileged_access {
                 let mut debug_struct = f.debug_struct("RoleBinding");
                 debug_struct.field("role", &self.role);
                 debug_struct.field("condition_expression", &self.condition_expression);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3825,7 +3809,6 @@ impl std::fmt::Debug for ListEntitlementsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4038,7 +4021,6 @@ impl std::fmt::Debug for ListEntitlementsResponse {
         debug_struct.field("entitlements", &self.entitlements);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4311,7 +4293,6 @@ impl std::fmt::Debug for SearchEntitlementsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4634,7 +4615,6 @@ impl std::fmt::Debug for SearchEntitlementsResponse {
         let mut debug_struct = f.debug_struct("SearchEntitlementsResponse");
         debug_struct.field("entitlements", &self.entitlements);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4776,7 +4756,6 @@ impl std::fmt::Debug for GetEntitlementRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEntitlementRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5031,7 +5010,6 @@ impl std::fmt::Debug for CreateEntitlementRequest {
         debug_struct.field("entitlement_id", &self.entitlement_id);
         debug_struct.field("entitlement", &self.entitlement);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5237,7 +5215,6 @@ impl std::fmt::Debug for DeleteEntitlementRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5435,7 +5412,6 @@ impl std::fmt::Debug for UpdateEntitlementRequest {
         let mut debug_struct = f.debug_struct("UpdateEntitlementRequest");
         debug_struct.field("entitlement", &self.entitlement);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5968,7 +5944,6 @@ impl std::fmt::Debug for Grant {
             &self.additional_email_recipients,
         );
         debug_struct.field("externally_modified", &self.externally_modified);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6128,7 +6103,6 @@ pub mod grant {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Timeline");
             debug_struct.field("events", &self.events);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6957,7 +6931,6 @@ pub mod grant {
                 let mut debug_struct = f.debug_struct("Event");
                 debug_struct.field("event_time", &self.event_time);
                 debug_struct.field("event", &self.event);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -7131,7 +7104,6 @@ pub mod grant {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Requested");
                     debug_struct.field("expire_time", &self.expire_time);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7323,7 +7295,6 @@ pub mod grant {
                     let mut debug_struct = f.debug_struct("Approved");
                     debug_struct.field("reason", &self.reason);
                     debug_struct.field("actor", &self.actor);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7515,7 +7486,6 @@ pub mod grant {
                     let mut debug_struct = f.debug_struct("Denied");
                     debug_struct.field("reason", &self.reason);
                     debug_struct.field("actor", &self.actor);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7706,7 +7676,6 @@ pub mod grant {
                     let mut debug_struct = f.debug_struct("Revoked");
                     debug_struct.field("reason", &self.reason);
                     debug_struct.field("actor", &self.actor);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -7887,7 +7856,6 @@ pub mod grant {
                     let mut debug_struct = f.debug_struct("Scheduled");
                     debug_struct
                         .field("scheduled_activation_time", &self.scheduled_activation_time);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8014,7 +7982,6 @@ pub mod grant {
             impl std::fmt::Debug for Activated {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Activated");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8182,7 +8149,6 @@ pub mod grant {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("ActivationFailed");
                     debug_struct.field("error", &self.error);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8308,7 +8274,6 @@ pub mod grant {
             impl std::fmt::Debug for Expired {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Expired");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8434,7 +8399,6 @@ pub mod grant {
             impl std::fmt::Debug for Ended {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Ended");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8561,7 +8525,6 @@ pub mod grant {
             impl std::fmt::Debug for ExternallyModified {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("ExternallyModified");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -8791,7 +8754,6 @@ pub mod grant {
             let mut debug_struct = f.debug_struct("AuditTrail");
             debug_struct.field("access_grant_time", &self.access_grant_time);
             debug_struct.field("access_remove_time", &self.access_remove_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9175,7 +9137,6 @@ impl std::fmt::Debug for Justification {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Justification");
         debug_struct.field("justification", &self.justification);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9453,7 +9414,6 @@ impl std::fmt::Debug for ListGrantsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9666,7 +9626,6 @@ impl std::fmt::Debug for ListGrantsResponse {
         debug_struct.field("grants", &self.grants);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9938,7 +9897,6 @@ impl std::fmt::Debug for SearchGrantsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10270,7 +10228,6 @@ impl std::fmt::Debug for SearchGrantsResponse {
         let mut debug_struct = f.debug_struct("SearchGrantsResponse");
         debug_struct.field("grants", &self.grants);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10412,7 +10369,6 @@ impl std::fmt::Debug for GetGrantRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGrantRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10581,7 +10537,6 @@ impl std::fmt::Debug for ApproveGrantRequest {
         let mut debug_struct = f.debug_struct("ApproveGrantRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10750,7 +10705,6 @@ impl std::fmt::Debug for DenyGrantRequest {
         let mut debug_struct = f.debug_struct("DenyGrantRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10917,7 +10871,6 @@ impl std::fmt::Debug for RevokeGrantRequest {
         let mut debug_struct = f.debug_struct("RevokeGrantRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11134,7 +11087,6 @@ impl std::fmt::Debug for CreateGrantRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("grant", &self.grant);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11459,7 +11411,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -168,7 +168,6 @@ impl std::fmt::Debug for GuestOsScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GuestOsScan");
         debug_struct.field("core_source", &self.core_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -311,7 +310,6 @@ impl std::fmt::Debug for VSphereScan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VSphereScan");
         debug_struct.field("core_source", &self.core_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -911,7 +909,6 @@ impl std::fmt::Debug for Collector {
         debug_struct.field("vsphere_scan", &self.vsphere_scan);
         debug_struct.field("collection_days", &self.collection_days);
         debug_struct.field("eula_uri", &self.eula_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1376,7 +1373,6 @@ impl std::fmt::Debug for Annotation {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1720,7 +1716,6 @@ impl std::fmt::Debug for CreateAnnotationRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("annotation", &self.annotation);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1862,7 +1857,6 @@ impl std::fmt::Debug for GetAnnotationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAnnotationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2092,7 +2086,6 @@ impl std::fmt::Debug for CreateCollectorRequest {
         debug_struct.field("collector_id", &self.collector_id);
         debug_struct.field("collector", &self.collector);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2356,7 +2349,6 @@ impl std::fmt::Debug for ListCollectorsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2569,7 +2561,6 @@ impl std::fmt::Debug for ListCollectorsResponse {
         debug_struct.field("collectors", &self.collectors);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2711,7 +2702,6 @@ impl std::fmt::Debug for GetCollectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCollectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2891,7 +2881,6 @@ impl std::fmt::Debug for DeleteCollectorRequest {
         let mut debug_struct = f.debug_struct("DeleteCollectorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3123,7 +3112,6 @@ impl std::fmt::Debug for UpdateCollectorRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("collector", &self.collector);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3303,7 +3291,6 @@ impl std::fmt::Debug for ResumeCollectorRequest {
         let mut debug_struct = f.debug_struct("ResumeCollectorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3483,7 +3470,6 @@ impl std::fmt::Debug for RegisterCollectorRequest {
         let mut debug_struct = f.debug_struct("RegisterCollectorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3663,7 +3649,6 @@ impl std::fmt::Debug for PauseCollectorRequest {
         let mut debug_struct = f.debug_struct("PauseCollectorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3988,7 +3973,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -202,7 +202,6 @@ impl std::fmt::Debug for CreateAssessmentRequest {
         let mut debug_struct = f.debug_struct("CreateAssessmentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("assessment", &self.assessment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -462,7 +461,6 @@ impl std::fmt::Debug for TransactionEvent {
         debug_struct.field("reason", &self.reason);
         debug_struct.field("value", &self.value);
         debug_struct.field("event_time", &self.event_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1080,7 +1078,6 @@ impl std::fmt::Debug for AnnotateAssessmentRequest {
         debug_struct.field("account_id", &self.account_id);
         debug_struct.field("hashed_account_id", &self.hashed_account_id);
         debug_struct.field("transaction_event", &self.transaction_event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1585,7 +1582,6 @@ impl serde::ser::Serialize for AnnotateAssessmentResponse {
 impl std::fmt::Debug for AnnotateAssessmentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnnotateAssessmentResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1882,7 +1878,6 @@ impl std::fmt::Debug for EndpointVerificationInfo {
         debug_struct.field("request_token", &self.request_token);
         debug_struct.field("last_verification_time", &self.last_verification_time);
         debug_struct.field("endpoint", &self.endpoint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2142,7 +2137,6 @@ impl std::fmt::Debug for AccountVerificationInfo {
             &self.latest_verification_result,
         );
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2702,7 +2696,6 @@ impl std::fmt::Debug for PrivatePasswordLeakVerification {
             "reencrypted_user_credentials_hash",
             &self.reencrypted_user_credentials_hash,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3306,7 +3299,6 @@ impl std::fmt::Debug for Assessment {
         debug_struct.field("fraud_signals", &self.fraud_signals);
         debug_struct.field("phone_fraud_assessment", &self.phone_fraud_assessment);
         debug_struct.field("assessment_environment", &self.assessment_environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3909,7 +3901,6 @@ impl std::fmt::Debug for Event {
         debug_struct.field("transaction_data", &self.transaction_data);
         debug_struct.field("user_info", &self.user_info);
         debug_struct.field("fraud_prevention", &self.fraud_prevention);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4625,7 +4616,6 @@ impl std::fmt::Debug for TransactionData {
         debug_struct.field("merchants", &self.merchants);
         debug_struct.field("items", &self.items);
         debug_struct.field("gateway_info", &self.gateway_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4913,7 +4903,6 @@ pub mod transaction_data {
             debug_struct.field("administrative_area", &self.administrative_area);
             debug_struct.field("region_code", &self.region_code);
             debug_struct.field("postal_code", &self.postal_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5214,7 +5203,6 @@ pub mod transaction_data {
             debug_struct.field("email_verified", &self.email_verified);
             debug_struct.field("phone_number", &self.phone_number);
             debug_struct.field("phone_verified", &self.phone_verified);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5476,7 +5464,6 @@ pub mod transaction_data {
             debug_struct.field("value", &self.value);
             debug_struct.field("quantity", &self.quantity);
             debug_struct.field("merchant_account_id", &self.merchant_account_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5711,7 +5698,6 @@ pub mod transaction_data {
             debug_struct.field("gateway_response_code", &self.gateway_response_code);
             debug_struct.field("avs_response_code", &self.avs_response_code);
             debug_struct.field("cvv_response_code", &self.cvv_response_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5927,7 +5913,6 @@ impl std::fmt::Debug for UserInfo {
         debug_struct.field("create_account_time", &self.create_account_time);
         debug_struct.field("account_id", &self.account_id);
         debug_struct.field("user_ids", &self.user_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6195,7 +6180,6 @@ impl std::fmt::Debug for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserId");
         debug_struct.field("id_oneof", &self.id_oneof);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6469,7 +6453,6 @@ impl std::fmt::Debug for RiskAnalysis {
         debug_struct.field("reasons", &self.reasons);
         debug_struct.field("extended_verdict_reasons", &self.extended_verdict_reasons);
         debug_struct.field("challenge", &self.challenge);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7110,7 +7093,6 @@ impl std::fmt::Debug for TokenProperties {
         debug_struct.field("android_package_name", &self.android_package_name);
         debug_struct.field("ios_bundle_id", &self.ios_bundle_id);
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7570,7 +7552,6 @@ impl std::fmt::Debug for FraudPreventionAssessment {
         debug_struct.field("stolen_instrument_verdict", &self.stolen_instrument_verdict);
         debug_struct.field("card_testing_verdict", &self.card_testing_verdict);
         debug_struct.field("behavioral_trust_verdict", &self.behavioral_trust_verdict);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7740,7 +7721,6 @@ pub mod fraud_prevention_assessment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StolenInstrumentVerdict");
             debug_struct.field("risk", &self.risk);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7905,7 +7885,6 @@ pub mod fraud_prevention_assessment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CardTestingVerdict");
             debug_struct.field("risk", &self.risk);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8070,7 +8049,6 @@ pub mod fraud_prevention_assessment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BehavioralTrustVerdict");
             debug_struct.field("trust", &self.trust);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8263,7 +8241,6 @@ impl std::fmt::Debug for FraudSignals {
         let mut debug_struct = f.debug_struct("FraudSignals");
         debug_struct.field("user_signals", &self.user_signals);
         debug_struct.field("card_signals", &self.card_signals);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8486,7 +8463,6 @@ pub mod fraud_signals {
             let mut debug_struct = f.debug_struct("UserSignals");
             debug_struct.field("active_days_lower_bound", &self.active_days_lower_bound);
             debug_struct.field("synthetic_risk", &self.synthetic_risk);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8641,7 +8617,6 @@ pub mod fraud_signals {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CardSignals");
             debug_struct.field("card_labels", &self.card_labels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8988,7 +8963,6 @@ impl std::fmt::Debug for SmsTollFraudVerdict {
         let mut debug_struct = f.debug_struct("SmsTollFraudVerdict");
         debug_struct.field("risk", &self.risk);
         debug_struct.field("reasons", &self.reasons);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9273,7 +9247,6 @@ impl std::fmt::Debug for PhoneFraudAssessment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PhoneFraudAssessment");
         debug_struct.field("sms_toll_fraud_verdict", &self.sms_toll_fraud_verdict);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9418,7 +9391,6 @@ impl std::fmt::Debug for AccountDefenderAssessment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccountDefenderAssessment");
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9760,7 +9732,6 @@ impl std::fmt::Debug for CreateKeyRequest {
         let mut debug_struct = f.debug_struct("CreateKeyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9975,7 +9946,6 @@ impl std::fmt::Debug for ListKeysRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10161,7 +10131,6 @@ impl std::fmt::Debug for ListKeysResponse {
         let mut debug_struct = f.debug_struct("ListKeysResponse");
         debug_struct.field("keys", &self.keys);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10304,7 +10273,6 @@ impl std::fmt::Debug for RetrieveLegacySecretKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveLegacySecretKeyRequest");
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10447,7 +10415,6 @@ impl std::fmt::Debug for GetKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10638,7 +10605,6 @@ impl std::fmt::Debug for UpdateKeyRequest {
         let mut debug_struct = f.debug_struct("UpdateKeyRequest");
         debug_struct.field("key", &self.key);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10781,7 +10747,6 @@ impl std::fmt::Debug for DeleteKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10962,7 +10927,6 @@ impl std::fmt::Debug for CreateFirewallPolicyRequest {
         let mut debug_struct = f.debug_struct("CreateFirewallPolicyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("firewall_policy", &self.firewall_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11177,7 +11141,6 @@ impl std::fmt::Debug for ListFirewallPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11368,7 +11331,6 @@ impl std::fmt::Debug for ListFirewallPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListFirewallPoliciesResponse");
         debug_struct.field("firewall_policies", &self.firewall_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11511,7 +11473,6 @@ impl std::fmt::Debug for GetFirewallPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFirewallPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11704,7 +11665,6 @@ impl std::fmt::Debug for UpdateFirewallPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateFirewallPolicyRequest");
         debug_struct.field("firewall_policy", &self.firewall_policy);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11847,7 +11807,6 @@ impl std::fmt::Debug for DeleteFirewallPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFirewallPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12019,7 +11978,6 @@ impl std::fmt::Debug for ReorderFirewallPoliciesRequest {
         let mut debug_struct = f.debug_struct("ReorderFirewallPoliciesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12133,7 +12091,6 @@ impl serde::ser::Serialize for ReorderFirewallPoliciesResponse {
 impl std::fmt::Debug for ReorderFirewallPoliciesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReorderFirewallPoliciesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12309,7 +12266,6 @@ impl std::fmt::Debug for MigrateKeyRequest {
         let mut debug_struct = f.debug_struct("MigrateKeyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("skip_billing_check", &self.skip_billing_check);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12452,7 +12408,6 @@ impl std::fmt::Debug for GetMetricsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMetricsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12698,7 +12653,6 @@ impl std::fmt::Debug for Metrics {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("score_metrics", &self.score_metrics);
         debug_struct.field("challenge_metrics", &self.challenge_metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12848,7 +12802,6 @@ impl std::fmt::Debug for RetrieveLegacySecretKeyResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetrieveLegacySecretKeyResponse");
         debug_struct.field("legacy_secret_key", &self.legacy_secret_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13408,7 +13361,6 @@ impl std::fmt::Debug for Key {
         debug_struct.field("testing_options", &self.testing_options);
         debug_struct.field("waf_settings", &self.waf_settings);
         debug_struct.field("platform_settings", &self.platform_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13627,7 +13579,6 @@ impl std::fmt::Debug for TestingOptions {
         let mut debug_struct = f.debug_struct("TestingOptions");
         debug_struct.field("testing_score", &self.testing_score);
         debug_struct.field("testing_challenge", &self.testing_challenge);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14049,7 +14000,6 @@ impl std::fmt::Debug for WebKeySettings {
             "challenge_security_preference",
             &self.challenge_security_preference,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14556,7 +14506,6 @@ impl std::fmt::Debug for AndroidKeySettings {
             "support_non_google_app_store_distribution",
             &self.support_non_google_app_store_distribution,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14771,7 +14720,6 @@ impl std::fmt::Debug for IOSKeySettings {
         debug_struct.field("allow_all_bundle_ids", &self.allow_all_bundle_ids);
         debug_struct.field("allowed_bundle_ids", &self.allowed_bundle_ids);
         debug_struct.field("apple_developer_id", &self.apple_developer_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14885,7 +14833,6 @@ impl serde::ser::Serialize for ExpressKeySettings {
 impl std::fmt::Debug for ExpressKeySettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExpressKeySettings");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15083,7 +15030,6 @@ impl std::fmt::Debug for AppleDeveloperId {
         debug_struct.field("private_key", &self.private_key);
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("team_id", &self.team_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15263,7 +15209,6 @@ impl std::fmt::Debug for ScoreDistribution {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScoreDistribution");
         debug_struct.field("score_buckets", &self.score_buckets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15457,7 +15402,6 @@ impl std::fmt::Debug for ScoreMetrics {
         let mut debug_struct = f.debug_struct("ScoreMetrics");
         debug_struct.field("overall_metrics", &self.overall_metrics);
         debug_struct.field("action_metrics", &self.action_metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15756,7 +15700,6 @@ impl std::fmt::Debug for ChallengeMetrics {
         debug_struct.field("nocaptcha_count", &self.nocaptcha_count);
         debug_struct.field("failed_count", &self.failed_count);
         debug_struct.field("passed_count", &self.passed_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15950,7 +15893,6 @@ impl std::fmt::Debug for FirewallPolicyAssessment {
         let mut debug_struct = f.debug_struct("FirewallPolicyAssessment");
         debug_struct.field("error", &self.error);
         debug_struct.field("firewall_policy", &self.firewall_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16440,7 +16382,6 @@ impl std::fmt::Debug for FirewallAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FirewallAction");
         debug_struct.field("firewall_action_oneof", &self.firewall_action_oneof);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16562,7 +16503,6 @@ pub mod firewall_action {
     impl std::fmt::Debug for AllowAction {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AllowAction");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16680,7 +16620,6 @@ pub mod firewall_action {
     impl std::fmt::Debug for BlockAction {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BlockAction");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16801,7 +16740,6 @@ pub mod firewall_action {
     impl std::fmt::Debug for IncludeRecaptchaScriptAction {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IncludeRecaptchaScriptAction");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16919,7 +16857,6 @@ pub mod firewall_action {
     impl std::fmt::Debug for RedirectAction {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RedirectAction");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17066,7 +17003,6 @@ pub mod firewall_action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SubstituteAction");
             debug_struct.field("path", &self.path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17238,7 +17174,6 @@ pub mod firewall_action {
             let mut debug_struct = f.debug_struct("SetHeaderAction");
             debug_struct.field("key", &self.key);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17533,7 +17468,6 @@ impl std::fmt::Debug for FirewallPolicy {
         debug_struct.field("path", &self.path);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17754,7 +17688,6 @@ impl std::fmt::Debug for ListRelatedAccountGroupMembershipsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17958,7 +17891,6 @@ impl std::fmt::Debug for ListRelatedAccountGroupMembershipsResponse {
             &self.related_account_group_memberships,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18178,7 +18110,6 @@ impl std::fmt::Debug for ListRelatedAccountGroupsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18369,7 +18300,6 @@ impl std::fmt::Debug for ListRelatedAccountGroupsResponse {
         let mut debug_struct = f.debug_struct("ListRelatedAccountGroupsResponse");
         debug_struct.field("related_account_groups", &self.related_account_groups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18673,7 +18603,6 @@ impl std::fmt::Debug for SearchRelatedAccountGroupMembershipsRequest {
         debug_struct.field("hashed_account_id", &self.hashed_account_id);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18877,7 +18806,6 @@ impl std::fmt::Debug for SearchRelatedAccountGroupMembershipsResponse {
             &self.related_account_group_memberships,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19058,7 +18986,6 @@ impl std::fmt::Debug for AddIpOverrideRequest {
         let mut debug_struct = f.debug_struct("AddIpOverrideRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("ip_override_data", &self.ip_override_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19172,7 +19099,6 @@ impl serde::ser::Serialize for AddIpOverrideResponse {
 impl std::fmt::Debug for AddIpOverrideResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddIpOverrideResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19353,7 +19279,6 @@ impl std::fmt::Debug for RemoveIpOverrideRequest {
         let mut debug_struct = f.debug_struct("RemoveIpOverrideRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("ip_override_data", &self.ip_override_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19467,7 +19392,6 @@ impl serde::ser::Serialize for RemoveIpOverrideResponse {
 impl std::fmt::Debug for RemoveIpOverrideResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveIpOverrideResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19684,7 +19608,6 @@ impl std::fmt::Debug for ListIpOverridesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19875,7 +19798,6 @@ impl std::fmt::Debug for ListIpOverridesResponse {
         let mut debug_struct = f.debug_struct("ListIpOverridesResponse");
         debug_struct.field("ip_overrides", &self.ip_overrides);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20096,7 +20018,6 @@ impl std::fmt::Debug for RelatedAccountGroupMembership {
         debug_struct.field("name", &self.name);
         debug_struct.field("account_id", &self.account_id);
         debug_struct.field("hashed_account_id", &self.hashed_account_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20240,7 +20161,6 @@ impl std::fmt::Debug for RelatedAccountGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RelatedAccountGroup");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20412,7 +20332,6 @@ impl std::fmt::Debug for WafSettings {
         let mut debug_struct = f.debug_struct("WafSettings");
         debug_struct.field("waf_service", &self.waf_service);
         debug_struct.field("waf_feature", &self.waf_feature);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20888,7 +20807,6 @@ impl std::fmt::Debug for AssessmentEnvironment {
         let mut debug_struct = f.debug_struct("AssessmentEnvironment");
         debug_struct.field("client", &self.client);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21069,7 +20987,6 @@ impl std::fmt::Debug for IpOverrideData {
         let mut debug_struct = f.debug_struct("IpOverrideData");
         debug_struct.field("ip", &self.ip);
         debug_struct.field("override_type", &self.override_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/recommender/logging/v1/src/model.rs
+++ b/src/generated/cloud/recommender/logging/v1/src/model.rs
@@ -258,7 +258,6 @@ impl std::fmt::Debug for ActionLog {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_metadata", &self.state_metadata);
         debug_struct.field("recommendation_name", &self.recommendation_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -493,7 +492,6 @@ impl std::fmt::Debug for InsightActionLog {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_metadata", &self.state_metadata);
         debug_struct.field("insight", &self.insight);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -525,7 +525,6 @@ impl std::fmt::Debug for Insight {
             "associated_recommendations",
             &self.associated_recommendations,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -679,7 +678,6 @@ pub mod insight {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RecommendationReference");
             debug_struct.field("recommendation", &self.recommendation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1166,7 +1164,6 @@ impl std::fmt::Debug for InsightStateInfo {
         let mut debug_struct = f.debug_struct("InsightStateInfo");
         debug_struct.field("state", &self.state);
         debug_struct.field("state_metadata", &self.state_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1674,7 +1671,6 @@ impl std::fmt::Debug for InsightTypeConfig {
         debug_struct.field("revision_id", &self.revision_id);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1829,7 +1825,6 @@ impl std::fmt::Debug for InsightTypeGenerationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InsightTypeGenerationConfig");
         debug_struct.field("params", &self.params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2329,7 +2324,6 @@ impl std::fmt::Debug for Recommendation {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("associated_insights", &self.associated_insights);
         debug_struct.field("xor_group_id", &self.xor_group_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2480,7 +2474,6 @@ pub mod recommendation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InsightReference");
             debug_struct.field("insight", &self.insight);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2815,7 +2808,6 @@ impl std::fmt::Debug for RecommendationContent {
         let mut debug_struct = f.debug_struct("RecommendationContent");
         debug_struct.field("operation_groups", &self.operation_groups);
         debug_struct.field("overview", &self.overview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2961,7 +2953,6 @@ impl std::fmt::Debug for OperationGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OperationGroup");
         debug_struct.field("operations", &self.operations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3476,7 +3467,6 @@ impl std::fmt::Debug for Operation {
         debug_struct.field("path_filters", &self.path_filters);
         debug_struct.field("path_value_matchers", &self.path_value_matchers);
         debug_struct.field("path_value", &self.path_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3679,7 +3669,6 @@ impl std::fmt::Debug for ValueMatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ValueMatcher");
         debug_struct.field("match_variant", &self.match_variant);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3925,7 +3914,6 @@ impl std::fmt::Debug for CostProjection {
         debug_struct.field("cost", &self.cost);
         debug_struct.field("duration", &self.duration);
         debug_struct.field("cost_in_local_currency", &self.cost_in_local_currency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4078,7 +4066,6 @@ impl std::fmt::Debug for SecurityProjection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecurityProjection");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4277,7 +4264,6 @@ impl std::fmt::Debug for SustainabilityProjection {
         let mut debug_struct = f.debug_struct("SustainabilityProjection");
         debug_struct.field("kg_c_o2e", &self.kg_c_o2e);
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4462,7 +4448,6 @@ impl std::fmt::Debug for ReliabilityProjection {
         let mut debug_struct = f.debug_struct("ReliabilityProjection");
         debug_struct.field("risks", &self.risks);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5003,7 +4988,6 @@ impl std::fmt::Debug for Impact {
         let mut debug_struct = f.debug_struct("Impact");
         debug_struct.field("category", &self.category);
         debug_struct.field("projection", &self.projection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5367,7 +5351,6 @@ impl std::fmt::Debug for RecommendationStateInfo {
         let mut debug_struct = f.debug_struct("RecommendationStateInfo");
         debug_struct.field("state", &self.state);
         debug_struct.field("state_metadata", &self.state_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5898,7 +5881,6 @@ impl std::fmt::Debug for RecommenderConfig {
         debug_struct.field("revision_id", &self.revision_id);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6053,7 +6035,6 @@ impl std::fmt::Debug for RecommenderGenerationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RecommenderGenerationConfig");
         debug_struct.field("params", &self.params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6341,7 +6322,6 @@ impl std::fmt::Debug for ListInsightsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6527,7 +6507,6 @@ impl std::fmt::Debug for ListInsightsResponse {
         let mut debug_struct = f.debug_struct("ListInsightsResponse");
         debug_struct.field("insights", &self.insights);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6669,7 +6648,6 @@ impl std::fmt::Debug for GetInsightRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInsightRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6874,7 +6852,6 @@ impl std::fmt::Debug for MarkInsightAcceptedRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("state_metadata", &self.state_metadata);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7162,7 +7139,6 @@ impl std::fmt::Debug for ListRecommendationsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7352,7 +7328,6 @@ impl std::fmt::Debug for ListRecommendationsResponse {
         let mut debug_struct = f.debug_struct("ListRecommendationsResponse");
         debug_struct.field("recommendations", &self.recommendations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7494,7 +7469,6 @@ impl std::fmt::Debug for GetRecommendationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRecommendationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7661,7 +7635,6 @@ impl std::fmt::Debug for MarkRecommendationDismissedRequest {
         let mut debug_struct = f.debug_struct("MarkRecommendationDismissedRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7868,7 +7841,6 @@ impl std::fmt::Debug for MarkRecommendationClaimedRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("state_metadata", &self.state_metadata);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8075,7 +8047,6 @@ impl std::fmt::Debug for MarkRecommendationSucceededRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("state_metadata", &self.state_metadata);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8282,7 +8253,6 @@ impl std::fmt::Debug for MarkRecommendationFailedRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("state_metadata", &self.state_metadata);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8435,7 +8405,6 @@ impl std::fmt::Debug for GetRecommenderConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRecommenderConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8654,7 +8623,6 @@ impl std::fmt::Debug for UpdateRecommenderConfigRequest {
         debug_struct.field("recommender_config", &self.recommender_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8807,7 +8775,6 @@ impl std::fmt::Debug for GetInsightTypeConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInsightTypeConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9026,7 +8993,6 @@ impl std::fmt::Debug for UpdateInsightTypeConfigRequest {
         debug_struct.field("insight_type_config", &self.insight_type_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -265,7 +265,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -488,7 +487,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -712,7 +710,6 @@ impl std::fmt::Debug for ListClustersResponse {
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -936,7 +933,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1080,7 +1076,6 @@ impl std::fmt::Debug for GetClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1250,7 +1245,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         let mut debug_struct = f.debug_struct("DeleteClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1396,7 +1390,6 @@ impl std::fmt::Debug for GetClusterCertificateAuthorityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClusterCertificateAuthorityRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1620,7 +1613,6 @@ impl std::fmt::Debug for ListBackupCollectionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1848,7 +1840,6 @@ impl std::fmt::Debug for ListBackupCollectionsResponse {
         debug_struct.field("backup_collections", &self.backup_collections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1992,7 +1983,6 @@ impl std::fmt::Debug for GetBackupCollectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupCollectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2214,7 +2204,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2428,7 +2417,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2571,7 +2559,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2740,7 +2727,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2950,7 +2936,6 @@ impl std::fmt::Debug for ExportBackupRequest {
         let mut debug_struct = f.debug_struct("ExportBackupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3182,7 +3167,6 @@ impl std::fmt::Debug for BackupClusterRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("ttl", &self.ttl);
         debug_struct.field("backup_id", &self.backup_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4505,7 +4489,6 @@ impl std::fmt::Debug for Cluster {
         debug_struct.field("automated_backup_config", &self.automated_backup_config);
         debug_struct.field("encryption_info", &self.encryption_info);
         debug_struct.field("import_sources", &self.import_sources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4708,7 +4691,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StateInfo");
             debug_struct.field("info", &self.info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4967,7 +4949,6 @@ pub mod cluster {
                 let mut debug_struct = f.debug_struct("UpdateInfo");
                 debug_struct.field("target_shard_count", &self.target_shard_count);
                 debug_struct.field("target_replica_count", &self.target_replica_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -5125,7 +5106,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GcsBackupSource");
             debug_struct.field("uris", &self.uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5275,7 +5255,6 @@ pub mod cluster {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ManagedBackupSource");
             debug_struct.field("backup", &self.backup);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5703,7 +5682,6 @@ impl std::fmt::Debug for AutomatedBackupConfig {
         debug_struct.field("automated_backup_mode", &self.automated_backup_mode);
         debug_struct.field("retention", &self.retention);
         debug_struct.field("schedule", &self.schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5867,7 +5845,6 @@ pub mod automated_backup_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FixedFrequencySchedule");
             debug_struct.field("start_time", &self.start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6257,7 +6234,6 @@ impl std::fmt::Debug for BackupCollection {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6857,7 +6833,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("state", &self.state);
         debug_struct.field("encryption_info", &self.encryption_info);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7366,7 +7341,6 @@ impl std::fmt::Debug for BackupFile {
         debug_struct.field("file_name", &self.file_name);
         debug_struct.field("size_bytes", &self.size_bytes);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7543,7 +7517,6 @@ impl std::fmt::Debug for PscServiceAttachment {
         let mut debug_struct = f.debug_struct("PscServiceAttachment");
         debug_struct.field("service_attachment", &self.service_attachment);
         debug_struct.field("connection_type", &self.connection_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7850,7 +7823,6 @@ impl std::fmt::Debug for CrossClusterReplicationConfig {
         debug_struct.field("secondary_clusters", &self.secondary_clusters);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("membership", &self.membership);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8027,7 +7999,6 @@ pub mod cross_cluster_replication_config {
             let mut debug_struct = f.debug_struct("RemoteCluster");
             debug_struct.field("cluster", &self.cluster);
             debug_struct.field("uid", &self.uid);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8219,7 +8190,6 @@ pub mod cross_cluster_replication_config {
             let mut debug_struct = f.debug_struct("Membership");
             debug_struct.field("primary_cluster", &self.primary_cluster);
             debug_struct.field("secondary_clusters", &self.secondary_clusters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8595,7 +8565,6 @@ impl std::fmt::Debug for ClusterMaintenancePolicy {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("weekly_maintenance_window", &self.weekly_maintenance_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8774,7 +8743,6 @@ impl std::fmt::Debug for ClusterWeeklyMaintenanceWindow {
         let mut debug_struct = f.debug_struct("ClusterWeeklyMaintenanceWindow");
         debug_struct.field("day", &self.day);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8967,7 +8935,6 @@ impl std::fmt::Debug for ClusterMaintenanceSchedule {
         let mut debug_struct = f.debug_struct("ClusterMaintenanceSchedule");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9110,7 +9077,6 @@ impl std::fmt::Debug for PscConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PscConfig");
         debug_struct.field("network", &self.network);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9334,7 +9300,6 @@ impl std::fmt::Debug for DiscoveryEndpoint {
         debug_struct.field("address", &self.address);
         debug_struct.field("port", &self.port);
         debug_struct.field("psc_config", &self.psc_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9678,7 +9643,6 @@ impl std::fmt::Debug for PscConnection {
         debug_struct.field("service_attachment", &self.service_attachment);
         debug_struct.field("psc_connection_status", &self.psc_connection_status);
         debug_struct.field("connection_type", &self.connection_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9830,7 +9794,6 @@ impl std::fmt::Debug for ClusterEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ClusterEndpoint");
         debug_struct.field("connections", &self.connections);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10084,7 +10047,6 @@ impl std::fmt::Debug for ConnectionDetail {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConnectionDetail");
         debug_struct.field("connection", &self.connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10449,7 +10411,6 @@ impl std::fmt::Debug for PscAutoConnection {
         debug_struct.field("service_attachment", &self.service_attachment);
         debug_struct.field("psc_connection_status", &self.psc_connection_status);
         debug_struct.field("connection_type", &self.connection_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10774,7 +10735,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10995,7 +10955,6 @@ impl std::fmt::Debug for CertificateAuthority {
         let mut debug_struct = f.debug_struct("CertificateAuthority");
         debug_struct.field("name", &self.name);
         debug_struct.field("server_ca", &self.server_ca);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11153,7 +11112,6 @@ pub mod certificate_authority {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ManagedCertificateAuthority");
             debug_struct.field("ca_certs", &self.ca_certs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11310,7 +11268,6 @@ pub mod certificate_authority {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CertChain");
                 debug_struct.field("certificates", &self.certificates);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -11546,7 +11503,6 @@ impl std::fmt::Debug for ClusterPersistenceConfig {
         debug_struct.field("mode", &self.mode);
         debug_struct.field("rdb_config", &self.rdb_config);
         debug_struct.field("aof_config", &self.aof_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11744,7 +11700,6 @@ pub mod cluster_persistence_config {
             let mut debug_struct = f.debug_struct("RDBConfig");
             debug_struct.field("rdb_snapshot_period", &self.rdb_snapshot_period);
             debug_struct.field("rdb_snapshot_start_time", &self.rdb_snapshot_start_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12047,7 +12002,6 @@ pub mod cluster_persistence_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AOFConfig");
             debug_struct.field("append_fsync", &self.append_fsync);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12515,7 +12469,6 @@ impl std::fmt::Debug for ZoneDistributionConfig {
         let mut debug_struct = f.debug_struct("ZoneDistributionConfig");
         debug_struct.field("mode", &self.mode);
         debug_struct.field("zone", &self.zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12870,7 +12823,6 @@ impl std::fmt::Debug for RescheduleClusterMaintenanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("reschedule_type", &self.reschedule_type);
         debug_struct.field("schedule_time", &self.schedule_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13249,7 +13201,6 @@ impl std::fmt::Debug for EncryptionInfo {
         debug_struct.field("kms_key_versions", &self.kms_key_versions);
         debug_struct.field("kms_key_primary_state", &self.kms_key_primary_state);
         debug_struct.field("last_update_time", &self.last_update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -193,7 +193,6 @@ impl std::fmt::Debug for NodeInfo {
         let mut debug_struct = f.debug_struct("NodeInfo");
         debug_struct.field("id", &self.id);
         debug_struct.field("zone", &self.zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1510,7 +1509,6 @@ impl std::fmt::Debug for Instance {
             "available_maintenance_versions",
             &self.available_maintenance_versions,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2619,7 +2617,6 @@ impl std::fmt::Debug for PersistenceConfig {
         debug_struct.field("rdb_snapshot_period", &self.rdb_snapshot_period);
         debug_struct.field("rdb_next_snapshot_time", &self.rdb_next_snapshot_time);
         debug_struct.field("rdb_snapshot_start_time", &self.rdb_snapshot_start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3124,7 +3121,6 @@ impl std::fmt::Debug for RescheduleMaintenanceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("reschedule_type", &self.reschedule_type);
         debug_struct.field("schedule_time", &self.schedule_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3526,7 +3522,6 @@ impl std::fmt::Debug for MaintenancePolicy {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("description", &self.description);
         debug_struct.field("weekly_maintenance_window", &self.weekly_maintenance_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3743,7 +3738,6 @@ impl std::fmt::Debug for WeeklyMaintenanceWindow {
         debug_struct.field("day", &self.day);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4003,7 +3997,6 @@ impl std::fmt::Debug for MaintenanceSchedule {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("can_reschedule", &self.can_reschedule);
         debug_struct.field("schedule_deadline_time", &self.schedule_deadline_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4231,7 +4224,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4457,7 +4449,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4603,7 +4594,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4750,7 +4740,6 @@ impl std::fmt::Debug for GetInstanceAuthStringRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceAuthStringRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4893,7 +4882,6 @@ impl std::fmt::Debug for InstanceAuthString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstanceAuthString");
         debug_struct.field("auth_string", &self.auth_string);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5109,7 +5097,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5313,7 +5300,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("UpdateInstanceRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5486,7 +5472,6 @@ impl std::fmt::Debug for UpgradeInstanceRequest {
         let mut debug_struct = f.debug_struct("UpgradeInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("redis_version", &self.redis_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5633,7 +5618,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5775,7 +5759,6 @@ impl std::fmt::Debug for GcsSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsSource");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5961,7 +5944,6 @@ impl std::fmt::Debug for InputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6158,7 +6140,6 @@ impl std::fmt::Debug for ImportInstanceRequest {
         let mut debug_struct = f.debug_struct("ImportInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("input_config", &self.input_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6301,7 +6282,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6494,7 +6474,6 @@ impl std::fmt::Debug for OutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6691,7 +6670,6 @@ impl std::fmt::Debug for ExportInstanceRequest {
         let mut debug_struct = f.debug_struct("ExportInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("output_config", &self.output_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6871,7 +6849,6 @@ impl std::fmt::Debug for FailoverInstanceRequest {
         let mut debug_struct = f.debug_struct("FailoverInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("data_protection_mode", &self.data_protection_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7332,7 +7309,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("cancel_requested", &self.cancel_requested);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7492,7 +7468,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("available_zones", &self.available_zones);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7607,7 +7582,6 @@ impl serde::ser::Serialize for ZoneMetadata {
 impl std::fmt::Debug for ZoneMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ZoneMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7882,7 +7856,6 @@ impl std::fmt::Debug for TlsCertificate {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("sha1_fingerprint", &self.sha1_fingerprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -399,7 +399,6 @@ impl std::fmt::Debug for Folder {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("delete_time", &self.delete_time);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -680,7 +679,6 @@ impl std::fmt::Debug for GetFolderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFolderRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -933,7 +931,6 @@ impl std::fmt::Debug for ListFoldersRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1120,7 +1117,6 @@ impl std::fmt::Debug for ListFoldersResponse {
         let mut debug_struct = f.debug_struct("ListFoldersResponse");
         debug_struct.field("folders", &self.folders);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1365,7 +1361,6 @@ impl std::fmt::Debug for SearchFoldersRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("query", &self.query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1552,7 +1547,6 @@ impl std::fmt::Debug for SearchFoldersResponse {
         let mut debug_struct = f.debug_struct("SearchFoldersResponse");
         debug_struct.field("folders", &self.folders);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1706,7 +1700,6 @@ impl std::fmt::Debug for CreateFolderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateFolderRequest");
         debug_struct.field("folder", &self.folder);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1875,7 +1868,6 @@ impl std::fmt::Debug for CreateFolderMetadata {
         let mut debug_struct = f.debug_struct("CreateFolderMetadata");
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2076,7 +2068,6 @@ impl std::fmt::Debug for UpdateFolderRequest {
         let mut debug_struct = f.debug_struct("UpdateFolderRequest");
         debug_struct.field("folder", &self.folder);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2191,7 +2182,6 @@ impl serde::ser::Serialize for UpdateFolderMetadata {
 impl std::fmt::Debug for UpdateFolderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateFolderMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2365,7 +2355,6 @@ impl std::fmt::Debug for MoveFolderRequest {
         let mut debug_struct = f.debug_struct("MoveFolderRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination_parent", &self.destination_parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2563,7 +2552,6 @@ impl std::fmt::Debug for MoveFolderMetadata {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("source_parent", &self.source_parent);
         debug_struct.field("destination_parent", &self.destination_parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2706,7 +2694,6 @@ impl std::fmt::Debug for DeleteFolderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFolderRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2821,7 +2808,6 @@ impl serde::ser::Serialize for DeleteFolderMetadata {
 impl std::fmt::Debug for DeleteFolderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFolderMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2964,7 +2950,6 @@ impl std::fmt::Debug for UndeleteFolderRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteFolderRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3079,7 +3064,6 @@ impl serde::ser::Serialize for UndeleteFolderMetadata {
 impl std::fmt::Debug for UndeleteFolderMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteFolderMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3492,7 +3476,6 @@ impl std::fmt::Debug for Organization {
         debug_struct.field("delete_time", &self.delete_time);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("owner", &self.owner);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3788,7 +3771,6 @@ impl std::fmt::Debug for GetOrganizationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrganizationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4020,7 +4002,6 @@ impl std::fmt::Debug for SearchOrganizationsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("query", &self.query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4210,7 +4191,6 @@ impl std::fmt::Debug for SearchOrganizationsResponse {
         let mut debug_struct = f.debug_struct("SearchOrganizationsResponse");
         debug_struct.field("organizations", &self.organizations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4325,7 +4305,6 @@ impl serde::ser::Serialize for DeleteOrganizationMetadata {
 impl std::fmt::Debug for DeleteOrganizationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteOrganizationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4440,7 +4419,6 @@ impl serde::ser::Serialize for UndeleteOrganizationMetadata {
 impl std::fmt::Debug for UndeleteOrganizationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteOrganizationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4887,7 +4865,6 @@ impl std::fmt::Debug for Project {
         debug_struct.field("delete_time", &self.delete_time);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5179,7 +5156,6 @@ impl std::fmt::Debug for GetProjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProjectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5431,7 +5407,6 @@ impl std::fmt::Debug for ListProjectsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5637,7 +5612,6 @@ impl std::fmt::Debug for ListProjectsResponse {
         let mut debug_struct = f.debug_struct("ListProjectsResponse");
         debug_struct.field("projects", &self.projects);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5888,7 +5862,6 @@ impl std::fmt::Debug for SearchProjectsRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6092,7 +6065,6 @@ impl std::fmt::Debug for SearchProjectsResponse {
         let mut debug_struct = f.debug_struct("SearchProjectsResponse");
         debug_struct.field("projects", &self.projects);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6257,7 +6229,6 @@ impl std::fmt::Debug for CreateProjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateProjectRequest");
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6465,7 +6436,6 @@ impl std::fmt::Debug for CreateProjectMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("gettable", &self.gettable);
         debug_struct.field("ready", &self.ready);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6664,7 +6634,6 @@ impl std::fmt::Debug for UpdateProjectRequest {
         let mut debug_struct = f.debug_struct("UpdateProjectRequest");
         debug_struct.field("project", &self.project);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6779,7 +6748,6 @@ impl serde::ser::Serialize for UpdateProjectMetadata {
 impl std::fmt::Debug for UpdateProjectMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateProjectMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6954,7 +6922,6 @@ impl std::fmt::Debug for MoveProjectRequest {
         let mut debug_struct = f.debug_struct("MoveProjectRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("destination_parent", &self.destination_parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7069,7 +7036,6 @@ impl serde::ser::Serialize for MoveProjectMetadata {
 impl std::fmt::Debug for MoveProjectMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MoveProjectMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7214,7 +7180,6 @@ impl std::fmt::Debug for DeleteProjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProjectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7329,7 +7294,6 @@ impl serde::ser::Serialize for DeleteProjectMetadata {
 impl std::fmt::Debug for DeleteProjectMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProjectMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7475,7 +7439,6 @@ impl std::fmt::Debug for UndeleteProjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteProjectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7590,7 +7553,6 @@ impl serde::ser::Serialize for UndeleteProjectMetadata {
 impl std::fmt::Debug for UndeleteProjectMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteProjectMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7826,7 +7788,6 @@ impl std::fmt::Debug for TagBinding {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tag_value", &self.tag_value);
         debug_struct.field("tag_value_namespaced_name", &self.tag_value_namespaced_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7940,7 +7901,6 @@ impl serde::ser::Serialize for CreateTagBindingMetadata {
 impl std::fmt::Debug for CreateTagBindingMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateTagBindingMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8121,7 +8081,6 @@ impl std::fmt::Debug for CreateTagBindingRequest {
         let mut debug_struct = f.debug_struct("CreateTagBindingRequest");
         debug_struct.field("tag_binding", &self.tag_binding);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8235,7 +8194,6 @@ impl serde::ser::Serialize for DeleteTagBindingMetadata {
 impl std::fmt::Debug for DeleteTagBindingMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagBindingMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8379,7 +8337,6 @@ impl std::fmt::Debug for DeleteTagBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8596,7 +8553,6 @@ impl std::fmt::Debug for ListTagBindingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8792,7 +8748,6 @@ impl std::fmt::Debug for ListTagBindingsResponse {
         let mut debug_struct = f.debug_struct("ListTagBindingsResponse");
         debug_struct.field("tag_bindings", &self.tag_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9009,7 +8964,6 @@ impl std::fmt::Debug for ListEffectiveTagsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9205,7 +9159,6 @@ impl std::fmt::Debug for ListEffectiveTagsResponse {
         let mut debug_struct = f.debug_struct("ListEffectiveTagsResponse");
         debug_struct.field("effective_tags", &self.effective_tags);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9502,7 +9455,6 @@ impl std::fmt::Debug for EffectiveTag {
         debug_struct.field("namespaced_tag_key", &self.namespaced_tag_key);
         debug_struct.field("tag_key_parent_name", &self.tag_key_parent_name);
         debug_struct.field("inherited", &self.inherited);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9770,7 +9722,6 @@ impl std::fmt::Debug for TagHold {
         debug_struct.field("origin", &self.origin);
         debug_struct.field("help_link", &self.help_link);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9977,7 +9928,6 @@ impl std::fmt::Debug for CreateTagHoldRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tag_hold", &self.tag_hold);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10093,7 +10043,6 @@ impl serde::ser::Serialize for CreateTagHoldMetadata {
 impl std::fmt::Debug for CreateTagHoldMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateTagHoldMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10263,7 +10212,6 @@ impl std::fmt::Debug for DeleteTagHoldRequest {
         let mut debug_struct = f.debug_struct("DeleteTagHoldRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10379,7 +10327,6 @@ impl serde::ser::Serialize for DeleteTagHoldMetadata {
 impl std::fmt::Debug for DeleteTagHoldMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagHoldMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10630,7 +10577,6 @@ impl std::fmt::Debug for ListTagHoldsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10826,7 +10772,6 @@ impl std::fmt::Debug for ListTagHoldsResponse {
         let mut debug_struct = f.debug_struct("ListTagHoldsResponse");
         debug_struct.field("tag_holds", &self.tag_holds);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11256,7 +11201,6 @@ impl std::fmt::Debug for TagKey {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("purpose", &self.purpose);
         debug_struct.field("purpose_data", &self.purpose_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11473,7 +11417,6 @@ impl std::fmt::Debug for ListTagKeysRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11660,7 +11603,6 @@ impl std::fmt::Debug for ListTagKeysResponse {
         let mut debug_struct = f.debug_struct("ListTagKeysResponse");
         debug_struct.field("tag_keys", &self.tag_keys);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11803,7 +11745,6 @@ impl std::fmt::Debug for GetTagKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTagKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11948,7 +11889,6 @@ impl std::fmt::Debug for GetNamespacedTagKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNamespacedTagKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12130,7 +12070,6 @@ impl std::fmt::Debug for CreateTagKeyRequest {
         let mut debug_struct = f.debug_struct("CreateTagKeyRequest");
         debug_struct.field("tag_key", &self.tag_key);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12244,7 +12183,6 @@ impl serde::ser::Serialize for CreateTagKeyMetadata {
 impl std::fmt::Debug for CreateTagKeyMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateTagKeyMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12467,7 +12405,6 @@ impl std::fmt::Debug for UpdateTagKeyRequest {
         debug_struct.field("tag_key", &self.tag_key);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12581,7 +12518,6 @@ impl serde::ser::Serialize for UpdateTagKeyMetadata {
 impl std::fmt::Debug for UpdateTagKeyMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateTagKeyMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12778,7 +12714,6 @@ impl std::fmt::Debug for DeleteTagKeyRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12892,7 +12827,6 @@ impl serde::ser::Serialize for DeleteTagKeyMetadata {
 impl std::fmt::Debug for DeleteTagKeyMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagKeyMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13250,7 +13184,6 @@ impl std::fmt::Debug for TagValue {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13467,7 +13400,6 @@ impl std::fmt::Debug for ListTagValuesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13656,7 +13588,6 @@ impl std::fmt::Debug for ListTagValuesResponse {
         let mut debug_struct = f.debug_struct("ListTagValuesResponse");
         debug_struct.field("tag_values", &self.tag_values);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13799,7 +13730,6 @@ impl std::fmt::Debug for GetTagValueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTagValueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13950,7 +13880,6 @@ impl std::fmt::Debug for GetNamespacedTagValueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNamespacedTagValueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14132,7 +14061,6 @@ impl std::fmt::Debug for CreateTagValueRequest {
         let mut debug_struct = f.debug_struct("CreateTagValueRequest");
         debug_struct.field("tag_value", &self.tag_value);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14246,7 +14174,6 @@ impl serde::ser::Serialize for CreateTagValueMetadata {
 impl std::fmt::Debug for CreateTagValueMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateTagValueMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14467,7 +14394,6 @@ impl std::fmt::Debug for UpdateTagValueRequest {
         debug_struct.field("tag_value", &self.tag_value);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14581,7 +14507,6 @@ impl serde::ser::Serialize for UpdateTagValueMetadata {
 impl std::fmt::Debug for UpdateTagValueMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateTagValueMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14777,7 +14702,6 @@ impl std::fmt::Debug for DeleteTagValueRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14891,7 +14815,6 @@ impl serde::ser::Serialize for DeleteTagValueMetadata {
 impl std::fmt::Debug for DeleteTagValueMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagValueMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -266,7 +266,6 @@ impl std::fmt::Debug for ProductLevelConfig {
             "merchant_center_product_id_field",
             &self.merchant_center_product_id_field,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -756,7 +755,6 @@ impl std::fmt::Debug for CatalogAttribute {
         debug_struct.field("exact_searchable_option", &self.exact_searchable_option);
         debug_struct.field("retrievable_option", &self.retrievable_option);
         debug_struct.field("facet_config", &self.facet_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1080,7 +1078,6 @@ pub mod catalog_attribute {
             debug_struct.field("merged_facet_values", &self.merged_facet_values);
             debug_struct.field("merged_facet", &self.merged_facet);
             debug_struct.field("rerank_config", &self.rerank_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1332,7 +1329,6 @@ pub mod catalog_attribute {
                 debug_struct.field("values", &self.values);
                 debug_struct.field("start_time", &self.start_time);
                 debug_struct.field("end_time", &self.end_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1525,7 +1521,6 @@ pub mod catalog_attribute {
                 let mut debug_struct = f.debug_struct("MergedFacetValue");
                 debug_struct.field("values", &self.values);
                 debug_struct.field("merged_value", &self.merged_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1690,7 +1685,6 @@ pub mod catalog_attribute {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("MergedFacet");
                 debug_struct.field("merged_facet_key", &self.merged_facet_key);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1882,7 +1876,6 @@ pub mod catalog_attribute {
                 let mut debug_struct = f.debug_struct("RerankConfig");
                 debug_struct.field("rerank_facet", &self.rerank_facet);
                 debug_struct.field("facet_values", &self.facet_values);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2913,7 +2906,6 @@ impl std::fmt::Debug for AttributesConfig {
         debug_struct.field("name", &self.name);
         debug_struct.field("catalog_attributes", &self.catalog_attributes);
         debug_struct.field("attribute_config_level", &self.attribute_config_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3464,7 +3456,6 @@ impl std::fmt::Debug for CompletionConfig {
             "last_allowlist_import_operation",
             &self.last_allowlist_import_operation,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3672,7 +3663,6 @@ impl std::fmt::Debug for Catalog {
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("product_level_config", &self.product_level_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3913,7 +3903,6 @@ impl std::fmt::Debug for ListCatalogsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4109,7 +4098,6 @@ impl std::fmt::Debug for ListCatalogsResponse {
         let mut debug_struct = f.debug_struct("ListCatalogsResponse");
         debug_struct.field("catalogs", &self.catalogs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4318,7 +4306,6 @@ impl std::fmt::Debug for UpdateCatalogRequest {
         let mut debug_struct = f.debug_struct("UpdateCatalogRequest");
         debug_struct.field("catalog", &self.catalog);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4557,7 +4544,6 @@ impl std::fmt::Debug for SetDefaultBranchRequest {
         debug_struct.field("branch_id", &self.branch_id);
         debug_struct.field("note", &self.note);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4700,7 +4686,6 @@ impl std::fmt::Debug for GetDefaultBranchRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDefaultBranchRequest");
         debug_struct.field("catalog", &self.catalog);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4911,7 +4896,6 @@ impl std::fmt::Debug for GetDefaultBranchResponse {
         debug_struct.field("branch", &self.branch);
         debug_struct.field("set_time", &self.set_time);
         debug_struct.field("note", &self.note);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5058,7 +5042,6 @@ impl std::fmt::Debug for GetCompletionConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCompletionConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5279,7 +5262,6 @@ impl std::fmt::Debug for UpdateCompletionConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateCompletionConfigRequest");
         debug_struct.field("completion_config", &self.completion_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5426,7 +5408,6 @@ impl std::fmt::Debug for GetAttributesConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAttributesConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5634,7 +5615,6 @@ impl std::fmt::Debug for UpdateAttributesConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateAttributesConfigRequest");
         debug_struct.field("attributes_config", &self.attributes_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5826,7 +5806,6 @@ impl std::fmt::Debug for AddCatalogAttributeRequest {
         let mut debug_struct = f.debug_struct("AddCatalogAttributeRequest");
         debug_struct.field("attributes_config", &self.attributes_config);
         debug_struct.field("catalog_attribute", &self.catalog_attribute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6005,7 +5984,6 @@ impl std::fmt::Debug for RemoveCatalogAttributeRequest {
         let mut debug_struct = f.debug_struct("RemoveCatalogAttributeRequest");
         debug_struct.field("attributes_config", &self.attributes_config);
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6243,7 +6221,6 @@ impl std::fmt::Debug for ReplaceCatalogAttributeRequest {
         debug_struct.field("attributes_config", &self.attributes_config);
         debug_struct.field("catalog_attribute", &self.catalog_attribute);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6469,7 +6446,6 @@ impl std::fmt::Debug for Condition {
         debug_struct.field("query_terms", &self.query_terms);
         debug_struct.field("active_time_range", &self.active_time_range);
         debug_struct.field("page_categories", &self.page_categories);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6650,7 +6626,6 @@ pub mod condition {
             let mut debug_struct = f.debug_struct("QueryTerm");
             debug_struct.field("value", &self.value);
             debug_struct.field("full_match", &self.full_match);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6845,7 +6820,6 @@ pub mod condition {
             let mut debug_struct = f.debug_struct("TimeRange");
             debug_struct.field("start_time", &self.start_time);
             debug_struct.field("end_time", &self.end_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7623,7 +7597,6 @@ impl std::fmt::Debug for Rule {
         let mut debug_struct = f.debug_struct("Rule");
         debug_struct.field("condition", &self.condition);
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7851,7 +7824,6 @@ pub mod rule {
             let mut debug_struct = f.debug_struct("BoostAction");
             debug_struct.field("boost", &self.boost);
             debug_struct.field("products_filter", &self.products_filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8029,7 +8001,6 @@ pub mod rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FilterAction");
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8186,7 +8157,6 @@ pub mod rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RedirectAction");
             debug_struct.field("redirect_uri", &self.redirect_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8340,7 +8310,6 @@ pub mod rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TwowaySynonymsAction");
             debug_struct.field("synonyms", &self.synonyms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8555,7 +8524,6 @@ pub mod rule {
             debug_struct.field("query_terms", &self.query_terms);
             debug_struct.field("synonyms", &self.synonyms);
             debug_struct.field("oneway_terms", &self.oneway_terms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8768,7 +8736,6 @@ pub mod rule {
             debug_struct.field("query_terms", &self.query_terms);
             debug_struct.field("do_not_associate_terms", &self.do_not_associate_terms);
             debug_struct.field("terms", &self.terms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8975,7 +8942,6 @@ pub mod rule {
             debug_struct.field("query_terms", &self.query_terms);
             debug_struct.field("replacement_term", &self.replacement_term);
             debug_struct.field("term", &self.term);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9125,7 +9091,6 @@ pub mod rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IgnoreAction");
             debug_struct.field("ignore_terms", &self.ignore_terms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9320,7 +9285,6 @@ pub mod rule {
                 "facet_position_adjustments",
                 &self.facet_position_adjustments,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9532,7 +9496,6 @@ pub mod rule {
                 let mut debug_struct = f.debug_struct("FacetPositionAdjustment");
                 debug_struct.field("attribute_name", &self.attribute_name);
                 debug_struct.field("position", &self.position);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9706,7 +9669,6 @@ pub mod rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RemoveFacetAction");
             debug_struct.field("attribute_names", &self.attribute_names);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9932,7 +9894,6 @@ pub mod rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PinAction");
             debug_struct.field("pin_map", &self.pin_map);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10163,7 +10124,6 @@ impl std::fmt::Debug for Audience {
         let mut debug_struct = f.debug_struct("Audience");
         debug_struct.field("genders", &self.genders);
         debug_struct.field("age_groups", &self.age_groups);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10366,7 +10326,6 @@ impl std::fmt::Debug for ColorInfo {
         let mut debug_struct = f.debug_struct("ColorInfo");
         debug_struct.field("color_families", &self.color_families);
         debug_struct.field("colors", &self.colors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10704,7 +10663,6 @@ impl std::fmt::Debug for CustomAttribute {
         debug_struct.field("numbers", &self.numbers);
         debug_struct.field("searchable", &self.searchable);
         debug_struct.field("indexable", &self.indexable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10904,7 +10862,6 @@ impl std::fmt::Debug for FulfillmentInfo {
         let mut debug_struct = f.debug_struct("FulfillmentInfo");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("place_ids", &self.place_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11151,7 +11108,6 @@ impl std::fmt::Debug for Image {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("height", &self.height);
         debug_struct.field("width", &self.width);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11562,7 +11518,6 @@ impl std::fmt::Debug for Interval {
         let mut debug_struct = f.debug_struct("Interval");
         debug_struct.field("min", &self.min);
         debug_struct.field("max", &self.max);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12066,7 +12021,6 @@ impl std::fmt::Debug for PriceInfo {
         debug_struct.field("price_effective_time", &self.price_effective_time);
         debug_struct.field("price_expire_time", &self.price_expire_time);
         debug_struct.field("price_range", &self.price_range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12289,7 +12243,6 @@ pub mod price_info {
             let mut debug_struct = f.debug_struct("PriceRange");
             debug_struct.field("price", &self.price);
             debug_struct.field("original_price", &self.original_price);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12572,7 +12525,6 @@ impl std::fmt::Debug for Rating {
         debug_struct.field("rating_count", &self.rating_count);
         debug_struct.field("average_rating", &self.average_rating);
         debug_struct.field("rating_histogram", &self.rating_histogram);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12846,7 +12798,6 @@ impl std::fmt::Debug for UserInfo {
         debug_struct.field("ip_address", &self.ip_address);
         debug_struct.field("user_agent", &self.user_agent);
         debug_struct.field("direct_user_request", &self.direct_user_request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13133,7 +13084,6 @@ impl std::fmt::Debug for LocalInventory {
         debug_struct.field("price_info", &self.price_info);
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("fulfillment_types", &self.fulfillment_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13389,7 +13339,6 @@ impl std::fmt::Debug for PinControlMetadata {
         let mut debug_struct = f.debug_struct("PinControlMetadata");
         debug_struct.field("all_matched_pins", &self.all_matched_pins);
         debug_struct.field("dropped_pins", &self.dropped_pins);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13543,7 +13492,6 @@ pub mod pin_control_metadata {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ProductPins");
             debug_struct.field("product_id", &self.product_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13689,7 +13637,6 @@ impl std::fmt::Debug for StringList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StringList");
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13859,7 +13806,6 @@ impl std::fmt::Debug for DoubleList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DoubleList");
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14310,7 +14256,6 @@ impl std::fmt::Debug for CompleteQueryRequest {
             &self.enable_attribute_suggestions,
         );
         debug_struct.field("entity", &self.entity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14608,7 +14553,6 @@ impl std::fmt::Debug for CompleteQueryResponse {
         debug_struct.field("attribution_token", &self.attribution_token);
         debug_struct.field("recent_search_results", &self.recent_search_results);
         debug_struct.field("attribute_results", &self.attribute_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14806,7 +14750,6 @@ pub mod complete_query_response {
             let mut debug_struct = f.debug_struct("CompletionResult");
             debug_struct.field("suggestion", &self.suggestion);
             debug_struct.field("attributes", &self.attributes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14956,7 +14899,6 @@ pub mod complete_query_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RecentSearchResult");
             debug_struct.field("recent_search", &self.recent_search);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15104,7 +15046,6 @@ pub mod complete_query_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AttributeResult");
             debug_struct.field("suggestions", &self.suggestions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15480,7 +15421,6 @@ impl std::fmt::Debug for Control {
         debug_struct.field("solution_types", &self.solution_types);
         debug_struct.field("search_solution_use_case", &self.search_solution_use_case);
         debug_struct.field("control", &self.control);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15709,7 +15649,6 @@ impl std::fmt::Debug for CreateControlRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("control", &self.control);
         debug_struct.field("control_id", &self.control_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15908,7 +15847,6 @@ impl std::fmt::Debug for UpdateControlRequest {
         let mut debug_struct = f.debug_struct("UpdateControlRequest");
         debug_struct.field("control", &self.control);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16051,7 +15989,6 @@ impl std::fmt::Debug for DeleteControlRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteControlRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16194,7 +16131,6 @@ impl std::fmt::Debug for GetControlRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetControlRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16441,7 +16377,6 @@ impl std::fmt::Debug for ListControlsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16626,7 +16561,6 @@ impl std::fmt::Debug for ListControlsResponse {
         let mut debug_struct = f.debug_struct("ListControlsResponse");
         debug_struct.field("controls", &self.controls);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16882,7 +16816,6 @@ impl std::fmt::Debug for OutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17042,7 +16975,6 @@ pub mod output_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GcsDestination");
             debug_struct.field("output_uri_prefix", &self.output_uri_prefix);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17246,7 +17178,6 @@ pub mod output_config {
             debug_struct.field("dataset_id", &self.dataset_id);
             debug_struct.field("table_id_prefix", &self.table_id_prefix);
             debug_struct.field("table_type", &self.table_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17441,7 +17372,6 @@ impl std::fmt::Debug for ExportErrorsConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportErrorsConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17679,7 +17609,6 @@ impl std::fmt::Debug for ExportAnalyticsMetricsRequest {
         debug_struct.field("catalog", &self.catalog);
         debug_struct.field("output_config", &self.output_config);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17872,7 +17801,6 @@ impl std::fmt::Debug for ExportMetadata {
         let mut debug_struct = f.debug_struct("ExportMetadata");
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18094,7 +18022,6 @@ impl std::fmt::Debug for ExportAnalyticsMetricsResponse {
         debug_struct.field("error_samples", &self.error_samples);
         debug_struct.field("errors_config", &self.errors_config);
         debug_struct.field("output_result", &self.output_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18278,7 +18205,6 @@ impl std::fmt::Debug for OutputResult {
         let mut debug_struct = f.debug_struct("OutputResult");
         debug_struct.field("bigquery_result", &self.bigquery_result);
         debug_struct.field("gcs_result", &self.gcs_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18447,7 +18373,6 @@ impl std::fmt::Debug for BigQueryOutputResult {
         let mut debug_struct = f.debug_struct("BigQueryOutputResult");
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18590,7 +18515,6 @@ impl std::fmt::Debug for GcsOutputResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsOutputResult");
         debug_struct.field("output_uri", &self.output_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18807,7 +18731,6 @@ impl std::fmt::Debug for GenerativeQuestionsFeatureConfig {
         debug_struct.field("catalog", &self.catalog);
         debug_struct.field("feature_enabled", &self.feature_enabled);
         debug_struct.field("minimum_products", &self.minimum_products);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19130,7 +19053,6 @@ impl std::fmt::Debug for GenerativeQuestionConfig {
         debug_struct.field("example_values", &self.example_values);
         debug_struct.field("frequency", &self.frequency);
         debug_struct.field("allowed_in_conversation", &self.allowed_in_conversation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19343,7 +19265,6 @@ impl std::fmt::Debug for UpdateGenerativeQuestionsFeatureConfigRequest {
             &self.generative_questions_feature_config,
         );
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19488,7 +19409,6 @@ impl std::fmt::Debug for GetGenerativeQuestionsFeatureConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGenerativeQuestionsFeatureConfigRequest");
         debug_struct.field("catalog", &self.catalog);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19631,7 +19551,6 @@ impl std::fmt::Debug for ListGenerativeQuestionConfigsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListGenerativeQuestionConfigsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19792,7 +19711,6 @@ impl std::fmt::Debug for ListGenerativeQuestionConfigsResponse {
             "generative_question_configs",
             &self.generative_question_configs,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20000,7 +19918,6 @@ impl std::fmt::Debug for UpdateGenerativeQuestionConfigRequest {
             &self.generative_question_config,
         );
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20179,7 +20096,6 @@ impl std::fmt::Debug for BatchUpdateGenerativeQuestionConfigsRequest {
         let mut debug_struct = f.debug_struct("BatchUpdateGenerativeQuestionConfigsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("requests", &self.requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20341,7 +20257,6 @@ impl std::fmt::Debug for BatchUpdateGenerativeQuestionConfigsResponse {
             "generative_question_configs",
             &self.generative_question_configs,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20551,7 +20466,6 @@ impl std::fmt::Debug for GcsSource {
         let mut debug_struct = f.debug_struct("GcsSource");
         debug_struct.field("input_uris", &self.input_uris);
         debug_struct.field("data_schema", &self.data_schema);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20907,7 +20821,6 @@ impl std::fmt::Debug for BigQuerySource {
         debug_struct.field("gcs_staging_dir", &self.gcs_staging_dir);
         debug_struct.field("data_schema", &self.data_schema);
         debug_struct.field("partition", &self.partition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21071,7 +20984,6 @@ impl std::fmt::Debug for ProductInlineSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProductInlineSource");
         debug_struct.field("products", &self.products);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21217,7 +21129,6 @@ impl std::fmt::Debug for UserEventInlineSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserEventInlineSource");
         debug_struct.field("user_events", &self.user_events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21401,7 +21312,6 @@ impl std::fmt::Debug for ImportErrorsConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportErrorsConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21794,7 +21704,6 @@ impl std::fmt::Debug for ImportProductsRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("reconciliation_mode", &self.reconciliation_mode);
         debug_struct.field("notification_pubsub_topic", &self.notification_pubsub_topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22151,7 +22060,6 @@ impl std::fmt::Debug for ImportUserEventsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("input_config", &self.input_config);
         debug_struct.field("errors_config", &self.errors_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22371,7 +22279,6 @@ impl std::fmt::Debug for ImportCompletionDataRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("input_config", &self.input_config);
         debug_struct.field("notification_pubsub_topic", &self.notification_pubsub_topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22676,7 +22583,6 @@ impl std::fmt::Debug for ProductInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProductInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22998,7 +22904,6 @@ impl std::fmt::Debug for UserEventInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserEventInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23219,7 +23124,6 @@ impl std::fmt::Debug for CompletionDataInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CompletionDataInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23597,7 +23501,6 @@ impl std::fmt::Debug for ImportMetadata {
         debug_struct.field("failure_count", &self.failure_count);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("notification_pubsub_topic", &self.notification_pubsub_topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23785,7 +23688,6 @@ impl std::fmt::Debug for ImportProductsResponse {
         let mut debug_struct = f.debug_struct("ImportProductsResponse");
         debug_struct.field("error_samples", &self.error_samples);
         debug_struct.field("errors_config", &self.errors_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24008,7 +23910,6 @@ impl std::fmt::Debug for ImportUserEventsResponse {
         debug_struct.field("error_samples", &self.error_samples);
         debug_struct.field("errors_config", &self.errors_config);
         debug_struct.field("import_summary", &self.import_summary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24217,7 +24118,6 @@ impl std::fmt::Debug for UserEventImportSummary {
         let mut debug_struct = f.debug_struct("UserEventImportSummary");
         debug_struct.field("joined_events_count", &self.joined_events_count);
         debug_struct.field("unjoined_events_count", &self.unjoined_events_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24368,7 +24268,6 @@ impl std::fmt::Debug for ImportCompletionDataResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportCompletionDataResponse");
         debug_struct.field("error_samples", &self.error_samples);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25027,7 +24926,6 @@ impl std::fmt::Debug for Model {
         debug_struct.field("filtering_option", &self.filtering_option);
         debug_struct.field("serving_config_lists", &self.serving_config_lists);
         debug_struct.field("model_features_config", &self.model_features_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25183,7 +25081,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ServingConfigList");
             debug_struct.field("serving_config_ids", &self.serving_config_ids);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25343,7 +25240,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FrequentlyBoughtTogetherFeaturesConfig");
             debug_struct.field("context_products_type", &self.context_products_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25548,7 +25444,6 @@ pub mod model {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ModelFeaturesConfig");
             debug_struct.field("type_dedicated_config", &self.type_dedicated_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26471,7 +26366,6 @@ impl std::fmt::Debug for CreateModelRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("model", &self.model);
         debug_struct.field("dry_run", &self.dry_run);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26664,7 +26558,6 @@ impl std::fmt::Debug for UpdateModelRequest {
         let mut debug_struct = f.debug_struct("UpdateModelRequest");
         debug_struct.field("model", &self.model);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26810,7 +26703,6 @@ impl std::fmt::Debug for GetModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26954,7 +26846,6 @@ impl std::fmt::Debug for PauseModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27098,7 +26989,6 @@ impl std::fmt::Debug for ResumeModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27314,7 +27204,6 @@ impl std::fmt::Debug for ListModelsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27460,7 +27349,6 @@ impl std::fmt::Debug for DeleteModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27645,7 +27533,6 @@ impl std::fmt::Debug for ListModelsResponse {
         let mut debug_struct = f.debug_struct("ListModelsResponse");
         debug_struct.field("models", &self.models);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27790,7 +27677,6 @@ impl std::fmt::Debug for TuneModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TuneModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27934,7 +27820,6 @@ impl std::fmt::Debug for CreateModelMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateModelMetadata");
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28078,7 +27963,6 @@ impl std::fmt::Debug for TuneModelMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TuneModelMetadata");
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28192,7 +28076,6 @@ impl serde::ser::Serialize for TuneModelResponse {
 impl std::fmt::Debug for TuneModelResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TuneModelResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28679,7 +28562,6 @@ impl std::fmt::Debug for PredictRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("params", &self.params);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28918,7 +28800,6 @@ impl std::fmt::Debug for PredictResponse {
         debug_struct.field("attribution_token", &self.attribution_token);
         debug_struct.field("missing_ids", &self.missing_ids);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29108,7 +28989,6 @@ pub mod predict_response {
             let mut debug_struct = f.debug_struct("PredictionResult");
             debug_struct.field("id", &self.id);
             debug_struct.field("metadata", &self.metadata);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30737,7 +30617,6 @@ impl std::fmt::Debug for Product {
         debug_struct.field("variants", &self.variants);
         debug_struct.field("local_inventories", &self.local_inventories);
         debug_struct.field("expiration", &self.expiration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31368,7 +31247,6 @@ impl std::fmt::Debug for CreateProductRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("product", &self.product);
         debug_struct.field("product_id", &self.product_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31525,7 +31403,6 @@ impl std::fmt::Debug for GetProductRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProductRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31774,7 +31651,6 @@ impl std::fmt::Debug for UpdateProductRequest {
         debug_struct.field("product", &self.product);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31945,7 +31821,6 @@ impl std::fmt::Debug for DeleteProductRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProductRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32308,7 +32183,6 @@ impl std::fmt::Debug for ListProductsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32504,7 +32378,6 @@ impl std::fmt::Debug for ListProductsResponse {
         let mut debug_struct = f.debug_struct("ListProductsResponse");
         debug_struct.field("products", &self.products);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32848,7 +32721,6 @@ impl std::fmt::Debug for SetInventoryRequest {
         debug_struct.field("set_mask", &self.set_mask);
         debug_struct.field("set_time", &self.set_time);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32967,7 +32839,6 @@ impl serde::ser::Serialize for SetInventoryMetadata {
 impl std::fmt::Debug for SetInventoryMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SetInventoryMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33086,7 +32957,6 @@ impl serde::ser::Serialize for SetInventoryResponse {
 impl std::fmt::Debug for SetInventoryResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SetInventoryResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33403,7 +33273,6 @@ impl std::fmt::Debug for AddFulfillmentPlacesRequest {
         debug_struct.field("place_ids", &self.place_ids);
         debug_struct.field("add_time", &self.add_time);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33522,7 +33391,6 @@ impl serde::ser::Serialize for AddFulfillmentPlacesMetadata {
 impl std::fmt::Debug for AddFulfillmentPlacesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddFulfillmentPlacesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33641,7 +33509,6 @@ impl serde::ser::Serialize for AddFulfillmentPlacesResponse {
 impl std::fmt::Debug for AddFulfillmentPlacesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddFulfillmentPlacesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33954,7 +33821,6 @@ impl std::fmt::Debug for AddLocalInventoriesRequest {
         debug_struct.field("add_mask", &self.add_mask);
         debug_struct.field("add_time", &self.add_time);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34073,7 +33939,6 @@ impl serde::ser::Serialize for AddLocalInventoriesMetadata {
 impl std::fmt::Debug for AddLocalInventoriesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddLocalInventoriesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34194,7 +34059,6 @@ impl serde::ser::Serialize for AddLocalInventoriesResponse {
 impl std::fmt::Debug for AddLocalInventoriesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddLocalInventoriesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34450,7 +34314,6 @@ impl std::fmt::Debug for RemoveLocalInventoriesRequest {
         debug_struct.field("place_ids", &self.place_ids);
         debug_struct.field("remove_time", &self.remove_time);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34569,7 +34432,6 @@ impl serde::ser::Serialize for RemoveLocalInventoriesMetadata {
 impl std::fmt::Debug for RemoveLocalInventoriesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveLocalInventoriesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34690,7 +34552,6 @@ impl serde::ser::Serialize for RemoveLocalInventoriesResponse {
 impl std::fmt::Debug for RemoveLocalInventoriesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveLocalInventoriesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35002,7 +34863,6 @@ impl std::fmt::Debug for RemoveFulfillmentPlacesRequest {
         debug_struct.field("place_ids", &self.place_ids);
         debug_struct.field("remove_time", &self.remove_time);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35121,7 +34981,6 @@ impl serde::ser::Serialize for RemoveFulfillmentPlacesMetadata {
 impl std::fmt::Debug for RemoveFulfillmentPlacesMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveFulfillmentPlacesMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35240,7 +35099,6 @@ impl serde::ser::Serialize for RemoveFulfillmentPlacesResponse {
 impl std::fmt::Debug for RemoveFulfillmentPlacesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveFulfillmentPlacesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35391,7 +35249,6 @@ impl std::fmt::Debug for Promotion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Promotion");
         debug_struct.field("promotion_id", &self.promotion_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35506,7 +35363,6 @@ impl serde::ser::Serialize for PurgeMetadata {
 impl std::fmt::Debug for PurgeMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PurgeMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35789,7 +35645,6 @@ impl std::fmt::Debug for PurgeProductsMetadata {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("success_count", &self.success_count);
         debug_struct.field("failure_count", &self.failure_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36027,7 +35882,6 @@ impl std::fmt::Debug for PurgeProductsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36221,7 +36075,6 @@ impl std::fmt::Debug for PurgeProductsResponse {
         let mut debug_struct = f.debug_struct("PurgeProductsResponse");
         debug_struct.field("purge_count", &self.purge_count);
         debug_struct.field("purge_sample", &self.purge_sample);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36441,7 +36294,6 @@ impl std::fmt::Debug for PurgeUserEventsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36605,7 +36457,6 @@ impl std::fmt::Debug for PurgeUserEventsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PurgeUserEventsResponse");
         debug_struct.field("purged_events_count", &self.purged_events_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36774,7 +36625,6 @@ impl std::fmt::Debug for ProductAttributeValue {
         let mut debug_struct = f.debug_struct("ProductAttributeValue");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36952,7 +36802,6 @@ impl std::fmt::Debug for ProductAttributeInterval {
         let mut debug_struct = f.debug_struct("ProductAttributeInterval");
         debug_struct.field("name", &self.name);
         debug_struct.field("interval", &self.interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37242,7 +37091,6 @@ impl std::fmt::Debug for Tile {
         let mut debug_struct = f.debug_struct("Tile");
         debug_struct.field("representative_product_id", &self.representative_product_id);
         debug_struct.field("product_attribute", &self.product_attribute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38547,7 +38395,6 @@ impl std::fmt::Debug for SearchRequest {
         debug_struct.field("region_code", &self.region_code);
         debug_struct.field("place_id", &self.place_id);
         debug_struct.field("user_attributes", &self.user_attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38872,7 +38719,6 @@ pub mod search_request {
             debug_struct.field("limit", &self.limit);
             debug_struct.field("excluded_filter_keys", &self.excluded_filter_keys);
             debug_struct.field("enable_dynamic_position", &self.enable_dynamic_position);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39408,7 +39254,6 @@ pub mod search_request {
                 debug_struct.field("order_by", &self.order_by);
                 debug_struct.field("query", &self.query);
                 debug_struct.field("return_min_max", &self.return_min_max);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -39566,7 +39411,6 @@ pub mod search_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DynamicFacetSpec");
             debug_struct.field("mode", &self.mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39915,7 +39759,6 @@ pub mod search_request {
                 "skip_boost_spec_validation",
                 &self.skip_boost_spec_validation,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40149,7 +39992,6 @@ pub mod search_request {
                 let mut debug_struct = f.debug_struct("ConditionBoostSpec");
                 debug_struct.field("condition", &self.condition);
                 debug_struct.field("boost", &self.boost);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -40333,7 +40175,6 @@ pub mod search_request {
             let mut debug_struct = f.debug_struct("QueryExpansionSpec");
             debug_struct.field("condition", &self.condition);
             debug_struct.field("pin_unexpanded_results", &self.pin_unexpanded_results);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40637,7 +40478,6 @@ pub mod search_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PersonalizationSpec");
             debug_struct.field("mode", &self.mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40938,7 +40778,6 @@ pub mod search_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SpellCorrectionSpec");
             debug_struct.field("mode", &self.mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -41329,7 +41168,6 @@ pub mod search_request {
             );
             debug_struct.field("conversation_id", &self.conversation_id);
             debug_struct.field("user_answer", &self.user_answer);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -41582,7 +41420,6 @@ pub mod search_request {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("UserAnswer");
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -41814,7 +41651,6 @@ pub mod search_request {
                     let mut debug_struct = f.debug_struct("SelectedAnswer");
                     debug_struct.field("product_attribute_values", &self.product_attribute_values);
                     debug_struct.field("product_attribute_value", &self.product_attribute_value);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -42020,7 +41856,6 @@ pub mod search_request {
             let mut debug_struct = f.debug_struct("TileNavigationSpec");
             debug_struct.field("tile_navigation_requested", &self.tile_navigation_requested);
             debug_struct.field("applied_tiles", &self.applied_tiles);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -42846,7 +42681,6 @@ impl std::fmt::Debug for SearchResponse {
             &self.conversational_search_result,
         );
         debug_struct.field("tile_navigation_result", &self.tile_navigation_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43322,7 +43156,6 @@ pub mod search_response {
             debug_struct.field("variant_rollup_values", &self.variant_rollup_values);
             debug_struct.field("personal_labels", &self.personal_labels);
             debug_struct.field("model_scores", &self.model_scores);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43528,7 +43361,6 @@ pub mod search_response {
             debug_struct.field("key", &self.key);
             debug_struct.field("values", &self.values);
             debug_struct.field("dynamic_facet", &self.dynamic_facet);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43947,7 +43779,6 @@ pub mod search_response {
                 debug_struct.field("min_value", &self.min_value);
                 debug_struct.field("max_value", &self.max_value);
                 debug_struct.field("facet_value", &self.facet_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -44161,7 +43992,6 @@ pub mod search_response {
             let mut debug_struct = f.debug_struct("QueryExpansionInfo");
             debug_struct.field("expanded_query", &self.expanded_query);
             debug_struct.field("pinned_result_count", &self.pinned_result_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44504,7 +44334,6 @@ pub mod search_response {
             debug_struct.field("followup_question", &self.followup_question);
             debug_struct.field("suggested_answers", &self.suggested_answers);
             debug_struct.field("additional_filter", &self.additional_filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44682,7 +44511,6 @@ pub mod search_response {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("SuggestedAnswer");
                 debug_struct.field("product_attribute_value", &self.product_attribute_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -44855,7 +44683,6 @@ pub mod search_response {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("AdditionalFilter");
                 debug_struct.field("product_attribute_value", &self.product_attribute_value);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -45006,7 +44833,6 @@ pub mod search_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TileNavigationResult");
             debug_struct.field("tiles", &self.tiles);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45229,7 +45055,6 @@ impl std::fmt::Debug for ExperimentInfo {
         let mut debug_struct = f.debug_struct("ExperimentInfo");
         debug_struct.field("experiment", &self.experiment);
         debug_struct.field("experiment_metadata", &self.experiment_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45429,7 +45254,6 @@ pub mod experiment_info {
             let mut debug_struct = f.debug_struct("ServingConfigExperiment");
             debug_struct.field("original_serving_config", &self.original_serving_config);
             debug_struct.field("experiment_serving_config", &self.experiment_serving_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46400,7 +46224,6 @@ impl std::fmt::Debug for ServingConfig {
         debug_struct.field("ignore_recs_denylist", &self.ignore_recs_denylist);
         debug_struct.field("personalization_spec", &self.personalization_spec);
         debug_struct.field("solution_types", &self.solution_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46751,7 +46574,6 @@ impl std::fmt::Debug for CreateServingConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("serving_config", &self.serving_config);
         debug_struct.field("serving_config_id", &self.serving_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46951,7 +46773,6 @@ impl std::fmt::Debug for UpdateServingConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateServingConfigRequest");
         debug_struct.field("serving_config", &self.serving_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47094,7 +46915,6 @@ impl std::fmt::Debug for DeleteServingConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServingConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47237,7 +47057,6 @@ impl std::fmt::Debug for GetServingConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServingConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47453,7 +47272,6 @@ impl std::fmt::Debug for ListServingConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47639,7 +47457,6 @@ impl std::fmt::Debug for ListServingConfigsResponse {
         let mut debug_struct = f.debug_struct("ListServingConfigsResponse");
         debug_struct.field("serving_configs", &self.serving_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47810,7 +47627,6 @@ impl std::fmt::Debug for AddControlRequest {
         let mut debug_struct = f.debug_struct("AddControlRequest");
         debug_struct.field("serving_config", &self.serving_config);
         debug_struct.field("control_id", &self.control_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47981,7 +47797,6 @@ impl std::fmt::Debug for RemoveControlRequest {
         let mut debug_struct = f.debug_struct("RemoveControlRequest");
         debug_struct.field("serving_config", &self.serving_config);
         debug_struct.field("control_id", &self.control_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48926,7 +48741,6 @@ impl std::fmt::Debug for UserEvent {
         debug_struct.field("referrer_uri", &self.referrer_uri);
         debug_struct.field("page_view_id", &self.page_view_id);
         debug_struct.field("entity", &self.entity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49160,7 +48974,6 @@ impl std::fmt::Debug for ProductDetail {
         let mut debug_struct = f.debug_struct("ProductDetail");
         debug_struct.field("product", &self.product);
         debug_struct.field("quantity", &self.quantity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49401,7 +49214,6 @@ impl std::fmt::Debug for CompletionDetail {
         );
         debug_struct.field("selected_suggestion", &self.selected_suggestion);
         debug_struct.field("selected_position", &self.selected_position);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49711,7 +49523,6 @@ impl std::fmt::Debug for PurchaseTransaction {
         debug_struct.field("tax", &self.tax);
         debug_struct.field("cost", &self.cost);
         debug_struct.field("currency_code", &self.currency_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49920,7 +49731,6 @@ impl std::fmt::Debug for WriteUserEventRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("user_event", &self.user_event);
         debug_struct.field("write_async", &self.write_async);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50262,7 +50072,6 @@ impl std::fmt::Debug for CollectUserEventRequest {
         debug_struct.field("ets", &self.ets);
         debug_struct.field("raw_json", &self.raw_json);
         debug_struct.field("conversion_rule", &self.conversion_rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50457,7 +50266,6 @@ impl std::fmt::Debug for RejoinUserEventsRequest {
         let mut debug_struct = f.debug_struct("RejoinUserEventsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("user_event_rejoin_scope", &self.user_event_rejoin_scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50776,7 +50584,6 @@ impl std::fmt::Debug for RejoinUserEventsResponse {
             "rejoined_user_events_count",
             &self.rejoined_user_events_count,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50890,7 +50697,6 @@ impl serde::ser::Serialize for RejoinUserEventsMetadata {
 impl std::fmt::Debug for RejoinUserEventsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RejoinUserEventsMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -500,7 +500,6 @@ impl std::fmt::Debug for SubmitBuildRequest {
         debug_struct.field("tags", &self.tags);
         debug_struct.field("source", &self.source);
         debug_struct.field("build_type", &self.build_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -622,7 +621,6 @@ pub mod submit_build_request {
     impl std::fmt::Debug for DockerBuild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DockerBuild");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -959,7 +957,6 @@ pub mod submit_build_request {
             debug_struct.field("environment_variables", &self.environment_variables);
             debug_struct.field("enable_automatic_updates", &self.enable_automatic_updates);
             debug_struct.field("project_descriptor", &self.project_descriptor);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1189,7 +1186,6 @@ impl std::fmt::Debug for SubmitBuildResponse {
         debug_struct.field("build_operation", &self.build_operation);
         debug_struct.field("base_image_uri", &self.base_image_uri);
         debug_struct.field("base_image_warning", &self.base_image_warning);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1405,7 +1401,6 @@ impl std::fmt::Debug for StorageSource {
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("object", &self.object);
         debug_struct.field("generation", &self.generation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1844,7 +1839,6 @@ impl std::fmt::Debug for Condition {
         debug_struct.field("last_transition_time", &self.last_transition_time);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("reasons", &self.reasons);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2906,7 +2900,6 @@ impl std::fmt::Debug for GetExecutionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetExecutionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3148,7 +3141,6 @@ impl std::fmt::Debug for ListExecutionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3334,7 +3326,6 @@ impl std::fmt::Debug for ListExecutionsResponse {
         let mut debug_struct = f.debug_struct("ListExecutionsResponse");
         debug_struct.field("executions", &self.executions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3532,7 +3523,6 @@ impl std::fmt::Debug for DeleteExecutionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3730,7 +3720,6 @@ impl std::fmt::Debug for CancelExecutionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4878,7 +4867,6 @@ impl std::fmt::Debug for Execution {
         debug_struct.field("log_uri", &self.log_uri);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5207,7 +5195,6 @@ impl std::fmt::Debug for ExecutionTemplate {
         debug_struct.field("parallelism", &self.parallelism);
         debug_struct.field("task_count", &self.task_count);
         debug_struct.field("template", &self.template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5441,7 +5428,6 @@ impl std::fmt::Debug for CreateJobRequest {
         debug_struct.field("job", &self.job);
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5585,7 +5571,6 @@ impl std::fmt::Debug for GetJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5793,7 +5778,6 @@ impl std::fmt::Debug for UpdateJobRequest {
         debug_struct.field("job", &self.job);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6034,7 +6018,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6220,7 +6203,6 @@ impl std::fmt::Debug for ListJobsResponse {
         let mut debug_struct = f.debug_struct("ListJobsResponse");
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6417,7 +6399,6 @@ impl std::fmt::Debug for DeleteJobRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6651,7 +6632,6 @@ impl std::fmt::Debug for RunJobRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("overrides", &self.overrides);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6890,7 +6870,6 @@ pub mod run_job_request {
             debug_struct.field("container_overrides", &self.container_overrides);
             debug_struct.field("task_count", &self.task_count);
             debug_struct.field("timeout", &self.timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7133,7 +7112,6 @@ pub mod run_job_request {
                 debug_struct.field("args", &self.args);
                 debug_struct.field("env", &self.env);
                 debug_struct.field("clear_args", &self.clear_args);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8214,7 +8192,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("create_execution", &self.create_execution);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8521,7 +8498,6 @@ impl std::fmt::Debug for ExecutionReference {
         debug_struct.field("completion_time", &self.completion_time);
         debug_struct.field("delete_time", &self.delete_time);
         debug_struct.field("completion_status", &self.completion_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9236,7 +9212,6 @@ impl std::fmt::Debug for Container {
         debug_struct.field("depends_on", &self.depends_on);
         debug_struct.field("base_image_uri", &self.base_image_uri);
         debug_struct.field("build_info", &self.build_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9445,7 +9420,6 @@ impl std::fmt::Debug for ResourceRequirements {
         debug_struct.field("limits", &self.limits);
         debug_struct.field("cpu_idle", &self.cpu_idle);
         debug_struct.field("startup_cpu_boost", &self.startup_cpu_boost);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9699,7 +9673,6 @@ impl std::fmt::Debug for EnvVar {
         let mut debug_struct = f.debug_struct("EnvVar");
         debug_struct.field("name", &self.name);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9871,7 +9844,6 @@ impl std::fmt::Debug for EnvVarSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnvVarSource");
         debug_struct.field("secret_key_ref", &self.secret_key_ref);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10043,7 +10015,6 @@ impl std::fmt::Debug for SecretKeySelector {
         let mut debug_struct = f.debug_struct("SecretKeySelector");
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10232,7 +10203,6 @@ impl std::fmt::Debug for ContainerPort {
         let mut debug_struct = f.debug_struct("ContainerPort");
         debug_struct.field("name", &self.name);
         debug_struct.field("container_port", &self.container_port);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10404,7 +10374,6 @@ impl std::fmt::Debug for VolumeMount {
         let mut debug_struct = f.debug_struct("VolumeMount");
         debug_struct.field("name", &self.name);
         debug_struct.field("mount_path", &self.mount_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10823,7 +10792,6 @@ impl std::fmt::Debug for Volume {
         let mut debug_struct = f.debug_struct("Volume");
         debug_struct.field("name", &self.name);
         debug_struct.field("volume_type", &self.volume_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11085,7 +11053,6 @@ impl std::fmt::Debug for SecretVolumeSource {
         debug_struct.field("secret", &self.secret);
         debug_struct.field("items", &self.items);
         debug_struct.field("default_mode", &self.default_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11311,7 +11278,6 @@ impl std::fmt::Debug for VersionToPath {
         debug_struct.field("path", &self.path);
         debug_struct.field("version", &self.version);
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11463,7 +11429,6 @@ impl std::fmt::Debug for CloudSqlInstance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudSqlInstance");
         debug_struct.field("instances", &self.instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11648,7 +11613,6 @@ impl std::fmt::Debug for EmptyDirVolumeSource {
         let mut debug_struct = f.debug_struct("EmptyDirVolumeSource");
         debug_struct.field("medium", &self.medium);
         debug_struct.field("size_limit", &self.size_limit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11973,7 +11937,6 @@ impl std::fmt::Debug for NFSVolumeSource {
         debug_struct.field("server", &self.server);
         debug_struct.field("path", &self.path);
         debug_struct.field("read_only", &self.read_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12172,7 +12135,6 @@ impl std::fmt::Debug for GCSVolumeSource {
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("read_only", &self.read_only);
         debug_struct.field("mount_options", &self.mount_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12646,7 +12608,6 @@ impl std::fmt::Debug for Probe {
         debug_struct.field("period_seconds", &self.period_seconds);
         debug_struct.field("failure_threshold", &self.failure_threshold);
         debug_struct.field("probe_type", &self.probe_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12883,7 +12844,6 @@ impl std::fmt::Debug for HTTPGetAction {
         debug_struct.field("path", &self.path);
         debug_struct.field("http_headers", &self.http_headers);
         debug_struct.field("port", &self.port);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13050,7 +13010,6 @@ impl std::fmt::Debug for HTTPHeader {
         let mut debug_struct = f.debug_struct("HTTPHeader");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13212,7 +13171,6 @@ impl std::fmt::Debug for TCPSocketAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TCPSocketAction");
         debug_struct.field("port", &self.port);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13402,7 +13360,6 @@ impl std::fmt::Debug for GRPCAction {
         let mut debug_struct = f.debug_struct("GRPCAction");
         debug_struct.field("port", &self.port);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13572,7 +13529,6 @@ impl std::fmt::Debug for BuildInfo {
         let mut debug_struct = f.debug_struct("BuildInfo");
         debug_struct.field("function_target", &self.function_target);
         debug_struct.field("source_location", &self.source_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13716,7 +13672,6 @@ impl std::fmt::Debug for GetRevisionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRevisionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13958,7 +13913,6 @@ impl std::fmt::Debug for ListRevisionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14144,7 +14098,6 @@ impl std::fmt::Debug for ListRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListRevisionsResponse");
         debug_struct.field("revisions", &self.revisions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14343,7 +14296,6 @@ impl std::fmt::Debug for DeleteRevisionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15649,7 +15601,6 @@ impl std::fmt::Debug for Revision {
         );
         debug_struct.field("creator", &self.creator);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16455,7 +16406,6 @@ impl std::fmt::Debug for RevisionTemplate {
             "gpu_zonal_redundancy_disabled",
             &self.gpu_zonal_redundancy_disabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16690,7 +16640,6 @@ impl std::fmt::Debug for CreateServiceRequest {
         debug_struct.field("service", &self.service);
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16935,7 +16884,6 @@ impl std::fmt::Debug for UpdateServiceRequest {
         debug_struct.field("service", &self.service);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17177,7 +17125,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17363,7 +17310,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17507,7 +17453,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17704,7 +17649,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18987,7 +18931,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("build_config", &self.build_config);
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19159,7 +19102,6 @@ impl std::fmt::Debug for RevisionScalingStatus {
             "desired_min_instance_count",
             &self.desired_min_instance_count,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19303,7 +19245,6 @@ impl std::fmt::Debug for GetTaskRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTaskRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19545,7 +19486,6 @@ impl std::fmt::Debug for ListTasksRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19731,7 +19671,6 @@ impl std::fmt::Debug for ListTasksResponse {
         let mut debug_struct = f.debug_struct("ListTasksResponse");
         debug_struct.field("tasks", &self.tasks);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20999,7 +20938,6 @@ impl std::fmt::Debug for Task {
             &self.gpu_zonal_redundancy_disabled,
         );
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21249,7 +21187,6 @@ impl std::fmt::Debug for TaskAttemptResult {
         debug_struct.field("status", &self.status);
         debug_struct.field("exit_code", &self.exit_code);
         debug_struct.field("term_signal", &self.term_signal);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21755,7 +21692,6 @@ impl std::fmt::Debug for TaskTemplate {
             &self.gpu_zonal_redundancy_disabled,
         );
         debug_struct.field("retries", &self.retries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22009,7 +21945,6 @@ impl std::fmt::Debug for TrafficTarget {
         debug_struct.field("revision", &self.revision);
         debug_struct.field("percent", &self.percent);
         debug_struct.field("tag", &self.tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22270,7 +22205,6 @@ impl std::fmt::Debug for TrafficTargetStatus {
         debug_struct.field("percent", &self.percent);
         debug_struct.field("tag", &self.tag);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22478,7 +22412,6 @@ impl std::fmt::Debug for VpcAccess {
         debug_struct.field("connector", &self.connector);
         debug_struct.field("egress", &self.egress);
         debug_struct.field("network_interfaces", &self.network_interfaces);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22689,7 +22622,6 @@ pub mod vpc_access {
             debug_struct.field("network", &self.network);
             debug_struct.field("subnetwork", &self.subnetwork);
             debug_struct.field("tags", &self.tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23087,7 +23019,6 @@ impl std::fmt::Debug for BinaryAuthorization {
         let mut debug_struct = f.debug_struct("BinaryAuthorization");
         debug_struct.field("breakglass_justification", &self.breakglass_justification);
         debug_struct.field("binauthz_method", &self.binauthz_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23315,7 +23246,6 @@ impl std::fmt::Debug for RevisionScaling {
         let mut debug_struct = f.debug_struct("RevisionScaling");
         debug_struct.field("min_instance_count", &self.min_instance_count);
         debug_struct.field("max_instance_count", &self.max_instance_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23460,7 +23390,6 @@ impl std::fmt::Debug for ServiceMesh {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceMesh");
         debug_struct.field("mesh", &self.mesh);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23712,7 +23641,6 @@ impl std::fmt::Debug for ServiceScaling {
         debug_struct.field("min_instance_count", &self.min_instance_count);
         debug_struct.field("scaling_mode", &self.scaling_mode);
         debug_struct.field("manual_instance_count", &self.manual_instance_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23993,7 +23921,6 @@ impl std::fmt::Debug for NodeSelector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodeSelector");
         debug_struct.field("accelerator", &self.accelerator);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24369,7 +24296,6 @@ impl std::fmt::Debug for BuildConfig {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("environment_variables", &self.environment_variables);
         debug_struct.field("service_account", &self.service_account);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -253,7 +253,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -451,7 +450,6 @@ impl std::fmt::Debug for ListJobsResponse {
         let mut debug_struct = f.debug_struct("ListJobsResponse");
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -597,7 +595,6 @@ impl std::fmt::Debug for GetJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -786,7 +783,6 @@ impl std::fmt::Debug for CreateJobRequest {
         let mut debug_struct = f.debug_struct("CreateJobRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -985,7 +981,6 @@ impl std::fmt::Debug for UpdateJobRequest {
         let mut debug_struct = f.debug_struct("UpdateJobRequest");
         debug_struct.field("job", &self.job);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1131,7 +1126,6 @@ impl std::fmt::Debug for DeleteJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1277,7 +1271,6 @@ impl std::fmt::Debug for PauseJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1423,7 +1416,6 @@ impl std::fmt::Debug for ResumeJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1569,7 +1561,6 @@ impl std::fmt::Debug for RunJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RunJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2304,7 +2295,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("retry_config", &self.retry_config);
         debug_struct.field("attempt_deadline", &self.attempt_deadline);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2864,7 +2854,6 @@ impl std::fmt::Debug for RetryConfig {
         debug_struct.field("min_backoff_duration", &self.min_backoff_duration);
         debug_struct.field("max_backoff_duration", &self.max_backoff_duration);
         debug_struct.field("max_doublings", &self.max_doublings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3302,7 +3291,6 @@ impl std::fmt::Debug for HttpTarget {
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
         debug_struct.field("authorization_header", &self.authorization_header);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3686,7 +3674,6 @@ impl std::fmt::Debug for AppEngineHttpTarget {
         debug_struct.field("relative_uri", &self.relative_uri);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3921,7 +3908,6 @@ impl std::fmt::Debug for PubsubTarget {
         debug_struct.field("topic_name", &self.topic_name);
         debug_struct.field("data", &self.data);
         debug_struct.field("attributes", &self.attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4231,7 +4217,6 @@ impl std::fmt::Debug for AppEngineRouting {
         debug_struct.field("version", &self.version);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("host", &self.host);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4410,7 +4395,6 @@ impl std::fmt::Debug for OAuthToken {
         let mut debug_struct = f.debug_struct("OAuthToken");
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4590,7 +4574,6 @@ impl std::fmt::Debug for OidcToken {
         let mut debug_struct = f.debug_struct("OidcToken");
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("audience", &self.audience);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -788,7 +788,6 @@ impl std::fmt::Debug for Secret {
         );
         debug_struct.field("tags", &self.tags);
         debug_struct.field("expiration", &self.expiration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1303,7 +1302,6 @@ impl std::fmt::Debug for SecretVersion {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1711,7 +1709,6 @@ impl std::fmt::Debug for Replication {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Replication");
         debug_struct.field("replication", &self.replication);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1904,7 +1901,6 @@ pub mod replication {
                 "customer_managed_encryption",
                 &self.customer_managed_encryption,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2069,7 +2065,6 @@ pub mod replication {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UserManaged");
             debug_struct.field("replicas", &self.replicas);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2298,7 +2293,6 @@ pub mod replication {
                     "customer_managed_encryption",
                     &self.customer_managed_encryption,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2475,7 +2469,6 @@ impl std::fmt::Debug for CustomerManagedEncryption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomerManagedEncryption");
         debug_struct.field("kms_key_name", &self.kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2740,7 +2733,6 @@ impl std::fmt::Debug for ReplicationStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplicationStatus");
         debug_struct.field("replication_status", &self.replication_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2930,7 +2922,6 @@ pub mod replication_status {
                 "customer_managed_encryption",
                 &self.customer_managed_encryption,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3092,7 +3083,6 @@ pub mod replication_status {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UserManagedStatus");
             debug_struct.field("replicas", &self.replicas);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3313,7 +3303,6 @@ pub mod replication_status {
                     "customer_managed_encryption",
                     &self.customer_managed_encryption,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3494,7 +3483,6 @@ impl std::fmt::Debug for CustomerManagedEncryptionStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomerManagedEncryptionStatus");
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3641,7 +3629,6 @@ impl std::fmt::Debug for Topic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Topic");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3864,7 +3851,6 @@ impl std::fmt::Debug for Rotation {
         let mut debug_struct = f.debug_struct("Rotation");
         debug_struct.field("next_rotation_time", &self.next_rotation_time);
         debug_struct.field("rotation_period", &self.rotation_period);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4106,7 +4092,6 @@ impl std::fmt::Debug for SecretPayload {
         let mut debug_struct = f.debug_struct("SecretPayload");
         debug_struct.field("data", &self.data);
         debug_struct.field("data_crc32c", &self.data_crc32c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4359,7 +4344,6 @@ impl std::fmt::Debug for ListSecretsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4604,7 +4588,6 @@ impl std::fmt::Debug for ListSecretsResponse {
         debug_struct.field("secrets", &self.secrets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4822,7 +4805,6 @@ impl std::fmt::Debug for CreateSecretRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("secret_id", &self.secret_id);
         debug_struct.field("secret", &self.secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5012,7 +4994,6 @@ impl std::fmt::Debug for AddSecretVersionRequest {
         let mut debug_struct = f.debug_struct("AddSecretVersionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5161,7 +5142,6 @@ impl std::fmt::Debug for GetSecretRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSecretRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5414,7 +5394,6 @@ impl std::fmt::Debug for ListSecretVersionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5660,7 +5639,6 @@ impl std::fmt::Debug for ListSecretVersionsResponse {
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5815,7 +5793,6 @@ impl std::fmt::Debug for GetSecretVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSecretVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6011,7 +5988,6 @@ impl std::fmt::Debug for UpdateSecretRequest {
         let mut debug_struct = f.debug_struct("UpdateSecretRequest");
         debug_struct.field("secret", &self.secret);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6166,7 +6142,6 @@ impl std::fmt::Debug for AccessSecretVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccessSecretVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6352,7 +6327,6 @@ impl std::fmt::Debug for AccessSecretVersionResponse {
         let mut debug_struct = f.debug_struct("AccessSecretVersionResponse");
         debug_struct.field("name", &self.name);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6530,7 +6504,6 @@ impl std::fmt::Debug for DeleteSecretRequest {
         let mut debug_struct = f.debug_struct("DeleteSecretRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6710,7 +6683,6 @@ impl std::fmt::Debug for DisableSecretVersionRequest {
         let mut debug_struct = f.debug_struct("DisableSecretVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6890,7 +6862,6 @@ impl std::fmt::Debug for EnableSecretVersionRequest {
         let mut debug_struct = f.debug_struct("EnableSecretVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7070,7 +7041,6 @@ impl std::fmt::Debug for DestroySecretVersionRequest {
         let mut debug_struct = f.debug_struct("DestroySecretVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -443,7 +443,6 @@ impl std::fmt::Debug for Instance {
         debug_struct.field("state_note", &self.state_note);
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("host_config", &self.host_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -671,7 +670,6 @@ pub mod instance {
             debug_struct.field("api", &self.api);
             debug_struct.field("git_http", &self.git_http);
             debug_struct.field("git_ssh", &self.git_ssh);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -941,7 +939,6 @@ pub mod instance {
             debug_struct.field("http_service_attachment", &self.http_service_attachment);
             debug_struct.field("ssh_service_attachment", &self.ssh_service_attachment);
             debug_struct.field("psc_allowed_projects", &self.psc_allowed_projects);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1630,7 +1627,6 @@ impl std::fmt::Debug for Repository {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("uris", &self.uris);
         debug_struct.field("initial_config", &self.initial_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1832,7 +1828,6 @@ pub mod repository {
             debug_struct.field("html", &self.html);
             debug_struct.field("git_https", &self.git_https);
             debug_struct.field("api", &self.api);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2183,7 +2178,6 @@ pub mod repository {
             debug_struct.field("gitignores", &self.gitignores);
             debug_struct.field("license", &self.license);
             debug_struct.field("readme", &self.readme);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2786,7 +2780,6 @@ impl std::fmt::Debug for BranchRule {
         debug_struct.field("allow_stale_reviews", &self.allow_stale_reviews);
         debug_struct.field("require_linear_history", &self.require_linear_history);
         debug_struct.field("required_status_checks", &self.required_status_checks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2936,7 +2929,6 @@ pub mod branch_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Check");
             debug_struct.field("context", &self.context);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3201,7 +3193,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3413,7 +3404,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3555,7 +3545,6 @@ impl std::fmt::Debug for GetInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3797,7 +3786,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3977,7 +3965,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4302,7 +4289,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4571,7 +4557,6 @@ impl std::fmt::Debug for ListRepositoriesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4755,7 +4740,6 @@ impl std::fmt::Debug for ListRepositoriesResponse {
         let mut debug_struct = f.debug_struct("ListRepositoriesResponse");
         debug_struct.field("repositories", &self.repositories);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4899,7 +4883,6 @@ impl std::fmt::Debug for GetRepositoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRepositoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5106,7 +5089,6 @@ impl std::fmt::Debug for CreateRepositoryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("repository", &self.repository);
         debug_struct.field("repository_id", &self.repository_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5277,7 +5259,6 @@ impl std::fmt::Debug for DeleteRepositoryRequest {
         let mut debug_struct = f.debug_struct("DeleteRepositoryRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5421,7 +5402,6 @@ impl std::fmt::Debug for GetBranchRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBranchRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5623,7 +5603,6 @@ impl std::fmt::Debug for CreateBranchRuleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("branch_rule", &self.branch_rule);
         debug_struct.field("branch_rule_id", &self.branch_rule_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5832,7 +5811,6 @@ impl std::fmt::Debug for ListBranchRulesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6000,7 +5978,6 @@ impl std::fmt::Debug for DeleteBranchRuleRequest {
         let mut debug_struct = f.debug_struct("DeleteBranchRuleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6221,7 +6198,6 @@ impl std::fmt::Debug for UpdateBranchRuleRequest {
         debug_struct.field("branch_rule", &self.branch_rule);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6407,7 +6383,6 @@ impl std::fmt::Debug for ListBranchRulesResponse {
         let mut debug_struct = f.debug_struct("ListBranchRulesResponse");
         debug_struct.field("branch_rules", &self.branch_rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -904,7 +904,6 @@ impl std::fmt::Debug for CertificateAuthority {
         debug_struct.field("user_defined_access_urls", &self.user_defined_access_urls);
         debug_struct.field("satisfies_pzs", &self.satisfies_pzs);
         debug_struct.field("satisfies_pzi", &self.satisfies_pzi);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1105,7 +1104,6 @@ pub mod certificate_authority {
             let mut debug_struct = f.debug_struct("AccessUrls");
             debug_struct.field("ca_certificate_access_url", &self.ca_certificate_access_url);
             debug_struct.field("crl_access_urls", &self.crl_access_urls);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1358,7 +1356,6 @@ pub mod certificate_authority {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("KeyVersionSpec");
             debug_struct.field("key_version", &self.key_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1584,7 +1581,6 @@ pub mod certificate_authority {
                 &self.aia_issuing_certificate_urls,
             );
             debug_struct.field("crl_access_urls", &self.crl_access_urls);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2415,7 +2411,6 @@ impl std::fmt::Debug for CaPool {
         debug_struct.field("issuance_policy", &self.issuance_policy);
         debug_struct.field("publishing_options", &self.publishing_options);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2660,7 +2655,6 @@ pub mod ca_pool {
             debug_struct.field("publish_ca_cert", &self.publish_ca_cert);
             debug_struct.field("publish_crl", &self.publish_crl);
             debug_struct.field("encoding_format", &self.encoding_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3272,7 +3266,6 @@ pub mod ca_pool {
             debug_struct.field("baseline_values", &self.baseline_values);
             debug_struct.field("identity_constraints", &self.identity_constraints);
             debug_struct.field("passthrough_extensions", &self.passthrough_extensions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3565,7 +3558,6 @@ pub mod ca_pool {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("AllowedKeyType");
                 debug_struct.field("key_type", &self.key_type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3818,7 +3810,6 @@ pub mod ca_pool {
                     let mut debug_struct = f.debug_struct("RsaKeyType");
                     debug_struct.field("min_modulus_size", &self.min_modulus_size);
                     debug_struct.field("max_modulus_size", &self.max_modulus_size);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -3984,7 +3975,6 @@ pub mod ca_pool {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("EcKeyType");
                     debug_struct.field("signature_algorithm", &self.signature_algorithm);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -4377,7 +4367,6 @@ pub mod ca_pool {
                     "allow_config_based_issuance",
                     &self.allow_config_based_issuance,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4978,7 +4967,6 @@ impl std::fmt::Debug for CertificateRevocationList {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("revision_id", &self.revision_id);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5198,7 +5186,6 @@ pub mod certificate_revocation_list {
             debug_struct.field("certificate", &self.certificate);
             debug_struct.field("hex_serial_number", &self.hex_serial_number);
             debug_struct.field("revocation_reason", &self.revocation_reason);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6016,7 +6003,6 @@ impl std::fmt::Debug for Certificate {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("certificate_config", &self.certificate_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6216,7 +6202,6 @@ pub mod certificate {
             let mut debug_struct = f.debug_struct("RevocationDetails");
             debug_struct.field("revocation_state", &self.revocation_state);
             debug_struct.field("revocation_time", &self.revocation_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6735,7 +6720,6 @@ impl std::fmt::Debug for CertificateTemplate {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7066,7 +7050,6 @@ impl std::fmt::Debug for X509Parameters {
         debug_struct.field("aia_ocsp_servers", &self.aia_ocsp_servers);
         debug_struct.field("name_constraints", &self.name_constraints);
         debug_struct.field("additional_extensions", &self.additional_extensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7297,7 +7280,6 @@ pub mod x_509_parameters {
             let mut debug_struct = f.debug_struct("CaOptions");
             debug_struct.field("is_ca", &self.is_ca);
             debug_struct.field("max_issuer_path_length", &self.max_issuer_path_length);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7708,7 +7690,6 @@ pub mod x_509_parameters {
             debug_struct.field("excluded_email_addresses", &self.excluded_email_addresses);
             debug_struct.field("permitted_uris", &self.permitted_uris);
             debug_struct.field("excluded_uris", &self.excluded_uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7961,7 +7942,6 @@ impl std::fmt::Debug for SubordinateConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SubordinateConfig");
         debug_struct.field("subordinate_config", &self.subordinate_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8116,7 +8096,6 @@ pub mod subordinate_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SubordinateConfigChain");
             debug_struct.field("pem_certificates", &self.pem_certificates);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8328,7 +8307,6 @@ impl std::fmt::Debug for PublicKey {
         let mut debug_struct = f.debug_struct("PublicKey");
         debug_struct.field("key", &self.key);
         debug_struct.field("format", &self.format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8758,7 +8736,6 @@ impl std::fmt::Debug for CertificateConfig {
         debug_struct.field("x509_config", &self.x509_config);
         debug_struct.field("public_key", &self.public_key);
         debug_struct.field("subject_key_id", &self.subject_key_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8958,7 +8935,6 @@ pub mod certificate_config {
             let mut debug_struct = f.debug_struct("SubjectConfig");
             debug_struct.field("subject", &self.subject);
             debug_struct.field("subject_alt_name", &self.subject_alt_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9106,7 +9082,6 @@ pub mod certificate_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("KeyId");
             debug_struct.field("key_id", &self.key_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9566,7 +9541,6 @@ impl std::fmt::Debug for CertificateDescription {
         );
         debug_struct.field("cert_fingerprint", &self.cert_fingerprint);
         debug_struct.field("tbs_certificate_digest", &self.tbs_certificate_digest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9908,7 +9882,6 @@ pub mod certificate_description {
             debug_struct.field("lifetime", &self.lifetime);
             debug_struct.field("not_before_time", &self.not_before_time);
             debug_struct.field("not_after_time", &self.not_after_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10056,7 +10029,6 @@ pub mod certificate_description {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("KeyId");
             debug_struct.field("key_id", &self.key_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10202,7 +10174,6 @@ pub mod certificate_description {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CertificateFingerprint");
             debug_struct.field("sha256_hash", &self.sha256_hash);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10380,7 +10351,6 @@ impl std::fmt::Debug for ObjectId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ObjectId");
         debug_struct.field("object_id_path", &self.object_id_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10608,7 +10578,6 @@ impl std::fmt::Debug for X509Extension {
         debug_struct.field("object_id", &self.object_id);
         debug_struct.field("critical", &self.critical);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10846,7 +10815,6 @@ impl std::fmt::Debug for KeyUsage {
             "unknown_extended_key_usages",
             &self.unknown_extended_key_usages,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11210,7 +11178,6 @@ pub mod key_usage {
             debug_struct.field("crl_sign", &self.crl_sign);
             debug_struct.field("encipher_only", &self.encipher_only);
             debug_struct.field("decipher_only", &self.decipher_only);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11496,7 +11463,6 @@ pub mod key_usage {
             debug_struct.field("email_protection", &self.email_protection);
             debug_struct.field("time_stamping", &self.time_stamping);
             debug_struct.field("ocsp_signing", &self.ocsp_signing);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11764,7 +11730,6 @@ impl std::fmt::Debug for AttributeTypeAndValue {
         let mut debug_struct = f.debug_struct("AttributeTypeAndValue");
         debug_struct.field("value", &self.value);
         debug_struct.field("attribute_type", &self.attribute_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11933,7 +11898,6 @@ impl std::fmt::Debug for RelativeDistinguishedName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RelativeDistinguishedName");
         debug_struct.field("attributes", &self.attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12294,7 +12258,6 @@ impl std::fmt::Debug for Subject {
         debug_struct.field("street_address", &self.street_address);
         debug_struct.field("postal_code", &self.postal_code);
         debug_struct.field("rdn_sequence", &self.rdn_sequence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12562,7 +12525,6 @@ impl std::fmt::Debug for SubjectAltNames {
         debug_struct.field("email_addresses", &self.email_addresses);
         debug_struct.field("ip_addresses", &self.ip_addresses);
         debug_struct.field("custom_sans", &self.custom_sans);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12830,7 +12792,6 @@ impl std::fmt::Debug for CertificateIdentityConstraints {
             "allow_subject_alt_names_passthrough",
             &self.allow_subject_alt_names_passthrough,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13019,7 +12980,6 @@ impl std::fmt::Debug for CertificateExtensionConstraints {
         let mut debug_struct = f.debug_struct("CertificateExtensionConstraints");
         debug_struct.field("known_extensions", &self.known_extensions);
         debug_struct.field("additional_extensions", &self.additional_extensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13593,7 +13553,6 @@ impl std::fmt::Debug for CreateCertificateRequest {
             "issuing_certificate_authority_id",
             &self.issuing_certificate_authority_id,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13743,7 +13702,6 @@ impl std::fmt::Debug for GetCertificateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14030,7 +13988,6 @@ impl std::fmt::Debug for ListCertificatesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14252,7 +14209,6 @@ impl std::fmt::Debug for ListCertificatesResponse {
         debug_struct.field("certificates", &self.certificates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14472,7 +14428,6 @@ impl std::fmt::Debug for RevokeCertificateRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("reason", &self.reason);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14706,7 +14661,6 @@ impl std::fmt::Debug for UpdateCertificateRequest {
         debug_struct.field("certificate", &self.certificate);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14964,7 +14918,6 @@ impl std::fmt::Debug for ActivateCertificateAuthorityRequest {
         debug_struct.field("pem_ca_certificate", &self.pem_ca_certificate);
         debug_struct.field("subordinate_config", &self.subordinate_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15226,7 +15179,6 @@ impl std::fmt::Debug for CreateCertificateAuthorityRequest {
         debug_struct.field("certificate_authority_id", &self.certificate_authority_id);
         debug_struct.field("certificate_authority", &self.certificate_authority);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15449,7 +15401,6 @@ impl std::fmt::Debug for DisableCertificateAuthorityRequest {
             "ignore_dependent_resources",
             &self.ignore_dependent_resources,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15636,7 +15587,6 @@ impl std::fmt::Debug for EnableCertificateAuthorityRequest {
         let mut debug_struct = f.debug_struct("EnableCertificateAuthorityRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15785,7 +15735,6 @@ impl std::fmt::Debug for FetchCertificateAuthorityCsrRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchCertificateAuthorityCsrRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15931,7 +15880,6 @@ impl std::fmt::Debug for FetchCertificateAuthorityCsrResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchCertificateAuthorityCsrResponse");
         debug_struct.field("pem_csr", &self.pem_csr);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16082,7 +16030,6 @@ impl std::fmt::Debug for GetCertificateAuthorityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateAuthorityRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16367,7 +16314,6 @@ impl std::fmt::Debug for ListCertificateAuthoritiesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16595,7 +16541,6 @@ impl std::fmt::Debug for ListCertificateAuthoritiesResponse {
         debug_struct.field("certificate_authorities", &self.certificate_authorities);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16782,7 +16727,6 @@ impl std::fmt::Debug for UndeleteCertificateAuthorityRequest {
         let mut debug_struct = f.debug_struct("UndeleteCertificateAuthorityRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17067,7 +17011,6 @@ impl std::fmt::Debug for DeleteCertificateAuthorityRequest {
             "ignore_dependent_resources",
             &self.ignore_dependent_resources,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17303,7 +17246,6 @@ impl std::fmt::Debug for UpdateCertificateAuthorityRequest {
         debug_struct.field("certificate_authority", &self.certificate_authority);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17557,7 +17499,6 @@ impl std::fmt::Debug for CreateCaPoolRequest {
         debug_struct.field("ca_pool_id", &self.ca_pool_id);
         debug_struct.field("ca_pool", &self.ca_pool);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17792,7 +17733,6 @@ impl std::fmt::Debug for UpdateCaPoolRequest {
         debug_struct.field("ca_pool", &self.ca_pool);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18015,7 +17955,6 @@ impl std::fmt::Debug for DeleteCaPoolRequest {
             "ignore_dependent_resources",
             &self.ignore_dependent_resources,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18203,7 +18142,6 @@ impl std::fmt::Debug for FetchCaCertsRequest {
         let mut debug_struct = f.debug_struct("FetchCaCertsRequest");
         debug_struct.field("ca_pool", &self.ca_pool);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18360,7 +18298,6 @@ impl std::fmt::Debug for FetchCaCertsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchCaCertsResponse");
         debug_struct.field("ca_certs", &self.ca_certs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18512,7 +18449,6 @@ pub mod fetch_ca_certs_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CertChain");
             debug_struct.field("certificates", &self.certificates);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18662,7 +18598,6 @@ impl std::fmt::Debug for GetCaPoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCaPoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18944,7 +18879,6 @@ impl std::fmt::Debug for ListCaPoolsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19167,7 +19101,6 @@ impl std::fmt::Debug for ListCaPoolsResponse {
         debug_struct.field("ca_pools", &self.ca_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19319,7 +19252,6 @@ impl std::fmt::Debug for GetCertificateRevocationListRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateRevocationListRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19603,7 +19535,6 @@ impl std::fmt::Debug for ListCertificateRevocationListsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19842,7 +19773,6 @@ impl std::fmt::Debug for ListCertificateRevocationListsResponse {
         );
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20089,7 +20019,6 @@ impl std::fmt::Debug for UpdateCertificateRevocationListRequest {
         );
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20347,7 +20276,6 @@ impl std::fmt::Debug for CreateCertificateTemplateRequest {
         debug_struct.field("certificate_template_id", &self.certificate_template_id);
         debug_struct.field("certificate_template", &self.certificate_template);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20534,7 +20462,6 @@ impl std::fmt::Debug for DeleteCertificateTemplateRequest {
         let mut debug_struct = f.debug_struct("DeleteCertificateTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20685,7 +20612,6 @@ impl std::fmt::Debug for GetCertificateTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCertificateTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20968,7 +20894,6 @@ impl std::fmt::Debug for ListCertificateTemplatesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21196,7 +21121,6 @@ impl std::fmt::Debug for ListCertificateTemplatesResponse {
         debug_struct.field("certificate_templates", &self.certificate_templates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21432,7 +21356,6 @@ impl std::fmt::Debug for UpdateCertificateTemplateRequest {
         debug_struct.field("certificate_template", &self.certificate_template);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21759,7 +21682,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/security/publicca/v1/src/model.rs
+++ b/src/generated/cloud/security/publicca/v1/src/model.rs
@@ -240,7 +240,6 @@ impl std::fmt::Debug for ExternalAccountKey {
         debug_struct.field("name", &self.name);
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("b64_mac_key", &self.b64_mac_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -428,7 +427,6 @@ impl std::fmt::Debug for CreateExternalAccountKeyRequest {
         let mut debug_struct = f.debug_struct("CreateExternalAccountKeyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("external_account_key", &self.external_account_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -495,7 +495,6 @@ impl std::fmt::Debug for Access {
             &self.service_account_delegation_info,
         );
         debug_struct.field("user_name", &self.user_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -673,7 +672,6 @@ impl std::fmt::Debug for ServiceAccountDelegationInfo {
         let mut debug_struct = f.debug_struct("ServiceAccountDelegationInfo");
         debug_struct.field("principal_email", &self.principal_email);
         debug_struct.field("principal_subject", &self.principal_subject);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -816,7 +814,6 @@ impl std::fmt::Debug for Geolocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Geolocation");
         debug_struct.field("region_code", &self.region_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -976,7 +973,6 @@ impl std::fmt::Debug for AffectedResources {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AffectedResources");
         debug_struct.field("count", &self.count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1273,7 +1269,6 @@ impl std::fmt::Debug for AiModel {
         debug_struct.field("publisher", &self.publisher);
         debug_struct.field("deployment_platform", &self.deployment_platform);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1582,7 +1577,6 @@ impl std::fmt::Debug for Application {
         let mut debug_struct = f.debug_struct("Application");
         debug_struct.field("base_uri", &self.base_uri);
         debug_struct.field("full_uri", &self.full_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2016,7 +2010,6 @@ impl std::fmt::Debug for AttackExposure {
             "exposed_low_value_resources_count",
             &self.exposed_low_value_resources_count,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2362,7 +2355,6 @@ impl std::fmt::Debug for AttackPath {
         debug_struct.field("name", &self.name);
         debug_struct.field("path_nodes", &self.path_nodes);
         debug_struct.field("edges", &self.edges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2661,7 +2653,6 @@ pub mod attack_path {
             debug_struct.field("associated_findings", &self.associated_findings);
             debug_struct.field("uuid", &self.uuid);
             debug_struct.field("attack_steps", &self.attack_steps);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2877,7 +2868,6 @@ pub mod attack_path {
                 debug_struct.field("canonical_finding", &self.canonical_finding);
                 debug_struct.field("finding_category", &self.finding_category);
                 debug_struct.field("name", &self.name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3154,7 +3144,6 @@ pub mod attack_path {
                 debug_struct.field("display_name", &self.display_name);
                 debug_struct.field("labels", &self.labels);
                 debug_struct.field("description", &self.description);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3475,7 +3464,6 @@ pub mod attack_path {
             let mut debug_struct = f.debug_struct("AttackPathEdge");
             debug_struct.field("source", &self.source);
             debug_struct.field("destination", &self.destination);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3896,7 +3884,6 @@ impl std::fmt::Debug for BackupDisasterRecovery {
         debug_struct.field("appliance", &self.appliance);
         debug_struct.field("backup_type", &self.backup_type);
         debug_struct.field("backup_create_time", &self.backup_create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4282,7 +4269,6 @@ impl std::fmt::Debug for BigQueryExport {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("most_recent_editor", &self.most_recent_editor);
         debug_struct.field("principal", &self.principal);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4432,7 +4418,6 @@ impl std::fmt::Debug for Chokepoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Chokepoint");
         debug_struct.field("related_findings", &self.related_findings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4767,7 +4752,6 @@ impl std::fmt::Debug for CloudArmor {
         debug_struct.field("attack", &self.attack);
         debug_struct.field("threat_vector", &self.threat_vector);
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4964,7 +4948,6 @@ impl std::fmt::Debug for SecurityPolicy {
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("preview", &self.preview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5261,7 +5244,6 @@ impl std::fmt::Debug for Requests {
         debug_struct.field("short_term_allowed", &self.short_term_allowed);
         debug_struct.field("long_term_allowed", &self.long_term_allowed);
         debug_struct.field("long_term_denied", &self.long_term_denied);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5426,7 +5408,6 @@ impl std::fmt::Debug for AdaptiveProtection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdaptiveProtection");
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5752,7 +5733,6 @@ impl std::fmt::Debug for Attack {
         debug_struct.field("classification", &self.classification);
         debug_struct.field("volume_pps", &self.volume_pps);
         debug_struct.field("volume_bps", &self.volume_bps);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5930,7 +5910,6 @@ impl std::fmt::Debug for CloudDlpDataProfile {
         let mut debug_struct = f.debug_struct("CloudDlpDataProfile");
         debug_struct.field("data_profile", &self.data_profile);
         debug_struct.field("parent_type", &self.parent_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6314,7 +6293,6 @@ impl std::fmt::Debug for CloudDlpInspection {
         debug_struct.field("info_type", &self.info_type);
         debug_struct.field("info_type_count", &self.info_type_count);
         debug_struct.field("full_scan", &self.full_scan);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6511,7 +6489,6 @@ impl std::fmt::Debug for Compliance {
         debug_struct.field("standard", &self.standard);
         debug_struct.field("version", &self.version);
         debug_struct.field("ids", &self.ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6797,7 +6774,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("source_ip", &self.source_ip);
         debug_struct.field("source_port", &self.source_port);
         debug_struct.field("protocol", &self.protocol);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7101,7 +7077,6 @@ impl std::fmt::Debug for ContactDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ContactDetails");
         debug_struct.field("contacts", &self.contacts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7243,7 +7218,6 @@ impl std::fmt::Debug for Contact {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Contact");
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7503,7 +7477,6 @@ impl std::fmt::Debug for Container {
         debug_struct.field("image_id", &self.image_id);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7737,7 +7710,6 @@ impl std::fmt::Debug for DataAccessEvent {
         debug_struct.field("principal_email", &self.principal_email);
         debug_struct.field("operation", &self.operation);
         debug_struct.field("event_time", &self.event_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8146,7 +8118,6 @@ impl std::fmt::Debug for DataFlowEvent {
         debug_struct.field("operation", &self.operation);
         debug_struct.field("violated_location", &self.violated_location);
         debug_struct.field("event_time", &self.event_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8576,7 +8547,6 @@ impl std::fmt::Debug for DataRetentionDeletionEvent {
         debug_struct.field("data_object_count", &self.data_object_count);
         debug_struct.field("max_retention_allowed", &self.max_retention_allowed);
         debug_struct.field("event_type", &self.event_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8996,7 +8966,6 @@ impl std::fmt::Debug for Database {
         debug_struct.field("query", &self.query);
         debug_struct.field("grantees", &self.grantees);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9139,7 +9108,6 @@ impl std::fmt::Debug for Disk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Disk");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9366,7 +9334,6 @@ impl std::fmt::Debug for Exfiltration {
         debug_struct.field("sources", &self.sources);
         debug_struct.field("targets", &self.targets);
         debug_struct.field("total_exfiltrated_bytes", &self.total_exfiltrated_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9541,7 +9508,6 @@ impl std::fmt::Debug for ExfilResource {
         let mut debug_struct = f.debug_struct("ExfilResource");
         debug_struct.field("name", &self.name);
         debug_struct.field("components", &self.components);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10026,7 +9992,6 @@ impl std::fmt::Debug for ExternalSystem {
         debug_struct.field("case_create_time", &self.case_create_time);
         debug_struct.field("case_close_time", &self.case_close_time);
         debug_struct.field("ticket_info", &self.ticket_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10315,7 +10280,6 @@ pub mod external_system {
             debug_struct.field("uri", &self.uri);
             debug_struct.field("status", &self.status);
             debug_struct.field("update_time", &self.update_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10696,7 +10660,6 @@ impl std::fmt::Debug for File {
         debug_struct.field("contents", &self.contents);
         debug_struct.field("disk_path", &self.disk_path);
         debug_struct.field("operations", &self.operations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10881,7 +10844,6 @@ pub mod file {
             let mut debug_struct = f.debug_struct("DiskPath");
             debug_struct.field("partition_uuid", &self.partition_uuid);
             debug_struct.field("relative_path", &self.relative_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11033,7 +10995,6 @@ pub mod file {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FileOperation");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13421,7 +13382,6 @@ impl std::fmt::Debug for Finding {
         debug_struct.field("ai_model", &self.ai_model);
         debug_struct.field("chokepoint", &self.chokepoint);
         debug_struct.field("vertex_ai", &self.vertex_ai);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13622,7 +13582,6 @@ pub mod finding {
             let mut debug_struct = f.debug_struct("MuteInfo");
             debug_struct.field("static_mute", &self.static_mute);
             debug_struct.field("dynamic_mute_records", &self.dynamic_mute_records);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13818,7 +13777,6 @@ pub mod finding {
                 let mut debug_struct = f.debug_struct("StaticMute");
                 debug_struct.field("state", &self.state);
                 debug_struct.field("apply_time", &self.apply_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -14014,7 +13972,6 @@ pub mod finding {
                 let mut debug_struct = f.debug_struct("DynamicMuteRecord");
                 debug_struct.field("mute_config", &self.mute_config);
                 debug_struct.field("match_time", &self.match_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -14847,7 +14804,6 @@ impl std::fmt::Debug for Folder {
             "resource_folder_display_name",
             &self.resource_folder_display_name,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15018,7 +14974,6 @@ impl std::fmt::Debug for GroupMembership {
         let mut debug_struct = f.debug_struct("GroupMembership");
         debug_struct.field("group_type", &self.group_type);
         debug_struct.field("group_id", &self.group_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15352,7 +15307,6 @@ impl std::fmt::Debug for IamBinding {
         debug_struct.field("action", &self.action);
         debug_struct.field("role", &self.role);
         debug_struct.field("member", &self.member);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15729,7 +15683,6 @@ impl std::fmt::Debug for Indicator {
         debug_struct.field("domains", &self.domains);
         debug_struct.field("signatures", &self.signatures);
         debug_struct.field("uris", &self.uris);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16029,7 +15982,6 @@ pub mod indicator {
             let mut debug_struct = f.debug_struct("ProcessSignature");
             debug_struct.field("signature_type", &self.signature_type);
             debug_struct.field("signature", &self.signature);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16221,7 +16173,6 @@ pub mod indicator {
                 let mut debug_struct = f.debug_struct("MemoryHashSignature");
                 debug_struct.field("binary_family", &self.binary_family);
                 debug_struct.field("detections", &self.detections);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16453,7 +16404,6 @@ pub mod indicator {
                     let mut debug_struct = f.debug_struct("Detection");
                     debug_struct.field("binary", &self.binary);
                     debug_struct.field("percent_pages_matched", &self.percent_pages_matched);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -16608,7 +16558,6 @@ pub mod indicator {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("YaraRuleSignature");
                 debug_struct.field("yara_rule", &self.yara_rule);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17112,7 +17061,6 @@ impl std::fmt::Debug for IpRules {
         debug_struct.field("destination_ip_ranges", &self.destination_ip_ranges);
         debug_struct.field("exposed_services", &self.exposed_services);
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17441,7 +17389,6 @@ impl std::fmt::Debug for IpRule {
         let mut debug_struct = f.debug_struct("IpRule");
         debug_struct.field("protocol", &self.protocol);
         debug_struct.field("port_ranges", &self.port_ranges);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17655,7 +17602,6 @@ pub mod ip_rule {
             let mut debug_struct = f.debug_struct("PortRange");
             debug_struct.field("min", &self.min);
             debug_struct.field("max", &self.max);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17802,7 +17748,6 @@ impl std::fmt::Debug for Allowed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Allowed");
         debug_struct.field("ip_rules", &self.ip_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17948,7 +17893,6 @@ impl std::fmt::Debug for Denied {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Denied");
         debug_struct.field("ip_rules", &self.ip_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18187,7 +18131,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("state", &self.state);
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18619,7 +18562,6 @@ impl std::fmt::Debug for KernelRootkit {
             "unexpected_processes_in_runqueue",
             &self.unexpected_processes_in_runqueue,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18974,7 +18916,6 @@ impl std::fmt::Debug for Kubernetes {
         debug_struct.field("bindings", &self.bindings);
         debug_struct.field("access_reviews", &self.access_reviews);
         debug_struct.field("objects", &self.objects);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19206,7 +19147,6 @@ pub mod kubernetes {
             debug_struct.field("name", &self.name);
             debug_struct.field("labels", &self.labels);
             debug_struct.field("containers", &self.containers);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19352,7 +19292,6 @@ pub mod kubernetes {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Node");
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19529,7 +19468,6 @@ pub mod kubernetes {
             let mut debug_struct = f.debug_struct("NodePool");
             debug_struct.field("name", &self.name);
             debug_struct.field("nodes", &self.nodes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19725,7 +19663,6 @@ pub mod kubernetes {
             debug_struct.field("kind", &self.kind);
             debug_struct.field("ns", &self.ns);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20105,7 +20042,6 @@ pub mod kubernetes {
             debug_struct.field("name", &self.name);
             debug_struct.field("role", &self.role);
             debug_struct.field("subjects", &self.subjects);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20305,7 +20241,6 @@ pub mod kubernetes {
             debug_struct.field("kind", &self.kind);
             debug_struct.field("ns", &self.ns);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20754,7 +20689,6 @@ pub mod kubernetes {
             debug_struct.field("subresource", &self.subresource);
             debug_struct.field("verb", &self.verb);
             debug_struct.field("version", &self.version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21007,7 +20941,6 @@ pub mod kubernetes {
             debug_struct.field("ns", &self.ns);
             debug_struct.field("name", &self.name);
             debug_struct.field("containers", &self.containers);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21178,7 +21111,6 @@ impl std::fmt::Debug for Label {
         let mut debug_struct = f.debug_struct("Label");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21321,7 +21253,6 @@ impl std::fmt::Debug for LoadBalancer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoadBalancer");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21512,7 +21443,6 @@ impl std::fmt::Debug for LogEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LogEntry");
         debug_struct.field("log_entry", &self.log_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21765,7 +21695,6 @@ impl std::fmt::Debug for CloudLoggingEntry {
         debug_struct.field("log_id", &self.log_id);
         debug_struct.field("resource_container", &self.resource_container);
         debug_struct.field("timestamp", &self.timestamp);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22040,7 +21969,6 @@ impl std::fmt::Debug for MitreAttack {
         debug_struct.field("additional_tactics", &self.additional_tactics);
         debug_struct.field("additional_techniques", &self.additional_techniques);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23904,7 +23832,6 @@ impl std::fmt::Debug for MuteConfig {
         debug_struct.field("most_recent_editor", &self.most_recent_editor);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("expiry_time", &self.expiry_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24192,7 +24119,6 @@ impl std::fmt::Debug for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Network");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24424,7 +24350,6 @@ impl std::fmt::Debug for Notebook {
         debug_struct.field("service", &self.service);
         debug_struct.field("last_author", &self.last_author);
         debug_struct.field("notebook_update_time", &self.notebook_update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24773,7 +24698,6 @@ impl std::fmt::Debug for NotificationConfig {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("notify_config", &self.notify_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24944,7 +24868,6 @@ pub mod notification_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StreamingConfig");
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25206,7 +25129,6 @@ impl std::fmt::Debug for NotificationMessage {
         debug_struct.field("notification_config_name", &self.notification_config_name);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("event", &self.event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25365,7 +25287,6 @@ impl std::fmt::Debug for OrgPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OrgPolicy");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25856,7 +25777,6 @@ impl std::fmt::Debug for Process {
         debug_struct.field("pid", &self.pid);
         debug_struct.field("parent_pid", &self.parent_pid);
         debug_struct.field("user_id", &self.user_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26024,7 +25944,6 @@ impl std::fmt::Debug for EnvironmentVariable {
         let mut debug_struct = f.debug_struct("EnvironmentVariable");
         debug_struct.field("name", &self.name);
         debug_struct.field("val", &self.val);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26556,7 +26475,6 @@ impl std::fmt::Debug for Resource {
         debug_struct.field("resource_path", &self.resource_path);
         debug_struct.field("resource_path_string", &self.resource_path_string);
         debug_struct.field("cloud_provider_metadata", &self.cloud_provider_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26855,7 +26773,6 @@ impl std::fmt::Debug for GcpMetadata {
         debug_struct.field("parent_display_name", &self.parent_display_name);
         debug_struct.field("folders", &self.folders);
         debug_struct.field("organization", &self.organization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27083,7 +27000,6 @@ impl std::fmt::Debug for AwsMetadata {
         debug_struct.field("organization", &self.organization);
         debug_struct.field("organizational_units", &self.organizational_units);
         debug_struct.field("account", &self.account);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27237,7 +27153,6 @@ pub mod aws_metadata {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AwsOrganization");
             debug_struct.field("id", &self.id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27413,7 +27328,6 @@ pub mod aws_metadata {
             let mut debug_struct = f.debug_struct("AwsOrganizationalUnit");
             debug_struct.field("id", &self.id);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27583,7 +27497,6 @@ pub mod aws_metadata {
             let mut debug_struct = f.debug_struct("AwsAccount");
             debug_struct.field("id", &self.id);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27849,7 +27762,6 @@ impl std::fmt::Debug for AzureMetadata {
         debug_struct.field("subscription", &self.subscription);
         debug_struct.field("resource_group", &self.resource_group);
         debug_struct.field("tenant", &self.tenant);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28029,7 +27941,6 @@ pub mod azure_metadata {
             let mut debug_struct = f.debug_struct("AzureManagementGroup");
             debug_struct.field("id", &self.id);
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28204,7 +28115,6 @@ pub mod azure_metadata {
             let mut debug_struct = f.debug_struct("AzureSubscription");
             debug_struct.field("id", &self.id);
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28374,7 +28284,6 @@ pub mod azure_metadata {
             let mut debug_struct = f.debug_struct("AzureResourceGroup");
             debug_struct.field("id", &self.id);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28549,7 +28458,6 @@ pub mod azure_metadata {
             let mut debug_struct = f.debug_struct("AzureTenant");
             debug_struct.field("id", &self.id);
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28701,7 +28609,6 @@ impl std::fmt::Debug for ResourcePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourcePath");
         debug_struct.field("nodes", &self.nodes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28914,7 +28821,6 @@ pub mod resource_path {
             debug_struct.field("node_type", &self.node_type);
             debug_struct.field("id", &self.id);
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29590,7 +29496,6 @@ impl std::fmt::Debug for ResourceValueConfig {
             "sensitive_data_protection_mapping",
             &self.sensitive_data_protection_mapping,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29795,7 +29700,6 @@ pub mod resource_value_config {
                 "medium_sensitivity_mapping",
                 &self.medium_sensitivity_mapping,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30036,7 +29940,6 @@ impl std::fmt::Debug for SecurityMarks {
         debug_struct.field("name", &self.name);
         debug_struct.field("marks", &self.marks);
         debug_struct.field("canonical_name", &self.canonical_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30392,7 +30295,6 @@ impl std::fmt::Debug for SecurityPosture {
         debug_struct.field("policy_set", &self.policy_set);
         debug_struct.field("policy", &self.policy);
         debug_struct.field("policy_drift_details", &self.policy_drift_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30604,7 +30506,6 @@ pub mod security_posture {
             debug_struct.field("field", &self.field);
             debug_struct.field("expected_value", &self.expected_value);
             debug_struct.field("detected_value", &self.detected_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30782,7 +30683,6 @@ impl std::fmt::Debug for BatchCreateResourceValueConfigsRequest {
         let mut debug_struct = f.debug_struct("BatchCreateResourceValueConfigsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("requests", &self.requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30933,7 +30833,6 @@ impl std::fmt::Debug for BatchCreateResourceValueConfigsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchCreateResourceValueConfigsResponse");
         debug_struct.field("resource_value_configs", &self.resource_value_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31169,7 +31068,6 @@ impl std::fmt::Debug for BulkMuteFindingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("mute_state", &self.mute_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31421,7 +31319,6 @@ impl serde::ser::Serialize for BulkMuteFindingsResponse {
 impl std::fmt::Debug for BulkMuteFindingsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BulkMuteFindingsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31636,7 +31533,6 @@ impl std::fmt::Debug for CreateBigQueryExportRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("big_query_export", &self.big_query_export);
         debug_struct.field("big_query_export_id", &self.big_query_export_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31848,7 +31744,6 @@ impl std::fmt::Debug for CreateFindingRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("finding_id", &self.finding_id);
         debug_struct.field("finding", &self.finding);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32059,7 +31954,6 @@ impl std::fmt::Debug for CreateMuteConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("mute_config", &self.mute_config);
         debug_struct.field("mute_config_id", &self.mute_config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32272,7 +32166,6 @@ impl std::fmt::Debug for CreateNotificationConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("config_id", &self.config_id);
         debug_struct.field("notification_config", &self.notification_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32451,7 +32344,6 @@ impl std::fmt::Debug for CreateResourceValueConfigRequest {
         let mut debug_struct = f.debug_struct("CreateResourceValueConfigRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("resource_value_config", &self.resource_value_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32631,7 +32523,6 @@ impl std::fmt::Debug for CreateSourceRequest {
         let mut debug_struct = f.debug_struct("CreateSourceRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32780,7 +32671,6 @@ impl std::fmt::Debug for DeleteBigQueryExportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBigQueryExportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32933,7 +32823,6 @@ impl std::fmt::Debug for DeleteMuteConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteMuteConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33083,7 +32972,6 @@ impl std::fmt::Debug for DeleteNotificationConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteNotificationConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33225,7 +33113,6 @@ impl std::fmt::Debug for DeleteResourceValueConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteResourceValueConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33368,7 +33255,6 @@ impl std::fmt::Debug for BigQueryDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryDestination");
         debug_struct.field("dataset", &self.dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33597,7 +33483,6 @@ impl std::fmt::Debug for ExportFindingsMetadata {
         let mut debug_struct = f.debug_struct("ExportFindingsMetadata");
         debug_struct.field("export_start_time", &self.export_start_time);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33725,7 +33610,6 @@ impl serde::ser::Serialize for ExportFindingsResponse {
 impl std::fmt::Debug for ExportFindingsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportFindingsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33874,7 +33758,6 @@ impl std::fmt::Debug for GetBigQueryExportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBigQueryExportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34027,7 +33910,6 @@ impl std::fmt::Debug for GetMuteConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMuteConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34177,7 +34059,6 @@ impl std::fmt::Debug for GetNotificationConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNotificationConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34320,7 +34201,6 @@ impl std::fmt::Debug for GetResourceValueConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetResourceValueConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34463,7 +34343,6 @@ impl std::fmt::Debug for GetSourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34807,7 +34686,6 @@ impl std::fmt::Debug for GroupFindingsRequest {
         debug_struct.field("group_by", &self.group_by);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35040,7 +34918,6 @@ impl std::fmt::Debug for GroupFindingsResponse {
         debug_struct.field("group_by_results", &self.group_by_results);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35233,7 +35110,6 @@ impl std::fmt::Debug for GroupResult {
         let mut debug_struct = f.debug_struct("GroupResult");
         debug_struct.field("properties", &self.properties);
         debug_struct.field("count", &self.count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35483,7 +35359,6 @@ impl std::fmt::Debug for ListAttackPathsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35671,7 +35546,6 @@ impl std::fmt::Debug for ListAttackPathsResponse {
         let mut debug_struct = f.debug_struct("ListAttackPathsResponse");
         debug_struct.field("attack_paths", &self.attack_paths);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35819,7 +35693,6 @@ impl std::fmt::Debug for GetSimulationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSimulationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35964,7 +35837,6 @@ impl std::fmt::Debug for GetValuedResourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetValuedResourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36186,7 +36058,6 @@ impl std::fmt::Debug for ListBigQueryExportsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36377,7 +36248,6 @@ impl std::fmt::Debug for ListBigQueryExportsResponse {
         let mut debug_struct = f.debug_struct("ListBigQueryExportsResponse");
         debug_struct.field("big_query_exports", &self.big_query_exports);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36774,7 +36644,6 @@ impl std::fmt::Debug for ListFindingsRequest {
         debug_struct.field("field_mask", &self.field_mask);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37012,7 +36881,6 @@ impl std::fmt::Debug for ListFindingsResponse {
         debug_struct.field("list_findings_results", &self.list_findings_results);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37215,7 +37083,6 @@ pub mod list_findings_response {
             let mut debug_struct = f.debug_struct("ListFindingsResult");
             debug_struct.field("finding", &self.finding);
             debug_struct.field("resource", &self.resource);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37785,7 +37652,6 @@ pub mod list_findings_response {
                 debug_struct.field("resource_path", &self.resource_path);
                 debug_struct.field("resource_path_string", &self.resource_path_string);
                 debug_struct.field("cloud_provider_metadata", &self.cloud_provider_metadata);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -38031,7 +37897,6 @@ impl std::fmt::Debug for ListMuteConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38218,7 +38083,6 @@ impl std::fmt::Debug for ListMuteConfigsResponse {
         let mut debug_struct = f.debug_struct("ListMuteConfigsResponse");
         debug_struct.field("mute_configs", &self.mute_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38437,7 +38301,6 @@ impl std::fmt::Debug for ListNotificationConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38628,7 +38491,6 @@ impl std::fmt::Debug for ListNotificationConfigsResponse {
         let mut debug_struct = f.debug_struct("ListNotificationConfigsResponse");
         debug_struct.field("notification_configs", &self.notification_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38852,7 +38714,6 @@ impl std::fmt::Debug for ListResourceValueConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39043,7 +38904,6 @@ impl std::fmt::Debug for ListResourceValueConfigsResponse {
         let mut debug_struct = f.debug_struct("ListResourceValueConfigsResponse");
         debug_struct.field("resource_value_configs", &self.resource_value_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39260,7 +39120,6 @@ impl std::fmt::Debug for ListSourcesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39446,7 +39305,6 @@ impl std::fmt::Debug for ListSourcesResponse {
         let mut debug_struct = f.debug_struct("ListSourcesResponse");
         debug_struct.field("sources", &self.sources);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39737,7 +39595,6 @@ impl std::fmt::Debug for ListValuedResourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39972,7 +39829,6 @@ impl std::fmt::Debug for ListValuedResourcesResponse {
         debug_struct.field("valued_resources", &self.valued_resources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40155,7 +40011,6 @@ impl std::fmt::Debug for SetFindingStateRequest {
         let mut debug_struct = f.debug_struct("SetFindingStateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40338,7 +40193,6 @@ impl std::fmt::Debug for SetMuteRequest {
         let mut debug_struct = f.debug_struct("SetMuteRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("mute", &self.mute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40531,7 +40385,6 @@ impl std::fmt::Debug for UpdateBigQueryExportRequest {
         let mut debug_struct = f.debug_struct("UpdateBigQueryExportRequest");
         debug_struct.field("big_query_export", &self.big_query_export);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40725,7 +40578,6 @@ impl std::fmt::Debug for UpdateExternalSystemRequest {
         let mut debug_struct = f.debug_struct("UpdateExternalSystemRequest");
         debug_struct.field("external_system", &self.external_system);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40926,7 +40778,6 @@ impl std::fmt::Debug for UpdateFindingRequest {
         let mut debug_struct = f.debug_struct("UpdateFindingRequest");
         debug_struct.field("finding", &self.finding);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41118,7 +40969,6 @@ impl std::fmt::Debug for UpdateMuteConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateMuteConfigRequest");
         debug_struct.field("mute_config", &self.mute_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41311,7 +41161,6 @@ impl std::fmt::Debug for UpdateNotificationConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateNotificationConfigRequest");
         debug_struct.field("notification_config", &self.notification_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41507,7 +41356,6 @@ impl std::fmt::Debug for UpdateResourceValueConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateResourceValueConfigRequest");
         debug_struct.field("resource_value_config", &self.resource_value_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41702,7 +41550,6 @@ impl std::fmt::Debug for UpdateSecurityMarksRequest {
         let mut debug_struct = f.debug_struct("UpdateSecurityMarksRequest");
         debug_struct.field("security_marks", &self.security_marks);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41894,7 +41741,6 @@ impl std::fmt::Debug for UpdateSourceRequest {
         let mut debug_struct = f.debug_struct("UpdateSourceRequest");
         debug_struct.field("source", &self.source);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42147,7 +41993,6 @@ impl std::fmt::Debug for Simulation {
             &self.resource_value_configs_metadata,
         );
         debug_struct.field("cloud_provider", &self.cloud_provider);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42387,7 +42232,6 @@ impl std::fmt::Debug for Source {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("canonical_name", &self.canonical_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42586,7 +42430,6 @@ impl std::fmt::Debug for ToxicCombination {
         let mut debug_struct = f.debug_struct("ToxicCombination");
         debug_struct.field("attack_exposure_score", &self.attack_exposure_score);
         debug_struct.field("related_findings", &self.related_findings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42935,7 +42778,6 @@ impl std::fmt::Debug for ValuedResource {
             "resource_value_configs_used",
             &self.resource_value_configs_used,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43222,7 +43064,6 @@ impl std::fmt::Debug for ResourceValueConfigMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceValueConfigMetadata");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43403,7 +43244,6 @@ impl std::fmt::Debug for VertexAi {
         let mut debug_struct = f.debug_struct("VertexAi");
         debug_struct.field("datasets", &self.datasets);
         debug_struct.field("pipelines", &self.pipelines);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43609,7 +43449,6 @@ pub mod vertex_ai {
             debug_struct.field("name", &self.name);
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -43784,7 +43623,6 @@ pub mod vertex_ai {
             let mut debug_struct = f.debug_struct("Pipeline");
             debug_struct.field("name", &self.name);
             debug_struct.field("display_name", &self.display_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -44152,7 +43990,6 @@ impl std::fmt::Debug for Vulnerability {
         debug_struct.field("provider_risk_score", &self.provider_risk_score);
         debug_struct.field("reachable", &self.reachable);
         debug_struct.field("cwes", &self.cwes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44573,7 +44410,6 @@ impl std::fmt::Debug for Cve {
         debug_struct.field("zero_day", &self.zero_day);
         debug_struct.field("exploit_release_date", &self.exploit_release_date);
         debug_struct.field("first_exploitation_date", &self.first_exploitation_date);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45053,7 +44889,6 @@ impl std::fmt::Debug for Reference {
         let mut debug_struct = f.debug_struct("Reference");
         debug_struct.field("source", &self.source);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45449,7 +45284,6 @@ impl std::fmt::Debug for Cvssv3 {
         debug_struct.field("confidentiality_impact", &self.confidentiality_impact);
         debug_struct.field("integrity_impact", &self.integrity_impact);
         debug_struct.field("availability_impact", &self.availability_impact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46525,7 +46359,6 @@ impl std::fmt::Debug for Package {
         debug_struct.field("cpe_uri", &self.cpe_uri);
         debug_struct.field("package_type", &self.package_type);
         debug_struct.field("package_version", &self.package_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46739,7 +46572,6 @@ impl std::fmt::Debug for SecurityBulletin {
         debug_struct.field("bulletin_id", &self.bulletin_id);
         debug_struct.field("submission_time", &self.submission_time);
         debug_struct.field("suggested_upgrade_version", &self.suggested_upgrade_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46911,7 +46743,6 @@ impl std::fmt::Debug for Cwe {
         let mut debug_struct = f.debug_struct("Cwe");
         debug_struct.field("id", &self.id);
         debug_struct.field("references", &self.references);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -391,7 +391,6 @@ impl std::fmt::Debug for PolicyRule {
         let mut debug_struct = f.debug_struct("PolicyRule");
         debug_struct.field("condition", &self.condition);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -590,7 +589,6 @@ pub mod policy_rule {
             let mut debug_struct = f.debug_struct("StringValues");
             debug_struct.field("allowed_values", &self.allowed_values);
             debug_struct.field("denied_values", &self.denied_values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -982,7 +980,6 @@ impl std::fmt::Debug for CustomConstraint {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1441,7 +1438,6 @@ impl std::fmt::Debug for OrgPolicyConstraint {
         let mut debug_struct = f.debug_struct("OrgPolicyConstraint");
         debug_struct.field("canned_constraint_id", &self.canned_constraint_id);
         debug_struct.field("policy_rules", &self.policy_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1625,7 +1621,6 @@ impl std::fmt::Debug for OrgPolicyConstraintCustom {
         let mut debug_struct = f.debug_struct("OrgPolicyConstraintCustom");
         debug_struct.field("custom_constraint", &self.custom_constraint);
         debug_struct.field("policy_rules", &self.policy_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1978,7 +1973,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("error_message", &self.error_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2401,7 +2395,6 @@ impl std::fmt::Debug for Posture {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("reconciling", &self.reconciling);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2742,7 +2735,6 @@ impl std::fmt::Debug for PolicySet {
         debug_struct.field("policy_set_id", &self.policy_set_id);
         debug_struct.field("description", &self.description);
         debug_struct.field("policies", &self.policies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2980,7 +2972,6 @@ impl std::fmt::Debug for Policy {
         debug_struct.field("compliance_standards", &self.compliance_standards);
         debug_struct.field("constraint", &self.constraint);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3155,7 +3146,6 @@ pub mod policy {
             let mut debug_struct = f.debug_struct("ComplianceStandard");
             debug_struct.field("standard", &self.standard);
             debug_struct.field("control", &self.control);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3530,7 +3520,6 @@ impl std::fmt::Debug for Constraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Constraint");
         debug_struct.field("implementation", &self.implementation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3764,7 +3753,6 @@ impl std::fmt::Debug for ListPosturesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3977,7 +3965,6 @@ impl std::fmt::Debug for ListPosturesResponse {
         debug_struct.field("postures", &self.postures);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4190,7 +4177,6 @@ impl std::fmt::Debug for ListPostureRevisionsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4375,7 +4361,6 @@ impl std::fmt::Debug for ListPostureRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListPostureRevisionsResponse");
         debug_struct.field("revisions", &self.revisions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4543,7 +4528,6 @@ impl std::fmt::Debug for GetPostureRequest {
         let mut debug_struct = f.debug_struct("GetPostureRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4748,7 +4732,6 @@ impl std::fmt::Debug for CreatePostureRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("posture_id", &self.posture_id);
         debug_struct.field("posture", &self.posture);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4968,7 +4951,6 @@ impl std::fmt::Debug for UpdatePostureRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("posture", &self.posture);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5135,7 +5117,6 @@ impl std::fmt::Debug for DeletePostureRequest {
         let mut debug_struct = f.debug_struct("DeletePostureRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5336,7 +5317,6 @@ impl std::fmt::Debug for ExtractPostureRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("posture_id", &self.posture_id);
         debug_struct.field("workload", &self.workload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5890,7 +5870,6 @@ impl std::fmt::Debug for PostureDeployment {
             &self.desired_posture_revision_id,
         );
         debug_struct.field("failure_message", &self.failure_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6302,7 +6281,6 @@ impl std::fmt::Debug for ListPostureDeploymentsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6520,7 +6498,6 @@ impl std::fmt::Debug for ListPostureDeploymentsResponse {
         debug_struct.field("posture_deployments", &self.posture_deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6662,7 +6639,6 @@ impl std::fmt::Debug for GetPostureDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPostureDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6873,7 +6849,6 @@ impl std::fmt::Debug for CreatePostureDeploymentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("posture_deployment_id", &self.posture_deployment_id);
         debug_struct.field("posture_deployment", &self.posture_deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7069,7 +7044,6 @@ impl std::fmt::Debug for UpdatePostureDeploymentRequest {
         let mut debug_struct = f.debug_struct("UpdatePostureDeploymentRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("posture_deployment", &self.posture_deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7236,7 +7210,6 @@ impl std::fmt::Debug for DeletePostureDeploymentRequest {
         let mut debug_struct = f.debug_struct("DeletePostureDeploymentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7487,7 +7460,6 @@ impl std::fmt::Debug for PostureTemplate {
         debug_struct.field("description", &self.description);
         debug_struct.field("state", &self.state);
         debug_struct.field("policy_sets", &self.policy_sets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7865,7 +7837,6 @@ impl std::fmt::Debug for ListPostureTemplatesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8055,7 +8026,6 @@ impl std::fmt::Debug for ListPostureTemplatesResponse {
         let mut debug_struct = f.debug_struct("ListPostureTemplatesResponse");
         debug_struct.field("posture_templates", &self.posture_templates);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8224,7 +8194,6 @@ impl std::fmt::Debug for GetPostureTemplateRequest {
         let mut debug_struct = f.debug_struct("GetPostureTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8397,7 +8366,6 @@ impl std::fmt::Debug for SecurityHealthAnalyticsModule {
         let mut debug_struct = f.debug_struct("SecurityHealthAnalyticsModule");
         debug_struct.field("module_name", &self.module_name);
         debug_struct.field("module_enablement_state", &self.module_enablement_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8637,7 +8605,6 @@ impl std::fmt::Debug for SecurityHealthAnalyticsCustomModule {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("config", &self.config);
         debug_struct.field("module_enablement_state", &self.module_enablement_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8952,7 +8919,6 @@ impl std::fmt::Debug for CustomConfig {
         debug_struct.field("severity", &self.severity);
         debug_struct.field("description", &self.description);
         debug_struct.field("recommendation", &self.recommendation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9108,7 +9074,6 @@ pub mod custom_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CustomOutputSpec");
             debug_struct.field("properties", &self.properties);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9302,7 +9267,6 @@ pub mod custom_config {
                 let mut debug_struct = f.debug_struct("Property");
                 debug_struct.field("name", &self.name);
                 debug_struct.field("value_expression", &self.value_expression);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9452,7 +9416,6 @@ pub mod custom_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ResourceSelector");
             debug_struct.field("resource_types", &self.resource_types);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/servicedirectory/v1/src/model.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/model.rs
@@ -360,7 +360,6 @@ impl std::fmt::Debug for Endpoint {
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("network", &self.network);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -615,7 +614,6 @@ impl std::fmt::Debug for ResolveServiceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("max_endpoints", &self.max_endpoints);
         debug_struct.field("endpoint_filter", &self.endpoint_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -770,7 +768,6 @@ impl std::fmt::Debug for ResolveServiceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResolveServiceResponse");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -981,7 +978,6 @@ impl std::fmt::Debug for Namespace {
         debug_struct.field("name", &self.name);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1195,7 +1191,6 @@ impl std::fmt::Debug for CreateNamespaceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("namespace_id", &self.namespace_id);
         debug_struct.field("namespace", &self.namespace);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1499,7 +1494,6 @@ impl std::fmt::Debug for ListNamespacesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1688,7 +1682,6 @@ impl std::fmt::Debug for ListNamespacesResponse {
         let mut debug_struct = f.debug_struct("ListNamespacesResponse");
         debug_struct.field("namespaces", &self.namespaces);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1833,7 +1826,6 @@ impl std::fmt::Debug for GetNamespaceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNamespaceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2026,7 +2018,6 @@ impl std::fmt::Debug for UpdateNamespaceRequest {
         let mut debug_struct = f.debug_struct("UpdateNamespaceRequest");
         debug_struct.field("namespace", &self.namespace);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2171,7 +2162,6 @@ impl std::fmt::Debug for DeleteNamespaceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteNamespaceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2384,7 +2374,6 @@ impl std::fmt::Debug for CreateServiceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2691,7 +2680,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2880,7 +2868,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3027,7 +3014,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3220,7 +3206,6 @@ impl std::fmt::Debug for UpdateServiceRequest {
         let mut debug_struct = f.debug_struct("UpdateServiceRequest");
         debug_struct.field("service", &self.service);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3365,7 +3350,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3578,7 +3562,6 @@ impl std::fmt::Debug for CreateEndpointRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("endpoint_id", &self.endpoint_id);
         debug_struct.field("endpoint", &self.endpoint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3888,7 +3871,6 @@ impl std::fmt::Debug for ListEndpointsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4077,7 +4059,6 @@ impl std::fmt::Debug for ListEndpointsResponse {
         let mut debug_struct = f.debug_struct("ListEndpointsResponse");
         debug_struct.field("endpoints", &self.endpoints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4224,7 +4205,6 @@ impl std::fmt::Debug for GetEndpointRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEndpointRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4417,7 +4397,6 @@ impl std::fmt::Debug for UpdateEndpointRequest {
         let mut debug_struct = f.debug_struct("UpdateEndpointRequest");
         debug_struct.field("endpoint", &self.endpoint);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4562,7 +4541,6 @@ impl std::fmt::Debug for DeleteEndpointRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEndpointRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4825,7 +4803,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("endpoints", &self.endpoints);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -587,7 +587,6 @@ impl std::fmt::Debug for Event {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("next_update_time", &self.next_update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1879,7 +1878,6 @@ impl std::fmt::Debug for OrganizationEvent {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("next_update_time", &self.next_update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2709,7 +2707,6 @@ impl std::fmt::Debug for EventUpdate {
         debug_struct.field("description", &self.description);
         debug_struct.field("symptom", &self.symptom);
         debug_struct.field("workaround", &self.workaround);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2852,7 +2849,6 @@ impl std::fmt::Debug for Location {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Location");
         debug_struct.field("location_name", &self.location_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3020,7 +3016,6 @@ impl std::fmt::Debug for Product {
         let mut debug_struct = f.debug_struct("Product");
         debug_struct.field("product_name", &self.product_name);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3209,7 +3204,6 @@ impl std::fmt::Debug for EventImpact {
         let mut debug_struct = f.debug_struct("EventImpact");
         debug_struct.field("product", &self.product);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3462,7 +3456,6 @@ impl std::fmt::Debug for OrganizationImpact {
         debug_struct.field("events", &self.events);
         debug_struct.field("asset", &self.asset);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3634,7 +3627,6 @@ impl std::fmt::Debug for Asset {
         let mut debug_struct = f.debug_struct("Asset");
         debug_struct.field("asset_name", &self.asset_name);
         debug_struct.field("asset_type", &self.asset_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3926,7 +3918,6 @@ impl std::fmt::Debug for ListEventsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4143,7 +4134,6 @@ impl std::fmt::Debug for ListEventsResponse {
         debug_struct.field("events", &self.events);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4291,7 +4281,6 @@ impl std::fmt::Debug for GetEventRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEventRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4588,7 +4577,6 @@ impl std::fmt::Debug for ListOrganizationEventsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4810,7 +4798,6 @@ impl std::fmt::Debug for ListOrganizationEventsResponse {
         debug_struct.field("organization_events", &self.organization_events);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4960,7 +4947,6 @@ impl std::fmt::Debug for GetOrganizationEventRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrganizationEventRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5231,7 +5217,6 @@ impl std::fmt::Debug for ListOrganizationImpactsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5456,7 +5441,6 @@ impl std::fmt::Debug for ListOrganizationImpactsResponse {
         debug_struct.field("organization_impacts", &self.organization_impacts);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5606,7 +5590,6 @@ impl std::fmt::Debug for GetOrganizationImpactRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrganizationImpactRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/shell/v1/src/model.rs
+++ b/src/generated/cloud/shell/v1/src/model.rs
@@ -411,7 +411,6 @@ impl std::fmt::Debug for Environment {
         debug_struct.field("ssh_host", &self.ssh_host);
         debug_struct.field("ssh_port", &self.ssh_port);
         debug_struct.field("public_keys", &self.public_keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -713,7 +712,6 @@ impl std::fmt::Debug for GetEnvironmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEnvironmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -828,7 +826,6 @@ impl serde::ser::Serialize for CreateEnvironmentMetadata {
 impl std::fmt::Debug for CreateEnvironmentMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateEnvironmentMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -943,7 +940,6 @@ impl serde::ser::Serialize for DeleteEnvironmentMetadata {
 impl std::fmt::Debug for DeleteEnvironmentMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteEnvironmentMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1148,7 +1144,6 @@ impl std::fmt::Debug for StartEnvironmentRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("public_keys", &self.public_keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1385,7 +1380,6 @@ impl std::fmt::Debug for AuthorizeEnvironmentRequest {
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("id_token", &self.id_token);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1502,7 +1496,6 @@ impl serde::ser::Serialize for AuthorizeEnvironmentResponse {
 impl std::fmt::Debug for AuthorizeEnvironmentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AuthorizeEnvironmentResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1619,7 +1612,6 @@ impl serde::ser::Serialize for AuthorizeEnvironmentMetadata {
 impl std::fmt::Debug for AuthorizeEnvironmentMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AuthorizeEnvironmentMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1769,7 +1761,6 @@ impl std::fmt::Debug for StartEnvironmentMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartEnvironmentMetadata");
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2092,7 +2083,6 @@ impl std::fmt::Debug for StartEnvironmentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartEnvironmentResponse");
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2268,7 +2258,6 @@ impl std::fmt::Debug for AddPublicKeyRequest {
         let mut debug_struct = f.debug_struct("AddPublicKeyRequest");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2413,7 +2402,6 @@ impl std::fmt::Debug for AddPublicKeyResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddPublicKeyResponse");
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2530,7 +2518,6 @@ impl serde::ser::Serialize for AddPublicKeyMetadata {
 impl std::fmt::Debug for AddPublicKeyMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddPublicKeyMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2701,7 +2688,6 @@ impl std::fmt::Debug for RemovePublicKeyRequest {
         let mut debug_struct = f.debug_struct("RemovePublicKeyRequest");
         debug_struct.field("environment", &self.environment);
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2818,7 +2804,6 @@ impl serde::ser::Serialize for RemovePublicKeyResponse {
 impl std::fmt::Debug for RemovePublicKeyResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemovePublicKeyResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2935,7 +2920,6 @@ impl serde::ser::Serialize for RemovePublicKeyMetadata {
 impl std::fmt::Debug for RemovePublicKeyMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemovePublicKeyMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3085,7 +3069,6 @@ impl std::fmt::Debug for CloudShellErrorDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudShellErrorDetails");
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -265,7 +265,6 @@ impl std::fmt::Debug for CreateRecognizerRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("recognizer_id", &self.recognizer_id);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1559,7 +1558,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("progress_percent", &self.progress_percent);
         debug_struct.field("request", &self.request);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1860,7 +1858,6 @@ impl std::fmt::Debug for ListRecognizersRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2053,7 +2050,6 @@ impl std::fmt::Debug for ListRecognizersResponse {
         let mut debug_struct = f.debug_struct("ListRecognizersResponse");
         debug_struct.field("recognizers", &self.recognizers);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2199,7 +2195,6 @@ impl std::fmt::Debug for GetRecognizerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRecognizerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2423,7 +2418,6 @@ impl std::fmt::Debug for UpdateRecognizerRequest {
         debug_struct.field("recognizer", &self.recognizer);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2650,7 +2644,6 @@ impl std::fmt::Debug for DeleteRecognizerRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2851,7 +2844,6 @@ impl std::fmt::Debug for UndeleteRecognizerRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3517,7 +3509,6 @@ impl std::fmt::Debug for Recognizer {
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3795,7 +3786,6 @@ impl serde::ser::Serialize for AutoDetectDecodingConfig {
 impl std::fmt::Debug for AutoDetectDecodingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutoDetectDecodingConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4043,7 +4033,6 @@ impl std::fmt::Debug for ExplicitDecodingConfig {
         debug_struct.field("encoding", &self.encoding);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("audio_channel_count", &self.audio_channel_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4466,7 +4455,6 @@ impl std::fmt::Debug for SpeakerDiarizationConfig {
         let mut debug_struct = f.debug_struct("SpeakerDiarizationConfig");
         debug_struct.field("min_speaker_count", &self.min_speaker_count);
         debug_struct.field("max_speaker_count", &self.max_speaker_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4896,7 +4884,6 @@ impl std::fmt::Debug for RecognitionFeatures {
         debug_struct.field("multi_channel_mode", &self.multi_channel_mode);
         debug_struct.field("diarization_config", &self.diarization_config);
         debug_struct.field("max_alternatives", &self.max_alternatives);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5190,7 +5177,6 @@ impl std::fmt::Debug for TranscriptNormalization {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TranscriptNormalization");
         debug_struct.field("entries", &self.entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5391,7 +5377,6 @@ pub mod transcript_normalization {
             debug_struct.field("search", &self.search);
             debug_struct.field("replace", &self.replace);
             debug_struct.field("case_sensitive", &self.case_sensitive);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5536,7 +5521,6 @@ impl std::fmt::Debug for TranslationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TranslationConfig");
         debug_struct.field("target_language", &self.target_language);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5720,7 +5704,6 @@ impl std::fmt::Debug for SpeechAdaptation {
         let mut debug_struct = f.debug_struct("SpeechAdaptation");
         debug_struct.field("phrase_sets", &self.phrase_sets);
         debug_struct.field("custom_classes", &self.custom_classes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5973,7 +5956,6 @@ pub mod speech_adaptation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AdaptationPhraseSet");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6184,7 +6166,6 @@ impl std::fmt::Debug for DenoiserConfig {
         let mut debug_struct = f.debug_struct("DenoiserConfig");
         debug_struct.field("denoise_audio", &self.denoise_audio);
         debug_struct.field("snr_threshold", &self.snr_threshold);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6698,7 +6679,6 @@ impl std::fmt::Debug for RecognitionConfig {
         debug_struct.field("translation_config", &self.translation_config);
         debug_struct.field("denoiser_config", &self.denoiser_config);
         debug_struct.field("decoding_config", &self.decoding_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7095,7 +7075,6 @@ impl std::fmt::Debug for RecognizeRequest {
         debug_struct.field("config", &self.config);
         debug_struct.field("config_mask", &self.config_mask);
         debug_struct.field("audio_source", &self.audio_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7306,7 +7285,6 @@ impl std::fmt::Debug for RecognitionResponseMetadata {
         let mut debug_struct = f.debug_struct("RecognitionResponseMetadata");
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("total_billed_duration", &self.total_billed_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7533,7 +7511,6 @@ impl std::fmt::Debug for SpeechRecognitionAlternative {
         debug_struct.field("transcript", &self.transcript);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("words", &self.words);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7847,7 +7824,6 @@ impl std::fmt::Debug for WordInfo {
         debug_struct.field("word", &self.word);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("speaker_label", &self.speaker_label);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8111,7 +8087,6 @@ impl std::fmt::Debug for SpeechRecognitionResult {
         debug_struct.field("channel_tag", &self.channel_tag);
         debug_struct.field("result_end_offset", &self.result_end_offset);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8300,7 +8275,6 @@ impl std::fmt::Debug for RecognizeResponse {
         let mut debug_struct = f.debug_struct("RecognizeResponse");
         debug_struct.field("results", &self.results);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8523,7 +8497,6 @@ impl std::fmt::Debug for StreamingRecognitionFeatures {
         );
         debug_struct.field("interim_results", &self.interim_results);
         debug_struct.field("voice_activity_timeout", &self.voice_activity_timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8726,7 +8699,6 @@ pub mod streaming_recognition_features {
             let mut debug_struct = f.debug_struct("VoiceActivityTimeout");
             debug_struct.field("speech_start_timeout", &self.speech_start_timeout);
             debug_struct.field("speech_end_timeout", &self.speech_end_timeout);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8979,7 +8951,6 @@ impl std::fmt::Debug for StreamingRecognitionConfig {
         debug_struct.field("config", &self.config);
         debug_struct.field("config_mask", &self.config_mask);
         debug_struct.field("streaming_features", &self.streaming_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9291,7 +9262,6 @@ impl std::fmt::Debug for StreamingRecognizeRequest {
         let mut debug_struct = f.debug_struct("StreamingRecognizeRequest");
         debug_struct.field("recognizer", &self.recognizer);
         debug_struct.field("streaming_request", &self.streaming_request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9662,7 +9632,6 @@ impl std::fmt::Debug for BatchRecognizeRequest {
         debug_struct.field("files", &self.files);
         debug_struct.field("recognition_output_config", &self.recognition_output_config);
         debug_struct.field("processing_strategy", &self.processing_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9938,7 +9907,6 @@ impl std::fmt::Debug for GcsOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsOutputConfig");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10052,7 +10020,6 @@ impl serde::ser::Serialize for InlineOutputConfig {
 impl std::fmt::Debug for InlineOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InlineOutputConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10166,7 +10133,6 @@ impl serde::ser::Serialize for NativeOutputFileFormatConfig {
 impl std::fmt::Debug for NativeOutputFileFormatConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NativeOutputFileFormatConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10281,7 +10247,6 @@ impl serde::ser::Serialize for VttOutputFileFormatConfig {
 impl std::fmt::Debug for VttOutputFileFormatConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VttOutputFileFormatConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10397,7 +10362,6 @@ impl serde::ser::Serialize for SrtOutputFileFormatConfig {
 impl std::fmt::Debug for SrtOutputFileFormatConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SrtOutputFileFormatConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10626,7 +10590,6 @@ impl std::fmt::Debug for OutputFormatConfig {
         debug_struct.field("native", &self.native);
         debug_struct.field("vtt", &self.vtt);
         debug_struct.field("srt", &self.srt);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10911,7 +10874,6 @@ impl std::fmt::Debug for RecognitionOutputConfig {
         let mut debug_struct = f.debug_struct("RecognitionOutputConfig");
         debug_struct.field("output_format_config", &self.output_format_config);
         debug_struct.field("output", &self.output);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11130,7 +11092,6 @@ impl std::fmt::Debug for BatchRecognizeResponse {
         let mut debug_struct = f.debug_struct("BatchRecognizeResponse");
         debug_struct.field("results", &self.results);
         debug_struct.field("total_billed_duration", &self.total_billed_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11318,7 +11279,6 @@ impl std::fmt::Debug for BatchRecognizeResults {
         let mut debug_struct = f.debug_struct("BatchRecognizeResults");
         debug_struct.field("results", &self.results);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11514,7 +11474,6 @@ impl std::fmt::Debug for CloudStorageResult {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("vtt_format_uri", &self.vtt_format_uri);
         debug_struct.field("srt_format_uri", &self.srt_format_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11721,7 +11680,6 @@ impl std::fmt::Debug for InlineResult {
         debug_struct.field("transcript", &self.transcript);
         debug_struct.field("vtt_captions", &self.vtt_captions);
         debug_struct.field("srt_captions", &self.srt_captions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12103,7 +12061,6 @@ impl std::fmt::Debug for BatchRecognizeFileResult {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("transcript", &self.transcript);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12353,7 +12310,6 @@ impl std::fmt::Debug for BatchRecognizeTranscriptionMetadata {
         debug_struct.field("progress_percent", &self.progress_percent);
         debug_struct.field("error", &self.error);
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12513,7 +12469,6 @@ impl std::fmt::Debug for BatchRecognizeMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchRecognizeMetadata");
         debug_struct.field("transcription_metadata", &self.transcription_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12798,7 +12753,6 @@ impl std::fmt::Debug for BatchRecognizeFileMetadata {
         debug_struct.field("config", &self.config);
         debug_struct.field("config_mask", &self.config_mask);
         debug_struct.field("audio_source", &self.audio_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13160,7 +13114,6 @@ impl std::fmt::Debug for StreamingRecognitionResult {
         debug_struct.field("result_end_offset", &self.result_end_offset);
         debug_struct.field("channel_tag", &self.channel_tag);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13472,7 +13425,6 @@ impl std::fmt::Debug for StreamingRecognizeResponse {
         debug_struct.field("speech_event_type", &self.speech_event_type);
         debug_struct.field("speech_event_offset", &self.speech_event_offset);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13844,7 +13796,6 @@ impl std::fmt::Debug for Config {
         debug_struct.field("name", &self.name);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13991,7 +13942,6 @@ impl std::fmt::Debug for GetConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14187,7 +14137,6 @@ impl std::fmt::Debug for UpdateConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateConfigRequest");
         debug_struct.field("config", &self.config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14743,7 +14692,6 @@ impl std::fmt::Debug for CustomClass {
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14893,7 +14841,6 @@ pub mod custom_class {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ClassItem");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15633,7 +15580,6 @@ impl std::fmt::Debug for PhraseSet {
         debug_struct.field("reconciling", &self.reconciling);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15842,7 +15788,6 @@ pub mod phrase_set {
             let mut debug_struct = f.debug_struct("Phrase");
             debug_struct.field("value", &self.value);
             debug_struct.field("boost", &self.boost);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16216,7 +16161,6 @@ impl std::fmt::Debug for CreateCustomClassRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("custom_class_id", &self.custom_class_id);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16469,7 +16413,6 @@ impl std::fmt::Debug for ListCustomClassesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16663,7 +16606,6 @@ impl std::fmt::Debug for ListCustomClassesResponse {
         let mut debug_struct = f.debug_struct("ListCustomClassesResponse");
         debug_struct.field("custom_classes", &self.custom_classes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16809,7 +16751,6 @@ impl std::fmt::Debug for GetCustomClassRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCustomClassRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17035,7 +16976,6 @@ impl std::fmt::Debug for UpdateCustomClassRequest {
         debug_struct.field("custom_class", &self.custom_class);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17263,7 +17203,6 @@ impl std::fmt::Debug for DeleteCustomClassRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17465,7 +17404,6 @@ impl std::fmt::Debug for UndeleteCustomClassRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17705,7 +17643,6 @@ impl std::fmt::Debug for CreatePhraseSetRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("phrase_set_id", &self.phrase_set_id);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17957,7 +17894,6 @@ impl std::fmt::Debug for ListPhraseSetsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18151,7 +18087,6 @@ impl std::fmt::Debug for ListPhraseSetsResponse {
         let mut debug_struct = f.debug_struct("ListPhraseSetsResponse");
         debug_struct.field("phrase_sets", &self.phrase_sets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18297,7 +18232,6 @@ impl std::fmt::Debug for GetPhraseSetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPhraseSetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18522,7 +18456,6 @@ impl std::fmt::Debug for UpdatePhraseSetRequest {
         debug_struct.field("phrase_set", &self.phrase_set);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18749,7 +18682,6 @@ impl std::fmt::Debug for DeletePhraseSetRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18950,7 +18882,6 @@ impl std::fmt::Debug for UndeletePhraseSetRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19119,7 +19050,6 @@ impl std::fmt::Debug for ModelFeature {
         let mut debug_struct = f.debug_struct("ModelFeature");
         debug_struct.field("feature", &self.feature);
         debug_struct.field("release_state", &self.release_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19265,7 +19195,6 @@ impl std::fmt::Debug for ModelFeatures {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ModelFeatures");
         debug_struct.field("model_feature", &self.model_feature);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19420,7 +19349,6 @@ impl std::fmt::Debug for ModelMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ModelMetadata");
         debug_struct.field("model_features", &self.model_features);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19574,7 +19502,6 @@ impl std::fmt::Debug for LanguageMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LanguageMetadata");
         debug_struct.field("models", &self.models);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19725,7 +19652,6 @@ impl std::fmt::Debug for AccessMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccessMetadata");
         debug_struct.field("constraint_type", &self.constraint_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20055,7 +19981,6 @@ impl std::fmt::Debug for LocationsMetadata {
         let mut debug_struct = f.debug_struct("LocationsMetadata");
         debug_struct.field("languages", &self.languages);
         debug_struct.field("access_metadata", &self.access_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -234,7 +234,6 @@ impl std::fmt::Debug for SqlBackupRunsDeleteRequest {
         debug_struct.field("id", &self.id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -444,7 +443,6 @@ impl std::fmt::Debug for SqlBackupRunsGetRequest {
         debug_struct.field("id", &self.id);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -646,7 +644,6 @@ impl std::fmt::Debug for SqlBackupRunsInsertRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -885,7 +882,6 @@ impl std::fmt::Debug for SqlBackupRunsListRequest {
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1622,7 +1618,6 @@ impl std::fmt::Debug for BackupRun {
         debug_struct.field("backup_kind", &self.backup_kind);
         debug_struct.field("time_zone", &self.time_zone);
         debug_struct.field("max_chargeable_bytes", &self.max_chargeable_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1833,7 +1828,6 @@ impl std::fmt::Debug for BackupRunsListResponse {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2038,7 +2032,6 @@ impl std::fmt::Debug for GetConnectSettingsRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("read_time", &self.read_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2420,7 +2413,6 @@ impl std::fmt::Debug for ConnectSettings {
         debug_struct.field("psc_enabled", &self.psc_enabled);
         debug_struct.field("dns_name", &self.dns_name);
         debug_struct.field("server_ca_mode", &self.server_ca_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2853,7 +2845,6 @@ impl std::fmt::Debug for GenerateEphemeralCertRequest {
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("read_time", &self.read_time);
         debug_struct.field("valid_duration", &self.valid_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3007,7 +2998,6 @@ impl std::fmt::Debug for GenerateEphemeralCertResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateEphemeralCertResponse");
         debug_struct.field("ephemeral_cert", &self.ephemeral_cert);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3199,7 +3189,6 @@ impl std::fmt::Debug for SqlDatabasesDeleteRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3391,7 +3380,6 @@ impl std::fmt::Debug for SqlDatabasesGetRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3593,7 +3581,6 @@ impl std::fmt::Debug for SqlDatabasesInsertRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3760,7 +3747,6 @@ impl std::fmt::Debug for SqlDatabasesListRequest {
         let mut debug_struct = f.debug_struct("SqlDatabasesListRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3987,7 +3973,6 @@ impl std::fmt::Debug for SqlDatabasesUpdateRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4157,7 +4142,6 @@ impl std::fmt::Debug for DatabasesListResponse {
         let mut debug_struct = f.debug_struct("DatabasesListResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4304,7 +4288,6 @@ impl std::fmt::Debug for SqlFlagsListRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlFlagsListRequest");
         debug_struct.field("database_version", &self.database_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4474,7 +4457,6 @@ impl std::fmt::Debug for FlagsListResponse {
         let mut debug_struct = f.debug_struct("FlagsListResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4987,7 +4969,6 @@ impl std::fmt::Debug for Flag {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("in_beta", &self.in_beta);
         debug_struct.field("allowed_int_values", &self.allowed_int_values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5154,7 +5135,6 @@ impl std::fmt::Debug for SqlInstancesAddServerCaRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesAddServerCaRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5357,7 +5337,6 @@ impl std::fmt::Debug for SqlInstancesCloneRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5524,7 +5503,6 @@ impl std::fmt::Debug for SqlInstancesDeleteRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesDeleteRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5726,7 +5704,6 @@ impl std::fmt::Debug for SqlInstancesDemoteMasterRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5929,7 +5906,6 @@ impl std::fmt::Debug for SqlInstancesDemoteRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6131,7 +6107,6 @@ impl std::fmt::Debug for SqlInstancesExportRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6333,7 +6308,6 @@ impl std::fmt::Debug for SqlInstancesFailoverRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6500,7 +6474,6 @@ impl std::fmt::Debug for SqlInstancesGetRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesGetRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6702,7 +6675,6 @@ impl std::fmt::Debug for SqlInstancesImportRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6881,7 +6853,6 @@ impl std::fmt::Debug for SqlInstancesInsertRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesInsertRequest");
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7130,7 +7101,6 @@ impl std::fmt::Debug for SqlInstancesListRequest {
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7297,7 +7267,6 @@ impl std::fmt::Debug for SqlInstancesListServerCasRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesListServerCasRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7500,7 +7469,6 @@ impl std::fmt::Debug for SqlInstancesPatchRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7698,7 +7666,6 @@ impl std::fmt::Debug for SqlInstancesPromoteReplicaRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("failover", &self.failover);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7904,7 +7871,6 @@ impl std::fmt::Debug for SqlInstancesSwitchoverRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("db_timeout", &self.db_timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8071,7 +8037,6 @@ impl std::fmt::Debug for SqlInstancesResetSslConfigRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesResetSslConfigRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8238,7 +8203,6 @@ impl std::fmt::Debug for SqlInstancesRestartRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesRestartRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8442,7 +8406,6 @@ impl std::fmt::Debug for SqlInstancesRestoreBackupRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8646,7 +8609,6 @@ impl std::fmt::Debug for SqlInstancesRotateServerCaRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8813,7 +8775,6 @@ impl std::fmt::Debug for SqlInstancesStartReplicaRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesStartReplicaRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8980,7 +8941,6 @@ impl std::fmt::Debug for SqlInstancesStopReplicaRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesStopReplicaRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9182,7 +9142,6 @@ impl std::fmt::Debug for SqlInstancesTruncateLogRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9385,7 +9344,6 @@ impl std::fmt::Debug for SqlInstancesPerformDiskShrinkRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9588,7 +9546,6 @@ impl std::fmt::Debug for SqlInstancesUpdateRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9792,7 +9749,6 @@ impl std::fmt::Debug for SqlInstancesRescheduleMaintenanceRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9995,7 +9951,6 @@ impl std::fmt::Debug for SqlInstancesReencryptRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10156,7 +10111,6 @@ impl std::fmt::Debug for InstancesReencryptRequest {
             "backup_reencryption_config",
             &self.backup_reencryption_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10369,7 +10323,6 @@ impl std::fmt::Debug for BackupReencryptionConfig {
         let mut debug_struct = f.debug_struct("BackupReencryptionConfig");
         debug_struct.field("backup_limit", &self.backup_limit);
         debug_struct.field("backup_type", &self.backup_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10675,7 +10628,6 @@ impl std::fmt::Debug for SqlInstancesGetDiskShrinkConfigRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesGetDiskShrinkConfigRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11070,7 +11022,6 @@ impl std::fmt::Debug for SqlInstancesVerifyExternalSyncSettingsRequest {
         debug_struct.field("migration_type", &self.migration_type);
         debug_struct.field("sync_parallel_level", &self.sync_parallel_level);
         debug_struct.field("sync_config", &self.sync_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11714,7 +11665,6 @@ impl std::fmt::Debug for SqlInstancesStartExternalSyncRequest {
         debug_struct.field("sync_parallel_level", &self.sync_parallel_level);
         debug_struct.field("migration_type", &self.migration_type);
         debug_struct.field("sync_config", &self.sync_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11894,7 +11844,6 @@ impl std::fmt::Debug for SqlInstancesResetReplicaSizeRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesResetReplicaSizeRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12099,7 +12048,6 @@ impl std::fmt::Debug for SqlInstancesCreateEphemeralCertRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12253,7 +12201,6 @@ impl std::fmt::Debug for InstancesCloneRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesCloneRequest");
         debug_struct.field("clone_context", &self.clone_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12407,7 +12354,6 @@ impl std::fmt::Debug for InstancesDemoteMasterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesDemoteMasterRequest");
         debug_struct.field("demote_master_context", &self.demote_master_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12562,7 +12508,6 @@ impl std::fmt::Debug for InstancesDemoteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesDemoteRequest");
         debug_struct.field("demote_context", &self.demote_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12716,7 +12661,6 @@ impl std::fmt::Debug for InstancesExportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesExportRequest");
         debug_struct.field("export_context", &self.export_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12871,7 +12815,6 @@ impl std::fmt::Debug for InstancesFailoverRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesFailoverRequest");
         debug_struct.field("failover_context", &self.failover_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13038,7 +12981,6 @@ impl std::fmt::Debug for SslCertsCreateEphemeralRequest {
         let mut debug_struct = f.debug_struct("SslCertsCreateEphemeralRequest");
         debug_struct.field("public_key", &self.public_key);
         debug_struct.field("access_token", &self.access_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13192,7 +13134,6 @@ impl std::fmt::Debug for InstancesImportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesImportRequest");
         debug_struct.field("import_context", &self.import_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13435,7 +13376,6 @@ impl std::fmt::Debug for InstancesListResponse {
         debug_struct.field("warnings", &self.warnings);
         debug_struct.field("items", &self.items);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13630,7 +13570,6 @@ impl std::fmt::Debug for InstancesListServerCasResponse {
         debug_struct.field("certs", &self.certs);
         debug_struct.field("active_version", &self.active_version);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13784,7 +13723,6 @@ impl std::fmt::Debug for InstancesRestoreBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesRestoreBackupRequest");
         debug_struct.field("restore_backup_context", &self.restore_backup_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13940,7 +13878,6 @@ impl std::fmt::Debug for InstancesRotateServerCaRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesRotateServerCaRequest");
         debug_struct.field("rotate_server_ca_context", &self.rotate_server_ca_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14094,7 +14031,6 @@ impl std::fmt::Debug for InstancesTruncateLogRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstancesTruncateLogRequest");
         debug_struct.field("truncate_log_context", &self.truncate_log_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14255,7 +14191,6 @@ impl std::fmt::Debug for InstancesAcquireSsrsLeaseRequest {
             "acquire_ssrs_lease_context",
             &self.acquire_ssrs_lease_context,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14463,7 +14398,6 @@ impl std::fmt::Debug for SqlInstancesVerifyExternalSyncSettingsResponse {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("warnings", &self.warnings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14676,7 +14610,6 @@ impl std::fmt::Debug for SqlInstancesGetDiskShrinkConfigResponse {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("minimal_target_size_gb", &self.minimal_target_size_gb);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14844,7 +14777,6 @@ impl std::fmt::Debug for SqlInstancesGetLatestRecoveryTimeRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesGetLatestRecoveryTimeRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15024,7 +14956,6 @@ impl std::fmt::Debug for SqlInstancesGetLatestRecoveryTimeResponse {
         let mut debug_struct = f.debug_struct("SqlInstancesGetLatestRecoveryTimeResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("latest_recovery_time", &self.latest_recovery_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15426,7 +15357,6 @@ impl std::fmt::Debug for CloneContext {
         debug_struct.field("allocated_ip_range", &self.allocated_ip_range);
         debug_struct.field("database_names", &self.database_names);
         debug_struct.field("preferred_zone", &self.preferred_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15642,7 +15572,6 @@ impl std::fmt::Debug for BinLogCoordinates {
         debug_struct.field("bin_log_file_name", &self.bin_log_file_name);
         debug_struct.field("bin_log_position", &self.bin_log_position);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17433,7 +17362,6 @@ impl std::fmt::Debug for DatabaseInstance {
             "switch_transaction_logs_to_cloud_storage_enabled",
             &self.switch_transaction_logs_to_cloud_storage_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17622,7 +17550,6 @@ pub mod database_instance {
             let mut debug_struct = f.debug_struct("SqlFailoverReplica");
             debug_struct.field("name", &self.name);
             debug_struct.field("available", &self.available);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17871,7 +17798,6 @@ pub mod database_instance {
             debug_struct.field("can_defer", &self.can_defer);
             debug_struct.field("can_reschedule", &self.can_reschedule);
             debug_struct.field("schedule_deadline_time", &self.schedule_deadline_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18119,7 +18045,6 @@ pub mod database_instance {
                 "sql_min_recommended_increase_size_gb",
                 &self.sql_min_recommended_increase_size_gb,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18923,7 +18848,6 @@ impl std::fmt::Debug for GeminiInstanceConfig {
         debug_struct.field("active_query_enabled", &self.active_query_enabled);
         debug_struct.field("index_advisor_enabled", &self.index_advisor_enabled);
         debug_struct.field("flag_recommender_enabled", &self.flag_recommender_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19141,7 +19065,6 @@ impl std::fmt::Debug for ReplicationCluster {
         debug_struct.field("psa_write_endpoint", &self.psa_write_endpoint);
         debug_struct.field("failover_dr_replica_name", &self.failover_dr_replica_name);
         debug_struct.field("dr_replica", &self.dr_replica);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19369,7 +19292,6 @@ impl std::fmt::Debug for AvailableDatabaseVersion {
         debug_struct.field("major_version", &self.major_version);
         debug_struct.field("name", &self.name);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19530,7 +19452,6 @@ impl std::fmt::Debug for SqlInstancesRescheduleMaintenanceRequestBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlInstancesRescheduleMaintenanceRequestBody");
         debug_struct.field("reschedule", &self.reschedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19726,7 +19647,6 @@ pub mod sql_instances_reschedule_maintenance_request_body {
             let mut debug_struct = f.debug_struct("Reschedule");
             debug_struct.field("reschedule_type", &self.reschedule_type);
             debug_struct.field("schedule_time", &self.schedule_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20144,7 +20064,6 @@ impl std::fmt::Debug for DemoteMasterContext {
         debug_struct.field("master_instance_name", &self.master_instance_name);
         debug_struct.field("replica_configuration", &self.replica_configuration);
         debug_struct.field("skip_replication_setup", &self.skip_replication_setup);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20327,7 +20246,6 @@ impl std::fmt::Debug for DemoteContext {
             "source_representative_instance_name",
             &self.source_representative_instance_name,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20515,7 +20433,6 @@ impl std::fmt::Debug for FailoverContext {
         let mut debug_struct = f.debug_struct("FailoverContext");
         debug_struct.field("settings_version", &self.settings_version);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20754,7 +20671,6 @@ impl std::fmt::Debug for RestoreBackupContext {
         debug_struct.field("backup_run_id", &self.backup_run_id);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20923,7 +20839,6 @@ impl std::fmt::Debug for RotateServerCaContext {
         let mut debug_struct = f.debug_struct("RotateServerCaContext");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("next_version", &self.next_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21092,7 +21007,6 @@ impl std::fmt::Debug for TruncateLogContext {
         let mut debug_struct = f.debug_struct("TruncateLogContext");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("log_type", &self.log_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21290,7 +21204,6 @@ impl std::fmt::Debug for SqlExternalSyncSettingError {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22200,7 +22113,6 @@ impl std::fmt::Debug for OnPremisesConfiguration {
         debug_struct.field("client_key", &self.client_key);
         debug_struct.field("dump_file_path", &self.dump_file_path);
         debug_struct.field("source_instance", &self.source_instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22474,7 +22386,6 @@ impl std::fmt::Debug for ReplicaConfiguration {
         );
         debug_struct.field("failover_target", &self.failover_target);
         debug_struct.field("cascadable_replica", &self.cascadable_replica);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22682,7 +22593,6 @@ impl std::fmt::Debug for SqlInstancesAcquireSsrsLeaseRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22825,7 +22735,6 @@ impl std::fmt::Debug for SqlInstancesAcquireSsrsLeaseResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlInstancesAcquireSsrsLeaseResponse");
         debug_struct.field("operation_id", &self.operation_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22995,7 +22904,6 @@ impl std::fmt::Debug for SqlInstancesReleaseSsrsLeaseRequest {
         let mut debug_struct = f.debug_struct("SqlInstancesReleaseSsrsLeaseRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23138,7 +23046,6 @@ impl std::fmt::Debug for SqlInstancesReleaseSsrsLeaseResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlInstancesReleaseSsrsLeaseResponse");
         debug_struct.field("operation_id", &self.operation_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23305,7 +23212,6 @@ impl std::fmt::Debug for SqlOperationsGetRequest {
         let mut debug_struct = f.debug_struct("SqlOperationsGetRequest");
         debug_struct.field("operation", &self.operation);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23543,7 +23449,6 @@ impl std::fmt::Debug for SqlOperationsListRequest {
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23754,7 +23659,6 @@ impl std::fmt::Debug for OperationsListResponse {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23921,7 +23825,6 @@ impl std::fmt::Debug for SqlOperationsCancelRequest {
         let mut debug_struct = f.debug_struct("SqlOperationsCancelRequest");
         debug_struct.field("operation", &self.operation);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24152,7 +24055,6 @@ impl std::fmt::Debug for AclEntry {
         debug_struct.field("expiration_time", &self.expiration_time);
         debug_struct.field("name", &self.name);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24349,7 +24251,6 @@ impl std::fmt::Debug for ApiWarning {
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24719,7 +24620,6 @@ impl std::fmt::Debug for BackupRetentionSettings {
         let mut debug_struct = f.debug_struct("BackupRetentionSettings");
         debug_struct.field("retention_unit", &self.retention_unit);
         debug_struct.field("retained_backups", &self.retained_backups);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25386,7 +25286,6 @@ impl std::fmt::Debug for BackupConfiguration {
             "transactional_log_storage_state",
             &self.transactional_log_storage_state,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25715,7 +25614,6 @@ impl std::fmt::Debug for PerformDiskShrinkContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PerformDiskShrinkContext");
         debug_struct.field("target_size_gb", &self.target_size_gb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25901,7 +25799,6 @@ impl std::fmt::Debug for BackupContext {
         let mut debug_struct = f.debug_struct("BackupContext");
         debug_struct.field("backup_id", &self.backup_id);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26301,7 +26198,6 @@ impl std::fmt::Debug for Database {
         debug_struct.field("self_link", &self.self_link);
         debug_struct.field("project", &self.project);
         debug_struct.field("database_details", &self.database_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26501,7 +26397,6 @@ impl std::fmt::Debug for SqlServerDatabaseDetails {
         let mut debug_struct = f.debug_struct("SqlServerDatabaseDetails");
         debug_struct.field("compatibility_level", &self.compatibility_level);
         debug_struct.field("recovery_model", &self.recovery_model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26674,7 +26569,6 @@ impl std::fmt::Debug for DatabaseFlags {
         let mut debug_struct = f.debug_struct("DatabaseFlags");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26820,7 +26714,6 @@ impl std::fmt::Debug for MySqlSyncConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MySqlSyncConfig");
         debug_struct.field("initial_sync_flags", &self.initial_sync_flags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26989,7 +26882,6 @@ impl std::fmt::Debug for SyncFlags {
         let mut debug_struct = f.debug_struct("SyncFlags");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27183,7 +27075,6 @@ impl std::fmt::Debug for InstanceReference {
         debug_struct.field("name", &self.name);
         debug_struct.field("region", &self.region);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27381,7 +27272,6 @@ impl std::fmt::Debug for DemoteMasterConfiguration {
             "mysql_replica_configuration",
             &self.mysql_replica_configuration,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27657,7 +27547,6 @@ impl std::fmt::Debug for DemoteMasterMySqlReplicaConfiguration {
         debug_struct.field("client_key", &self.client_key);
         debug_struct.field("client_certificate", &self.client_certificate);
         debug_struct.field("ca_certificate", &self.ca_certificate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28044,7 +27933,6 @@ impl std::fmt::Debug for ExportContext {
         debug_struct.field("file_type", &self.file_type);
         debug_struct.field("offload", &self.offload);
         debug_struct.field("bak_export_options", &self.bak_export_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28316,7 +28204,6 @@ pub mod export_context {
             debug_struct.field("quote_character", &self.quote_character);
             debug_struct.field("fields_terminated_by", &self.fields_terminated_by);
             debug_struct.field("lines_terminated_by", &self.lines_terminated_by);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28684,7 +28571,6 @@ pub mod export_context {
             debug_struct.field("threads", &self.threads);
             debug_struct.field("parallel", &self.parallel);
             debug_struct.field("postgres_export_options", &self.postgres_export_options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28880,7 +28766,6 @@ pub mod export_context {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("MysqlExportOptions");
                 debug_struct.field("master_data", &self.master_data);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29081,7 +28966,6 @@ pub mod export_context {
                 let mut debug_struct = f.debug_struct("PostgresExportOptions");
                 debug_struct.field("clean", &self.clean);
                 debug_struct.field("if_exists", &self.if_exists);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -29402,7 +29286,6 @@ pub mod export_context {
             debug_struct.field("bak_type", &self.bak_type);
             debug_struct.field("copy_only", &self.copy_only);
             debug_struct.field("differential_base", &self.differential_base);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29768,7 +29651,6 @@ impl std::fmt::Debug for ImportContext {
         debug_struct.field("import_user", &self.import_user);
         debug_struct.field("bak_import_options", &self.bak_import_options);
         debug_struct.field("sql_import_options", &self.sql_import_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30032,7 +29914,6 @@ pub mod import_context {
             debug_struct.field("threads", &self.threads);
             debug_struct.field("parallel", &self.parallel);
             debug_struct.field("postgres_import_options", &self.postgres_import_options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30236,7 +30117,6 @@ pub mod import_context {
                 let mut debug_struct = f.debug_struct("PostgresImportOptions");
                 debug_struct.field("clean", &self.clean);
                 debug_struct.field("if_exists", &self.if_exists);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -30529,7 +30409,6 @@ pub mod import_context {
             debug_struct.field("quote_character", &self.quote_character);
             debug_struct.field("fields_terminated_by", &self.fields_terminated_by);
             debug_struct.field("lines_terminated_by", &self.lines_terminated_by);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30903,7 +30782,6 @@ pub mod import_context {
             debug_struct.field("bak_type", &self.bak_type);
             debug_struct.field("stop_at", &self.stop_at);
             debug_struct.field("stop_at_mark", &self.stop_at_mark);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31127,7 +31005,6 @@ pub mod import_context {
                 debug_struct.field("cert_path", &self.cert_path);
                 debug_struct.field("pvk_path", &self.pvk_path);
                 debug_struct.field("pvk_password", &self.pvk_password);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -31597,7 +31474,6 @@ impl std::fmt::Debug for IpConfiguration {
         debug_struct.field("ssl_mode", &self.ssl_mode);
         debug_struct.field("psc_config", &self.psc_config);
         debug_struct.field("server_ca_mode", &self.server_ca_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32095,7 +31971,6 @@ impl std::fmt::Debug for PscConfig {
         let mut debug_struct = f.debug_struct("PscConfig");
         debug_struct.field("psc_enabled", &self.psc_enabled);
         debug_struct.field("allowed_consumer_projects", &self.allowed_consumer_projects);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32326,7 +32201,6 @@ impl std::fmt::Debug for LocationPreference {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("secondary_zone", &self.secondary_zone);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32616,7 +32490,6 @@ impl std::fmt::Debug for MaintenanceWindow {
         debug_struct.field("day", &self.day);
         debug_struct.field("update_track", &self.update_track);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32818,7 +32691,6 @@ impl std::fmt::Debug for DenyMaintenancePeriod {
         debug_struct.field("start_date", &self.start_date);
         debug_struct.field("end_date", &self.end_date);
         debug_struct.field("time", &self.time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33135,7 +33007,6 @@ impl std::fmt::Debug for InsightsConfig {
         debug_struct.field("record_application_tags", &self.record_application_tags);
         debug_struct.field("query_string_length", &self.query_string_length);
         debug_struct.field("query_plans_per_minute", &self.query_plans_per_minute);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33630,7 +33501,6 @@ impl std::fmt::Debug for MySqlReplicaConfiguration {
         debug_struct.field("ssl_cipher", &self.ssl_cipher);
         debug_struct.field("verify_server_certificate", &self.verify_server_certificate);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33798,7 +33668,6 @@ impl std::fmt::Debug for DiskEncryptionConfiguration {
         let mut debug_struct = f.debug_struct("DiskEncryptionConfiguration");
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33969,7 +33838,6 @@ impl std::fmt::Debug for DiskEncryptionStatus {
         let mut debug_struct = f.debug_struct("DiskEncryptionStatus");
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34181,7 +34049,6 @@ impl std::fmt::Debug for IpMapping {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("ip_address", &self.ip_address);
         debug_struct.field("time_to_retire", &self.time_to_retire);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34897,7 +34764,6 @@ impl std::fmt::Debug for Operation {
             "acquire_ssrs_lease_context",
             &self.acquire_ssrs_lease_context,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35688,7 +35554,6 @@ impl std::fmt::Debug for OperationError {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35862,7 +35727,6 @@ impl std::fmt::Debug for OperationErrors {
         let mut debug_struct = f.debug_struct("OperationErrors");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36305,7 +36169,6 @@ impl std::fmt::Debug for PasswordValidationPolicy {
             "disallow_compromised_credentials",
             &self.disallow_compromised_credentials,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36580,7 +36443,6 @@ impl std::fmt::Debug for DataCacheConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataCacheConfig");
         debug_struct.field("data_cache_enabled", &self.data_cache_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38042,7 +37904,6 @@ impl std::fmt::Debug for Settings {
             "enable_dataplex_integration",
             &self.enable_dataplex_integration,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38616,7 +38477,6 @@ impl std::fmt::Debug for AdvancedMachineFeatures {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdvancedMachineFeatures");
         debug_struct.field("threads_per_core", &self.threads_per_core);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38996,7 +38856,6 @@ impl std::fmt::Debug for SslCert {
         debug_struct.field("sha1_fingerprint", &self.sha1_fingerprint);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("self_link", &self.self_link);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39180,7 +39039,6 @@ impl std::fmt::Debug for SslCertDetail {
         let mut debug_struct = f.debug_struct("SslCertDetail");
         debug_struct.field("cert_info", &self.cert_info);
         debug_struct.field("cert_private_key", &self.cert_private_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39347,7 +39205,6 @@ impl std::fmt::Debug for SqlActiveDirectoryConfig {
         let mut debug_struct = f.debug_struct("SqlActiveDirectoryConfig");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("domain", &self.domain);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39588,7 +39445,6 @@ impl std::fmt::Debug for SqlServerAuditConfig {
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("retention_interval", &self.retention_interval);
         debug_struct.field("upload_interval", &self.upload_interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39854,7 +39710,6 @@ impl std::fmt::Debug for AcquireSsrsLeaseContext {
         debug_struct.field("service_login", &self.service_login);
         debug_struct.field("report_database", &self.report_database);
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40049,7 +39904,6 @@ impl std::fmt::Debug for SqlSslCertsDeleteRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("sha1_fingerprint", &self.sha1_fingerprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40244,7 +40098,6 @@ impl std::fmt::Debug for SqlSslCertsGetRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("sha1_fingerprint", &self.sha1_fingerprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40445,7 +40298,6 @@ impl std::fmt::Debug for SqlSslCertsInsertRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40611,7 +40463,6 @@ impl std::fmt::Debug for SqlSslCertsListRequest {
         let mut debug_struct = f.debug_struct("SqlSslCertsListRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40755,7 +40606,6 @@ impl std::fmt::Debug for SslCertsInsertRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SslCertsInsertRequest");
         debug_struct.field("common_name", &self.common_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41009,7 +40859,6 @@ impl std::fmt::Debug for SslCertsInsertResponse {
         debug_struct.field("operation", &self.operation);
         debug_struct.field("server_ca_cert", &self.server_ca_cert);
         debug_struct.field("client_cert", &self.client_cert);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41179,7 +41028,6 @@ impl std::fmt::Debug for SslCertsListResponse {
         let mut debug_struct = f.debug_struct("SslCertsListResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41321,7 +41169,6 @@ impl std::fmt::Debug for SqlTiersListRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SqlTiersListRequest");
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41491,7 +41338,6 @@ impl std::fmt::Debug for TiersListResponse {
         let mut debug_struct = f.debug_struct("TiersListResponse");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41774,7 +41620,6 @@ impl std::fmt::Debug for Tier {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("disk_quota", &self.disk_quota);
         debug_struct.field("region", &self.region);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41990,7 +41835,6 @@ impl std::fmt::Debug for SqlUsersDeleteRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("name", &self.name);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42207,7 +42051,6 @@ impl std::fmt::Debug for SqlUsersGetRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project", &self.project);
         debug_struct.field("host", &self.host);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42408,7 +42251,6 @@ impl std::fmt::Debug for SqlUsersInsertRequest {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42574,7 +42416,6 @@ impl std::fmt::Debug for SqlUsersListRequest {
         let mut debug_struct = f.debug_struct("SqlUsersListRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("project", &self.project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42825,7 +42666,6 @@ impl std::fmt::Debug for SqlUsersUpdateRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project", &self.project);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43147,7 +42987,6 @@ impl std::fmt::Debug for UserPasswordValidationPolicy {
             "enable_password_verification",
             &self.enable_password_verification,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43328,7 +43167,6 @@ impl std::fmt::Debug for PasswordStatus {
         let mut debug_struct = f.debug_struct("PasswordStatus");
         debug_struct.field("locked", &self.locked);
         debug_struct.field("password_expiration_time", &self.password_expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43810,7 +43648,6 @@ impl std::fmt::Debug for User {
         debug_struct.field("password_policy", &self.password_policy);
         debug_struct.field("dual_password_type", &self.dual_password_type);
         debug_struct.field("user_details", &self.user_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44290,7 +44127,6 @@ impl std::fmt::Debug for SqlServerUserDetails {
         let mut debug_struct = f.debug_struct("SqlServerUserDetails");
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("server_roles", &self.server_roles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44488,7 +44324,6 @@ impl std::fmt::Debug for UsersListResponse {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("items", &self.items);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/storagebatchoperations/v1/src/model.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/model.rs
@@ -289,7 +289,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -502,7 +501,6 @@ impl std::fmt::Debug for ListJobsResponse {
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -645,7 +643,6 @@ impl std::fmt::Debug for GetJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -882,7 +879,6 @@ impl std::fmt::Debug for CreateJobRequest {
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("job", &self.job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1055,7 +1051,6 @@ impl std::fmt::Debug for CancelJobRequest {
         let mut debug_struct = f.debug_struct("CancelJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1228,7 +1223,6 @@ impl std::fmt::Debug for DeleteJobRequest {
         let mut debug_struct = f.debug_struct("DeleteJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1342,7 +1336,6 @@ impl serde::ser::Serialize for CancelJobResponse {
 impl std::fmt::Debug for CancelJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelJobResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1657,7 +1650,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2364,7 +2356,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("state", &self.state);
         debug_struct.field("source", &self.source);
         debug_struct.field("transformation", &self.transformation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2691,7 +2682,6 @@ impl std::fmt::Debug for BucketList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BucketList");
         debug_struct.field("buckets", &self.buckets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2966,7 +2956,6 @@ pub mod bucket_list {
             let mut debug_struct = f.debug_struct("Bucket");
             debug_struct.field("bucket", &self.bucket);
             debug_struct.field("object_configuration", &self.object_configuration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3141,7 +3130,6 @@ impl std::fmt::Debug for Manifest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Manifest");
         debug_struct.field("manifest_location", &self.manifest_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3294,7 +3282,6 @@ impl std::fmt::Debug for PrefixList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrefixList");
         debug_struct.field("included_object_prefixes", &self.included_object_prefixes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3470,7 +3457,6 @@ impl std::fmt::Debug for PutObjectHold {
         let mut debug_struct = f.debug_struct("PutObjectHold");
         debug_struct.field("temporary_hold", &self.temporary_hold);
         debug_struct.field("event_based_hold", &self.event_based_hold);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3772,7 +3758,6 @@ impl std::fmt::Debug for DeleteObject {
             "permanent_object_deletion_enabled",
             &self.permanent_object_deletion_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3934,7 +3919,6 @@ impl std::fmt::Debug for RewriteObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RewriteObject");
         debug_struct.field("kms_key", &self.kms_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4334,7 +4318,6 @@ impl std::fmt::Debug for PutMetadata {
         debug_struct.field("cache_control", &self.cache_control);
         debug_struct.field("custom_time", &self.custom_time);
         debug_struct.field("custom_metadata", &self.custom_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4551,7 +4534,6 @@ impl std::fmt::Debug for ErrorSummary {
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("error_count", &self.error_count);
         debug_struct.field("error_log_entries", &self.error_log_entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4724,7 +4706,6 @@ impl std::fmt::Debug for ErrorLogEntry {
         let mut debug_struct = f.debug_struct("ErrorLogEntry");
         debug_struct.field("object_uri", &self.object_uri);
         debug_struct.field("error_details", &self.error_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4979,7 +4960,6 @@ impl std::fmt::Debug for Counters {
         debug_struct.field("total_object_count", &self.total_object_count);
         debug_struct.field("succeeded_object_count", &self.succeeded_object_count);
         debug_struct.field("failed_object_count", &self.failed_object_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5165,7 +5145,6 @@ impl std::fmt::Debug for LoggingConfig {
         let mut debug_struct = f.debug_struct("LoggingConfig");
         debug_struct.field("log_actions", &self.log_actions);
         debug_struct.field("log_action_states", &self.log_action_states);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -294,7 +294,6 @@ impl std::fmt::Debug for ListReportConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -508,7 +507,6 @@ impl std::fmt::Debug for ListReportConfigsResponse {
         debug_struct.field("report_configs", &self.report_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -650,7 +648,6 @@ impl std::fmt::Debug for GetReportConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReportConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -867,7 +864,6 @@ impl std::fmt::Debug for CreateReportConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("report_config", &self.report_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1100,7 +1096,6 @@ impl std::fmt::Debug for UpdateReportConfigRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("report_config", &self.report_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1305,7 +1300,6 @@ impl std::fmt::Debug for DeleteReportConfigRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1714,7 +1708,6 @@ impl std::fmt::Debug for ReportDetail {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("target_datetime", &self.target_datetime);
         debug_struct.field("report_metrics", &self.report_metrics);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1891,7 +1884,6 @@ pub mod report_detail {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Metrics");
             debug_struct.field("processed_records_count", &self.processed_records_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2156,7 +2148,6 @@ impl std::fmt::Debug for ListReportDetailsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2370,7 +2361,6 @@ impl std::fmt::Debug for ListReportDetailsResponse {
         debug_struct.field("report_details", &self.report_details);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2512,7 +2502,6 @@ impl std::fmt::Debug for GetReportDetailRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReportDetailRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2837,7 +2826,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3058,7 +3046,6 @@ impl std::fmt::Debug for FrequencyOptions {
         debug_struct.field("frequency", &self.frequency);
         debug_struct.field("start_date", &self.start_date);
         debug_struct.field("end_date", &self.end_date);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3393,7 +3380,6 @@ impl std::fmt::Debug for CSVOptions {
         debug_struct.field("record_separator", &self.record_separator);
         debug_struct.field("delimiter", &self.delimiter);
         debug_struct.field("header_required", &self.header_required);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3507,7 +3493,6 @@ impl serde::ser::Serialize for ParquetOptions {
 impl std::fmt::Debug for ParquetOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ParquetOptions");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3650,7 +3635,6 @@ impl std::fmt::Debug for CloudStorageFilters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudStorageFilters");
         debug_struct.field("bucket", &self.bucket);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3823,7 +3807,6 @@ impl std::fmt::Debug for CloudStorageDestinationOptions {
         let mut debug_struct = f.debug_struct("CloudStorageDestinationOptions");
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("destination_path", &self.destination_path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4127,7 +4110,6 @@ impl std::fmt::Debug for ObjectMetadataReportOptions {
         debug_struct.field("metadata_fields", &self.metadata_fields);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("destination_options", &self.destination_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4679,7 +4661,6 @@ impl std::fmt::Debug for ReportConfig {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("report_format", &self.report_format);
         debug_struct.field("report_kind", &self.report_kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4872,7 +4853,6 @@ impl std::fmt::Debug for Identity {
         let mut debug_struct = f.debug_struct("Identity");
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6152,7 +6132,6 @@ impl std::fmt::Debug for DatasetConfig {
         debug_struct.field("source_options", &self.source_options);
         debug_struct.field("cloud_storage_locations", &self.cloud_storage_locations);
         debug_struct.field("cloud_storage_buckets", &self.cloud_storage_buckets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6333,7 +6312,6 @@ pub mod dataset_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SourceProjects");
             debug_struct.field("project_numbers", &self.project_numbers);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6510,7 +6488,6 @@ pub mod dataset_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SourceFolders");
             debug_struct.field("folder_numbers", &self.folder_numbers);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6657,7 +6634,6 @@ pub mod dataset_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudStorageLocations");
             debug_struct.field("locations", &self.locations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6808,7 +6784,6 @@ pub mod dataset_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudStorageBuckets");
             debug_struct.field("cloud_storage_buckets", &self.cloud_storage_buckets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7060,7 +7035,6 @@ pub mod dataset_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CloudStorageBucket");
                 debug_struct.field("cloud_storage_bucket", &self.cloud_storage_bucket);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -7247,7 +7221,6 @@ pub mod dataset_config {
             let mut debug_struct = f.debug_struct("Link");
             debug_struct.field("dataset", &self.dataset);
             debug_struct.field("linked", &self.linked);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7715,7 +7688,6 @@ pub mod dataset_config {
                 "non_storage_intelligence_entitled_bucket_ids",
                 &self.non_storage_intelligence_entitled_bucket_ids,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8525,7 +8497,6 @@ pub mod dataset_config {
                 "destination_project_check_result",
                 &self.destination_project_check_result,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8742,7 +8713,6 @@ pub mod dataset_config {
             let mut debug_struct = f.debug_struct("ValidationErrorsBeforeIngestion");
             debug_struct.field("bucket_errors", &self.bucket_errors);
             debug_struct.field("project_errors", &self.project_errors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9209,7 +9179,6 @@ impl std::fmt::Debug for ListDatasetConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9426,7 +9395,6 @@ impl std::fmt::Debug for ListDatasetConfigsResponse {
         debug_struct.field("dataset_configs", &self.dataset_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9571,7 +9539,6 @@ impl std::fmt::Debug for GetDatasetConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatasetConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9821,7 +9788,6 @@ impl std::fmt::Debug for CreateDatasetConfigRequest {
         debug_struct.field("dataset_config_id", &self.dataset_config_id);
         debug_struct.field("dataset_config", &self.dataset_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10055,7 +10021,6 @@ impl std::fmt::Debug for UpdateDatasetConfigRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("dataset_config", &self.dataset_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10236,7 +10201,6 @@ impl std::fmt::Debug for DeleteDatasetConfigRequest {
         let mut debug_struct = f.debug_struct("DeleteDatasetConfigRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10381,7 +10345,6 @@ impl std::fmt::Debug for LinkDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LinkDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10498,7 +10461,6 @@ impl serde::ser::Serialize for LinkDatasetResponse {
 impl std::fmt::Debug for LinkDatasetResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LinkDatasetResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10643,7 +10605,6 @@ impl std::fmt::Debug for UnlinkDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UnlinkDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10816,7 +10777,6 @@ impl std::fmt::Debug for LocationMetadata {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("report_config_available", &self.report_config_available);
         debug_struct.field("dataset_config_available", &self.dataset_config_available);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -257,7 +257,6 @@ impl std::fmt::Debug for Actor {
         debug_struct.field("email", &self.email);
         debug_struct.field("google_support", &self.google_support);
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -575,7 +574,6 @@ impl std::fmt::Debug for Attachment {
         debug_struct.field("filename", &self.filename);
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("size_bytes", &self.size_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -795,7 +793,6 @@ impl std::fmt::Debug for ListAttachmentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -982,7 +979,6 @@ impl std::fmt::Debug for ListAttachmentsResponse {
         let mut debug_struct = f.debug_struct("ListAttachmentsResponse");
         debug_struct.field("attachments", &self.attachments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1580,7 +1576,6 @@ impl std::fmt::Debug for Case {
         debug_struct.field("test_case", &self.test_case);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("priority", &self.priority);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2081,7 +2076,6 @@ impl std::fmt::Debug for CaseClassification {
         let mut debug_struct = f.debug_struct("CaseClassification");
         debug_struct.field("id", &self.id);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2223,7 +2217,6 @@ impl std::fmt::Debug for GetCaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2401,7 +2394,6 @@ impl std::fmt::Debug for CreateCaseRequest {
         let mut debug_struct = f.debug_struct("CreateCaseRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("case", &self.case);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2657,7 +2649,6 @@ impl std::fmt::Debug for ListCasesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2845,7 +2836,6 @@ impl std::fmt::Debug for ListCasesResponse {
         let mut debug_struct = f.debug_struct("ListCasesResponse");
         debug_struct.field("cases", &self.cases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3115,7 +3105,6 @@ impl std::fmt::Debug for SearchCasesRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3303,7 +3292,6 @@ impl std::fmt::Debug for SearchCasesResponse {
         let mut debug_struct = f.debug_struct("SearchCasesResponse");
         debug_struct.field("cases", &self.cases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3481,7 +3469,6 @@ impl std::fmt::Debug for EscalateCaseRequest {
         let mut debug_struct = f.debug_struct("EscalateCaseRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("escalation", &self.escalation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3678,7 +3665,6 @@ impl std::fmt::Debug for UpdateCaseRequest {
         let mut debug_struct = f.debug_struct("UpdateCaseRequest");
         debug_struct.field("case", &self.case);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3820,7 +3806,6 @@ impl std::fmt::Debug for CloseCaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloseCaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4036,7 +4021,6 @@ impl std::fmt::Debug for SearchCaseClassificationsRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4228,7 +4212,6 @@ impl std::fmt::Debug for SearchCaseClassificationsResponse {
         let mut debug_struct = f.debug_struct("SearchCaseClassificationsResponse");
         debug_struct.field("case_classifications", &self.case_classifications);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4506,7 +4489,6 @@ impl std::fmt::Debug for Comment {
         debug_struct.field("creator", &self.creator);
         debug_struct.field("body", &self.body);
         debug_struct.field("plain_text_body", &self.plain_text_body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4719,7 +4701,6 @@ impl std::fmt::Debug for ListCommentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4906,7 +4887,6 @@ impl std::fmt::Debug for ListCommentsResponse {
         let mut debug_struct = f.debug_struct("ListCommentsResponse");
         debug_struct.field("comments", &self.comments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5084,7 +5064,6 @@ impl std::fmt::Debug for CreateCommentRequest {
         let mut debug_struct = f.debug_struct("CreateCommentRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("comment", &self.comment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5253,7 +5232,6 @@ impl std::fmt::Debug for Escalation {
         let mut debug_struct = f.debug_struct("Escalation");
         debug_struct.field("reason", &self.reason);
         debug_struct.field("justification", &self.justification);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -217,7 +217,6 @@ impl std::fmt::Debug for TimestampRange {
         let mut debug_struct = f.debug_struct("TimestampRange");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -497,7 +496,6 @@ impl std::fmt::Debug for Location {
         debug_struct.field("postal_address", &self.postal_address);
         debug_struct.field("lat_lng", &self.lat_lng);
         debug_struct.field("radius_miles", &self.radius_miles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1015,7 +1013,6 @@ impl std::fmt::Debug for RequestMetadata {
         debug_struct.field("user_id", &self.user_id);
         debug_struct.field("allow_missing_ids", &self.allow_missing_ids);
         debug_struct.field("device_info", &self.device_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1159,7 +1156,6 @@ impl std::fmt::Debug for ResponseMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResponseMetadata");
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1331,7 +1327,6 @@ impl std::fmt::Debug for DeviceInfo {
         let mut debug_struct = f.debug_struct("DeviceInfo");
         debug_struct.field("device_type", &self.device_type);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1790,7 +1785,6 @@ impl std::fmt::Debug for CustomAttribute {
         debug_struct.field("long_values", &self.long_values);
         debug_struct.field("filterable", &self.filterable);
         debug_struct.field("keyword_searchable", &self.keyword_searchable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1990,7 +1984,6 @@ impl std::fmt::Debug for SpellingCorrection {
         debug_struct.field("corrected", &self.corrected);
         debug_struct.field("corrected_text", &self.corrected_text);
         debug_struct.field("corrected_html", &self.corrected_html);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2277,7 +2270,6 @@ impl std::fmt::Debug for CompensationInfo {
             "annualized_total_compensation_range",
             &self.annualized_total_compensation_range,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2732,7 +2724,6 @@ pub mod compensation_info {
             debug_struct.field("description", &self.description);
             debug_struct.field("expected_units_per_year", &self.expected_units_per_year);
             debug_struct.field("compensation_amount", &self.compensation_amount);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2951,7 +2942,6 @@ pub mod compensation_info {
             let mut debug_struct = f.debug_struct("CompensationRange");
             debug_struct.field("max_compensation", &self.max_compensation);
             debug_struct.field("min_compensation", &self.min_compensation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3760,7 +3750,6 @@ impl std::fmt::Debug for BatchOperationMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4458,7 +4447,6 @@ impl std::fmt::Debug for Company {
         );
         debug_struct.field("derived_info", &self.derived_info);
         debug_struct.field("suspended", &self.suspended);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4624,7 +4612,6 @@ pub mod company {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DerivedInfo");
             debug_struct.field("headquarters_location", &self.headquarters_location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4806,7 +4793,6 @@ impl std::fmt::Debug for CreateCompanyRequest {
         let mut debug_struct = f.debug_struct("CreateCompanyRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("company", &self.company);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4952,7 +4938,6 @@ impl std::fmt::Debug for GetCompanyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCompanyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5156,7 +5141,6 @@ impl std::fmt::Debug for UpdateCompanyRequest {
         let mut debug_struct = f.debug_struct("UpdateCompanyRequest");
         debug_struct.field("company", &self.company);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5302,7 +5286,6 @@ impl std::fmt::Debug for DeleteCompanyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCompanyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5552,7 +5535,6 @@ impl std::fmt::Debug for ListCompaniesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("require_open_jobs", &self.require_open_jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5775,7 +5757,6 @@ impl std::fmt::Debug for ListCompaniesResponse {
         debug_struct.field("companies", &self.companies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6124,7 +6105,6 @@ impl std::fmt::Debug for CompleteQueryRequest {
         debug_struct.field("company", &self.company);
         debug_struct.field("scope", &self.scope);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6621,7 +6601,6 @@ impl std::fmt::Debug for CompleteQueryResponse {
         let mut debug_struct = f.debug_struct("CompleteQueryResponse");
         debug_struct.field("completion_results", &self.completion_results);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6832,7 +6811,6 @@ pub mod complete_query_response {
             debug_struct.field("suggestion", &self.suggestion);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("image_uri", &self.image_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7146,7 +7124,6 @@ impl std::fmt::Debug for ClientEvent {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("event_notes", &self.event_notes);
         debug_struct.field("event", &self.event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7352,7 +7329,6 @@ impl std::fmt::Debug for JobEvent {
         let mut debug_struct = f.debug_struct("JobEvent");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("jobs", &self.jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7829,7 +7805,6 @@ impl std::fmt::Debug for CreateClientEventRequest {
         let mut debug_struct = f.debug_struct("CreateClientEventRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("client_event", &self.client_event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8520,7 +8495,6 @@ impl std::fmt::Debug for JobQuery {
         debug_struct.field("language_codes", &self.language_codes);
         debug_struct.field("publish_time_range", &self.publish_time_range);
         debug_struct.field("excluded_jobs", &self.excluded_jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8854,7 +8828,6 @@ impl std::fmt::Debug for LocationFilter {
         debug_struct.field("lat_lng", &self.lat_lng);
         debug_struct.field("distance_in_miles", &self.distance_in_miles);
         debug_struct.field("telecommute_preference", &self.telecommute_preference);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9268,7 +9241,6 @@ impl std::fmt::Debug for CompensationFilter {
             "include_jobs_with_unspecified_compensation_range",
             &self.include_jobs_with_unspecified_compensation_range,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9843,7 +9815,6 @@ impl std::fmt::Debug for CommuteFilter {
         debug_struct.field("travel_duration", &self.travel_duration);
         debug_struct.field("allow_imprecise_addresses", &self.allow_imprecise_addresses);
         debug_struct.field("traffic_option", &self.traffic_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10146,7 +10117,6 @@ impl std::fmt::Debug for HistogramQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HistogramQuery");
         debug_struct.field("histogram_query", &self.histogram_query);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10363,7 +10333,6 @@ impl std::fmt::Debug for HistogramQueryResult {
         let mut debug_struct = f.debug_struct("HistogramQueryResult");
         debug_struct.field("histogram_query", &self.histogram_query);
         debug_struct.field("histogram", &self.histogram);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11658,7 +11627,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("company_display_name", &self.company_display_name);
         debug_struct.field("derived_info", &self.derived_info);
         debug_struct.field("processing_options", &self.processing_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11876,7 +11844,6 @@ pub mod job {
             debug_struct.field("emails", &self.emails);
             debug_struct.field("instruction", &self.instruction);
             debug_struct.field("uris", &self.uris);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12069,7 +12036,6 @@ pub mod job {
             let mut debug_struct = f.debug_struct("DerivedInfo");
             debug_struct.field("locations", &self.locations);
             debug_struct.field("job_categories", &self.job_categories);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12270,7 +12236,6 @@ pub mod job {
                 &self.disable_street_address_resolution,
             );
             debug_struct.field("html_sanitization", &self.html_sanitization);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12452,7 +12417,6 @@ impl std::fmt::Debug for CreateJobRequest {
         let mut debug_struct = f.debug_struct("CreateJobRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12598,7 +12562,6 @@ impl std::fmt::Debug for GetJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12800,7 +12763,6 @@ impl std::fmt::Debug for UpdateJobRequest {
         let mut debug_struct = f.debug_struct("UpdateJobRequest");
         debug_struct.field("job", &self.job);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12946,7 +12908,6 @@ impl std::fmt::Debug for DeleteJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13249,7 +13210,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("job_view", &self.job_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13475,7 +13435,6 @@ impl std::fmt::Debug for ListJobsResponse {
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14403,7 +14362,6 @@ impl std::fmt::Debug for SearchJobsRequest {
         debug_struct.field("disable_keyword_match", &self.disable_keyword_match);
         debug_struct.field("keyword_match_mode", &self.keyword_match_mode);
         debug_struct.field("relevance_threshold", &self.relevance_threshold);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14622,7 +14580,6 @@ pub mod search_jobs_request {
             let mut debug_struct = f.debug_struct("CustomRankingInfo");
             debug_struct.field("importance_level", &self.importance_level);
             debug_struct.field("ranking_expression", &self.ranking_expression);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15893,7 +15850,6 @@ impl std::fmt::Debug for SearchJobsResponse {
             &self.broadened_query_jobs_count,
         );
         debug_struct.field("spell_correction", &self.spell_correction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16197,7 +16153,6 @@ pub mod search_jobs_response {
             debug_struct.field("job_title_snippet", &self.job_title_snippet);
             debug_struct.field("search_text_snippet", &self.search_text_snippet);
             debug_struct.field("commute_info", &self.commute_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16394,7 +16349,6 @@ pub mod search_jobs_response {
             let mut debug_struct = f.debug_struct("CommuteInfo");
             debug_struct.field("job_location", &self.job_location);
             debug_struct.field("travel_duration", &self.travel_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16569,7 +16523,6 @@ impl std::fmt::Debug for BatchCreateJobsRequest {
         let mut debug_struct = f.debug_struct("BatchCreateJobsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("jobs", &self.jobs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16799,7 +16752,6 @@ impl std::fmt::Debug for BatchUpdateJobsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16979,7 +16931,6 @@ impl std::fmt::Debug for BatchDeleteJobsRequest {
         let mut debug_struct = f.debug_struct("BatchDeleteJobsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17182,7 +17133,6 @@ impl std::fmt::Debug for JobResult {
         let mut debug_struct = f.debug_struct("JobResult");
         debug_struct.field("job", &self.job);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17336,7 +17286,6 @@ impl std::fmt::Debug for BatchCreateJobsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchCreateJobsResponse");
         debug_struct.field("job_results", &self.job_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17490,7 +17439,6 @@ impl std::fmt::Debug for BatchUpdateJobsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchUpdateJobsResponse");
         debug_struct.field("job_results", &self.job_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17644,7 +17592,6 @@ impl std::fmt::Debug for BatchDeleteJobsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchDeleteJobsResponse");
         debug_struct.field("job_results", &self.job_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17824,7 +17771,6 @@ impl std::fmt::Debug for Tenant {
         let mut debug_struct = f.debug_struct("Tenant");
         debug_struct.field("name", &self.name);
         debug_struct.field("external_id", &self.external_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18005,7 +17951,6 @@ impl std::fmt::Debug for CreateTenantRequest {
         let mut debug_struct = f.debug_struct("CreateTenantRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tenant", &self.tenant);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18150,7 +18095,6 @@ impl std::fmt::Debug for GetTenantRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTenantRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18353,7 +18297,6 @@ impl std::fmt::Debug for UpdateTenantRequest {
         let mut debug_struct = f.debug_struct("UpdateTenantRequest");
         debug_struct.field("tenant", &self.tenant);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18498,7 +18441,6 @@ impl std::fmt::Debug for DeleteTenantRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTenantRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18714,7 +18656,6 @@ impl std::fmt::Debug for ListTenantsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18937,7 +18878,6 @@ impl std::fmt::Debug for ListTenantsResponse {
         debug_struct.field("tenants", &self.tenants);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -298,7 +298,6 @@ impl std::fmt::Debug for ListQueuesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -497,7 +496,6 @@ impl std::fmt::Debug for ListQueuesResponse {
         let mut debug_struct = f.debug_struct("ListQueuesResponse");
         debug_struct.field("queues", &self.queues);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -642,7 +640,6 @@ impl std::fmt::Debug for GetQueueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQueueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -833,7 +830,6 @@ impl std::fmt::Debug for CreateQueueRequest {
         let mut debug_struct = f.debug_struct("CreateQueueRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("queue", &self.queue);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1036,7 +1032,6 @@ impl std::fmt::Debug for UpdateQueueRequest {
         let mut debug_struct = f.debug_struct("UpdateQueueRequest");
         debug_struct.field("queue", &self.queue);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1182,7 +1177,6 @@ impl std::fmt::Debug for DeleteQueueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteQueueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1328,7 +1322,6 @@ impl std::fmt::Debug for PurgeQueueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PurgeQueueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1474,7 +1467,6 @@ impl std::fmt::Debug for PauseQueueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseQueueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1620,7 +1612,6 @@ impl std::fmt::Debug for ResumeQueueRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeQueueRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1900,7 +1891,6 @@ impl std::fmt::Debug for ListTasksRequest {
         debug_struct.field("response_view", &self.response_view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2097,7 +2087,6 @@ impl std::fmt::Debug for ListTasksResponse {
         let mut debug_struct = f.debug_struct("ListTasksResponse");
         debug_struct.field("tasks", &self.tasks);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2287,7 +2276,6 @@ impl std::fmt::Debug for GetTaskRequest {
         let mut debug_struct = f.debug_struct("GetTaskRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("response_view", &self.response_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2551,7 +2539,6 @@ impl std::fmt::Debug for CreateTaskRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("task", &self.task);
         debug_struct.field("response_view", &self.response_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2697,7 +2684,6 @@ impl std::fmt::Debug for DeleteTaskRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTaskRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2887,7 +2873,6 @@ impl std::fmt::Debug for RunTaskRequest {
         let mut debug_struct = f.debug_struct("RunTaskRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("response_view", &self.response_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3361,7 +3346,6 @@ impl std::fmt::Debug for Queue {
             "stackdriver_logging_config",
             &self.stackdriver_logging_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3859,7 +3843,6 @@ impl std::fmt::Debug for RateLimits {
         debug_struct.field("max_dispatches_per_second", &self.max_dispatches_per_second);
         debug_struct.field("max_burst_size", &self.max_burst_size);
         debug_struct.field("max_concurrent_dispatches", &self.max_concurrent_dispatches);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4276,7 +4259,6 @@ impl std::fmt::Debug for RetryConfig {
         debug_struct.field("min_backoff", &self.min_backoff);
         debug_struct.field("max_backoff", &self.max_backoff);
         debug_struct.field("max_doublings", &self.max_doublings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4442,7 +4424,6 @@ impl std::fmt::Debug for StackdriverLoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StackdriverLoggingConfig");
         debug_struct.field("sampling_ratio", &self.sampling_ratio);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4905,7 +4886,6 @@ impl std::fmt::Debug for HttpRequest {
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
         debug_struct.field("authorization_header", &self.authorization_header);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5373,7 +5353,6 @@ impl std::fmt::Debug for AppEngineHttpRequest {
         debug_struct.field("relative_uri", &self.relative_uri);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5681,7 +5660,6 @@ impl std::fmt::Debug for AppEngineRouting {
         debug_struct.field("version", &self.version);
         debug_struct.field("instance", &self.instance);
         debug_struct.field("host", &self.host);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5861,7 +5839,6 @@ impl std::fmt::Debug for OAuthToken {
         let mut debug_struct = f.debug_struct("OAuthToken");
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6042,7 +6019,6 @@ impl std::fmt::Debug for OidcToken {
         let mut debug_struct = f.debug_struct("OidcToken");
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("audience", &self.audience);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6687,7 +6663,6 @@ impl std::fmt::Debug for Task {
         debug_struct.field("last_attempt", &self.last_attempt);
         debug_struct.field("view", &self.view);
         debug_struct.field("message_type", &self.message_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7144,7 +7119,6 @@ impl std::fmt::Debug for Attempt {
         debug_struct.field("dispatch_time", &self.dispatch_time);
         debug_struct.field("response_time", &self.response_time);
         debug_struct.field("response_status", &self.response_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -369,7 +369,6 @@ impl std::fmt::Debug for OrchestrationCluster {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("tna_version", &self.tna_version);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -893,7 +892,6 @@ impl std::fmt::Debug for EdgeSlm {
         debug_struct.field("tna_version", &self.tna_version);
         debug_struct.field("state", &self.state);
         debug_struct.field("workload_cluster_type", &self.workload_cluster_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1727,7 +1725,6 @@ impl std::fmt::Debug for Blueprint {
         debug_struct.field("source_provider", &self.source_provider);
         debug_struct.field("deployment_level", &self.deployment_level);
         debug_struct.field("rollback_support", &self.rollback_support);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2160,7 +2157,6 @@ impl std::fmt::Debug for PublicBlueprint {
         debug_struct.field("deployment_level", &self.deployment_level);
         debug_struct.field("source_provider", &self.source_provider);
         debug_struct.field("rollback_support", &self.rollback_support);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2740,7 +2736,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("workload_cluster", &self.workload_cluster);
         debug_struct.field("deployment_level", &self.deployment_level);
         debug_struct.field("rollback_support", &self.rollback_support);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3124,7 +3119,6 @@ impl std::fmt::Debug for HydratedDeployment {
         debug_struct.field("state", &self.state);
         debug_struct.field("files", &self.files);
         debug_struct.field("workload_cluster", &self.workload_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3528,7 +3522,6 @@ impl std::fmt::Debug for ListOrchestrationClustersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3746,7 +3739,6 @@ impl std::fmt::Debug for ListOrchestrationClustersResponse {
         debug_struct.field("orchestration_clusters", &self.orchestration_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3888,7 +3880,6 @@ impl std::fmt::Debug for GetOrchestrationClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrchestrationClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4138,7 +4129,6 @@ impl std::fmt::Debug for CreateOrchestrationClusterRequest {
         debug_struct.field("orchestration_cluster_id", &self.orchestration_cluster_id);
         debug_struct.field("orchestration_cluster", &self.orchestration_cluster);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4318,7 +4308,6 @@ impl std::fmt::Debug for DeleteOrchestrationClusterRequest {
         let mut debug_struct = f.debug_struct("DeleteOrchestrationClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4582,7 +4571,6 @@ impl std::fmt::Debug for ListEdgeSlmsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4796,7 +4784,6 @@ impl std::fmt::Debug for ListEdgeSlmsResponse {
         debug_struct.field("edge_slms", &self.edge_slms);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4938,7 +4925,6 @@ impl std::fmt::Debug for GetEdgeSlmRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEdgeSlmRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5183,7 +5169,6 @@ impl std::fmt::Debug for CreateEdgeSlmRequest {
         debug_struct.field("edge_slm_id", &self.edge_slm_id);
         debug_struct.field("edge_slm", &self.edge_slm);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5363,7 +5348,6 @@ impl std::fmt::Debug for DeleteEdgeSlmRequest {
         let mut debug_struct = f.debug_struct("DeleteEdgeSlmRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5569,7 +5553,6 @@ impl std::fmt::Debug for CreateBlueprintRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("blueprint_id", &self.blueprint_id);
         debug_struct.field("blueprint", &self.blueprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5760,7 +5743,6 @@ impl std::fmt::Debug for UpdateBlueprintRequest {
         let mut debug_struct = f.debug_struct("UpdateBlueprintRequest");
         debug_struct.field("blueprint", &self.blueprint);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5932,7 +5914,6 @@ impl std::fmt::Debug for GetBlueprintRequest {
         let mut debug_struct = f.debug_struct("GetBlueprintRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6077,7 +6058,6 @@ impl std::fmt::Debug for DeleteBlueprintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBlueprintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6319,7 +6299,6 @@ impl std::fmt::Debug for ListBlueprintsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6505,7 +6484,6 @@ impl std::fmt::Debug for ListBlueprintsResponse {
         let mut debug_struct = f.debug_struct("ListBlueprintsResponse");
         debug_struct.field("blueprints", &self.blueprints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6648,7 +6626,6 @@ impl std::fmt::Debug for ApproveBlueprintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApproveBlueprintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6790,7 +6767,6 @@ impl std::fmt::Debug for ProposeBlueprintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProposeBlueprintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6932,7 +6908,6 @@ impl std::fmt::Debug for RejectBlueprintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RejectBlueprintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7145,7 +7120,6 @@ impl std::fmt::Debug for ListBlueprintRevisionsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7331,7 +7305,6 @@ impl std::fmt::Debug for ListBlueprintRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListBlueprintRevisionsResponse");
         debug_struct.field("blueprints", &self.blueprints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7579,7 +7552,6 @@ impl std::fmt::Debug for SearchBlueprintRevisionsRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7765,7 +7737,6 @@ impl std::fmt::Debug for SearchBlueprintRevisionsResponse {
         let mut debug_struct = f.debug_struct("SearchBlueprintRevisionsResponse");
         debug_struct.field("blueprints", &self.blueprints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7907,7 +7878,6 @@ impl std::fmt::Debug for DiscardBlueprintChangesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscardBlueprintChangesRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8021,7 +7991,6 @@ impl serde::ser::Serialize for DiscardBlueprintChangesResponse {
 impl std::fmt::Debug for DiscardBlueprintChangesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscardBlueprintChangesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8236,7 +8205,6 @@ impl std::fmt::Debug for ListPublicBlueprintsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8427,7 +8395,6 @@ impl std::fmt::Debug for ListPublicBlueprintsResponse {
         let mut debug_struct = f.debug_struct("ListPublicBlueprintsResponse");
         debug_struct.field("public_blueprints", &self.public_blueprints);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8569,7 +8536,6 @@ impl std::fmt::Debug for GetPublicBlueprintRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPublicBlueprintRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8775,7 +8741,6 @@ impl std::fmt::Debug for CreateDeploymentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("deployment_id", &self.deployment_id);
         debug_struct.field("deployment", &self.deployment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8966,7 +8931,6 @@ impl std::fmt::Debug for UpdateDeploymentRequest {
         let mut debug_struct = f.debug_struct("UpdateDeploymentRequest");
         debug_struct.field("deployment", &self.deployment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9139,7 +9103,6 @@ impl std::fmt::Debug for GetDeploymentRequest {
         let mut debug_struct = f.debug_struct("GetDeploymentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9281,7 +9244,6 @@ impl std::fmt::Debug for RemoveDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9523,7 +9485,6 @@ impl std::fmt::Debug for ListDeploymentsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9709,7 +9670,6 @@ impl std::fmt::Debug for ListDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListDeploymentsResponse");
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9922,7 +9882,6 @@ impl std::fmt::Debug for ListDeploymentRevisionsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10108,7 +10067,6 @@ impl std::fmt::Debug for ListDeploymentRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListDeploymentRevisionsResponse");
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10357,7 +10315,6 @@ impl std::fmt::Debug for SearchDeploymentRevisionsRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10543,7 +10500,6 @@ impl std::fmt::Debug for SearchDeploymentRevisionsResponse {
         let mut debug_struct = f.debug_struct("SearchDeploymentRevisionsResponse");
         debug_struct.field("deployments", &self.deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10685,7 +10641,6 @@ impl std::fmt::Debug for DiscardDeploymentChangesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscardDeploymentChangesRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10799,7 +10754,6 @@ impl serde::ser::Serialize for DiscardDeploymentChangesResponse {
 impl std::fmt::Debug for DiscardDeploymentChangesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscardDeploymentChangesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10943,7 +10897,6 @@ impl std::fmt::Debug for ApplyDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApplyDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11085,7 +11038,6 @@ impl std::fmt::Debug for ComputeDeploymentStatusRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ComputeDeploymentStatusRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11289,7 +11241,6 @@ impl std::fmt::Debug for ComputeDeploymentStatusResponse {
         debug_struct.field("name", &self.name);
         debug_struct.field("aggregated_status", &self.aggregated_status);
         debug_struct.field("resource_statuses", &self.resource_statuses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11457,7 +11408,6 @@ impl std::fmt::Debug for RollbackDeploymentRequest {
         let mut debug_struct = f.debug_struct("RollbackDeploymentRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11782,7 +11732,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11924,7 +11873,6 @@ impl std::fmt::Debug for GetHydratedDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetHydratedDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12140,7 +12088,6 @@ impl std::fmt::Debug for ListHydratedDeploymentsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12331,7 +12278,6 @@ impl std::fmt::Debug for ListHydratedDeploymentsResponse {
         let mut debug_struct = f.debug_struct("ListHydratedDeploymentsResponse");
         debug_struct.field("hydrated_deployments", &self.hydrated_deployments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12523,7 +12469,6 @@ impl std::fmt::Debug for UpdateHydratedDeploymentRequest {
         let mut debug_struct = f.debug_struct("UpdateHydratedDeploymentRequest");
         debug_struct.field("hydrated_deployment", &self.hydrated_deployment);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12665,7 +12610,6 @@ impl std::fmt::Debug for ApplyHydratedDeploymentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApplyHydratedDeploymentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12918,7 +12862,6 @@ impl std::fmt::Debug for ManagementConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ManagementConfig");
         debug_struct.field("oneof_config", &self.oneof_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13319,7 +13262,6 @@ impl std::fmt::Debug for StandardManagementConfig {
             "master_authorized_networks_config",
             &self.master_authorized_networks_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13701,7 +13643,6 @@ impl std::fmt::Debug for FullManagementConfig {
             "master_authorized_networks_config",
             &self.master_authorized_networks_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13854,7 +13795,6 @@ impl std::fmt::Debug for MasterAuthorizedNetworksConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MasterAuthorizedNetworksConfig");
         debug_struct.field("cidr_blocks", &self.cidr_blocks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14038,7 +13978,6 @@ pub mod master_authorized_networks_config {
             let mut debug_struct = f.debug_struct("CidrBlock");
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("cidr_block", &self.cidr_block);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14258,7 +14197,6 @@ impl std::fmt::Debug for File {
         debug_struct.field("content", &self.content);
         debug_struct.field("deleted", &self.deleted);
         debug_struct.field("editable", &self.editable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14596,7 +14534,6 @@ impl std::fmt::Debug for ResourceStatus {
         debug_struct.field("resource_type", &self.resource_type);
         debug_struct.field("status", &self.status);
         debug_struct.field("nf_deploy_status", &self.nf_deploy_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14834,7 +14771,6 @@ impl std::fmt::Debug for NFDeployStatus {
         debug_struct.field("targeted_nfs", &self.targeted_nfs);
         debug_struct.field("ready_nfs", &self.ready_nfs);
         debug_struct.field("sites", &self.sites);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15076,7 +15012,6 @@ impl std::fmt::Debug for NFDeploySiteStatus {
         debug_struct.field("pending_deletion", &self.pending_deletion);
         debug_struct.field("hydration", &self.hydration);
         debug_struct.field("workload", &self.workload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15255,7 +15190,6 @@ impl std::fmt::Debug for HydrationStatus {
         let mut debug_struct = f.debug_struct("HydrationStatus");
         debug_struct.field("site_version", &self.site_version);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15450,7 +15384,6 @@ impl std::fmt::Debug for SiteVersion {
         debug_struct.field("nf_vendor", &self.nf_vendor);
         debug_struct.field("nf_type", &self.nf_type);
         debug_struct.field("nf_version", &self.nf_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15629,7 +15562,6 @@ impl std::fmt::Debug for WorkloadStatus {
         let mut debug_struct = f.debug_struct("WorkloadStatus");
         debug_struct.field("site_version", &self.site_version);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -174,7 +174,6 @@ impl std::fmt::Debug for ListVoicesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListVoicesRequest");
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -319,7 +318,6 @@ impl std::fmt::Debug for ListVoicesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListVoicesResponse");
         debug_struct.field("voices", &self.voices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -571,7 +569,6 @@ impl std::fmt::Debug for Voice {
         debug_struct.field("name", &self.name);
         debug_struct.field("ssml_gender", &self.ssml_gender);
         debug_struct.field("natural_sample_rate_hertz", &self.natural_sample_rate_hertz);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -739,7 +736,6 @@ impl std::fmt::Debug for AdvancedVoiceOptions {
             "low_latency_journey_synthesis",
             &self.low_latency_journey_synthesis,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1003,7 +999,6 @@ impl std::fmt::Debug for SynthesizeSpeechRequest {
         debug_struct.field("voice", &self.voice);
         debug_struct.field("audio_config", &self.audio_config);
         debug_struct.field("advanced_voice_options", &self.advanced_voice_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1234,7 +1229,6 @@ impl std::fmt::Debug for CustomPronunciationParams {
         debug_struct.field("phrase", &self.phrase);
         debug_struct.field("phonetic_encoding", &self.phonetic_encoding);
         debug_struct.field("pronunciation", &self.pronunciation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1558,7 +1552,6 @@ impl std::fmt::Debug for CustomPronunciations {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomPronunciations");
         debug_struct.field("pronunciations", &self.pronunciations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1707,7 +1700,6 @@ impl std::fmt::Debug for MultiSpeakerMarkup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MultiSpeakerMarkup");
         debug_struct.field("turns", &self.turns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1883,7 +1875,6 @@ pub mod multi_speaker_markup {
             let mut debug_struct = f.debug_struct("Turn");
             debug_struct.field("speaker", &self.speaker);
             debug_struct.field("text", &self.text);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2261,7 +2252,6 @@ impl std::fmt::Debug for SynthesisInput {
         let mut debug_struct = f.debug_struct("SynthesisInput");
         debug_struct.field("custom_pronunciations", &self.custom_pronunciations);
         debug_struct.field("input_source", &self.input_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2580,7 +2570,6 @@ impl std::fmt::Debug for VoiceSelectionParams {
         debug_struct.field("ssml_gender", &self.ssml_gender);
         debug_struct.field("custom_voice", &self.custom_voice);
         debug_struct.field("voice_clone", &self.voice_clone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2956,7 +2945,6 @@ impl std::fmt::Debug for AudioConfig {
         debug_struct.field("volume_gain_db", &self.volume_gain_db);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("effects_profile_id", &self.effects_profile_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3133,7 +3121,6 @@ impl std::fmt::Debug for CustomVoiceParams {
         let mut debug_struct = f.debug_struct("CustomVoiceParams");
         debug_struct.field("model", &self.model);
         debug_struct.field("reported_usage", &self.reported_usage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3421,7 +3408,6 @@ impl std::fmt::Debug for VoiceCloneParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VoiceCloneParams");
         debug_struct.field("voice_cloning_key", &self.voice_cloning_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3587,7 +3573,6 @@ impl std::fmt::Debug for SynthesizeSpeechResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SynthesizeSpeechResponse");
         debug_struct.field("audio_content", &self.audio_content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3828,7 +3813,6 @@ impl std::fmt::Debug for StreamingAudioConfig {
         debug_struct.field("audio_encoding", &self.audio_encoding);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("speaking_rate", &self.speaking_rate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4064,7 +4048,6 @@ impl std::fmt::Debug for StreamingSynthesizeConfig {
         debug_struct.field("voice", &self.voice);
         debug_struct.field("streaming_audio_config", &self.streaming_audio_config);
         debug_struct.field("custom_pronunciations", &self.custom_pronunciations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4296,7 +4279,6 @@ impl std::fmt::Debug for StreamingSynthesisInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StreamingSynthesisInput");
         debug_struct.field("input_source", &self.input_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4569,7 +4551,6 @@ impl std::fmt::Debug for StreamingSynthesizeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StreamingSynthesizeRequest");
         debug_struct.field("streaming_request", &self.streaming_request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4753,7 +4734,6 @@ impl std::fmt::Debug for StreamingSynthesizeResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StreamingSynthesizeResponse");
         debug_struct.field("audio_content", &self.audio_content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5035,7 +5015,6 @@ impl std::fmt::Debug for SynthesizeLongAudioRequest {
         debug_struct.field("audio_config", &self.audio_config);
         debug_struct.field("output_gcs_uri", &self.output_gcs_uri);
         debug_struct.field("voice", &self.voice);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5149,7 +5128,6 @@ impl serde::ser::Serialize for SynthesizeLongAudioResponse {
 impl std::fmt::Debug for SynthesizeLongAudioResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SynthesizeLongAudioResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5388,7 +5366,6 @@ impl std::fmt::Debug for SynthesizeLongAudioMetadata {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("last_update_time", &self.last_update_time);
         debug_struct.field("progress_percentage", &self.progress_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -232,7 +232,6 @@ impl std::fmt::Debug for BigqueryMapping {
         debug_struct.field("timestamp_column", &self.timestamp_column);
         debug_struct.field("group_id_column", &self.group_id_column);
         debug_struct.field("dimension_column", &self.dimension_column);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -421,7 +420,6 @@ impl std::fmt::Debug for DataSource {
         let mut debug_struct = f.debug_struct("DataSource");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("bq_mapping", &self.bq_mapping);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -727,7 +725,6 @@ impl std::fmt::Debug for DataSet {
         debug_struct.field("state", &self.state);
         debug_struct.field("status", &self.status);
         debug_struct.field("ttl", &self.ttl);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1290,7 +1287,6 @@ impl std::fmt::Debug for EventDimension {
         let mut debug_struct = f.debug_struct("EventDimension");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1571,7 +1567,6 @@ impl std::fmt::Debug for Event {
         debug_struct.field("dimensions", &self.dimensions);
         debug_struct.field("group_id", &self.group_id);
         debug_struct.field("event_time", &self.event_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1761,7 +1756,6 @@ impl std::fmt::Debug for AppendEventsRequest {
         let mut debug_struct = f.debug_struct("AppendEventsRequest");
         debug_struct.field("events", &self.events);
         debug_struct.field("dataset", &self.dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1907,7 +1901,6 @@ impl std::fmt::Debug for AppendEventsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AppendEventsResponse");
         debug_struct.field("dropped_events", &self.dropped_events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2086,7 +2079,6 @@ impl std::fmt::Debug for CreateDataSetRequest {
         let mut debug_struct = f.debug_struct("CreateDataSetRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("dataset", &self.dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2228,7 +2220,6 @@ impl std::fmt::Debug for DeleteDataSetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDataSetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2440,7 +2431,6 @@ impl std::fmt::Debug for ListDataSetsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2625,7 +2615,6 @@ impl std::fmt::Debug for ListDataSetsResponse {
         let mut debug_struct = f.debug_struct("ListDataSetsResponse");
         debug_struct.field("datasets", &self.datasets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2880,7 +2869,6 @@ impl std::fmt::Debug for PinnedDimension {
         let mut debug_struct = f.debug_struct("PinnedDimension");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3188,7 +3176,6 @@ impl std::fmt::Debug for ForecastParams {
         debug_struct.field("noise_threshold", &self.noise_threshold);
         debug_struct.field("seasonality_hint", &self.seasonality_hint);
         debug_struct.field("horizon_duration", &self.horizon_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3565,7 +3552,6 @@ impl std::fmt::Debug for TimeseriesPoint {
         let mut debug_struct = f.debug_struct("TimeseriesPoint");
         debug_struct.field("time", &self.time);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3714,7 +3700,6 @@ impl std::fmt::Debug for Timeseries {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Timeseries");
         debug_struct.field("point", &self.point);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4296,7 +4281,6 @@ impl std::fmt::Debug for EvaluatedSlice {
         debug_struct.field("history", &self.history);
         debug_struct.field("forecast", &self.forecast);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4524,7 +4508,6 @@ impl std::fmt::Debug for SlicingParams {
         let mut debug_struct = f.debug_struct("SlicingParams");
         debug_struct.field("dimension_names", &self.dimension_names);
         debug_struct.field("pinned_dimensions", &self.pinned_dimensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4903,7 +4886,6 @@ impl std::fmt::Debug for TimeseriesParams {
         debug_struct.field("granularity", &self.granularity);
         debug_struct.field("metric", &self.metric);
         debug_struct.field("metric_aggregation_method", &self.metric_aggregation_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5465,7 +5447,6 @@ impl std::fmt::Debug for QueryDataSetRequest {
         debug_struct.field("timeseries_params", &self.timeseries_params);
         debug_struct.field("forecast_params", &self.forecast_params);
         debug_struct.field("return_timeseries", &self.return_timeseries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5646,7 +5627,6 @@ impl std::fmt::Debug for QueryDataSetResponse {
         let mut debug_struct = f.debug_struct("QueryDataSetResponse");
         debug_struct.field("name", &self.name);
         debug_struct.field("slices", &self.slices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5945,7 +5925,6 @@ impl std::fmt::Debug for EvaluateSliceRequest {
         debug_struct.field("detection_time", &self.detection_time);
         debug_struct.field("timeseries_params", &self.timeseries_params);
         debug_struct.field("forecast_params", &self.forecast_params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6218,7 +6197,6 @@ impl std::fmt::Debug for EvaluateTimeseriesRequest {
         debug_struct.field("timeseries", &self.timeseries);
         debug_struct.field("granularity", &self.granularity);
         debug_struct.field("forecast_params", &self.forecast_params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -209,7 +209,6 @@ impl std::fmt::Debug for GuestAttributes {
         let mut debug_struct = f.debug_struct("GuestAttributes");
         debug_struct.field("query_path", &self.query_path);
         debug_struct.field("query_value", &self.query_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -358,7 +357,6 @@ impl std::fmt::Debug for GuestAttributesValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GuestAttributesValue");
         debug_struct.field("items", &self.items);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -550,7 +548,6 @@ impl std::fmt::Debug for GuestAttributesEntry {
         debug_struct.field("namespace", &self.namespace);
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -723,7 +720,6 @@ impl std::fmt::Debug for AttachedDisk {
         let mut debug_struct = f.debug_struct("AttachedDisk");
         debug_struct.field("source_disk", &self.source_disk);
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1055,7 +1051,6 @@ impl std::fmt::Debug for SchedulingConfig {
         debug_struct.field("preemptible", &self.preemptible);
         debug_struct.field("reserved", &self.reserved);
         debug_struct.field("spot", &self.spot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1278,7 +1273,6 @@ impl std::fmt::Debug for NetworkEndpoint {
         debug_struct.field("ip_address", &self.ip_address);
         debug_struct.field("port", &self.port);
         debug_struct.field("access_config", &self.access_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1421,7 +1415,6 @@ impl std::fmt::Debug for AccessConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccessConfig");
         debug_struct.field("external_ip", &self.external_ip);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1692,7 +1685,6 @@ impl std::fmt::Debug for NetworkConfig {
         debug_struct.field("enable_external_ips", &self.enable_external_ips);
         debug_struct.field("can_ip_forward", &self.can_ip_forward);
         debug_struct.field("queue_count", &self.queue_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1864,7 +1856,6 @@ impl std::fmt::Debug for ServiceAccount {
         let mut debug_struct = f.debug_struct("ServiceAccount");
         debug_struct.field("email", &self.email);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2781,7 +2772,6 @@ impl std::fmt::Debug for Node {
         debug_struct.field("accelerator_config", &self.accelerator_config);
         debug_struct.field("queued_resource", &self.queued_resource);
         debug_struct.field("multislice_node", &self.multislice_node);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3782,7 +3772,6 @@ impl std::fmt::Debug for QueuedResource {
         debug_struct.field("reservation_name", &self.reservation_name);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("tier", &self.tier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3940,7 +3929,6 @@ pub mod queued_resource {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Tpu");
             debug_struct.field("node_spec", &self.node_spec);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4271,7 +4259,6 @@ pub mod queued_resource {
                 debug_struct.field("parent", &self.parent);
                 debug_struct.field("node", &self.node);
                 debug_struct.field("name_strategy", &self.name_strategy);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4500,7 +4487,6 @@ pub mod queued_resource {
                     let mut debug_struct = f.debug_struct("MultisliceParams");
                     debug_struct.field("node_count", &self.node_count);
                     debug_struct.field("node_id_prefix", &self.node_id_prefix);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -4636,7 +4622,6 @@ pub mod queued_resource {
     impl std::fmt::Debug for Spot {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Spot");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4795,7 +4780,6 @@ pub mod queued_resource {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Guaranteed");
             debug_struct.field("min_duration", &self.min_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5198,7 +5182,6 @@ pub mod queued_resource {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QueueingPolicy");
             debug_struct.field("start_timing_constraints", &self.start_timing_constraints);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5928,7 +5911,6 @@ impl std::fmt::Debug for QueuedResourceState {
         debug_struct.field("state", &self.state);
         debug_struct.field("state_initiator", &self.state_initiator);
         debug_struct.field("state_data", &self.state_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6050,7 +6032,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for CreatingData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CreatingData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6167,7 +6148,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for AcceptedData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AcceptedData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6284,7 +6264,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for ProvisioningData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ProvisioningData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6441,7 +6420,6 @@ pub mod queued_resource_state {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("FailedData");
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6558,7 +6536,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for DeletingData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DeletingData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6675,7 +6652,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for ActiveData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ActiveData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6792,7 +6768,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for SuspendingData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SuspendingData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6909,7 +6884,6 @@ pub mod queued_resource_state {
     impl std::fmt::Debug for SuspendedData {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SuspendedData");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7478,7 +7452,6 @@ impl std::fmt::Debug for ListNodesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7693,7 +7666,6 @@ impl std::fmt::Debug for ListNodesResponse {
         debug_struct.field("nodes", &self.nodes);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7837,7 +7809,6 @@ impl std::fmt::Debug for GetNodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNodeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8043,7 +8014,6 @@ impl std::fmt::Debug for CreateNodeRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("node_id", &self.node_id);
         debug_struct.field("node", &self.node);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8187,7 +8157,6 @@ impl std::fmt::Debug for DeleteNodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteNodeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8331,7 +8300,6 @@ impl std::fmt::Debug for StopNodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopNodeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8475,7 +8443,6 @@ impl std::fmt::Debug for StartNodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartNodeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8669,7 +8636,6 @@ impl std::fmt::Debug for UpdateNodeRequest {
         let mut debug_struct = f.debug_struct("UpdateNodeRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("node", &self.node);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8885,7 +8851,6 @@ impl std::fmt::Debug for ListQueuedResourcesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9106,7 +9071,6 @@ impl std::fmt::Debug for ListQueuedResourcesResponse {
         debug_struct.field("queued_resources", &self.queued_resources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9250,7 +9214,6 @@ impl std::fmt::Debug for GetQueuedResourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetQueuedResourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9489,7 +9452,6 @@ impl std::fmt::Debug for CreateQueuedResourceRequest {
         debug_struct.field("queued_resource_id", &self.queued_resource_id);
         debug_struct.field("queued_resource", &self.queued_resource);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9689,7 +9651,6 @@ impl std::fmt::Debug for DeleteQueuedResourceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9834,7 +9795,6 @@ impl std::fmt::Debug for ResetQueuedResourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetQueuedResourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9976,7 +9936,6 @@ impl std::fmt::Debug for ServiceIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceIdentity");
         debug_struct.field("email", &self.email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10121,7 +10080,6 @@ impl std::fmt::Debug for GenerateServiceIdentityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateServiceIdentityRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10278,7 +10236,6 @@ impl std::fmt::Debug for GenerateServiceIdentityResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateServiceIdentityResponse");
         debug_struct.field("identity", &self.identity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10478,7 +10435,6 @@ impl std::fmt::Debug for AcceleratorType {
         debug_struct.field("name", &self.name);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("accelerator_configs", &self.accelerator_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10622,7 +10578,6 @@ impl std::fmt::Debug for GetAcceleratorTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAcceleratorTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10888,7 +10843,6 @@ impl std::fmt::Debug for ListAcceleratorTypesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11109,7 +11063,6 @@ impl std::fmt::Debug for ListAcceleratorTypesResponse {
         debug_struct.field("accelerator_types", &self.accelerator_types);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11276,7 +11229,6 @@ impl std::fmt::Debug for RuntimeVersion {
         let mut debug_struct = f.debug_struct("RuntimeVersion");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11420,7 +11372,6 @@ impl std::fmt::Debug for GetRuntimeVersionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRuntimeVersionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11686,7 +11637,6 @@ impl std::fmt::Debug for ListRuntimeVersionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11907,7 +11857,6 @@ impl std::fmt::Debug for ListRuntimeVersionsResponse {
         debug_struct.field("runtime_versions", &self.runtime_versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12229,7 +12178,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_detail", &self.status_detail);
         debug_struct.field("cancel_requested", &self.cancel_requested);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12461,7 +12409,6 @@ impl std::fmt::Debug for Symptom {
         debug_struct.field("symptom_type", &self.symptom_type);
         debug_struct.field("details", &self.details);
         debug_struct.field("worker_id", &self.worker_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12829,7 +12776,6 @@ impl std::fmt::Debug for GetGuestAttributesRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("query_path", &self.query_path);
         debug_struct.field("worker_ids", &self.worker_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12982,7 +12928,6 @@ impl std::fmt::Debug for GetGuestAttributesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGuestAttributesResponse");
         debug_struct.field("guest_attributes", &self.guest_attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13150,7 +13095,6 @@ impl std::fmt::Debug for AcceleratorConfig {
         let mut debug_struct = f.debug_struct("AcceleratorConfig");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("topology", &self.topology);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13459,7 +13403,6 @@ impl std::fmt::Debug for ShieldedInstanceConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShieldedInstanceConfig");
         debug_struct.field("enable_secure_boot", &self.enable_secure_boot);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -374,7 +374,6 @@ impl std::fmt::Debug for AdaptiveMtDataset {
         debug_struct.field("example_count", &self.example_count);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -555,7 +554,6 @@ impl std::fmt::Debug for CreateAdaptiveMtDatasetRequest {
         let mut debug_struct = f.debug_struct("CreateAdaptiveMtDatasetRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("adaptive_mt_dataset", &self.adaptive_mt_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -698,7 +696,6 @@ impl std::fmt::Debug for DeleteAdaptiveMtDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAdaptiveMtDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -841,7 +838,6 @@ impl std::fmt::Debug for GetAdaptiveMtDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAdaptiveMtDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1086,7 +1082,6 @@ impl std::fmt::Debug for ListAdaptiveMtDatasetsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1278,7 +1273,6 @@ impl std::fmt::Debug for ListAdaptiveMtDatasetsResponse {
         let mut debug_struct = f.debug_struct("ListAdaptiveMtDatasetsResponse");
         debug_struct.field("adaptive_mt_datasets", &self.adaptive_mt_datasets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1559,7 +1553,6 @@ impl std::fmt::Debug for AdaptiveMtTranslateRequest {
         debug_struct.field("content", &self.content);
         debug_struct.field("reference_sentence_config", &self.reference_sentence_config);
         debug_struct.field("glossary_config", &self.glossary_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1742,7 +1735,6 @@ pub mod adaptive_mt_translate_request {
             let mut debug_struct = f.debug_struct("ReferenceSentencePair");
             debug_struct.field("source_sentence", &self.source_sentence);
             debug_struct.field("target_sentence", &self.target_sentence);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1898,7 +1890,6 @@ pub mod adaptive_mt_translate_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReferenceSentencePairList");
             debug_struct.field("reference_sentence_pairs", &self.reference_sentence_pairs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2121,7 +2112,6 @@ pub mod adaptive_mt_translate_request {
             );
             debug_struct.field("source_language_code", &self.source_language_code);
             debug_struct.field("target_language_code", &self.target_language_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2340,7 +2330,6 @@ pub mod adaptive_mt_translate_request {
                 "contextual_translation_enabled",
                 &self.contextual_translation_enabled,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2484,7 +2473,6 @@ impl std::fmt::Debug for AdaptiveMtTranslation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdaptiveMtTranslation");
         debug_struct.field("translated_text", &self.translated_text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2693,7 +2681,6 @@ impl std::fmt::Debug for AdaptiveMtTranslateResponse {
         debug_struct.field("translations", &self.translations);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("glossary_translations", &self.glossary_translations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2980,7 +2967,6 @@ impl std::fmt::Debug for AdaptiveMtFile {
         debug_struct.field("entry_count", &self.entry_count);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3123,7 +3109,6 @@ impl std::fmt::Debug for GetAdaptiveMtFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAdaptiveMtFileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3266,7 +3251,6 @@ impl std::fmt::Debug for DeleteAdaptiveMtFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAdaptiveMtFileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3539,7 +3523,6 @@ impl std::fmt::Debug for ImportAdaptiveMtFileRequest {
         let mut debug_struct = f.debug_struct("ImportAdaptiveMtFileRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3710,7 +3693,6 @@ impl std::fmt::Debug for ImportAdaptiveMtFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportAdaptiveMtFileResponse");
         debug_struct.field("adaptive_mt_file", &self.adaptive_mt_file);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3928,7 +3910,6 @@ impl std::fmt::Debug for ListAdaptiveMtFilesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4120,7 +4101,6 @@ impl std::fmt::Debug for ListAdaptiveMtFilesResponse {
         let mut debug_struct = f.debug_struct("ListAdaptiveMtFilesResponse");
         debug_struct.field("adaptive_mt_files", &self.adaptive_mt_files);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4389,7 +4369,6 @@ impl std::fmt::Debug for AdaptiveMtSentence {
         debug_struct.field("target_sentence", &self.target_sentence);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4608,7 +4587,6 @@ impl std::fmt::Debug for ListAdaptiveMtSentencesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4798,7 +4776,6 @@ impl std::fmt::Debug for ListAdaptiveMtSentencesResponse {
         let mut debug_struct = f.debug_struct("ListAdaptiveMtSentencesResponse");
         debug_struct.field("adaptive_mt_sentences", &self.adaptive_mt_sentences);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4978,7 +4955,6 @@ impl std::fmt::Debug for ImportDataRequest {
         let mut debug_struct = f.debug_struct("ImportDataRequest");
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("input_config", &self.input_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5128,7 +5104,6 @@ impl std::fmt::Debug for DatasetInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatasetInputConfig");
         debug_struct.field("input_files", &self.input_files);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5356,7 +5331,6 @@ pub mod dataset_input_config {
             let mut debug_struct = f.debug_struct("InputFile");
             debug_struct.field("usage", &self.usage);
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5625,7 +5599,6 @@ impl std::fmt::Debug for ImportDataMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5805,7 +5778,6 @@ impl std::fmt::Debug for ExportDataRequest {
         let mut debug_struct = f.debug_struct("ExportDataRequest");
         debug_struct.field("dataset", &self.dataset);
         debug_struct.field("output_config", &self.output_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5998,7 +5970,6 @@ impl std::fmt::Debug for DatasetOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatasetOutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6264,7 +6235,6 @@ impl std::fmt::Debug for ExportDataMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6406,7 +6376,6 @@ impl std::fmt::Debug for DeleteDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6658,7 +6627,6 @@ impl std::fmt::Debug for DeleteDatasetMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6800,7 +6768,6 @@ impl std::fmt::Debug for GetDatasetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatasetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7016,7 +6983,6 @@ impl std::fmt::Debug for ListDatasetsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7203,7 +7169,6 @@ impl std::fmt::Debug for ListDatasetsResponse {
         let mut debug_struct = f.debug_struct("ListDatasetsResponse");
         debug_struct.field("datasets", &self.datasets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7381,7 +7346,6 @@ impl std::fmt::Debug for CreateDatasetRequest {
         let mut debug_struct = f.debug_struct("CreateDatasetRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("dataset", &self.dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7633,7 +7597,6 @@ impl std::fmt::Debug for CreateDatasetMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7877,7 +7840,6 @@ impl std::fmt::Debug for ListExamplesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8064,7 +8026,6 @@ impl std::fmt::Debug for ListExamplesResponse {
         let mut debug_struct = f.debug_struct("ListExamplesResponse");
         debug_struct.field("examples", &self.examples);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8284,7 +8245,6 @@ impl std::fmt::Debug for Example {
         debug_struct.field("source_text", &self.source_text);
         debug_struct.field("target_text", &self.target_text);
         debug_struct.field("usage", &self.usage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8432,7 +8392,6 @@ impl std::fmt::Debug for BatchTransferResourcesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchTransferResourcesResponse");
         debug_struct.field("responses", &self.responses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8644,7 +8603,6 @@ pub mod batch_transfer_resources_response {
             debug_struct.field("source", &self.source);
             debug_struct.field("target", &self.target);
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9132,7 +9090,6 @@ impl std::fmt::Debug for Dataset {
         debug_struct.field("test_example_count", &self.test_example_count);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9311,7 +9268,6 @@ impl std::fmt::Debug for CreateModelRequest {
         let mut debug_struct = f.debug_struct("CreateModelRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9563,7 +9519,6 @@ impl std::fmt::Debug for CreateModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9806,7 +9761,6 @@ impl std::fmt::Debug for ListModelsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9993,7 +9947,6 @@ impl std::fmt::Debug for ListModelsResponse {
         let mut debug_struct = f.debug_struct("ListModelsResponse");
         debug_struct.field("models", &self.models);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10135,7 +10088,6 @@ impl std::fmt::Debug for GetModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10277,7 +10229,6 @@ impl std::fmt::Debug for DeleteModelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteModelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10529,7 +10480,6 @@ impl std::fmt::Debug for DeleteModelMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10998,7 +10948,6 @@ impl std::fmt::Debug for Model {
         debug_struct.field("test_example_count", &self.test_example_count);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11141,7 +11090,6 @@ impl std::fmt::Debug for GcsInputSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsInputSource");
         debug_struct.field("input_uri", &self.input_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11353,7 +11301,6 @@ impl std::fmt::Debug for FileInputSource {
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("content", &self.content);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11501,7 +11448,6 @@ impl std::fmt::Debug for GcsOutputDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsOutputDestination");
         debug_struct.field("output_uri_prefix", &self.output_uri_prefix);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11804,7 +11750,6 @@ impl std::fmt::Debug for GlossaryEntry {
         debug_struct.field("name", &self.name);
         debug_struct.field("description", &self.description);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12005,7 +11950,6 @@ pub mod glossary_entry {
             let mut debug_struct = f.debug_struct("GlossaryTermsPair");
             debug_struct.field("source_term", &self.source_term);
             debug_struct.field("target_term", &self.target_term);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12160,7 +12104,6 @@ pub mod glossary_entry {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GlossaryTermsSet");
             debug_struct.field("terms", &self.terms);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12340,7 +12283,6 @@ impl std::fmt::Debug for GlossaryTerm {
         let mut debug_struct = f.debug_struct("GlossaryTerm");
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("text", &self.text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12484,7 +12426,6 @@ impl std::fmt::Debug for TransliterationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TransliterationConfig");
         debug_struct.field("enable_transliteration", &self.enable_transliteration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12924,7 +12865,6 @@ impl std::fmt::Debug for TranslateTextRequest {
         debug_struct.field("glossary_config", &self.glossary_config);
         debug_struct.field("transliteration_config", &self.transliteration_config);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13108,7 +13048,6 @@ impl std::fmt::Debug for TranslateTextResponse {
         let mut debug_struct = f.debug_struct("TranslateTextResponse");
         debug_struct.field("translations", &self.translations);
         debug_struct.field("glossary_translations", &self.glossary_translations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13354,7 +13293,6 @@ impl std::fmt::Debug for Translation {
         debug_struct.field("model", &self.model);
         debug_struct.field("detected_language_code", &self.detected_language_code);
         debug_struct.field("glossary_config", &self.glossary_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13566,7 +13504,6 @@ impl std::fmt::Debug for RomanizeTextRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("contents", &self.contents);
         debug_struct.field("source_language_code", &self.source_language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13743,7 +13680,6 @@ impl std::fmt::Debug for Romanization {
         let mut debug_struct = f.debug_struct("Romanization");
         debug_struct.field("romanized_text", &self.romanized_text);
         debug_struct.field("detected_language_code", &self.detected_language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13892,7 +13828,6 @@ impl std::fmt::Debug for RomanizeTextResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RomanizeTextResponse");
         debug_struct.field("romanizations", &self.romanizations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14214,7 +14149,6 @@ impl std::fmt::Debug for DetectLanguageRequest {
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14415,7 +14349,6 @@ impl std::fmt::Debug for DetectedLanguage {
         let mut debug_struct = f.debug_struct("DetectedLanguage");
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14565,7 +14498,6 @@ impl std::fmt::Debug for DetectLanguageResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DetectLanguageResponse");
         debug_struct.field("languages", &self.languages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14787,7 +14719,6 @@ impl std::fmt::Debug for GetSupportedLanguagesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("display_language_code", &self.display_language_code);
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14937,7 +14868,6 @@ impl std::fmt::Debug for SupportedLanguages {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SupportedLanguages");
         debug_struct.field("languages", &self.languages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15163,7 +15093,6 @@ impl std::fmt::Debug for SupportedLanguage {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("support_source", &self.support_source);
         debug_struct.field("support_target", &self.support_target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15306,7 +15235,6 @@ impl std::fmt::Debug for GcsSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsSource");
         debug_struct.field("input_uri", &self.input_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15521,7 +15449,6 @@ impl std::fmt::Debug for InputConfig {
         let mut debug_struct = f.debug_struct("InputConfig");
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15702,7 +15629,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("output_uri_prefix", &self.output_uri_prefix);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15895,7 +15821,6 @@ impl std::fmt::Debug for OutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16276,7 +16201,6 @@ impl std::fmt::Debug for DocumentInputConfig {
         let mut debug_struct = f.debug_struct("DocumentInputConfig");
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16533,7 +16457,6 @@ impl std::fmt::Debug for DocumentOutputConfig {
         let mut debug_struct = f.debug_struct("DocumentOutputConfig");
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17157,7 +17080,6 @@ impl std::fmt::Debug for TranslateDocumentRequest {
             "enable_rotation_correction",
             &self.enable_rotation_correction,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17392,7 +17314,6 @@ impl std::fmt::Debug for DocumentTranslation {
         debug_struct.field("byte_stream_outputs", &self.byte_stream_outputs);
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("detected_language_code", &self.detected_language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17667,7 +17588,6 @@ impl std::fmt::Debug for TranslateDocumentResponse {
         );
         debug_struct.field("model", &self.model);
         debug_struct.field("glossary_config", &self.glossary_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18082,7 +18002,6 @@ impl std::fmt::Debug for BatchTranslateTextRequest {
         debug_struct.field("output_config", &self.output_config);
         debug_struct.field("glossaries", &self.glossaries);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18404,7 +18323,6 @@ impl std::fmt::Debug for BatchTranslateMetadata {
         debug_struct.field("failed_characters", &self.failed_characters);
         debug_struct.field("total_characters", &self.total_characters);
         debug_struct.field("submit_time", &self.submit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18902,7 +18820,6 @@ impl std::fmt::Debug for BatchTranslateResponse {
         debug_struct.field("failed_characters", &self.failed_characters);
         debug_struct.field("submit_time", &self.submit_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19091,7 +19008,6 @@ impl std::fmt::Debug for GlossaryInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GlossaryInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19580,7 +19496,6 @@ impl std::fmt::Debug for Glossary {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("languages", &self.languages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19765,7 +19680,6 @@ pub mod glossary {
             let mut debug_struct = f.debug_struct("LanguageCodePair");
             debug_struct.field("source_language_code", &self.source_language_code);
             debug_struct.field("target_language_code", &self.target_language_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19916,7 +19830,6 @@ pub mod glossary {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LanguageCodesSet");
             debug_struct.field("language_codes", &self.language_codes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20105,7 +20018,6 @@ impl std::fmt::Debug for CreateGlossaryRequest {
         let mut debug_struct = f.debug_struct("CreateGlossaryRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("glossary", &self.glossary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20296,7 +20208,6 @@ impl std::fmt::Debug for UpdateGlossaryRequest {
         let mut debug_struct = f.debug_struct("UpdateGlossaryRequest");
         debug_struct.field("glossary", &self.glossary);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20438,7 +20349,6 @@ impl std::fmt::Debug for GetGlossaryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGlossaryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20580,7 +20490,6 @@ impl std::fmt::Debug for DeleteGlossaryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGlossaryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20836,7 +20745,6 @@ impl std::fmt::Debug for ListGlossariesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21023,7 +20931,6 @@ impl std::fmt::Debug for ListGlossariesResponse {
         let mut debug_struct = f.debug_struct("ListGlossariesResponse");
         debug_struct.field("glossaries", &self.glossaries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21165,7 +21072,6 @@ impl std::fmt::Debug for GetGlossaryEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGlossaryEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21307,7 +21213,6 @@ impl std::fmt::Debug for DeleteGlossaryEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGlossaryEntryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21524,7 +21429,6 @@ impl std::fmt::Debug for ListGlossaryEntriesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21711,7 +21615,6 @@ impl std::fmt::Debug for ListGlossaryEntriesResponse {
         let mut debug_struct = f.debug_struct("ListGlossaryEntriesResponse");
         debug_struct.field("glossary_entries", &self.glossary_entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21890,7 +21793,6 @@ impl std::fmt::Debug for CreateGlossaryEntryRequest {
         let mut debug_struct = f.debug_struct("CreateGlossaryEntryRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("glossary_entry", &self.glossary_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22044,7 +21946,6 @@ impl std::fmt::Debug for UpdateGlossaryEntryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateGlossaryEntryRequest");
         debug_struct.field("glossary_entry", &self.glossary_entry);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22257,7 +22158,6 @@ impl std::fmt::Debug for CreateGlossaryMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("state", &self.state);
         debug_struct.field("submit_time", &self.submit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22642,7 +22542,6 @@ impl std::fmt::Debug for UpdateGlossaryMetadata {
         debug_struct.field("glossary", &self.glossary);
         debug_struct.field("state", &self.state);
         debug_struct.field("submit_time", &self.submit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23015,7 +22914,6 @@ impl std::fmt::Debug for DeleteGlossaryMetadata {
         debug_struct.field("name", &self.name);
         debug_struct.field("state", &self.state);
         debug_struct.field("submit_time", &self.submit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23399,7 +23297,6 @@ impl std::fmt::Debug for DeleteGlossaryResponse {
         debug_struct.field("name", &self.name);
         debug_struct.field("submit_time", &self.submit_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23928,7 +23825,6 @@ impl std::fmt::Debug for BatchTranslateDocumentRequest {
             "enable_rotation_correction",
             &self.enable_rotation_correction,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24117,7 +24013,6 @@ impl std::fmt::Debug for BatchDocumentInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchDocumentInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24343,7 +24238,6 @@ impl std::fmt::Debug for BatchDocumentOutputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchDocumentOutputConfig");
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24974,7 +24868,6 @@ impl std::fmt::Debug for BatchTranslateDocumentResponse {
         debug_struct.field("total_billable_characters", &self.total_billable_characters);
         debug_struct.field("submit_time", &self.submit_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25532,7 +25425,6 @@ impl std::fmt::Debug for BatchTranslateDocumentMetadata {
         debug_struct.field("failed_characters", &self.failed_characters);
         debug_struct.field("total_billable_characters", &self.total_billable_characters);
         debug_struct.field("submit_time", &self.submit_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25906,7 +25798,6 @@ impl std::fmt::Debug for TranslateTextGlossaryConfig {
             "contextual_translation_enabled",
             &self.contextual_translation_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -353,7 +353,6 @@ impl std::fmt::Debug for ElementaryStream {
         let mut debug_struct = f.debug_struct("ElementaryStream");
         debug_struct.field("key", &self.key);
         debug_struct.field("elementary_stream", &self.elementary_stream);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -647,7 +646,6 @@ impl std::fmt::Debug for MuxStream {
         debug_struct.field("elementary_streams", &self.elementary_streams);
         debug_struct.field("segment_settings", &self.segment_settings);
         debug_struct.field("encryption_id", &self.encryption_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1015,7 +1013,6 @@ impl std::fmt::Debug for Manifest {
         debug_struct.field("segment_keep_duration", &self.segment_keep_duration);
         debug_struct.field("use_timecode_as_timeline", &self.use_timecode_as_timeline);
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1593,7 +1590,6 @@ impl std::fmt::Debug for SpriteSheet {
         debug_struct.field("row_count", &self.row_count);
         debug_struct.field("interval", &self.interval);
         debug_struct.field("quality", &self.quality);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1818,7 +1814,6 @@ impl std::fmt::Debug for PreprocessingConfig {
         debug_struct.field("audio", &self.audio);
         debug_struct.field("crop", &self.crop);
         debug_struct.field("pad", &self.pad);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1996,7 +1991,6 @@ pub mod preprocessing_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Audio");
             debug_struct.field("lufs", &self.lufs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2297,7 +2291,6 @@ pub mod preprocessing_config {
             debug_struct.field("bottom_pixels", &self.bottom_pixels);
             debug_struct.field("left_pixels", &self.left_pixels);
             debug_struct.field("right_pixels", &self.right_pixels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2598,7 +2591,6 @@ pub mod preprocessing_config {
             debug_struct.field("bottom_pixels", &self.bottom_pixels);
             debug_struct.field("left_pixels", &self.left_pixels);
             debug_struct.field("right_pixels", &self.right_pixels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2790,7 +2782,6 @@ impl std::fmt::Debug for VideoStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VideoStream");
         debug_struct.field("codec_settings", &self.codec_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3601,7 +3592,6 @@ pub mod video_stream {
             debug_struct.field("profile", &self.profile);
             debug_struct.field("tune", &self.tune);
             debug_struct.field("gop_mode", &self.gop_mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4019,7 +4009,6 @@ impl std::fmt::Debug for AudioStream {
         debug_struct.field("channel_layout", &self.channel_layout);
         debug_struct.field("mapping", &self.mapping);
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4366,7 +4355,6 @@ pub mod audio_stream {
             debug_struct.field("input_channel", &self.input_channel);
             debug_struct.field("output_channel", &self.output_channel);
             debug_struct.field("gain_db", &self.gain_db);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4514,7 +4502,6 @@ impl std::fmt::Debug for TextStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TextStream");
         debug_struct.field("codec", &self.codec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4679,7 +4666,6 @@ impl std::fmt::Debug for SegmentSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SegmentSettings");
         debug_struct.field("segment_duration", &self.segment_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4949,7 +4935,6 @@ impl std::fmt::Debug for TimecodeConfig {
         let mut debug_struct = f.debug_struct("TimecodeConfig");
         debug_struct.field("source", &self.source);
         debug_struct.field("time_offset", &self.time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5550,7 +5535,6 @@ impl std::fmt::Debug for Input {
         debug_struct.field("preprocessing_config", &self.preprocessing_config);
         debug_struct.field("security_rules", &self.security_rules);
         debug_struct.field("input_stream_property", &self.input_stream_property);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5708,7 +5692,6 @@ pub mod input {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SecurityRule");
             debug_struct.field("ip_ranges", &self.ip_ranges);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6746,7 +6729,6 @@ impl std::fmt::Debug for Channel {
         debug_struct.field("input_config", &self.input_config);
         debug_struct.field("retention_config", &self.retention_config);
         debug_struct.field("static_overlays", &self.static_overlays);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6896,7 +6878,6 @@ pub mod channel {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Output");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7272,7 +7253,6 @@ impl std::fmt::Debug for NormalizedCoordinate {
         let mut debug_struct = f.debug_struct("NormalizedCoordinate");
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7475,7 +7455,6 @@ impl std::fmt::Debug for NormalizedResolution {
         let mut debug_struct = f.debug_struct("NormalizedResolution");
         debug_struct.field("w", &self.w);
         debug_struct.field("h", &self.h);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7743,7 +7722,6 @@ impl std::fmt::Debug for StaticOverlay {
         debug_struct.field("resolution", &self.resolution);
         debug_struct.field("position", &self.position);
         debug_struct.field("opacity", &self.opacity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7893,7 +7871,6 @@ impl std::fmt::Debug for InputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InputConfig");
         debug_struct.field("input_switch_mode", &self.input_switch_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8191,7 +8168,6 @@ impl std::fmt::Debug for LogConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LogConfig");
         debug_struct.field("log_severity", &self.log_severity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8533,7 +8509,6 @@ impl std::fmt::Debug for RetentionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetentionConfig");
         debug_struct.field("retention_window_duration", &self.retention_window_duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8754,7 +8729,6 @@ impl std::fmt::Debug for InputStreamProperty {
         debug_struct.field("last_establish_time", &self.last_establish_time);
         debug_struct.field("video_streams", &self.video_streams);
         debug_struct.field("audio_streams", &self.audio_streams);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8951,7 +8925,6 @@ impl std::fmt::Debug for VideoStreamProperty {
         let mut debug_struct = f.debug_struct("VideoStreamProperty");
         debug_struct.field("index", &self.index);
         debug_struct.field("video_format", &self.video_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9226,7 +9199,6 @@ impl std::fmt::Debug for VideoFormat {
         debug_struct.field("width_pixels", &self.width_pixels);
         debug_struct.field("height_pixels", &self.height_pixels);
         debug_struct.field("frame_rate", &self.frame_rate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9423,7 +9395,6 @@ impl std::fmt::Debug for AudioStreamProperty {
         let mut debug_struct = f.debug_struct("AudioStreamProperty");
         debug_struct.field("index", &self.index);
         debug_struct.field("audio_format", &self.audio_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9639,7 +9610,6 @@ impl std::fmt::Debug for AudioFormat {
         debug_struct.field("codec", &self.codec);
         debug_struct.field("channel_count", &self.channel_count);
         debug_struct.field("channel_layout", &self.channel_layout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9847,7 +9817,6 @@ impl std::fmt::Debug for InputAttachment {
         debug_struct.field("key", &self.key);
         debug_struct.field("input", &self.input);
         debug_struct.field("automatic_failover", &self.automatic_failover);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10006,7 +9975,6 @@ pub mod input_attachment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AutomaticFailover");
             debug_struct.field("input_keys", &self.input_keys);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10720,7 +10688,6 @@ impl std::fmt::Debug for Event {
         debug_struct.field("state", &self.state);
         debug_struct.field("error", &self.error);
         debug_struct.field("task", &self.task);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10875,7 +10842,6 @@ pub mod event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("InputSwitchTask");
             debug_struct.field("input_key", &self.input_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11031,7 +10997,6 @@ pub mod event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AdBreakTask");
             debug_struct.field("duration", &self.duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11216,7 +11181,6 @@ pub mod event {
             let mut debug_struct = f.debug_struct("SlateTask");
             debug_struct.field("duration", &self.duration);
             debug_struct.field("asset", &self.asset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11334,7 +11298,6 @@ pub mod event {
     impl std::fmt::Debug for ReturnToProgramTask {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ReturnToProgramTask");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11491,7 +11454,6 @@ pub mod event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MuteTask");
             debug_struct.field("duration", &self.duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11608,7 +11570,6 @@ pub mod event {
     impl std::fmt::Debug for UnmuteTask {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UnmuteTask");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12272,7 +12233,6 @@ impl std::fmt::Debug for Clip {
         debug_struct.field("slices", &self.slices);
         debug_struct.field("clip_manifests", &self.clip_manifests);
         debug_struct.field("output_type", &self.output_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12472,7 +12432,6 @@ pub mod clip {
             let mut debug_struct = f.debug_struct("TimeSlice");
             debug_struct.field("markin_time", &self.markin_time);
             debug_struct.field("markout_time", &self.markout_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12665,7 +12624,6 @@ pub mod clip {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Slice");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12861,7 +12819,6 @@ pub mod clip {
             let mut debug_struct = f.debug_struct("ClipManifest");
             debug_struct.field("manifest_key", &self.manifest_key);
             debug_struct.field("output_uri", &self.output_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13334,7 +13291,6 @@ impl std::fmt::Debug for TimeInterval {
         let mut debug_struct = f.debug_struct("TimeInterval");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13723,7 +13679,6 @@ impl std::fmt::Debug for DvrSession {
         debug_struct.field("error", &self.error);
         debug_struct.field("dvr_manifests", &self.dvr_manifests);
         debug_struct.field("dvr_windows", &self.dvr_windows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13910,7 +13865,6 @@ pub mod dvr_session {
             let mut debug_struct = f.debug_struct("DvrManifest");
             debug_struct.field("manifest_key", &self.manifest_key);
             debug_struct.field("output_uri", &self.output_uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14106,7 +14060,6 @@ pub mod dvr_session {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DvrWindow");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14788,7 +14741,6 @@ impl std::fmt::Debug for Asset {
         debug_struct.field("state", &self.state);
         debug_struct.field("error", &self.error);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14940,7 +14892,6 @@ pub mod asset {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("VideoAsset");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15085,7 +15036,6 @@ pub mod asset {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ImageAsset");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15692,7 +15642,6 @@ impl std::fmt::Debug for Encryption {
         debug_struct.field("drm_systems", &self.drm_systems);
         debug_struct.field("secret_source", &self.secret_source);
         debug_struct.field("encryption_mode", &self.encryption_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15847,7 +15796,6 @@ pub mod encryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SecretManagerSource");
             debug_struct.field("secret_version", &self.secret_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15964,7 +15912,6 @@ pub mod encryption {
     impl std::fmt::Debug for Widevine {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Widevine");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16081,7 +16028,6 @@ pub mod encryption {
     impl std::fmt::Debug for Fairplay {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Fairplay");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16198,7 +16144,6 @@ pub mod encryption {
     impl std::fmt::Debug for Playready {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Playready");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16315,7 +16260,6 @@ pub mod encryption {
     impl std::fmt::Debug for Clearkey {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Clearkey");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16580,7 +16524,6 @@ pub mod encryption {
             debug_struct.field("fairplay", &self.fairplay);
             debug_struct.field("playready", &self.playready);
             debug_struct.field("clearkey", &self.clearkey);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16697,7 +16640,6 @@ pub mod encryption {
     impl std::fmt::Debug for Aes128Encryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Aes128Encryption");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16814,7 +16756,6 @@ pub mod encryption {
     impl std::fmt::Debug for SampleAesEncryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SampleAesEncryption");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16962,7 +16903,6 @@ pub mod encryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MpegCommonEncryption");
             debug_struct.field("scheme", &self.scheme);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17276,7 +17216,6 @@ impl std::fmt::Debug for Pool {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("network_config", &self.network_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17436,7 +17375,6 @@ pub mod pool {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NetworkConfig");
             debug_struct.field("peered_network", &self.peered_network);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17682,7 +17620,6 @@ impl std::fmt::Debug for CreateAssetRequest {
         debug_struct.field("asset", &self.asset);
         debug_struct.field("asset_id", &self.asset_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17863,7 +17800,6 @@ impl std::fmt::Debug for DeleteAssetRequest {
         let mut debug_struct = f.debug_struct("DeleteAssetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18128,7 +18064,6 @@ impl std::fmt::Debug for ListAssetsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18341,7 +18276,6 @@ impl std::fmt::Debug for ListAssetsResponse {
         debug_struct.field("assets", &self.assets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18484,7 +18418,6 @@ impl std::fmt::Debug for GetAssetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAssetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18729,7 +18662,6 @@ impl std::fmt::Debug for CreateChannelRequest {
         debug_struct.field("channel", &self.channel);
         debug_struct.field("channel_id", &self.channel_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19000,7 +18932,6 @@ impl std::fmt::Debug for ListChannelsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19214,7 +19145,6 @@ impl std::fmt::Debug for ListChannelsResponse {
         debug_struct.field("channels", &self.channels);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19357,7 +19287,6 @@ impl std::fmt::Debug for GetChannelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetChannelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19566,7 +19495,6 @@ impl std::fmt::Debug for DeleteChannelRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19813,7 +19741,6 @@ impl std::fmt::Debug for UpdateChannelRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("channel", &self.channel);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19994,7 +19921,6 @@ impl std::fmt::Debug for StartChannelRequest {
         let mut debug_struct = f.debug_struct("StartChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20175,7 +20101,6 @@ impl std::fmt::Debug for StopChannelRequest {
         let mut debug_struct = f.debug_struct("StopChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20420,7 +20345,6 @@ impl std::fmt::Debug for CreateInputRequest {
         debug_struct.field("input", &self.input);
         debug_struct.field("input_id", &self.input_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20691,7 +20615,6 @@ impl std::fmt::Debug for ListInputsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20905,7 +20828,6 @@ impl std::fmt::Debug for ListInputsResponse {
         debug_struct.field("inputs", &self.inputs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21048,7 +20970,6 @@ impl std::fmt::Debug for GetInputRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInputRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21229,7 +21150,6 @@ impl std::fmt::Debug for DeleteInputRequest {
         let mut debug_struct = f.debug_struct("DeleteInputRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21469,7 +21389,6 @@ impl std::fmt::Debug for UpdateInputRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("input", &self.input);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21714,7 +21633,6 @@ impl std::fmt::Debug for CreateEventRequest {
         debug_struct.field("event", &self.event);
         debug_struct.field("event_id", &self.event_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21985,7 +21903,6 @@ impl std::fmt::Debug for ListEventsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22199,7 +22116,6 @@ impl std::fmt::Debug for ListEventsResponse {
         debug_struct.field("events", &self.events);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22342,7 +22258,6 @@ impl std::fmt::Debug for GetEventRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetEventRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22523,7 +22438,6 @@ impl std::fmt::Debug for DeleteEventRequest {
         let mut debug_struct = f.debug_struct("DeleteEventRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22637,7 +22551,6 @@ impl serde::ser::Serialize for ChannelOperationResponse {
 impl std::fmt::Debug for ChannelOperationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ChannelOperationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22901,7 +22814,6 @@ impl std::fmt::Debug for ListClipsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23114,7 +23026,6 @@ impl std::fmt::Debug for ListClipsResponse {
         debug_struct.field("clips", &self.clips);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23257,7 +23168,6 @@ impl std::fmt::Debug for GetClipRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClipRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23503,7 +23413,6 @@ impl std::fmt::Debug for CreateClipRequest {
         debug_struct.field("clip_id", &self.clip_id);
         debug_struct.field("clip", &self.clip);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23684,7 +23593,6 @@ impl std::fmt::Debug for DeleteClipRequest {
         let mut debug_struct = f.debug_struct("DeleteClipRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23948,7 +23856,6 @@ impl std::fmt::Debug for ListDvrSessionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24162,7 +24069,6 @@ impl std::fmt::Debug for ListDvrSessionsResponse {
         debug_struct.field("dvr_sessions", &self.dvr_sessions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24305,7 +24211,6 @@ impl std::fmt::Debug for GetDvrSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDvrSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24552,7 +24457,6 @@ impl std::fmt::Debug for CreateDvrSessionRequest {
         debug_struct.field("dvr_session_id", &self.dvr_session_id);
         debug_struct.field("dvr_session", &self.dvr_session);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24733,7 +24637,6 @@ impl std::fmt::Debug for DeleteDvrSessionRequest {
         let mut debug_struct = f.debug_struct("DeleteDvrSessionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24969,7 +24872,6 @@ impl std::fmt::Debug for UpdateDvrSessionRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("dvr_session", &self.dvr_session);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25270,7 +25172,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("verb", &self.verb);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25413,7 +25314,6 @@ impl std::fmt::Debug for GetPoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25647,7 +25547,6 @@ impl std::fmt::Debug for UpdatePoolRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("pool", &self.pool);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -198,7 +198,6 @@ impl std::fmt::Debug for LiveAdTagDetail {
         let mut debug_struct = f.debug_struct("LiveAdTagDetail");
         debug_struct.field("name", &self.name);
         debug_struct.field("ad_requests", &self.ad_requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -372,7 +371,6 @@ impl std::fmt::Debug for VodAdTagDetail {
         let mut debug_struct = f.debug_struct("VodAdTagDetail");
         debug_struct.field("name", &self.name);
         debug_struct.field("ad_requests", &self.ad_requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -590,7 +588,6 @@ impl std::fmt::Debug for AdRequest {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("request_metadata", &self.request_metadata);
         debug_struct.field("response_metadata", &self.response_metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -743,7 +740,6 @@ impl std::fmt::Debug for RequestMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RequestMetadata");
         debug_struct.field("headers", &self.headers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1052,7 +1048,6 @@ impl std::fmt::Debug for ResponseMetadata {
         debug_struct.field("size_bytes", &self.size_bytes);
         debug_struct.field("duration", &self.duration);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1404,7 +1399,6 @@ impl std::fmt::Debug for CdnKey {
         debug_struct.field("name", &self.name);
         debug_struct.field("hostname", &self.hostname);
         debug_struct.field("cdn_key_config", &self.cdn_key_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1609,7 +1603,6 @@ impl std::fmt::Debug for GoogleCdnKey {
         let mut debug_struct = f.debug_struct("GoogleCdnKey");
         debug_struct.field("private_key", &self.private_key);
         debug_struct.field("key_name", &self.key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1770,7 +1763,6 @@ impl std::fmt::Debug for AkamaiCdnKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AkamaiCdnKey");
         debug_struct.field("token_key", &self.token_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1995,7 +1987,6 @@ impl std::fmt::Debug for MediaCdnKey {
         debug_struct.field("private_key", &self.private_key);
         debug_struct.field("key_name", &self.key_name);
         debug_struct.field("token_config", &self.token_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2156,7 +2147,6 @@ pub mod media_cdn_key {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TokenConfig");
             debug_struct.field("query_parameter", &self.query_parameter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2335,7 +2325,6 @@ impl std::fmt::Debug for CompanionAds {
         let mut debug_struct = f.debug_struct("CompanionAds");
         debug_struct.field("display_requirement", &self.display_requirement);
         debug_struct.field("companions", &self.companions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3137,7 +3126,6 @@ impl std::fmt::Debug for Companion {
         debug_struct.field("ad_slot_id", &self.ad_slot_id);
         debug_struct.field("events", &self.events);
         debug_struct.field("ad_resource", &self.ad_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3298,7 +3286,6 @@ impl std::fmt::Debug for HtmlAdResource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HtmlAdResource");
         debug_struct.field("html_source", &self.html_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3440,7 +3427,6 @@ impl std::fmt::Debug for IframeAdResource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IframeAdResource");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3608,7 +3594,6 @@ impl std::fmt::Debug for StaticAdResource {
         let mut debug_struct = f.debug_struct("StaticAdResource");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("creative_type", &self.creative_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3837,7 +3822,6 @@ impl std::fmt::Debug for Event {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("id", &self.id);
         debug_struct.field("offset", &self.offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4316,7 +4300,6 @@ impl std::fmt::Debug for ProgressEvent {
         let mut debug_struct = f.debug_struct("ProgressEvent");
         debug_struct.field("time_offset", &self.time_offset);
         debug_struct.field("events", &self.events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4472,7 +4455,6 @@ impl std::fmt::Debug for FetchOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchOptions");
         debug_struct.field("headers", &self.headers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4894,7 +4876,6 @@ impl std::fmt::Debug for LiveConfig {
         debug_struct.field("stitching_policy", &self.stitching_policy);
         debug_struct.field("prefetch_config", &self.prefetch_config);
         debug_struct.field("source_fetch_options", &self.source_fetch_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5367,7 +5348,6 @@ impl std::fmt::Debug for PrefetchConfig {
             "initial_ad_request_duration",
             &self.initial_ad_request_duration,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5565,7 +5545,6 @@ impl std::fmt::Debug for GamLiveConfig {
         debug_struct.field("network_code", &self.network_code);
         debug_struct.field("asset_key", &self.asset_key);
         debug_struct.field("custom_asset_key", &self.custom_asset_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6037,7 +6016,6 @@ impl std::fmt::Debug for VodSession {
         debug_struct.field("ad_tracking", &self.ad_tracking);
         debug_struct.field("gam_settings", &self.gam_settings);
         debug_struct.field("vod_config", &self.vod_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6218,7 +6196,6 @@ pub mod vod_session {
             let mut debug_struct = f.debug_struct("GamSettings");
             debug_struct.field("network_code", &self.network_code);
             debug_struct.field("stream_id", &self.stream_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6407,7 +6384,6 @@ impl std::fmt::Debug for Interstitials {
         let mut debug_struct = f.debug_struct("Interstitials");
         debug_struct.field("ad_breaks", &self.ad_breaks);
         debug_struct.field("session_content", &self.session_content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6630,7 +6606,6 @@ impl std::fmt::Debug for VodSessionAd {
         debug_struct.field("duration", &self.duration);
         debug_struct.field("companion_ads", &self.companion_ads);
         debug_struct.field("activity_events", &self.activity_events);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6784,7 +6759,6 @@ impl std::fmt::Debug for VodSessionContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VodSessionContent");
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7032,7 +7006,6 @@ impl std::fmt::Debug for VodSessionAdBreak {
         debug_struct.field("ads", &self.ads);
         debug_struct.field("end_time_offset", &self.end_time_offset);
         debug_struct.field("start_time_offset", &self.start_time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7384,7 +7357,6 @@ impl std::fmt::Debug for LiveSession {
         debug_struct.field("gam_settings", &self.gam_settings);
         debug_struct.field("live_config", &self.live_config);
         debug_struct.field("ad_tracking", &self.ad_tracking);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7577,7 +7549,6 @@ pub mod live_session {
             let mut debug_struct = f.debug_struct("GamSettings");
             debug_struct.field("stream_id", &self.stream_id);
             debug_struct.field("targeting_parameters", &self.targeting_parameters);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7761,7 +7732,6 @@ impl std::fmt::Debug for ManifestOptions {
         let mut debug_struct = f.debug_struct("ManifestOptions");
         debug_struct.field("include_renditions", &self.include_renditions);
         debug_struct.field("bitrate_order", &self.bitrate_order);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8087,7 +8057,6 @@ impl std::fmt::Debug for RenditionFilter {
         let mut debug_struct = f.debug_struct("RenditionFilter");
         debug_struct.field("bitrate_bps", &self.bitrate_bps);
         debug_struct.field("codecs", &self.codecs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8294,7 +8263,6 @@ impl std::fmt::Debug for Slate {
         debug_struct.field("name", &self.name);
         debug_struct.field("uri", &self.uri);
         debug_struct.field("gam_slate", &self.gam_slate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8494,7 +8462,6 @@ pub mod slate {
             let mut debug_struct = f.debug_struct("GamSlate");
             debug_struct.field("network_code", &self.network_code);
             debug_struct.field("gam_slate_id", &self.gam_slate_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8673,7 +8640,6 @@ impl std::fmt::Debug for VodStitchDetail {
         let mut debug_struct = f.debug_struct("VodStitchDetail");
         debug_struct.field("name", &self.name);
         debug_struct.field("ad_stitch_details", &self.ad_stitch_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8938,7 +8904,6 @@ impl std::fmt::Debug for AdStitchDetail {
         debug_struct.field("ad_time_offset", &self.ad_time_offset);
         debug_struct.field("skip_reason", &self.skip_reason);
         debug_struct.field("media", &self.media);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9149,7 +9114,6 @@ impl std::fmt::Debug for CreateCdnKeyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("cdn_key", &self.cdn_key);
         debug_struct.field("cdn_key_id", &self.cdn_key_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9414,7 +9378,6 @@ impl std::fmt::Debug for ListCdnKeysRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9628,7 +9591,6 @@ impl std::fmt::Debug for ListCdnKeysResponse {
         debug_struct.field("cdn_keys", &self.cdn_keys);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9771,7 +9733,6 @@ impl std::fmt::Debug for GetCdnKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCdnKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9914,7 +9875,6 @@ impl std::fmt::Debug for DeleteCdnKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteCdnKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10107,7 +10067,6 @@ impl std::fmt::Debug for UpdateCdnKeyRequest {
         let mut debug_struct = f.debug_struct("UpdateCdnKeyRequest");
         debug_struct.field("cdn_key", &self.cdn_key);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10287,7 +10246,6 @@ impl std::fmt::Debug for CreateVodSessionRequest {
         let mut debug_struct = f.debug_struct("CreateVodSessionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("vod_session", &self.vod_session);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10430,7 +10388,6 @@ impl std::fmt::Debug for GetVodSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVodSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10643,7 +10600,6 @@ impl std::fmt::Debug for ListVodStitchDetailsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10833,7 +10789,6 @@ impl std::fmt::Debug for ListVodStitchDetailsResponse {
         let mut debug_struct = f.debug_struct("ListVodStitchDetailsResponse");
         debug_struct.field("vod_stitch_details", &self.vod_stitch_details);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10977,7 +10932,6 @@ impl std::fmt::Debug for GetVodStitchDetailRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVodStitchDetailRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11190,7 +11144,6 @@ impl std::fmt::Debug for ListVodAdTagDetailsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11380,7 +11333,6 @@ impl std::fmt::Debug for ListVodAdTagDetailsResponse {
         let mut debug_struct = f.debug_struct("ListVodAdTagDetailsResponse");
         debug_struct.field("vod_ad_tag_details", &self.vod_ad_tag_details);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11524,7 +11476,6 @@ impl std::fmt::Debug for GetVodAdTagDetailRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVodAdTagDetailRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11737,7 +11688,6 @@ impl std::fmt::Debug for ListLiveAdTagDetailsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11927,7 +11877,6 @@ impl std::fmt::Debug for ListLiveAdTagDetailsResponse {
         let mut debug_struct = f.debug_struct("ListLiveAdTagDetailsResponse");
         debug_struct.field("live_ad_tag_details", &self.live_ad_tag_details);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12070,7 +12019,6 @@ impl std::fmt::Debug for GetLiveAdTagDetailRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLiveAdTagDetailRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12316,7 +12264,6 @@ impl std::fmt::Debug for CreateSlateRequest {
         debug_struct.field("slate_id", &self.slate_id);
         debug_struct.field("slate", &self.slate);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12459,7 +12406,6 @@ impl std::fmt::Debug for GetSlateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSlateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12724,7 +12670,6 @@ impl std::fmt::Debug for ListSlatesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12937,7 +12882,6 @@ impl std::fmt::Debug for ListSlatesResponse {
         debug_struct.field("slates", &self.slates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13127,7 +13071,6 @@ impl std::fmt::Debug for UpdateSlateRequest {
         let mut debug_struct = f.debug_struct("UpdateSlateRequest");
         debug_struct.field("slate", &self.slate);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13270,7 +13213,6 @@ impl std::fmt::Debug for DeleteSlateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSlateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13450,7 +13392,6 @@ impl std::fmt::Debug for CreateLiveSessionRequest {
         let mut debug_struct = f.debug_struct("CreateLiveSessionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("live_session", &self.live_session);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13593,7 +13534,6 @@ impl std::fmt::Debug for GetLiveSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLiveSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13837,7 +13777,6 @@ impl std::fmt::Debug for CreateLiveConfigRequest {
         debug_struct.field("live_config_id", &self.live_config_id);
         debug_struct.field("live_config", &self.live_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14104,7 +14043,6 @@ impl std::fmt::Debug for ListLiveConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14318,7 +14256,6 @@ impl std::fmt::Debug for ListLiveConfigsResponse {
         debug_struct.field("live_configs", &self.live_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14462,7 +14399,6 @@ impl std::fmt::Debug for GetLiveConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLiveConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14605,7 +14541,6 @@ impl std::fmt::Debug for DeleteLiveConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteLiveConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14799,7 +14734,6 @@ impl std::fmt::Debug for UpdateLiveConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateLiveConfigRequest");
         debug_struct.field("live_config", &self.live_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15043,7 +14977,6 @@ impl std::fmt::Debug for CreateVodConfigRequest {
         debug_struct.field("vod_config_id", &self.vod_config_id);
         debug_struct.field("vod_config", &self.vod_config);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15311,7 +15244,6 @@ impl std::fmt::Debug for ListVodConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15525,7 +15457,6 @@ impl std::fmt::Debug for ListVodConfigsResponse {
         debug_struct.field("vod_configs", &self.vod_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15668,7 +15599,6 @@ impl std::fmt::Debug for GetVodConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVodConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15811,7 +15741,6 @@ impl std::fmt::Debug for DeleteVodConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteVodConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16005,7 +15934,6 @@ impl std::fmt::Debug for UpdateVodConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateVodConfigRequest");
         debug_struct.field("vod_config", &self.vod_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16246,7 +16174,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("target", &self.target);
         debug_struct.field("verb", &self.verb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16544,7 +16471,6 @@ impl std::fmt::Debug for VodConfig {
         debug_struct.field("gam_vod_config", &self.gam_vod_config);
         debug_struct.field("state", &self.state);
         debug_struct.field("source_fetch_options", &self.source_fetch_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16832,7 +16758,6 @@ impl std::fmt::Debug for GamVodConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GamVodConfig");
         debug_struct.field("network_code", &self.network_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -738,7 +738,6 @@ impl std::fmt::Debug for Job {
         debug_struct.field("optimization", &self.optimization);
         debug_struct.field("fill_content_gaps", &self.fill_content_gaps);
         debug_struct.field("job_config", &self.job_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1391,7 +1390,6 @@ impl std::fmt::Debug for JobTemplate {
         debug_struct.field("name", &self.name);
         debug_struct.field("config", &self.config);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1851,7 +1849,6 @@ impl std::fmt::Debug for JobConfig {
         debug_struct.field("sprite_sheets", &self.sprite_sheets);
         debug_struct.field("overlays", &self.overlays);
         debug_struct.field("encryptions", &self.encryptions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2063,7 +2060,6 @@ impl std::fmt::Debug for Input {
         debug_struct.field("key", &self.key);
         debug_struct.field("uri", &self.uri);
         debug_struct.field("preprocessing_config", &self.preprocessing_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2211,7 +2207,6 @@ impl std::fmt::Debug for Output {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Output");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2463,7 +2458,6 @@ impl std::fmt::Debug for EditAtom {
         debug_struct.field("inputs", &self.inputs);
         debug_struct.field("end_time_offset", &self.end_time_offset);
         debug_struct.field("start_time_offset", &self.start_time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2618,7 +2612,6 @@ impl std::fmt::Debug for AdBreak {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdBreak");
         debug_struct.field("start_time_offset", &self.start_time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2942,7 +2935,6 @@ impl std::fmt::Debug for ElementaryStream {
         let mut debug_struct = f.debug_struct("ElementaryStream");
         debug_struct.field("key", &self.key);
         debug_struct.field("elementary_stream", &self.elementary_stream);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3348,7 +3340,6 @@ impl std::fmt::Debug for MuxStream {
         debug_struct.field("segment_settings", &self.segment_settings);
         debug_struct.field("encryption_id", &self.encryption_id);
         debug_struct.field("container_config", &self.container_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3505,7 +3496,6 @@ pub mod mux_stream {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Fmp4Config");
             debug_struct.field("codec_tag", &self.codec_tag);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3796,7 +3786,6 @@ impl std::fmt::Debug for Manifest {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("mux_streams", &self.mux_streams);
         debug_struct.field("manifest_config", &self.manifest_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3959,7 +3948,6 @@ pub mod manifest {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DashConfig");
             debug_struct.field("segment_reference_scheme", &self.segment_reference_scheme);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4414,7 +4402,6 @@ impl std::fmt::Debug for PubsubDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PubsubDestination");
         debug_struct.field("topic", &self.topic);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5057,7 +5044,6 @@ impl std::fmt::Debug for SpriteSheet {
         debug_struct.field("end_time_offset", &self.end_time_offset);
         debug_struct.field("quality", &self.quality);
         debug_struct.field("extraction_strategy", &self.extraction_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5263,7 +5249,6 @@ impl std::fmt::Debug for Overlay {
         let mut debug_struct = f.debug_struct("Overlay");
         debug_struct.field("image", &self.image);
         debug_struct.field("animations", &self.animations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5474,7 +5459,6 @@ pub mod overlay {
             let mut debug_struct = f.debug_struct("NormalizedCoordinate");
             debug_struct.field("x", &self.x);
             debug_struct.field("y", &self.y);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5704,7 +5688,6 @@ pub mod overlay {
             debug_struct.field("uri", &self.uri);
             debug_struct.field("resolution", &self.resolution);
             debug_struct.field("alpha", &self.alpha);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5902,7 +5885,6 @@ pub mod overlay {
             let mut debug_struct = f.debug_struct("AnimationStatic");
             debug_struct.field("xy", &self.xy);
             debug_struct.field("start_time_offset", &self.start_time_offset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6165,7 +6147,6 @@ pub mod overlay {
             debug_struct.field("xy", &self.xy);
             debug_struct.field("start_time_offset", &self.start_time_offset);
             debug_struct.field("end_time_offset", &self.end_time_offset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6324,7 +6305,6 @@ pub mod overlay {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AnimationEnd");
             debug_struct.field("start_time_offset", &self.start_time_offset);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6635,7 +6615,6 @@ pub mod overlay {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Animation");
             debug_struct.field("animation_type", &self.animation_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7160,7 +7139,6 @@ impl std::fmt::Debug for PreprocessingConfig {
         debug_struct.field("crop", &self.crop);
         debug_struct.field("pad", &self.pad);
         debug_struct.field("deinterlace", &self.deinterlace);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7424,7 +7402,6 @@ pub mod preprocessing_config {
             debug_struct.field("saturation", &self.saturation);
             debug_struct.field("contrast", &self.contrast);
             debug_struct.field("brightness", &self.brightness);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7620,7 +7597,6 @@ pub mod preprocessing_config {
             let mut debug_struct = f.debug_struct("Denoise");
             debug_struct.field("strength", &self.strength);
             debug_struct.field("tune", &self.tune);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7812,7 +7788,6 @@ pub mod preprocessing_config {
             let mut debug_struct = f.debug_struct("Deblock");
             debug_struct.field("strength", &self.strength);
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8041,7 +8016,6 @@ pub mod preprocessing_config {
             debug_struct.field("lufs", &self.lufs);
             debug_struct.field("high_boost", &self.high_boost);
             debug_struct.field("low_boost", &self.low_boost);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8342,7 +8316,6 @@ pub mod preprocessing_config {
             debug_struct.field("bottom_pixels", &self.bottom_pixels);
             debug_struct.field("left_pixels", &self.left_pixels);
             debug_struct.field("right_pixels", &self.right_pixels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8643,7 +8616,6 @@ pub mod preprocessing_config {
             debug_struct.field("bottom_pixels", &self.bottom_pixels);
             debug_struct.field("left_pixels", &self.left_pixels);
             debug_struct.field("right_pixels", &self.right_pixels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8907,7 +8879,6 @@ pub mod preprocessing_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Deinterlace");
             debug_struct.field("deinterlacing_filter", &self.deinterlacing_filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9171,7 +9142,6 @@ pub mod preprocessing_config {
                 );
                 debug_struct.field("parity", &self.parity);
                 debug_struct.field("deinterlace_all_frames", &self.deinterlace_all_frames);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9388,7 +9358,6 @@ pub mod preprocessing_config {
                 debug_struct.field("mode", &self.mode);
                 debug_struct.field("parity", &self.parity);
                 debug_struct.field("deinterlace_all_frames", &self.deinterlace_all_frames);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9703,7 +9672,6 @@ impl std::fmt::Debug for VideoStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VideoStream");
         debug_struct.field("codec_settings", &self.codec_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9825,7 +9793,6 @@ pub mod video_stream {
     impl std::fmt::Debug for H264ColorFormatSDR {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("H264ColorFormatSDR");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9942,7 +9909,6 @@ pub mod video_stream {
     impl std::fmt::Debug for H264ColorFormatHLG {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("H264ColorFormatHLG");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11104,7 +11070,6 @@ pub mod video_stream {
             debug_struct.field("preset", &self.preset);
             debug_struct.field("gop_mode", &self.gop_mode);
             debug_struct.field("color_format", &self.color_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11252,7 +11217,6 @@ pub mod video_stream {
     impl std::fmt::Debug for H265ColorFormatSDR {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("H265ColorFormatSDR");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11369,7 +11333,6 @@ pub mod video_stream {
     impl std::fmt::Debug for H265ColorFormatHLG {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("H265ColorFormatHLG");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11486,7 +11449,6 @@ pub mod video_stream {
     impl std::fmt::Debug for H265ColorFormatHDR10 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("H265ColorFormatHDR10");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12681,7 +12643,6 @@ pub mod video_stream {
             debug_struct.field("preset", &self.preset);
             debug_struct.field("gop_mode", &self.gop_mode);
             debug_struct.field("color_format", &self.color_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12831,7 +12792,6 @@ pub mod video_stream {
     impl std::fmt::Debug for Vp9ColorFormatSDR {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Vp9ColorFormatSDR");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12948,7 +12908,6 @@ pub mod video_stream {
     impl std::fmt::Debug for Vp9ColorFormatHLG {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Vp9ColorFormatHLG");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13739,7 +13698,6 @@ pub mod video_stream {
             debug_struct.field("profile", &self.profile);
             debug_struct.field("gop_mode", &self.gop_mode);
             debug_struct.field("color_format", &self.color_format);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14347,7 +14305,6 @@ impl std::fmt::Debug for AudioStream {
         debug_struct.field("sample_rate_hertz", &self.sample_rate_hertz);
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14719,7 +14676,6 @@ pub mod audio_stream {
             debug_struct.field("input_channel", &self.input_channel);
             debug_struct.field("output_channel", &self.output_channel);
             debug_struct.field("gain_db", &self.gain_db);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14964,7 +14920,6 @@ impl std::fmt::Debug for TextStream {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("mapping", &self.mapping);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15201,7 +15156,6 @@ pub mod text_stream {
             debug_struct.field("atom_key", &self.atom_key);
             debug_struct.field("input_key", &self.input_key);
             debug_struct.field("input_track", &self.input_track);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15385,7 +15339,6 @@ impl std::fmt::Debug for SegmentSettings {
         let mut debug_struct = f.debug_struct("SegmentSettings");
         debug_struct.field("segment_duration", &self.segment_duration);
         debug_struct.field("individual_segments", &self.individual_segments);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15833,7 +15786,6 @@ impl std::fmt::Debug for Encryption {
         debug_struct.field("drm_systems", &self.drm_systems);
         debug_struct.field("encryption_mode", &self.encryption_mode);
         debug_struct.field("secret_source", &self.secret_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15955,7 +15907,6 @@ pub mod encryption {
     impl std::fmt::Debug for Aes128Encryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Aes128Encryption");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16072,7 +16023,6 @@ pub mod encryption {
     impl std::fmt::Debug for SampleAesEncryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SampleAesEncryption");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16222,7 +16172,6 @@ pub mod encryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MpegCommonEncryption");
             debug_struct.field("scheme", &self.scheme);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16376,7 +16325,6 @@ pub mod encryption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SecretManagerSource");
             debug_struct.field("secret_version", &self.secret_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16493,7 +16441,6 @@ pub mod encryption {
     impl std::fmt::Debug for Widevine {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Widevine");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16610,7 +16557,6 @@ pub mod encryption {
     impl std::fmt::Debug for Fairplay {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Fairplay");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16727,7 +16673,6 @@ pub mod encryption {
     impl std::fmt::Debug for Playready {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Playready");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16844,7 +16789,6 @@ pub mod encryption {
     impl std::fmt::Debug for Clearkey {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Clearkey");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17108,7 +17052,6 @@ pub mod encryption {
             debug_struct.field("fairplay", &self.fairplay);
             debug_struct.field("playready", &self.playready);
             debug_struct.field("clearkey", &self.clearkey);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17308,7 +17251,6 @@ impl std::fmt::Debug for CreateJobRequest {
         let mut debug_struct = f.debug_struct("CreateJobRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17575,7 +17517,6 @@ impl std::fmt::Debug for ListJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17718,7 +17659,6 @@ impl std::fmt::Debug for GetJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17888,7 +17828,6 @@ impl std::fmt::Debug for DeleteJobRequest {
         let mut debug_struct = f.debug_struct("DeleteJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18101,7 +18040,6 @@ impl std::fmt::Debug for ListJobsResponse {
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18311,7 +18249,6 @@ impl std::fmt::Debug for CreateJobTemplateRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("job_template", &self.job_template);
         debug_struct.field("job_template_id", &self.job_template_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18578,7 +18515,6 @@ impl std::fmt::Debug for ListJobTemplatesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18722,7 +18658,6 @@ impl std::fmt::Debug for GetJobTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18892,7 +18827,6 @@ impl std::fmt::Debug for DeleteJobTemplateRequest {
         let mut debug_struct = f.debug_struct("DeleteJobTemplateRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19106,7 +19040,6 @@ impl std::fmt::Debug for ListJobTemplatesResponse {
         debug_struct.field("job_templates", &self.job_templates);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -351,7 +351,6 @@ impl std::fmt::Debug for AnnotateVideoRequest {
         debug_struct.field("video_context", &self.video_context);
         debug_struct.field("output_uri", &self.output_uri);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -830,7 +829,6 @@ impl std::fmt::Debug for VideoContext {
         debug_struct.field("text_detection_config", &self.text_detection_config);
         debug_struct.field("person_detection_config", &self.person_detection_config);
         debug_struct.field("object_tracking_config", &self.object_tracking_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1151,7 +1149,6 @@ impl std::fmt::Debug for LabelDetectionConfig {
             "video_confidence_threshold",
             &self.video_confidence_threshold,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1295,7 +1292,6 @@ impl std::fmt::Debug for ShotChangeDetectionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShotChangeDetectionConfig");
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1439,7 +1435,6 @@ impl std::fmt::Debug for ObjectTrackingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ObjectTrackingConfig");
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1636,7 +1631,6 @@ impl std::fmt::Debug for FaceDetectionConfig {
         debug_struct.field("model", &self.model);
         debug_struct.field("include_bounding_boxes", &self.include_bounding_boxes);
         debug_struct.field("include_attributes", &self.include_attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1836,7 +1830,6 @@ impl std::fmt::Debug for PersonDetectionConfig {
         debug_struct.field("include_bounding_boxes", &self.include_bounding_boxes);
         debug_struct.field("include_pose_landmarks", &self.include_pose_landmarks);
         debug_struct.field("include_attributes", &self.include_attributes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1980,7 +1973,6 @@ impl std::fmt::Debug for ExplicitContentDetectionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExplicitContentDetectionConfig");
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2157,7 +2149,6 @@ impl std::fmt::Debug for TextDetectionConfig {
         let mut debug_struct = f.debug_struct("TextDetectionConfig");
         debug_struct.field("language_hints", &self.language_hints);
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2350,7 +2341,6 @@ impl std::fmt::Debug for VideoSegment {
         let mut debug_struct = f.debug_struct("VideoSegment");
         debug_struct.field("start_time_offset", &self.start_time_offset);
         debug_struct.field("end_time_offset", &self.end_time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2546,7 +2536,6 @@ impl std::fmt::Debug for LabelSegment {
         let mut debug_struct = f.debug_struct("LabelSegment");
         debug_struct.field("segment", &self.segment);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2744,7 +2733,6 @@ impl std::fmt::Debug for LabelFrame {
         let mut debug_struct = f.debug_struct("LabelFrame");
         debug_struct.field("time_offset", &self.time_offset);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2940,7 +2928,6 @@ impl std::fmt::Debug for Entity {
         debug_struct.field("entity_id", &self.entity_id);
         debug_struct.field("description", &self.description);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3206,7 +3193,6 @@ impl std::fmt::Debug for LabelAnnotation {
         debug_struct.field("segments", &self.segments);
         debug_struct.field("frames", &self.frames);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3390,7 +3376,6 @@ impl std::fmt::Debug for ExplicitContentFrame {
         let mut debug_struct = f.debug_struct("ExplicitContentFrame");
         debug_struct.field("time_offset", &self.time_offset);
         debug_struct.field("pornography_likelihood", &self.pornography_likelihood);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3566,7 +3551,6 @@ impl std::fmt::Debug for ExplicitContentAnnotation {
         let mut debug_struct = f.debug_struct("ExplicitContentAnnotation");
         debug_struct.field("frames", &self.frames);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3857,7 +3841,6 @@ impl std::fmt::Debug for NormalizedBoundingBox {
         debug_struct.field("top", &self.top);
         debug_struct.field("right", &self.right);
         debug_struct.field("bottom", &self.bottom);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4070,7 +4053,6 @@ impl std::fmt::Debug for FaceDetectionAnnotation {
         debug_struct.field("tracks", &self.tracks);
         debug_struct.field("thumbnail", &self.thumbnail);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4240,7 +4222,6 @@ impl std::fmt::Debug for PersonDetectionAnnotation {
         let mut debug_struct = f.debug_struct("PersonDetectionAnnotation");
         debug_struct.field("tracks", &self.tracks);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4393,7 +4374,6 @@ impl std::fmt::Debug for FaceSegment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FaceSegment");
         debug_struct.field("segment", &self.segment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4588,7 +4568,6 @@ impl std::fmt::Debug for FaceFrame {
         let mut debug_struct = f.debug_struct("FaceFrame");
         debug_struct.field("normalized_bounding_boxes", &self.normalized_bounding_boxes);
         debug_struct.field("time_offset", &self.time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4805,7 +4784,6 @@ impl std::fmt::Debug for FaceAnnotation {
         debug_struct.field("thumbnail", &self.thumbnail);
         debug_struct.field("segments", &self.segments);
         debug_struct.field("frames", &self.frames);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5063,7 +5041,6 @@ impl std::fmt::Debug for TimestampedObject {
         debug_struct.field("time_offset", &self.time_offset);
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("landmarks", &self.landmarks);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5324,7 +5301,6 @@ impl std::fmt::Debug for Track {
         debug_struct.field("timestamped_objects", &self.timestamped_objects);
         debug_struct.field("attributes", &self.attributes);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5536,7 +5512,6 @@ impl std::fmt::Debug for DetectedAttribute {
         debug_struct.field("name", &self.name);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5760,7 +5735,6 @@ impl std::fmt::Debug for DetectedLandmark {
         debug_struct.field("name", &self.name);
         debug_struct.field("point", &self.point);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6506,7 +6480,6 @@ impl std::fmt::Debug for VideoAnnotationResults {
             &self.person_detection_annotations,
         );
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6658,7 +6631,6 @@ impl std::fmt::Debug for AnnotateVideoResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnnotateVideoResponse");
         debug_struct.field("annotation_results", &self.annotation_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6985,7 +6957,6 @@ impl std::fmt::Debug for VideoAnnotationProgress {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("feature", &self.feature);
         debug_struct.field("segment", &self.segment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7137,7 +7108,6 @@ impl std::fmt::Debug for AnnotateVideoProgress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnnotateVideoProgress");
         debug_struct.field("annotation_progress", &self.annotation_progress);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7608,7 +7578,6 @@ impl std::fmt::Debug for SpeechTranscriptionConfig {
         );
         debug_struct.field("diarization_speaker_count", &self.diarization_speaker_count);
         debug_struct.field("enable_word_confidence", &self.enable_word_confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7759,7 +7728,6 @@ impl std::fmt::Debug for SpeechContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SpeechContext");
         debug_struct.field("phrases", &self.phrases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7939,7 +7907,6 @@ impl std::fmt::Debug for SpeechTranscription {
         let mut debug_struct = f.debug_struct("SpeechTranscription");
         debug_struct.field("alternatives", &self.alternatives);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8159,7 +8126,6 @@ impl std::fmt::Debug for SpeechRecognitionAlternative {
         debug_struct.field("transcript", &self.transcript);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("words", &self.words);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8478,7 +8444,6 @@ impl std::fmt::Debug for WordInfo {
         debug_struct.field("word", &self.word);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("speaker_tag", &self.speaker_tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8683,7 +8648,6 @@ impl std::fmt::Debug for NormalizedVertex {
         let mut debug_struct = f.debug_struct("NormalizedVertex");
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8848,7 +8812,6 @@ impl std::fmt::Debug for NormalizedBoundingPoly {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NormalizedBoundingPoly");
         debug_struct.field("vertices", &self.vertices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9073,7 +9036,6 @@ impl std::fmt::Debug for TextSegment {
         debug_struct.field("segment", &self.segment);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("frames", &self.frames);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9266,7 +9228,6 @@ impl std::fmt::Debug for TextFrame {
         let mut debug_struct = f.debug_struct("TextFrame");
         debug_struct.field("rotated_bounding_box", &self.rotated_bounding_box);
         debug_struct.field("time_offset", &self.time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9463,7 +9424,6 @@ impl std::fmt::Debug for TextAnnotation {
         debug_struct.field("text", &self.text);
         debug_struct.field("segments", &self.segments);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9655,7 +9615,6 @@ impl std::fmt::Debug for ObjectTrackingFrame {
         let mut debug_struct = f.debug_struct("ObjectTrackingFrame");
         debug_struct.field("normalized_bounding_box", &self.normalized_bounding_box);
         debug_struct.field("time_offset", &self.time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10053,7 +10012,6 @@ impl std::fmt::Debug for ObjectTrackingAnnotation {
         debug_struct.field("frames", &self.frames);
         debug_struct.field("version", &self.version);
         debug_struct.field("track_info", &self.track_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10288,7 +10246,6 @@ impl std::fmt::Debug for LogoRecognitionAnnotation {
         debug_struct.field("entity", &self.entity);
         debug_struct.field("tracks", &self.tracks);
         debug_struct.field("segments", &self.segments);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -230,7 +230,6 @@ impl std::fmt::Debug for Vertex {
         let mut debug_struct = f.debug_struct("Vertex");
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -435,7 +434,6 @@ impl std::fmt::Debug for NormalizedVertex {
         let mut debug_struct = f.debug_struct("NormalizedVertex");
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -613,7 +611,6 @@ impl std::fmt::Debug for BoundingPoly {
         let mut debug_struct = f.debug_struct("BoundingPoly");
         debug_struct.field("vertices", &self.vertices);
         debug_struct.field("normalized_vertices", &self.normalized_vertices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -861,7 +858,6 @@ impl std::fmt::Debug for Position {
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
         debug_struct.field("z", &self.z);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1078,7 +1074,6 @@ impl std::fmt::Debug for Feature {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("model", &self.model);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1482,7 +1477,6 @@ impl std::fmt::Debug for ImageSource {
         let mut debug_struct = f.debug_struct("ImageSource");
         debug_struct.field("gcs_image_uri", &self.gcs_image_uri);
         debug_struct.field("image_uri", &self.image_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1685,7 +1679,6 @@ impl std::fmt::Debug for Image {
         let mut debug_struct = f.debug_struct("Image");
         debug_struct.field("content", &self.content);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2354,7 +2347,6 @@ impl std::fmt::Debug for FaceAnnotation {
         debug_struct.field("under_exposed_likelihood", &self.under_exposed_likelihood);
         debug_struct.field("blurred_likelihood", &self.blurred_likelihood);
         debug_struct.field("headwear_likelihood", &self.headwear_likelihood);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2545,7 +2537,6 @@ pub mod face_annotation {
             let mut debug_struct = f.debug_struct("Landmark");
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("position", &self.position);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3096,7 +3087,6 @@ impl std::fmt::Debug for LocationInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationInfo");
         debug_struct.field("lat_lng", &self.lat_lng);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3307,7 +3297,6 @@ impl std::fmt::Debug for Property {
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
         debug_struct.field("uint64_value", &self.uint64_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3740,7 +3729,6 @@ impl std::fmt::Debug for EntityAnnotation {
         debug_struct.field("bounding_poly", &self.bounding_poly);
         debug_struct.field("locations", &self.locations);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4015,7 +4003,6 @@ impl std::fmt::Debug for LocalizedObjectAnnotation {
         debug_struct.field("name", &self.name);
         debug_struct.field("score", &self.score);
         debug_struct.field("bounding_poly", &self.bounding_poly);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4268,7 +4255,6 @@ impl std::fmt::Debug for SafeSearchAnnotation {
         debug_struct.field("medical", &self.medical);
         debug_struct.field("violence", &self.violence);
         debug_struct.field("racy", &self.racy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4459,7 +4445,6 @@ impl std::fmt::Debug for LatLongRect {
         let mut debug_struct = f.debug_struct("LatLongRect");
         debug_struct.field("min_lat_lng", &self.min_lat_lng);
         debug_struct.field("max_lat_lng", &self.max_lat_lng);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4702,7 +4687,6 @@ impl std::fmt::Debug for ColorInfo {
         debug_struct.field("color", &self.color);
         debug_struct.field("score", &self.score);
         debug_struct.field("pixel_fraction", &self.pixel_fraction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4847,7 +4831,6 @@ impl std::fmt::Debug for DominantColorsAnnotation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DominantColorsAnnotation");
         debug_struct.field("colors", &self.colors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5001,7 +4984,6 @@ impl std::fmt::Debug for ImageProperties {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImageProperties");
         debug_struct.field("dominant_colors", &self.dominant_colors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5245,7 +5227,6 @@ impl std::fmt::Debug for CropHint {
         debug_struct.field("bounding_poly", &self.bounding_poly);
         debug_struct.field("confidence", &self.confidence);
         debug_struct.field("importance_fraction", &self.importance_fraction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5391,7 +5372,6 @@ impl std::fmt::Debug for CropHintsAnnotation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CropHintsAnnotation");
         debug_struct.field("crop_hints", &self.crop_hints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5568,7 +5548,6 @@ impl std::fmt::Debug for CropHintsParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CropHintsParams");
         debug_struct.field("aspect_ratios", &self.aspect_ratios);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5713,7 +5692,6 @@ impl std::fmt::Debug for WebDetectionParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WebDetectionParams");
         debug_struct.field("include_geo_results", &self.include_geo_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5908,7 +5886,6 @@ impl std::fmt::Debug for TextDetectionParams {
             &self.enable_text_detection_confidence_score,
         );
         debug_struct.field("advanced_ocr_options", &self.advanced_ocr_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6247,7 +6224,6 @@ impl std::fmt::Debug for ImageContext {
         debug_struct.field("product_search_params", &self.product_search_params);
         debug_struct.field("web_detection_params", &self.web_detection_params);
         debug_struct.field("text_detection_params", &self.text_detection_params);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6466,7 +6442,6 @@ impl std::fmt::Debug for AnnotateImageRequest {
         debug_struct.field("image", &self.image);
         debug_struct.field("features", &self.features);
         debug_struct.field("image_context", &self.image_context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6654,7 +6629,6 @@ impl std::fmt::Debug for ImageAnnotationContext {
         let mut debug_struct = f.debug_struct("ImageAnnotationContext");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("page_number", &self.page_number);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7292,7 +7266,6 @@ impl std::fmt::Debug for AnnotateImageResponse {
         debug_struct.field("product_search_results", &self.product_search_results);
         debug_struct.field("error", &self.error);
         debug_struct.field("context", &self.context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7518,7 +7491,6 @@ impl std::fmt::Debug for BatchAnnotateImagesRequest {
         debug_struct.field("requests", &self.requests);
         debug_struct.field("parent", &self.parent);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7667,7 +7639,6 @@ impl std::fmt::Debug for BatchAnnotateImagesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchAnnotateImagesResponse");
         debug_struct.field("responses", &self.responses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7952,7 +7923,6 @@ impl std::fmt::Debug for AnnotateFileRequest {
         debug_struct.field("features", &self.features);
         debug_struct.field("image_context", &self.image_context);
         debug_struct.field("pages", &self.pages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8221,7 +8191,6 @@ impl std::fmt::Debug for AnnotateFileResponse {
         debug_struct.field("responses", &self.responses);
         debug_struct.field("total_pages", &self.total_pages);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8448,7 +8417,6 @@ impl std::fmt::Debug for BatchAnnotateFilesRequest {
         debug_struct.field("requests", &self.requests);
         debug_struct.field("parent", &self.parent);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8598,7 +8566,6 @@ impl std::fmt::Debug for BatchAnnotateFilesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchAnnotateFilesResponse");
         debug_struct.field("responses", &self.responses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8854,7 +8821,6 @@ impl std::fmt::Debug for AsyncAnnotateFileRequest {
         debug_struct.field("features", &self.features);
         debug_struct.field("image_context", &self.image_context);
         debug_struct.field("output_config", &self.output_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9008,7 +8974,6 @@ impl std::fmt::Debug for AsyncAnnotateFileResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AsyncAnnotateFileResponse");
         debug_struct.field("output_config", &self.output_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9271,7 +9236,6 @@ impl std::fmt::Debug for AsyncBatchAnnotateImagesRequest {
         debug_struct.field("output_config", &self.output_config);
         debug_struct.field("parent", &self.parent);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9425,7 +9389,6 @@ impl std::fmt::Debug for AsyncBatchAnnotateImagesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AsyncBatchAnnotateImagesResponse");
         debug_struct.field("output_config", &self.output_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9652,7 +9615,6 @@ impl std::fmt::Debug for AsyncBatchAnnotateFilesRequest {
         debug_struct.field("requests", &self.requests);
         debug_struct.field("parent", &self.parent);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9802,7 +9764,6 @@ impl std::fmt::Debug for AsyncBatchAnnotateFilesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AsyncBatchAnnotateFilesResponse");
         debug_struct.field("responses", &self.responses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10031,7 +9992,6 @@ impl std::fmt::Debug for InputConfig {
         debug_struct.field("gcs_source", &self.gcs_source);
         debug_struct.field("content", &self.content);
         debug_struct.field("mime_type", &self.mime_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10240,7 +10200,6 @@ impl std::fmt::Debug for OutputConfig {
         let mut debug_struct = f.debug_struct("OutputConfig");
         debug_struct.field("gcs_destination", &self.gcs_destination);
         debug_struct.field("batch_size", &self.batch_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10383,7 +10342,6 @@ impl std::fmt::Debug for GcsSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsSource");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10547,7 +10505,6 @@ impl std::fmt::Debug for GcsDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsDestination");
         debug_struct.field("uri", &self.uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10764,7 +10721,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("state", &self.state);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11170,7 +11126,6 @@ impl std::fmt::Debug for ProductSearchParams {
         debug_struct.field("product_set", &self.product_set);
         debug_struct.field("product_categories", &self.product_categories);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11396,7 +11351,6 @@ impl std::fmt::Debug for ProductSearchResults {
         debug_struct.field("index_time", &self.index_time);
         debug_struct.field("results", &self.results);
         debug_struct.field("product_grouped_results", &self.product_grouped_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11627,7 +11581,6 @@ pub mod product_search_results {
             debug_struct.field("product", &self.product);
             debug_struct.field("score", &self.score);
             debug_struct.field("image", &self.image);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11871,7 +11824,6 @@ pub mod product_search_results {
             debug_struct.field("language_code", &self.language_code);
             debug_struct.field("name", &self.name);
             debug_struct.field("score", &self.score);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12098,7 +12050,6 @@ pub mod product_search_results {
             debug_struct.field("bounding_poly", &self.bounding_poly);
             debug_struct.field("results", &self.results);
             debug_struct.field("object_annotations", &self.object_annotations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12377,7 +12328,6 @@ impl std::fmt::Debug for Product {
         debug_struct.field("description", &self.description);
         debug_struct.field("product_category", &self.product_category);
         debug_struct.field("product_labels", &self.product_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12554,7 +12504,6 @@ pub mod product {
             let mut debug_struct = f.debug_struct("KeyValue");
             debug_struct.field("key", &self.key);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12813,7 +12762,6 @@ impl std::fmt::Debug for ProductSet {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("index_time", &self.index_time);
         debug_struct.field("index_error", &self.index_error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13024,7 +12972,6 @@ impl std::fmt::Debug for ReferenceImage {
         debug_struct.field("name", &self.name);
         debug_struct.field("uri", &self.uri);
         debug_struct.field("bounding_polys", &self.bounding_polys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13234,7 +13181,6 @@ impl std::fmt::Debug for CreateProductRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("product", &self.product);
         debug_struct.field("product_id", &self.product_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13449,7 +13395,6 @@ impl std::fmt::Debug for ListProductsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13635,7 +13580,6 @@ impl std::fmt::Debug for ListProductsResponse {
         let mut debug_struct = f.debug_struct("ListProductsResponse");
         debug_struct.field("products", &self.products);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13780,7 +13724,6 @@ impl std::fmt::Debug for GetProductRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProductRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13977,7 +13920,6 @@ impl std::fmt::Debug for UpdateProductRequest {
         let mut debug_struct = f.debug_struct("UpdateProductRequest");
         debug_struct.field("product", &self.product);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14122,7 +14064,6 @@ impl std::fmt::Debug for DeleteProductRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProductRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14332,7 +14273,6 @@ impl std::fmt::Debug for CreateProductSetRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("product_set", &self.product_set);
         debug_struct.field("product_set_id", &self.product_set_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14546,7 +14486,6 @@ impl std::fmt::Debug for ListProductSetsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14733,7 +14672,6 @@ impl std::fmt::Debug for ListProductSetsResponse {
         let mut debug_struct = f.debug_struct("ListProductSetsResponse");
         debug_struct.field("product_sets", &self.product_sets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14878,7 +14816,6 @@ impl std::fmt::Debug for GetProductSetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProductSetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15074,7 +15011,6 @@ impl std::fmt::Debug for UpdateProductSetRequest {
         let mut debug_struct = f.debug_struct("UpdateProductSetRequest");
         debug_struct.field("product_set", &self.product_set);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15219,7 +15155,6 @@ impl std::fmt::Debug for DeleteProductSetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteProductSetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15436,7 +15371,6 @@ impl std::fmt::Debug for CreateReferenceImageRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("reference_image", &self.reference_image);
         debug_struct.field("reference_image_id", &self.reference_image_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15654,7 +15588,6 @@ impl std::fmt::Debug for ListReferenceImagesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15888,7 +15821,6 @@ impl std::fmt::Debug for ListReferenceImagesResponse {
         debug_struct.field("reference_images", &self.reference_images);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16033,7 +15965,6 @@ impl std::fmt::Debug for GetReferenceImageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReferenceImageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16178,7 +16109,6 @@ impl std::fmt::Debug for DeleteReferenceImageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteReferenceImageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16351,7 +16281,6 @@ impl std::fmt::Debug for AddProductToProductSetRequest {
         let mut debug_struct = f.debug_struct("AddProductToProductSetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("product", &self.product);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16525,7 +16454,6 @@ impl std::fmt::Debug for RemoveProductFromProductSetRequest {
         let mut debug_struct = f.debug_struct("RemoveProductFromProductSetRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("product", &self.product);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16740,7 +16668,6 @@ impl std::fmt::Debug for ListProductsInProductSetRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16926,7 +16853,6 @@ impl std::fmt::Debug for ListProductsInProductSetResponse {
         let mut debug_struct = f.debug_struct("ListProductsInProductSetResponse");
         debug_struct.field("products", &self.products);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17138,7 +17064,6 @@ impl std::fmt::Debug for ImportProductSetsGcsSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportProductSetsGcsSource");
         debug_struct.field("csv_file_uri", &self.csv_file_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17333,7 +17258,6 @@ impl std::fmt::Debug for ImportProductSetsInputConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportProductSetsInputConfig");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17529,7 +17453,6 @@ impl std::fmt::Debug for ImportProductSetsRequest {
         let mut debug_struct = f.debug_struct("ImportProductSetsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("input_config", &self.input_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17720,7 +17643,6 @@ impl std::fmt::Debug for ImportProductSetsResponse {
         let mut debug_struct = f.debug_struct("ImportProductSetsResponse");
         debug_struct.field("reference_images", &self.reference_images);
         debug_struct.field("statuses", &self.statuses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17948,7 +17870,6 @@ impl std::fmt::Debug for BatchOperationMetadata {
         debug_struct.field("state", &self.state);
         debug_struct.field("submit_time", &self.submit_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18248,7 +18169,6 @@ impl std::fmt::Debug for ProductSetPurgeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProductSetPurgeConfig");
         debug_struct.field("product_set_id", &self.product_set_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18545,7 +18465,6 @@ impl std::fmt::Debug for PurgeProductsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("force", &self.force);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18741,7 +18660,6 @@ impl std::fmt::Debug for TextAnnotation {
         let mut debug_struct = f.debug_struct("TextAnnotation");
         debug_struct.field("pages", &self.pages);
         debug_struct.field("text", &self.text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18941,7 +18859,6 @@ pub mod text_annotation {
             let mut debug_struct = f.debug_struct("DetectedLanguage");
             debug_struct.field("language_code", &self.language_code);
             debug_struct.field("confidence", &self.confidence);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19119,7 +19036,6 @@ pub mod text_annotation {
             let mut debug_struct = f.debug_struct("DetectedBreak");
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("is_prefix", &self.is_prefix);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19475,7 +19391,6 @@ pub mod text_annotation {
             let mut debug_struct = f.debug_struct("TextProperty");
             debug_struct.field("detected_languages", &self.detected_languages);
             debug_struct.field("detected_break", &self.detected_break);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19790,7 +19705,6 @@ impl std::fmt::Debug for Page {
         debug_struct.field("height", &self.height);
         debug_struct.field("blocks", &self.blocks);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20107,7 +20021,6 @@ impl std::fmt::Debug for Block {
         debug_struct.field("paragraphs", &self.paragraphs);
         debug_struct.field("block_type", &self.block_type);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20544,7 +20457,6 @@ impl std::fmt::Debug for Paragraph {
         debug_struct.field("bounding_box", &self.bounding_box);
         debug_struct.field("words", &self.words);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20823,7 +20735,6 @@ impl std::fmt::Debug for Word {
         debug_struct.field("bounding_box", &self.bounding_box);
         debug_struct.field("symbols", &self.symbols);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21098,7 +21009,6 @@ impl std::fmt::Debug for Symbol {
         debug_struct.field("bounding_box", &self.bounding_box);
         debug_struct.field("text", &self.text);
         debug_struct.field("confidence", &self.confidence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21424,7 +21334,6 @@ impl std::fmt::Debug for WebDetection {
         );
         debug_struct.field("visually_similar_images", &self.visually_similar_images);
         debug_struct.field("best_guess_labels", &self.best_guess_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21644,7 +21553,6 @@ pub mod web_detection {
             debug_struct.field("entity_id", &self.entity_id);
             debug_struct.field("score", &self.score);
             debug_struct.field("description", &self.description);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21832,7 +21740,6 @@ pub mod web_detection {
             let mut debug_struct = f.debug_struct("WebImage");
             debug_struct.field("url", &self.url);
             debug_struct.field("score", &self.score);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22120,7 +22027,6 @@ pub mod web_detection {
             debug_struct.field("page_title", &self.page_title);
             debug_struct.field("full_matching_images", &self.full_matching_images);
             debug_struct.field("partial_matching_images", &self.partial_matching_images);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22296,7 +22202,6 @@ pub mod web_detection {
             let mut debug_struct = f.debug_struct("WebLabel");
             debug_struct.field("label", &self.label);
             debug_struct.field("language_code", &self.language_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -463,7 +463,6 @@ impl std::fmt::Debug for ReplicationCycle {
         debug_struct.field("steps", &self.steps);
         debug_struct.field("state", &self.state);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -991,7 +990,6 @@ impl std::fmt::Debug for CycleStep {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("step", &self.step);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1122,7 +1120,6 @@ impl serde::ser::Serialize for InitializingReplicationStep {
 impl std::fmt::Debug for InitializingReplicationStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InitializingReplicationStep");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1450,7 +1447,6 @@ impl std::fmt::Debug for ReplicatingStep {
             "last_thirty_minutes_average_bytes_per_second",
             &self.last_thirty_minutes_average_bytes_per_second,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1564,7 +1560,6 @@ impl serde::ser::Serialize for PostProcessingStep {
 impl std::fmt::Debug for PostProcessingStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PostProcessingStep");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1719,7 +1714,6 @@ impl std::fmt::Debug for ReplicationSync {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplicationSync");
         debug_struct.field("last_sync_time", &self.last_sync_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2518,7 +2512,6 @@ impl std::fmt::Debug for MigratingVm {
         debug_struct.field("recent_cutover_jobs", &self.recent_cutover_jobs);
         debug_struct.field("target_vm_defaults", &self.target_vm_defaults);
         debug_struct.field("source_vm_details", &self.source_vm_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3178,7 +3171,6 @@ impl std::fmt::Debug for CloneJob {
         debug_struct.field("error", &self.error);
         debug_struct.field("steps", &self.steps);
         debug_struct.field("target_vm_details", &self.target_vm_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3735,7 +3727,6 @@ impl std::fmt::Debug for CloneStep {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("step", &self.step);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3866,7 +3857,6 @@ impl serde::ser::Serialize for AdaptingOSStep {
 impl std::fmt::Debug for AdaptingOSStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AdaptingOSStep");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3980,7 +3970,6 @@ impl serde::ser::Serialize for PreparingVMDisksStep {
 impl std::fmt::Debug for PreparingVMDisksStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PreparingVMDisksStep");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4094,7 +4083,6 @@ impl serde::ser::Serialize for InstantiatingMigratedVMStep {
 impl std::fmt::Debug for InstantiatingMigratedVMStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InstantiatingMigratedVMStep");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4590,7 +4578,6 @@ impl std::fmt::Debug for CutoverJob {
         debug_struct.field("state_message", &self.state_message);
         debug_struct.field("steps", &self.steps);
         debug_struct.field("target_vm_details", &self.target_vm_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5272,7 +5259,6 @@ impl std::fmt::Debug for CutoverStep {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("step", &self.step);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5407,7 +5393,6 @@ impl serde::ser::Serialize for ShuttingDownSourceVMStep {
 impl std::fmt::Debug for ShuttingDownSourceVMStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShuttingDownSourceVMStep");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5650,7 +5635,6 @@ impl std::fmt::Debug for CreateCloneJobRequest {
         debug_struct.field("clone_job_id", &self.clone_job_id);
         debug_struct.field("clone_job", &self.clone_job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5792,7 +5776,6 @@ impl std::fmt::Debug for CancelCloneJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelCloneJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5906,7 +5889,6 @@ impl serde::ser::Serialize for CancelCloneJobResponse {
 impl std::fmt::Debug for CancelCloneJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelCloneJobResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6176,7 +6158,6 @@ impl std::fmt::Debug for ListCloneJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6391,7 +6372,6 @@ impl std::fmt::Debug for ListCloneJobsResponse {
         debug_struct.field("clone_jobs", &self.clone_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6533,7 +6513,6 @@ impl std::fmt::Debug for GetCloneJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCloneJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6930,7 +6909,6 @@ impl std::fmt::Debug for Source {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("description", &self.description);
         debug_struct.field("source_details", &self.source_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7165,7 +7143,6 @@ impl std::fmt::Debug for VmwareSourceDetails {
         debug_struct.field("password", &self.password);
         debug_struct.field("vcenter_ip", &self.vcenter_ip);
         debug_struct.field("thumbprint", &self.thumbprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7602,7 +7579,6 @@ impl std::fmt::Debug for AwsSourceDetails {
         );
         debug_struct.field("public_ip", &self.public_ip);
         debug_struct.field("credentials_type", &self.credentials_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7785,7 +7761,6 @@ pub mod aws_source_details {
             let mut debug_struct = f.debug_struct("AccessKeyCredentials");
             debug_struct.field("access_key_id", &self.access_key_id);
             debug_struct.field("secret_access_key", &self.secret_access_key);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7955,7 +7930,6 @@ pub mod aws_source_details {
             let mut debug_struct = f.debug_struct("Tag");
             debug_struct.field("key", &self.key);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8687,7 +8661,6 @@ impl std::fmt::Debug for DatacenterConnector {
         );
         debug_struct.field("available_versions", &self.available_versions);
         debug_struct.field("upgrade_status", &self.upgrade_status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9112,7 +9085,6 @@ impl std::fmt::Debug for UpgradeStatus {
         debug_struct.field("error", &self.error);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("previous_version", &self.previous_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9456,7 +9428,6 @@ impl std::fmt::Debug for AvailableUpdates {
         let mut debug_struct = f.debug_struct("AvailableUpdates");
         debug_struct.field("new_deployable_appliance", &self.new_deployable_appliance);
         debug_struct.field("in_place_update", &self.in_place_update);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9677,7 +9648,6 @@ impl std::fmt::Debug for ApplianceVersion {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("critical", &self.critical);
         debug_struct.field("release_notes_uri", &self.release_notes_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9947,7 +9917,6 @@ impl std::fmt::Debug for ListSourcesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10161,7 +10130,6 @@ impl std::fmt::Debug for ListSourcesResponse {
         debug_struct.field("sources", &self.sources);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10303,7 +10271,6 @@ impl std::fmt::Debug for GetSourceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSourceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10545,7 +10512,6 @@ impl std::fmt::Debug for CreateSourceRequest {
         debug_struct.field("source_id", &self.source_id);
         debug_struct.field("source", &self.source);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10777,7 +10743,6 @@ impl std::fmt::Debug for UpdateSourceRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("source", &self.source);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10957,7 +10922,6 @@ impl std::fmt::Debug for DeleteSourceRequest {
         let mut debug_struct = f.debug_struct("DeleteSourceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11129,7 +11093,6 @@ impl std::fmt::Debug for FetchInventoryRequest {
         let mut debug_struct = f.debug_struct("FetchInventoryRequest");
         debug_struct.field("source", &self.source);
         debug_struct.field("force_refresh", &self.force_refresh);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11649,7 +11612,6 @@ impl std::fmt::Debug for VmwareVmDetails {
         debug_struct.field("committed_storage_mb", &self.committed_storage_mb);
         debug_struct.field("guest_description", &self.guest_description);
         debug_struct.field("boot_option", &self.boot_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12616,7 +12578,6 @@ impl std::fmt::Debug for AwsVmDetails {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("virtualization_type", &self.virtualization_type);
         debug_struct.field("architecture", &self.architecture);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13348,7 +13309,6 @@ impl std::fmt::Debug for AwsSecurityGroup {
         let mut debug_struct = f.debug_struct("AwsSecurityGroup");
         debug_struct.field("id", &self.id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13497,7 +13457,6 @@ impl std::fmt::Debug for VmwareVmsDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VmwareVmsDetails");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13642,7 +13601,6 @@ impl std::fmt::Debug for AwsVmsDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsVmsDetails");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13929,7 +13887,6 @@ impl std::fmt::Debug for FetchInventoryResponse {
         let mut debug_struct = f.debug_struct("FetchInventoryResponse");
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("source_vms", &self.source_vms);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14401,7 +14358,6 @@ impl std::fmt::Debug for UtilizationReport {
         debug_struct.field("frame_end_time", &self.frame_end_time);
         debug_struct.field("vm_count", &self.vm_count);
         debug_struct.field("vms", &self.vms);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14939,7 +14895,6 @@ impl std::fmt::Debug for VmUtilizationInfo {
         debug_struct.field("vm_id", &self.vm_id);
         debug_struct.field("utilization", &self.utilization);
         debug_struct.field("vm_details", &self.vm_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15459,7 +15414,6 @@ impl std::fmt::Debug for VmUtilizationMetrics {
             "network_throughput_average_kbps",
             &self.network_throughput_average_kbps,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15756,7 +15710,6 @@ impl std::fmt::Debug for ListUtilizationReportsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15975,7 +15928,6 @@ impl std::fmt::Debug for ListUtilizationReportsResponse {
         debug_struct.field("utilization_reports", &self.utilization_reports);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16144,7 +16096,6 @@ impl std::fmt::Debug for GetUtilizationReportRequest {
         let mut debug_struct = f.debug_struct("GetUtilizationReportRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16396,7 +16347,6 @@ impl std::fmt::Debug for CreateUtilizationReportRequest {
         debug_struct.field("utilization_report", &self.utilization_report);
         debug_struct.field("utilization_report_id", &self.utilization_report_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16576,7 +16526,6 @@ impl std::fmt::Debug for DeleteUtilizationReportRequest {
         let mut debug_struct = f.debug_struct("DeleteUtilizationReportRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16795,7 +16744,6 @@ impl std::fmt::Debug for ListDatacenterConnectorsResponse {
         debug_struct.field("datacenter_connectors", &self.datacenter_connectors);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16937,7 +16885,6 @@ impl std::fmt::Debug for GetDatacenterConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatacenterConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17186,7 +17133,6 @@ impl std::fmt::Debug for CreateDatacenterConnectorRequest {
         debug_struct.field("datacenter_connector_id", &self.datacenter_connector_id);
         debug_struct.field("datacenter_connector", &self.datacenter_connector);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17366,7 +17312,6 @@ impl std::fmt::Debug for DeleteDatacenterConnectorRequest {
         let mut debug_struct = f.debug_struct("DeleteDatacenterConnectorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17550,7 +17495,6 @@ impl std::fmt::Debug for UpgradeApplianceRequest {
         let mut debug_struct = f.debug_struct("UpgradeApplianceRequest");
         debug_struct.field("datacenter_connector", &self.datacenter_connector);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17664,7 +17608,6 @@ impl serde::ser::Serialize for UpgradeApplianceResponse {
 impl std::fmt::Debug for UpgradeApplianceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpgradeApplianceResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17935,7 +17878,6 @@ impl std::fmt::Debug for ListDatacenterConnectorsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18584,7 +18526,6 @@ impl std::fmt::Debug for ComputeEngineTargetDefaults {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("additional_licenses", &self.additional_licenses);
         debug_struct.field("hostname", &self.hostname);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19231,7 +19172,6 @@ impl std::fmt::Debug for ComputeEngineTargetDetails {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("additional_licenses", &self.additional_licenses);
         debug_struct.field("hostname", &self.hostname);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19452,7 +19392,6 @@ impl std::fmt::Debug for NetworkInterface {
         debug_struct.field("subnetwork", &self.subnetwork);
         debug_struct.field("internal_ip", &self.internal_ip);
         debug_struct.field("external_ip", &self.external_ip);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19621,7 +19560,6 @@ impl std::fmt::Debug for AppliedLicense {
         let mut debug_struct = f.debug_struct("AppliedLicense");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("os_license", &self.os_license);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19969,7 +19907,6 @@ impl std::fmt::Debug for SchedulingNodeAffinity {
         debug_struct.field("key", &self.key);
         debug_struct.field("operator", &self.operator);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20379,7 +20316,6 @@ impl std::fmt::Debug for ComputeScheduling {
         debug_struct.field("restart_type", &self.restart_type);
         debug_struct.field("node_affinities", &self.node_affinities);
         debug_struct.field("min_node_cpus", &self.min_node_cpus);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20833,7 +20769,6 @@ impl std::fmt::Debug for SchedulePolicy {
         let mut debug_struct = f.debug_struct("SchedulePolicy");
         debug_struct.field("idle_duration", &self.idle_duration);
         debug_struct.field("skip_os_adaptation", &self.skip_os_adaptation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21076,7 +21011,6 @@ impl std::fmt::Debug for CreateMigratingVmRequest {
         debug_struct.field("migrating_vm_id", &self.migrating_vm_id);
         debug_struct.field("migrating_vm", &self.migrating_vm);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21371,7 +21305,6 @@ impl std::fmt::Debug for ListMigratingVmsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21586,7 +21519,6 @@ impl std::fmt::Debug for ListMigratingVmsResponse {
         debug_struct.field("migrating_vms", &self.migrating_vms);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21753,7 +21685,6 @@ impl std::fmt::Debug for GetMigratingVmRequest {
         let mut debug_struct = f.debug_struct("GetMigratingVmRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21986,7 +21917,6 @@ impl std::fmt::Debug for UpdateMigratingVmRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("migrating_vm", &self.migrating_vm);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22128,7 +22058,6 @@ impl std::fmt::Debug for DeleteMigratingVmRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteMigratingVmRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22271,7 +22200,6 @@ impl std::fmt::Debug for StartMigrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartMigrationRequest");
         debug_struct.field("migrating_vm", &self.migrating_vm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22385,7 +22313,6 @@ impl serde::ser::Serialize for StartMigrationResponse {
 impl std::fmt::Debug for StartMigrationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartMigrationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22528,7 +22455,6 @@ impl std::fmt::Debug for PauseMigrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseMigrationRequest");
         debug_struct.field("migrating_vm", &self.migrating_vm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22642,7 +22568,6 @@ impl serde::ser::Serialize for PauseMigrationResponse {
 impl std::fmt::Debug for PauseMigrationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseMigrationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22785,7 +22710,6 @@ impl std::fmt::Debug for ResumeMigrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeMigrationRequest");
         debug_struct.field("migrating_vm", &self.migrating_vm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22899,7 +22823,6 @@ impl serde::ser::Serialize for ResumeMigrationResponse {
 impl std::fmt::Debug for ResumeMigrationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeMigrationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23042,7 +22965,6 @@ impl std::fmt::Debug for FinalizeMigrationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FinalizeMigrationRequest");
         debug_struct.field("migrating_vm", &self.migrating_vm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23156,7 +23078,6 @@ impl serde::ser::Serialize for FinalizeMigrationResponse {
 impl std::fmt::Debug for FinalizeMigrationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FinalizeMigrationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23424,7 +23345,6 @@ impl std::fmt::Debug for TargetProject {
         debug_struct.field("description", &self.description);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23566,7 +23486,6 @@ impl std::fmt::Debug for GetTargetProjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTargetProjectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23836,7 +23755,6 @@ impl std::fmt::Debug for ListTargetProjectsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24051,7 +23969,6 @@ impl std::fmt::Debug for ListTargetProjectsResponse {
         debug_struct.field("target_projects", &self.target_projects);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24297,7 +24214,6 @@ impl std::fmt::Debug for CreateTargetProjectRequest {
         debug_struct.field("target_project_id", &self.target_project_id);
         debug_struct.field("target_project", &self.target_project);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24530,7 +24446,6 @@ impl std::fmt::Debug for UpdateTargetProjectRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("target_project", &self.target_project);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24710,7 +24625,6 @@ impl std::fmt::Debug for DeleteTargetProjectRequest {
         let mut debug_struct = f.debug_struct("DeleteTargetProjectRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24978,7 +24892,6 @@ impl std::fmt::Debug for Group {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("description", &self.description);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25248,7 +25161,6 @@ impl std::fmt::Debug for ListGroupsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25462,7 +25374,6 @@ impl std::fmt::Debug for ListGroupsResponse {
         debug_struct.field("groups", &self.groups);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25604,7 +25515,6 @@ impl std::fmt::Debug for GetGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25846,7 +25756,6 @@ impl std::fmt::Debug for CreateGroupRequest {
         debug_struct.field("group_id", &self.group_id);
         debug_struct.field("group", &self.group);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26078,7 +25987,6 @@ impl std::fmt::Debug for UpdateGroupRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("group", &self.group);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26258,7 +26166,6 @@ impl std::fmt::Debug for DeleteGroupRequest {
         let mut debug_struct = f.debug_struct("DeleteGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26426,7 +26333,6 @@ impl std::fmt::Debug for AddGroupMigrationRequest {
         let mut debug_struct = f.debug_struct("AddGroupMigrationRequest");
         debug_struct.field("group", &self.group);
         debug_struct.field("migrating_vm", &self.migrating_vm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26540,7 +26446,6 @@ impl serde::ser::Serialize for AddGroupMigrationResponse {
 impl std::fmt::Debug for AddGroupMigrationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddGroupMigrationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26708,7 +26613,6 @@ impl std::fmt::Debug for RemoveGroupMigrationRequest {
         let mut debug_struct = f.debug_struct("RemoveGroupMigrationRequest");
         debug_struct.field("group", &self.group);
         debug_struct.field("migrating_vm", &self.migrating_vm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26822,7 +26726,6 @@ impl serde::ser::Serialize for RemoveGroupMigrationResponse {
 impl std::fmt::Debug for RemoveGroupMigrationResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RemoveGroupMigrationResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27065,7 +26968,6 @@ impl std::fmt::Debug for CreateCutoverJobRequest {
         debug_struct.field("cutover_job_id", &self.cutover_job_id);
         debug_struct.field("cutover_job", &self.cutover_job);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27207,7 +27109,6 @@ impl std::fmt::Debug for CancelCutoverJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelCutoverJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27321,7 +27222,6 @@ impl serde::ser::Serialize for CancelCutoverJobResponse {
 impl std::fmt::Debug for CancelCutoverJobResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelCutoverJobResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27591,7 +27491,6 @@ impl std::fmt::Debug for ListCutoverJobsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27806,7 +27705,6 @@ impl std::fmt::Debug for ListCutoverJobsResponse {
         debug_struct.field("cutover_jobs", &self.cutover_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27948,7 +27846,6 @@ impl std::fmt::Debug for GetCutoverJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCutoverJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28273,7 +28170,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28561,7 +28457,6 @@ impl std::fmt::Debug for MigrationError {
         debug_struct.field("action_item", &self.action_item);
         debug_struct.field("help_links", &self.help_links);
         debug_struct.field("error_time", &self.error_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28951,7 +28846,6 @@ impl std::fmt::Debug for AwsSourceVmDetails {
         let mut debug_struct = f.debug_struct("AwsSourceVmDetails");
         debug_struct.field("firmware", &self.firmware);
         debug_struct.field("committed_storage_bytes", &self.committed_storage_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29359,7 +29253,6 @@ impl std::fmt::Debug for ListReplicationCyclesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29578,7 +29471,6 @@ impl std::fmt::Debug for ListReplicationCyclesResponse {
         debug_struct.field("replication_cycles", &self.replication_cycles);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29720,7 +29612,6 @@ impl std::fmt::Debug for GetReplicationCycleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetReplicationCycleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -334,7 +334,6 @@ impl std::fmt::Debug for ListPrivateCloudsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -553,7 +552,6 @@ impl std::fmt::Debug for ListPrivateCloudsResponse {
         debug_struct.field("private_clouds", &self.private_clouds);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -702,7 +700,6 @@ impl std::fmt::Debug for GetPrivateCloudRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPrivateCloudRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -981,7 +978,6 @@ impl std::fmt::Debug for CreatePrivateCloudRequest {
         debug_struct.field("private_cloud", &self.private_cloud);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1206,7 +1202,6 @@ impl std::fmt::Debug for UpdatePrivateCloudRequest {
         debug_struct.field("private_cloud", &self.private_cloud);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1478,7 +1473,6 @@ impl std::fmt::Debug for DeletePrivateCloudRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("force", &self.force);
         debug_struct.field("delay_hours", &self.delay_hours);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1654,7 +1648,6 @@ impl std::fmt::Debug for UndeletePrivateCloudRequest {
         let mut debug_struct = f.debug_struct("UndeletePrivateCloudRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1949,7 +1942,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2167,7 +2159,6 @@ impl std::fmt::Debug for ListClustersResponse {
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2316,7 +2307,6 @@ impl std::fmt::Debug for GetClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2591,7 +2581,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2842,7 +2831,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3018,7 +3006,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         let mut debug_struct = f.debug_struct("DeleteClusterRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3245,7 +3232,6 @@ impl std::fmt::Debug for ListNodesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3434,7 +3420,6 @@ impl std::fmt::Debug for ListNodesResponse {
         let mut debug_struct = f.debug_struct("ListNodesResponse");
         debug_struct.field("nodes", &self.nodes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3581,7 +3566,6 @@ impl std::fmt::Debug for GetNodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNodeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3889,7 +3873,6 @@ impl std::fmt::Debug for ListExternalAddressesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4112,7 +4095,6 @@ impl std::fmt::Debug for ListExternalAddressesResponse {
         debug_struct.field("external_addresses", &self.external_addresses);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4343,7 +4325,6 @@ impl std::fmt::Debug for FetchNetworkPolicyExternalAddressesRequest {
         debug_struct.field("network_policy", &self.network_policy);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4540,7 +4521,6 @@ impl std::fmt::Debug for FetchNetworkPolicyExternalAddressesResponse {
         let mut debug_struct = f.debug_struct("FetchNetworkPolicyExternalAddressesResponse");
         debug_struct.field("external_addresses", &self.external_addresses);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4689,7 +4669,6 @@ impl std::fmt::Debug for GetExternalAddressRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetExternalAddressRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4955,7 +4934,6 @@ impl std::fmt::Debug for CreateExternalAddressRequest {
         debug_struct.field("external_address", &self.external_address);
         debug_struct.field("external_address_id", &self.external_address_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5193,7 +5171,6 @@ impl std::fmt::Debug for UpdateExternalAddressRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("external_address", &self.external_address);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5381,7 +5358,6 @@ impl std::fmt::Debug for DeleteExternalAddressRequest {
         let mut debug_struct = f.debug_struct("DeleteExternalAddressRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5608,7 +5584,6 @@ impl std::fmt::Debug for ListSubnetsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5826,7 +5801,6 @@ impl std::fmt::Debug for ListSubnetsResponse {
         debug_struct.field("subnets", &self.subnets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5975,7 +5949,6 @@ impl std::fmt::Debug for GetSubnetRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSubnetRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6172,7 +6145,6 @@ impl std::fmt::Debug for UpdateSubnetRequest {
         let mut debug_struct = f.debug_struct("UpdateSubnetRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("subnet", &self.subnet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6480,7 +6452,6 @@ impl std::fmt::Debug for ListExternalAccessRulesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6703,7 +6674,6 @@ impl std::fmt::Debug for ListExternalAccessRulesResponse {
         debug_struct.field("external_access_rules", &self.external_access_rules);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6852,7 +6822,6 @@ impl std::fmt::Debug for GetExternalAccessRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetExternalAccessRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7117,7 +7086,6 @@ impl std::fmt::Debug for CreateExternalAccessRuleRequest {
         debug_struct.field("external_access_rule", &self.external_access_rule);
         debug_struct.field("external_access_rule_id", &self.external_access_rule_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7354,7 +7322,6 @@ impl std::fmt::Debug for UpdateExternalAccessRuleRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("external_access_rule", &self.external_access_rule);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7542,7 +7509,6 @@ impl std::fmt::Debug for DeleteExternalAccessRuleRequest {
         let mut debug_struct = f.debug_struct("DeleteExternalAccessRuleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7851,7 +7817,6 @@ impl std::fmt::Debug for ListLoggingServersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8070,7 +8035,6 @@ impl std::fmt::Debug for ListLoggingServersResponse {
         debug_struct.field("logging_servers", &self.logging_servers);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8219,7 +8183,6 @@ impl std::fmt::Debug for GetLoggingServerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLoggingServerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8484,7 +8447,6 @@ impl std::fmt::Debug for CreateLoggingServerRequest {
         debug_struct.field("logging_server", &self.logging_server);
         debug_struct.field("logging_server_id", &self.logging_server_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8721,7 +8683,6 @@ impl std::fmt::Debug for UpdateLoggingServerRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("logging_server", &self.logging_server);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8909,7 +8870,6 @@ impl std::fmt::Debug for DeleteLoggingServerRequest {
         let mut debug_struct = f.debug_struct("DeleteLoggingServerRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9235,7 +9195,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9512,7 +9471,6 @@ impl std::fmt::Debug for ListNodeTypesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9731,7 +9689,6 @@ impl std::fmt::Debug for ListNodeTypesResponse {
         debug_struct.field("node_types", &self.node_types);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9880,7 +9837,6 @@ impl std::fmt::Debug for GetNodeTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNodeTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10031,7 +9987,6 @@ impl std::fmt::Debug for ShowNsxCredentialsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShowNsxCredentialsRequest");
         debug_struct.field("private_cloud", &self.private_cloud);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10216,7 +10171,6 @@ impl std::fmt::Debug for ShowVcenterCredentialsRequest {
         let mut debug_struct = f.debug_struct("ShowVcenterCredentialsRequest");
         debug_struct.field("private_cloud", &self.private_cloud);
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10406,7 +10360,6 @@ impl std::fmt::Debug for ResetNsxCredentialsRequest {
         let mut debug_struct = f.debug_struct("ResetNsxCredentialsRequest");
         debug_struct.field("private_cloud", &self.private_cloud);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10629,7 +10582,6 @@ impl std::fmt::Debug for ResetVcenterCredentialsRequest {
         debug_struct.field("private_cloud", &self.private_cloud);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10852,7 +10804,6 @@ impl std::fmt::Debug for ListHcxActivationKeysResponse {
         debug_struct.field("hcx_activation_keys", &self.hcx_activation_keys);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11080,7 +11031,6 @@ impl std::fmt::Debug for ListHcxActivationKeysRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11226,7 +11176,6 @@ impl std::fmt::Debug for GetHcxActivationKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetHcxActivationKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11492,7 +11441,6 @@ impl std::fmt::Debug for CreateHcxActivationKeyRequest {
         debug_struct.field("hcx_activation_key", &self.hcx_activation_key);
         debug_struct.field("hcx_activation_key_id", &self.hcx_activation_key_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11641,7 +11589,6 @@ impl std::fmt::Debug for GetDnsForwardingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDnsForwardingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11878,7 +11825,6 @@ impl std::fmt::Debug for UpdateDnsForwardingRequest {
         debug_struct.field("dns_forwarding", &self.dns_forwarding);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12143,7 +12089,6 @@ impl std::fmt::Debug for CreateNetworkPeeringRequest {
         debug_struct.field("network_peering_id", &self.network_peering_id);
         debug_struct.field("network_peering", &self.network_peering);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12331,7 +12276,6 @@ impl std::fmt::Debug for DeleteNetworkPeeringRequest {
         let mut debug_struct = f.debug_struct("DeleteNetworkPeeringRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12480,7 +12424,6 @@ impl std::fmt::Debug for GetNetworkPeeringRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNetworkPeeringRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12786,7 +12729,6 @@ impl std::fmt::Debug for ListNetworkPeeringsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13024,7 +12966,6 @@ impl std::fmt::Debug for UpdateNetworkPeeringRequest {
         debug_struct.field("network_peering", &self.network_peering);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13246,7 +13187,6 @@ impl std::fmt::Debug for ListNetworkPeeringsResponse {
         debug_struct.field("network_peerings", &self.network_peerings);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13499,7 +13439,6 @@ impl std::fmt::Debug for ListPeeringRoutesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13689,7 +13628,6 @@ impl std::fmt::Debug for ListPeeringRoutesResponse {
         let mut debug_struct = f.debug_struct("ListPeeringRoutesResponse");
         debug_struct.field("peering_routes", &self.peering_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13996,7 +13934,6 @@ impl std::fmt::Debug for ListNetworkPoliciesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14215,7 +14152,6 @@ impl std::fmt::Debug for ListNetworkPoliciesResponse {
         debug_struct.field("network_policies", &self.network_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14364,7 +14300,6 @@ impl std::fmt::Debug for GetNetworkPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNetworkPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14601,7 +14536,6 @@ impl std::fmt::Debug for UpdateNetworkPolicyRequest {
         debug_struct.field("network_policy", &self.network_policy);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14867,7 +14801,6 @@ impl std::fmt::Debug for CreateNetworkPolicyRequest {
         debug_struct.field("network_policy_id", &self.network_policy_id);
         debug_struct.field("network_policy", &self.network_policy);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15055,7 +14988,6 @@ impl std::fmt::Debug for DeleteNetworkPolicyRequest {
         let mut debug_struct = f.debug_struct("DeleteNetworkPolicyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15364,7 +15296,6 @@ impl std::fmt::Debug for ListManagementDnsZoneBindingsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15598,7 +15529,6 @@ impl std::fmt::Debug for ListManagementDnsZoneBindingsResponse {
         );
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15747,7 +15677,6 @@ impl std::fmt::Debug for GetManagementDnsZoneBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetManagementDnsZoneBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16031,7 +15960,6 @@ impl std::fmt::Debug for CreateManagementDnsZoneBindingRequest {
             &self.management_dns_zone_binding_id,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16279,7 +16207,6 @@ impl std::fmt::Debug for UpdateManagementDnsZoneBindingRequest {
             &self.management_dns_zone_binding,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16468,7 +16395,6 @@ impl std::fmt::Debug for DeleteManagementDnsZoneBindingRequest {
         let mut debug_struct = f.debug_struct("DeleteManagementDnsZoneBindingRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16654,7 +16580,6 @@ impl std::fmt::Debug for RepairManagementDnsZoneBindingRequest {
         let mut debug_struct = f.debug_struct("RepairManagementDnsZoneBindingRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16925,7 +16850,6 @@ impl std::fmt::Debug for CreateVmwareEngineNetworkRequest {
         debug_struct.field("vmware_engine_network_id", &self.vmware_engine_network_id);
         debug_struct.field("vmware_engine_network", &self.vmware_engine_network);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17163,7 +17087,6 @@ impl std::fmt::Debug for UpdateVmwareEngineNetworkRequest {
         debug_struct.field("vmware_engine_network", &self.vmware_engine_network);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17379,7 +17302,6 @@ impl std::fmt::Debug for DeleteVmwareEngineNetworkRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17528,7 +17450,6 @@ impl std::fmt::Debug for GetVmwareEngineNetworkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVmwareEngineNetworkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17834,7 +17755,6 @@ impl std::fmt::Debug for ListVmwareEngineNetworksRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18056,7 +17976,6 @@ impl std::fmt::Debug for ListVmwareEngineNetworksResponse {
         debug_struct.field("vmware_engine_networks", &self.vmware_engine_networks);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18321,7 +18240,6 @@ impl std::fmt::Debug for CreatePrivateConnectionRequest {
         debug_struct.field("private_connection_id", &self.private_connection_id);
         debug_struct.field("private_connection", &self.private_connection);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18470,7 +18388,6 @@ impl std::fmt::Debug for GetPrivateConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPrivateConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18776,7 +18693,6 @@ impl std::fmt::Debug for ListPrivateConnectionsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18998,7 +18914,6 @@ impl std::fmt::Debug for ListPrivateConnectionsResponse {
         debug_struct.field("private_connections", &self.private_connections);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19236,7 +19151,6 @@ impl std::fmt::Debug for UpdatePrivateConnectionRequest {
         debug_struct.field("private_connection", &self.private_connection);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19424,7 +19338,6 @@ impl std::fmt::Debug for DeletePrivateConnectionRequest {
         let mut debug_struct = f.debug_struct("DeletePrivateConnectionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19649,7 +19562,6 @@ impl std::fmt::Debug for ListPrivateConnectionPeeringRoutesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19841,7 +19753,6 @@ impl std::fmt::Debug for ListPrivateConnectionPeeringRoutesResponse {
         let mut debug_struct = f.debug_struct("ListPrivateConnectionPeeringRoutesResponse");
         debug_struct.field("peering_routes", &self.peering_routes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20068,7 +19979,6 @@ impl std::fmt::Debug for GrantDnsBindPermissionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("principal", &self.principal);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20295,7 +20205,6 @@ impl std::fmt::Debug for RevokeDnsBindPermissionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("principal", &self.principal);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20445,7 +20354,6 @@ impl std::fmt::Debug for GetDnsBindPermissionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDnsBindPermissionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20756,7 +20664,6 @@ impl std::fmt::Debug for NetworkConfig {
             &self.management_ip_address_layout_version,
         );
         debug_struct.field("dns_server_ip", &self.dns_server_ip);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20965,7 +20872,6 @@ impl std::fmt::Debug for NodeTypeConfig {
         let mut debug_struct = f.debug_struct("NodeTypeConfig");
         debug_struct.field("node_count", &self.node_count);
         debug_struct.field("custom_core_count", &self.custom_core_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21148,7 +21054,6 @@ impl std::fmt::Debug for StretchedClusterConfig {
         let mut debug_struct = f.debug_struct("StretchedClusterConfig");
         debug_struct.field("preferred_location", &self.preferred_location);
         debug_struct.field("secondary_location", &self.secondary_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21735,7 +21640,6 @@ impl std::fmt::Debug for PrivateCloud {
         debug_struct.field("vcenter", &self.vcenter);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21975,7 +21879,6 @@ pub mod private_cloud {
             debug_struct.field("cluster_id", &self.cluster_id);
             debug_struct.field("node_type_configs", &self.node_type_configs);
             debug_struct.field("stretched_cluster_config", &self.stretched_cluster_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22687,7 +22590,6 @@ impl std::fmt::Debug for Cluster {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("node_type_configs", &self.node_type_configs);
         debug_struct.field("stretched_cluster_config", &self.stretched_cluster_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23169,7 +23071,6 @@ impl std::fmt::Debug for Node {
         debug_struct.field("version", &self.version);
         debug_struct.field("custom_core_count", &self.custom_core_count);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23670,7 +23571,6 @@ impl std::fmt::Debug for ExternalAddress {
         debug_struct.field("state", &self.state);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24117,7 +24017,6 @@ impl std::fmt::Debug for Subnet {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("state", &self.state);
         debug_struct.field("vlan_id", &self.vlan_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24827,7 +24726,6 @@ impl std::fmt::Debug for ExternalAccessRule {
         debug_struct.field("destination_ports", &self.destination_ports);
         debug_struct.field("state", &self.state);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25121,7 +25019,6 @@ pub mod external_access_rule {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IpRange");
             debug_struct.field("ip_range", &self.ip_range);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25791,7 +25688,6 @@ impl std::fmt::Debug for LoggingServer {
         debug_struct.field("protocol", &self.protocol);
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26613,7 +26509,6 @@ impl std::fmt::Debug for NodeType {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("families", &self.families);
         debug_struct.field("capabilities", &self.capabilities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27044,7 +26939,6 @@ impl std::fmt::Debug for Credentials {
         let mut debug_struct = f.debug_struct("Credentials");
         debug_struct.field("username", &self.username);
         debug_struct.field("password", &self.password);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27314,7 +27208,6 @@ impl std::fmt::Debug for HcxActivationKey {
         debug_struct.field("state", &self.state);
         debug_struct.field("activation_key", &self.activation_key);
         debug_struct.field("uid", &self.uid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27677,7 +27570,6 @@ impl std::fmt::Debug for Hcx {
         debug_struct.field("version", &self.version);
         debug_struct.field("state", &self.state);
         debug_struct.field("fqdn", &self.fqdn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28040,7 +27932,6 @@ impl std::fmt::Debug for Nsx {
         debug_struct.field("version", &self.version);
         debug_struct.field("state", &self.state);
         debug_struct.field("fqdn", &self.fqdn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28396,7 +28287,6 @@ impl std::fmt::Debug for Vcenter {
         debug_struct.field("version", &self.version);
         debug_struct.field("state", &self.state);
         debug_struct.field("fqdn", &self.fqdn);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28836,7 +28726,6 @@ impl std::fmt::Debug for AutoscalingSettings {
         debug_struct.field("min_cluster_node_count", &self.min_cluster_node_count);
         debug_struct.field("max_cluster_node_count", &self.max_cluster_node_count);
         debug_struct.field("cool_down_period", &self.cool_down_period);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29051,7 +28940,6 @@ pub mod autoscaling_settings {
             let mut debug_struct = f.debug_struct("Thresholds");
             debug_struct.field("scale_out", &self.scale_out);
             debug_struct.field("scale_in", &self.scale_in);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29433,7 +29321,6 @@ pub mod autoscaling_settings {
                 &self.consumed_memory_thresholds,
             );
             debug_struct.field("storage_thresholds", &self.storage_thresholds);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29689,7 +29576,6 @@ impl std::fmt::Debug for DnsForwarding {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("forwarding_rules", &self.forwarding_rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29871,7 +29757,6 @@ pub mod dns_forwarding {
             let mut debug_struct = f.debug_struct("ForwardingRule");
             debug_struct.field("domain", &self.domain);
             debug_struct.field("name_servers", &self.name_servers);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30565,7 +30450,6 @@ impl std::fmt::Debug for NetworkPeering {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("vmware_engine_network", &self.vmware_engine_network);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31190,7 +31074,6 @@ impl std::fmt::Debug for PeeringRoute {
         debug_struct.field("priority", &self.priority);
         debug_struct.field("imported", &self.imported);
         debug_struct.field("direction", &self.direction);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31927,7 +31810,6 @@ impl std::fmt::Debug for NetworkPolicy {
             "vmware_engine_network_canonical",
             &self.vmware_engine_network_canonical,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32114,7 +31996,6 @@ pub mod network_policy {
             let mut debug_struct = f.debug_struct("NetworkService");
             debug_struct.field("enabled", &self.enabled);
             debug_struct.field("state", &self.state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32690,7 +32571,6 @@ impl std::fmt::Debug for ManagementDnsZoneBinding {
         debug_struct.field("description", &self.description);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("bind_network", &self.bind_network);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33254,7 +33134,6 @@ impl std::fmt::Debug for VmwareEngineNetwork {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("uid", &self.uid);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33440,7 +33319,6 @@ pub mod vmware_engine_network {
             let mut debug_struct = f.debug_struct("VpcNetwork");
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("network", &self.network);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34406,7 +34284,6 @@ impl std::fmt::Debug for PrivateConnection {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("service_network", &self.service_network);
         debug_struct.field("peering_state", &self.peering_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35139,7 +35016,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("capabilities", &self.capabilities);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35449,7 +35325,6 @@ impl std::fmt::Debug for DnsBindPermission {
         let mut debug_struct = f.debug_struct("DnsBindPermission");
         debug_struct.field("name", &self.name);
         debug_struct.field("principals", &self.principals);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35678,7 +35553,6 @@ impl std::fmt::Debug for Principal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Principal");
         debug_struct.field("principal", &self.principal);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -520,7 +520,6 @@ impl std::fmt::Debug for Connector {
         debug_struct.field("machine_type", &self.machine_type);
         debug_struct.field("min_instances", &self.min_instances);
         debug_struct.field("max_instances", &self.max_instances);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -701,7 +700,6 @@ pub mod connector {
             let mut debug_struct = f.debug_struct("Subnet");
             debug_struct.field("name", &self.name);
             debug_struct.field("project_id", &self.project_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1060,7 +1058,6 @@ impl std::fmt::Debug for CreateConnectorRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("connector_id", &self.connector_id);
         debug_struct.field("connector", &self.connector);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1202,7 +1199,6 @@ impl std::fmt::Debug for GetConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1414,7 +1410,6 @@ impl std::fmt::Debug for ListConnectorsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1599,7 +1594,6 @@ impl std::fmt::Debug for ListConnectorsResponse {
         let mut debug_struct = f.debug_struct("ListConnectorsResponse");
         debug_struct.field("connectors", &self.connectors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1741,7 +1735,6 @@ impl std::fmt::Debug for DeleteConnectorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConnectorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1984,7 +1977,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -259,7 +259,6 @@ impl std::fmt::Debug for ComputeThreatListDiffRequest {
         debug_struct.field("threat_type", &self.threat_type);
         debug_struct.field("version_token", &self.version_token);
         debug_struct.field("constraints", &self.constraints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -513,7 +512,6 @@ pub mod compute_threat_list_diff_request {
             debug_struct.field("max_diff_entries", &self.max_diff_entries);
             debug_struct.field("max_database_entries", &self.max_database_entries);
             debug_struct.field("supported_compressions", &self.supported_compressions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -864,7 +862,6 @@ impl std::fmt::Debug for ComputeThreatListDiffResponse {
         debug_struct.field("new_version_token", &self.new_version_token);
         debug_struct.field("checksum", &self.checksum);
         debug_struct.field("recommended_next_diff", &self.recommended_next_diff);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1038,7 +1035,6 @@ pub mod compute_threat_list_diff_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Checksum");
             debug_struct.field("sha256", &self.sha256);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1345,7 +1341,6 @@ impl std::fmt::Debug for SearchUrisRequest {
         let mut debug_struct = f.debug_struct("SearchUrisRequest");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("threat_types", &self.threat_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1498,7 +1493,6 @@ impl std::fmt::Debug for SearchUrisResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SearchUrisResponse");
         debug_struct.field("threat", &self.threat);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1694,7 +1688,6 @@ pub mod search_uris_response {
             let mut debug_struct = f.debug_struct("ThreatUri");
             debug_struct.field("threat_types", &self.threat_types);
             debug_struct.field("expire_time", &self.expire_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1889,7 +1882,6 @@ impl std::fmt::Debug for SearchHashesRequest {
         let mut debug_struct = f.debug_struct("SearchHashesRequest");
         debug_struct.field("hash_prefix", &self.hash_prefix);
         debug_struct.field("threat_types", &self.threat_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2076,7 +2068,6 @@ impl std::fmt::Debug for SearchHashesResponse {
         let mut debug_struct = f.debug_struct("SearchHashesResponse");
         debug_struct.field("threats", &self.threats);
         debug_struct.field("negative_expire_time", &self.negative_expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2322,7 +2313,6 @@ pub mod search_hashes_response {
             debug_struct.field("threat_types", &self.threat_types);
             debug_struct.field("hash", &self.hash);
             debug_struct.field("expire_time", &self.expire_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2511,7 +2501,6 @@ impl std::fmt::Debug for ThreatEntryAdditions {
         let mut debug_struct = f.debug_struct("ThreatEntryAdditions");
         debug_struct.field("raw_hashes", &self.raw_hashes);
         debug_struct.field("rice_hashes", &self.rice_hashes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2706,7 +2695,6 @@ impl std::fmt::Debug for ThreatEntryRemovals {
         let mut debug_struct = f.debug_struct("ThreatEntryRemovals");
         debug_struct.field("raw_indices", &self.raw_indices);
         debug_struct.field("rice_indices", &self.rice_indices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2876,7 +2864,6 @@ impl std::fmt::Debug for RawIndices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RawIndices");
         debug_struct.field("indices", &self.indices);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3092,7 +3079,6 @@ impl std::fmt::Debug for RawHashes {
         let mut debug_struct = f.debug_struct("RawHashes");
         debug_struct.field("prefix_size", &self.prefix_size);
         debug_struct.field("raw_hashes", &self.raw_hashes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3392,7 +3378,6 @@ impl std::fmt::Debug for RiceDeltaEncoding {
         debug_struct.field("rice_parameter", &self.rice_parameter);
         debug_struct.field("entry_count", &self.entry_count);
         debug_struct.field("encoded_data", &self.encoded_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3566,7 +3551,6 @@ impl std::fmt::Debug for Submission {
         let mut debug_struct = f.debug_struct("Submission");
         debug_struct.field("uri", &self.uri);
         debug_struct.field("threat_types", &self.threat_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3786,7 +3770,6 @@ impl std::fmt::Debug for ThreatInfo {
         debug_struct.field("abuse_type", &self.abuse_type);
         debug_struct.field("threat_confidence", &self.threat_confidence);
         debug_struct.field("threat_justification", &self.threat_justification);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4052,7 +4035,6 @@ pub mod threat_info {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Confidence");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4390,7 +4372,6 @@ pub mod threat_info {
             let mut debug_struct = f.debug_struct("ThreatJustification");
             debug_struct.field("labels", &self.labels);
             debug_struct.field("comments", &self.comments);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4853,7 +4834,6 @@ impl std::fmt::Debug for ThreatDiscovery {
         let mut debug_struct = f.debug_struct("ThreatDiscovery");
         debug_struct.field("platform", &self.platform);
         debug_struct.field("region_codes", &self.region_codes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5184,7 +5164,6 @@ impl std::fmt::Debug for CreateSubmissionRequest {
         let mut debug_struct = f.debug_struct("CreateSubmissionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("submission", &self.submission);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5438,7 +5417,6 @@ impl std::fmt::Debug for SubmitUriRequest {
         debug_struct.field("submission", &self.submission);
         debug_struct.field("threat_info", &self.threat_info);
         debug_struct.field("threat_discovery", &self.threat_discovery);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5655,7 +5633,6 @@ impl std::fmt::Debug for SubmitUriMetadata {
         debug_struct.field("state", &self.state);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -218,7 +218,6 @@ impl std::fmt::Debug for CrawledUrl {
         debug_struct.field("http_method", &self.http_method);
         debug_struct.field("url", &self.url);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -896,7 +895,6 @@ impl std::fmt::Debug for Finding {
         debug_struct.field("vulnerable_parameters", &self.vulnerable_parameters);
         debug_struct.field("xss", &self.xss);
         debug_struct.field("xxe", &self.xxe);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1219,7 +1217,6 @@ impl std::fmt::Debug for Form {
         let mut debug_struct = f.debug_struct("Form");
         debug_struct.field("action_uri", &self.action_uri);
         debug_struct.field("fields", &self.fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1416,7 +1413,6 @@ impl std::fmt::Debug for OutdatedLibrary {
         debug_struct.field("library_name", &self.library_name);
         debug_struct.field("version", &self.version);
         debug_struct.field("learn_more_urls", &self.learn_more_urls);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1586,7 +1582,6 @@ impl std::fmt::Debug for ViolatingResource {
         let mut debug_struct = f.debug_struct("ViolatingResource");
         debug_struct.field("content_type", &self.content_type);
         debug_struct.field("resource_url", &self.resource_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1732,7 +1727,6 @@ impl std::fmt::Debug for VulnerableParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VulnerableParameters");
         debug_struct.field("parameter_names", &self.parameter_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1914,7 +1908,6 @@ impl std::fmt::Debug for VulnerableHeaders {
         let mut debug_struct = f.debug_struct("VulnerableHeaders");
         debug_struct.field("headers", &self.headers);
         debug_struct.field("missing_headers", &self.missing_headers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2089,7 +2082,6 @@ pub mod vulnerable_headers {
             let mut debug_struct = f.debug_struct("Header");
             debug_struct.field("name", &self.name);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2321,7 +2313,6 @@ impl std::fmt::Debug for Xss {
         debug_struct.field("error_message", &self.error_message);
         debug_struct.field("attack_vector", &self.attack_vector);
         debug_struct.field("stored_xss_seeding_url", &self.stored_xss_seeding_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2724,7 +2715,6 @@ impl std::fmt::Debug for Xxe {
         let mut debug_struct = f.debug_struct("Xxe");
         debug_struct.field("payload_value", &self.payload_value);
         debug_struct.field("payload_location", &self.payload_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3044,7 +3034,6 @@ impl std::fmt::Debug for FindingTypeStats {
         let mut debug_struct = f.debug_struct("FindingTypeStats");
         debug_struct.field("finding_type", &self.finding_type);
         debug_struct.field("finding_count", &self.finding_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3573,7 +3562,6 @@ impl std::fmt::Debug for ScanConfig {
         debug_struct.field("managed_scan", &self.managed_scan);
         debug_struct.field("static_ip_scan", &self.static_ip_scan);
         debug_struct.field("ignore_http_status_errors", &self.ignore_http_status_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3899,7 +3887,6 @@ pub mod scan_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Authentication");
             debug_struct.field("authentication", &self.authentication);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4089,7 +4076,6 @@ pub mod scan_config {
                 let mut debug_struct = f.debug_struct("GoogleAccount");
                 debug_struct.field("username", &self.username);
                 debug_struct.field("password", &self.password);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4304,7 +4290,6 @@ pub mod scan_config {
                 debug_struct.field("username", &self.username);
                 debug_struct.field("password", &self.password);
                 debug_struct.field("login_url", &self.login_url);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4499,7 +4484,6 @@ pub mod scan_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("IapCredential");
                 debug_struct.field("iap_credentials", &self.iap_credentials);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4676,7 +4660,6 @@ pub mod scan_config {
                     let mut debug_struct = f.debug_struct("IapTestServiceAccountInfo");
                     debug_struct
                         .field("target_audience_client_id", &self.target_audience_client_id);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -4917,7 +4900,6 @@ pub mod scan_config {
             let mut debug_struct = f.debug_struct("Schedule");
             debug_struct.field("schedule_time", &self.schedule_time);
             debug_struct.field("interval_duration_days", &self.interval_duration_days);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5503,7 +5485,6 @@ impl std::fmt::Debug for ScanConfigError {
         let mut debug_struct = f.debug_struct("ScanConfigError");
         debug_struct.field("code", &self.code);
         debug_struct.field("field_name", &self.field_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6514,7 +6495,6 @@ impl std::fmt::Debug for ScanRun {
         debug_struct.field("progress_percent", &self.progress_percent);
         debug_struct.field("error_trace", &self.error_trace);
         debug_struct.field("warning_traces", &self.warning_traces);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7041,7 +7021,6 @@ impl std::fmt::Debug for ScanRunErrorTrace {
             "most_common_http_error_code",
             &self.most_common_http_error_code,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7593,7 +7572,6 @@ impl std::fmt::Debug for ScanRunLog {
         debug_struct.field("urls_tested_count", &self.urls_tested_count);
         debug_struct.field("has_findings", &self.has_findings);
         debug_struct.field("error_trace", &self.error_trace);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7738,7 +7716,6 @@ impl std::fmt::Debug for ScanRunWarningTrace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ScanRunWarningTrace");
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8088,7 +8065,6 @@ impl std::fmt::Debug for CreateScanConfigRequest {
         let mut debug_struct = f.debug_struct("CreateScanConfigRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("scan_config", &self.scan_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8231,7 +8207,6 @@ impl std::fmt::Debug for DeleteScanConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteScanConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8374,7 +8349,6 @@ impl std::fmt::Debug for GetScanConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetScanConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8591,7 +8565,6 @@ impl std::fmt::Debug for ListScanConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8786,7 +8759,6 @@ impl std::fmt::Debug for UpdateScanConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateScanConfigRequest");
         debug_struct.field("scan_config", &self.scan_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8973,7 +8945,6 @@ impl std::fmt::Debug for ListScanConfigsResponse {
         let mut debug_struct = f.debug_struct("ListScanConfigsResponse");
         debug_struct.field("scan_configs", &self.scan_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9116,7 +9087,6 @@ impl std::fmt::Debug for StartScanRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StartScanRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9260,7 +9230,6 @@ impl std::fmt::Debug for GetScanRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetScanRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9477,7 +9446,6 @@ impl std::fmt::Debug for ListScanRunsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9664,7 +9632,6 @@ impl std::fmt::Debug for ListScanRunsResponse {
         let mut debug_struct = f.debug_struct("ListScanRunsResponse");
         debug_struct.field("scan_runs", &self.scan_runs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9808,7 +9775,6 @@ impl std::fmt::Debug for StopScanRunRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StopScanRunRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10026,7 +9992,6 @@ impl std::fmt::Debug for ListCrawledUrlsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10213,7 +10178,6 @@ impl std::fmt::Debug for ListCrawledUrlsResponse {
         let mut debug_struct = f.debug_struct("ListCrawledUrlsResponse");
         debug_struct.field("crawled_urls", &self.crawled_urls);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10357,7 +10321,6 @@ impl std::fmt::Debug for GetFindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10603,7 +10566,6 @@ impl std::fmt::Debug for ListFindingsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10789,7 +10751,6 @@ impl std::fmt::Debug for ListFindingsResponse {
         let mut debug_struct = f.debug_struct("ListFindingsResponse");
         debug_struct.field("findings", &self.findings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10933,7 +10894,6 @@ impl std::fmt::Debug for ListFindingTypeStatsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListFindingTypeStatsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11083,7 +11043,6 @@ impl std::fmt::Debug for ListFindingTypeStatsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListFindingTypeStatsResponse");
         debug_struct.field("finding_type_stats", &self.finding_type_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -576,7 +576,6 @@ impl std::fmt::Debug for Execution {
         debug_struct.field("status", &self.status);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("state_error", &self.state_error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -788,7 +787,6 @@ pub mod execution {
             debug_struct.field("step", &self.step);
             debug_struct.field("routine", &self.routine);
             debug_struct.field("position", &self.position);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1059,7 +1057,6 @@ pub mod execution {
                 debug_struct.field("line", &self.line);
                 debug_struct.field("column", &self.column);
                 debug_struct.field("length", &self.length);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1212,7 +1209,6 @@ pub mod execution {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("StackTrace");
             debug_struct.field("elements", &self.elements);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1419,7 +1415,6 @@ pub mod execution {
             debug_struct.field("payload", &self.payload);
             debug_struct.field("context", &self.context);
             debug_struct.field("stack_trace", &self.stack_trace);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1578,7 +1573,6 @@ pub mod execution {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Status");
             debug_struct.field("current_steps", &self.current_steps);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1758,7 +1752,6 @@ pub mod execution {
                 let mut debug_struct = f.debug_struct("Step");
                 debug_struct.field("routine", &self.routine);
                 debug_struct.field("step", &self.step);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1934,7 +1927,6 @@ pub mod execution {
             let mut debug_struct = f.debug_struct("StateError");
             debug_struct.field("details", &self.details);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2680,7 +2672,6 @@ impl std::fmt::Debug for ListExecutionsRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2870,7 +2861,6 @@ impl std::fmt::Debug for ListExecutionsResponse {
         let mut debug_struct = f.debug_struct("ListExecutionsResponse");
         debug_struct.field("executions", &self.executions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3054,7 +3044,6 @@ impl std::fmt::Debug for CreateExecutionRequest {
         let mut debug_struct = f.debug_struct("CreateExecutionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("execution", &self.execution);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3228,7 +3217,6 @@ impl std::fmt::Debug for GetExecutionRequest {
         let mut debug_struct = f.debug_struct("GetExecutionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3376,7 +3364,6 @@ impl std::fmt::Debug for CancelExecutionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelExecutionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -823,7 +823,6 @@ impl std::fmt::Debug for Workflow {
         debug_struct.field("crypto_key_version", &self.crypto_key_version);
         debug_struct.field("tags", &self.tags);
         debug_struct.field("source_code", &self.source_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1003,7 +1002,6 @@ pub mod workflow {
             let mut debug_struct = f.debug_struct("StateError");
             debug_struct.field("details", &self.details);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1709,7 +1707,6 @@ impl std::fmt::Debug for ListWorkflowsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1927,7 +1924,6 @@ impl std::fmt::Debug for ListWorkflowsResponse {
         debug_struct.field("workflows", &self.workflows);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2103,7 +2099,6 @@ impl std::fmt::Debug for GetWorkflowRequest {
         let mut debug_struct = f.debug_struct("GetWorkflowRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2319,7 +2314,6 @@ impl std::fmt::Debug for CreateWorkflowRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("workflow", &self.workflow);
         debug_struct.field("workflow_id", &self.workflow_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2466,7 +2460,6 @@ impl std::fmt::Debug for DeleteWorkflowRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteWorkflowRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2661,7 +2654,6 @@ impl std::fmt::Debug for UpdateWorkflowRequest {
         let mut debug_struct = f.debug_struct("UpdateWorkflowRequest");
         debug_struct.field("workflow", &self.workflow);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2928,7 +2920,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("target", &self.target);
         debug_struct.field("verb", &self.verb);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3148,7 +3139,6 @@ impl std::fmt::Debug for ListWorkflowRevisionsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3338,7 +3328,6 @@ impl std::fmt::Debug for ListWorkflowRevisionsResponse {
         let mut debug_struct = f.debug_struct("ListWorkflowRevisionsResponse");
         debug_struct.field("workflows", &self.workflows);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -645,7 +645,6 @@ impl std::fmt::Debug for WorkstationCluster {
         debug_struct.field("private_cluster_config", &self.private_cluster_config);
         debug_struct.field("degraded", &self.degraded);
         debug_struct.field("conditions", &self.conditions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -899,7 +898,6 @@ pub mod workstation_cluster {
             debug_struct.field("cluster_hostname", &self.cluster_hostname);
             debug_struct.field("service_attachment_uri", &self.service_attachment_uri);
             debug_struct.field("allowed_projects", &self.allowed_projects);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1744,7 +1742,6 @@ impl std::fmt::Debug for WorkstationConfig {
         debug_struct.field("replica_zones", &self.replica_zones);
         debug_struct.field("degraded", &self.degraded);
         debug_struct.field("conditions", &self.conditions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1951,7 +1948,6 @@ pub mod workstation_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Host");
             debug_struct.field("config", &self.config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2608,7 +2604,6 @@ pub mod workstation_config {
                     &self.confidential_instance_config,
                 );
                 debug_struct.field("boot_disk_size_gb", &self.boot_disk_size_gb);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2843,7 +2838,6 @@ pub mod workstation_config {
                         "enable_integrity_monitoring",
                         &self.enable_integrity_monitoring,
                     );
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -3015,7 +3009,6 @@ pub mod workstation_config {
                         "enable_confidential_compute",
                         &self.enable_confidential_compute,
                     );
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -3251,7 +3244,6 @@ pub mod workstation_config {
             let mut debug_struct = f.debug_struct("PersistentDirectory");
             debug_struct.field("mount_path", &self.mount_path);
             debug_struct.field("directory_type", &self.directory_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3587,7 +3579,6 @@ pub mod workstation_config {
                 debug_struct.field("disk_type", &self.disk_type);
                 debug_struct.field("source_snapshot", &self.source_snapshot);
                 debug_struct.field("reclaim_policy", &self.reclaim_policy);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4061,7 +4052,6 @@ pub mod workstation_config {
             debug_struct.field("env", &self.env);
             debug_struct.field("working_dir", &self.working_dir);
             debug_struct.field("run_as_user", &self.run_as_user);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4251,7 +4241,6 @@ pub mod workstation_config {
             let mut debug_struct = f.debug_struct("CustomerEncryptionKey");
             debug_struct.field("kms_key", &self.kms_key);
             debug_struct.field("kms_key_service_account", &self.kms_key_service_account);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4439,7 +4428,6 @@ pub mod workstation_config {
             let mut debug_struct = f.debug_struct("ReadinessCheck");
             debug_struct.field("path", &self.path);
             debug_struct.field("port", &self.port);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4965,7 +4953,6 @@ impl std::fmt::Debug for Workstation {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("state", &self.state);
         debug_struct.field("host", &self.host);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5261,7 +5248,6 @@ impl std::fmt::Debug for GetWorkstationClusterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkstationClusterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5474,7 +5460,6 @@ impl std::fmt::Debug for ListWorkstationClustersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5693,7 +5678,6 @@ impl std::fmt::Debug for ListWorkstationClustersResponse {
         debug_struct.field("workstation_clusters", &self.workstation_clusters);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5928,7 +5912,6 @@ impl std::fmt::Debug for CreateWorkstationClusterRequest {
         debug_struct.field("workstation_cluster_id", &self.workstation_cluster_id);
         debug_struct.field("workstation_cluster", &self.workstation_cluster);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6175,7 +6158,6 @@ impl std::fmt::Debug for UpdateWorkstationClusterRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6397,7 +6379,6 @@ impl std::fmt::Debug for DeleteWorkstationClusterRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6539,7 +6520,6 @@ impl std::fmt::Debug for GetWorkstationConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkstationConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6752,7 +6732,6 @@ impl std::fmt::Debug for ListWorkstationConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6971,7 +6950,6 @@ impl std::fmt::Debug for ListWorkstationConfigsResponse {
         debug_struct.field("workstation_configs", &self.workstation_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7184,7 +7162,6 @@ impl std::fmt::Debug for ListUsableWorkstationConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7403,7 +7380,6 @@ impl std::fmt::Debug for ListUsableWorkstationConfigsResponse {
         debug_struct.field("workstation_configs", &self.workstation_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7639,7 +7615,6 @@ impl std::fmt::Debug for CreateWorkstationConfigRequest {
         debug_struct.field("workstation_config_id", &self.workstation_config_id);
         debug_struct.field("workstation_config", &self.workstation_config);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7887,7 +7862,6 @@ impl std::fmt::Debug for UpdateWorkstationConfigRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8109,7 +8083,6 @@ impl std::fmt::Debug for DeleteWorkstationConfigRequest {
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8251,7 +8224,6 @@ impl std::fmt::Debug for GetWorkstationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkstationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8464,7 +8436,6 @@ impl std::fmt::Debug for ListWorkstationsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8678,7 +8649,6 @@ impl std::fmt::Debug for ListWorkstationsResponse {
         debug_struct.field("workstations", &self.workstations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8891,7 +8861,6 @@ impl std::fmt::Debug for ListUsableWorkstationsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9105,7 +9074,6 @@ impl std::fmt::Debug for ListUsableWorkstationsResponse {
         debug_struct.field("workstations", &self.workstations);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9336,7 +9304,6 @@ impl std::fmt::Debug for CreateWorkstationRequest {
         debug_struct.field("workstation_id", &self.workstation_id);
         debug_struct.field("workstation", &self.workstation);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9582,7 +9549,6 @@ impl std::fmt::Debug for UpdateWorkstationRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("allow_missing", &self.allow_missing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9777,7 +9743,6 @@ impl std::fmt::Debug for DeleteWorkstationRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9972,7 +9937,6 @@ impl std::fmt::Debug for StartWorkstationRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10167,7 +10131,6 @@ impl std::fmt::Debug for StopWorkstationRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10428,7 +10391,6 @@ impl std::fmt::Debug for GenerateAccessTokenRequest {
         let mut debug_struct = f.debug_struct("GenerateAccessTokenRequest");
         debug_struct.field("workstation", &self.workstation);
         debug_struct.field("expiration", &self.expiration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10632,7 +10594,6 @@ impl std::fmt::Debug for GenerateAccessTokenResponse {
         let mut debug_struct = f.debug_struct("GenerateAccessTokenResponse");
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10952,7 +10913,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -384,7 +384,6 @@ impl std::fmt::Debug for LinuxNodeConfig {
             "transparent_hugepage_defrag",
             &self.transparent_hugepage_defrag,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -625,7 +624,6 @@ pub mod linux_node_config {
             let mut debug_struct = f.debug_struct("HugepagesConfig");
             debug_struct.field("hugepage_size2m", &self.hugepage_size2m);
             debug_struct.field("hugepage_size1g", &self.hugepage_size1g);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1226,7 +1224,6 @@ impl std::fmt::Debug for WindowsNodeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WindowsNodeConfig");
         debug_struct.field("os_version", &self.os_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2402,7 +2399,6 @@ impl std::fmt::Debug for NodeKubeletConfig {
         );
         debug_struct.field("max_parallel_image_pulls", &self.max_parallel_image_pulls);
         debug_struct.field("single_process_oom_kill", &self.single_process_oom_kill);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2597,7 +2593,6 @@ impl std::fmt::Debug for TopologyManager {
         let mut debug_struct = f.debug_struct("TopologyManager");
         debug_struct.field("policy", &self.policy);
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2749,7 +2744,6 @@ impl std::fmt::Debug for MemoryManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MemoryManager");
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3071,7 +3065,6 @@ impl std::fmt::Debug for EvictionSignals {
         debug_struct.field("imagefs_available", &self.imagefs_available);
         debug_struct.field("imagefs_inodes_free", &self.imagefs_inodes_free);
         debug_struct.field("pid_available", &self.pid_available);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3371,7 +3364,6 @@ impl std::fmt::Debug for EvictionGracePeriod {
         debug_struct.field("imagefs_available", &self.imagefs_available);
         debug_struct.field("imagefs_inodes_free", &self.imagefs_inodes_free);
         debug_struct.field("pid_available", &self.pid_available);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3675,7 +3667,6 @@ impl std::fmt::Debug for EvictionMinimumReclaim {
         debug_struct.field("imagefs_available", &self.imagefs_available);
         debug_struct.field("imagefs_inodes_free", &self.imagefs_inodes_free);
         debug_struct.field("pid_available", &self.pid_available);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5498,7 +5489,6 @@ impl std::fmt::Debug for NodeConfig {
         debug_struct.field("effective_cgroup_mode", &self.effective_cgroup_mode);
         debug_struct.field("flex_start", &self.flex_start);
         debug_struct.field("boot_disk", &self.boot_disk);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6059,7 +6049,6 @@ impl std::fmt::Debug for AdvancedMachineFeatures {
             "performance_monitoring_unit",
             &self.performance_monitoring_unit,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6760,7 +6749,6 @@ impl std::fmt::Debug for NodeNetworkConfig {
             &self.pod_ipv4_range_utilization,
         );
         debug_struct.field("subnetwork", &self.subnetwork);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6941,7 +6929,6 @@ pub mod node_network_config {
                 "total_egress_bandwidth_tier",
                 &self.total_egress_bandwidth_tier,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7244,7 +7231,6 @@ impl std::fmt::Debug for AdditionalNodeNetworkConfig {
         let mut debug_struct = f.debug_struct("AdditionalNodeNetworkConfig");
         debug_struct.field("network", &self.network);
         debug_struct.field("subnetwork", &self.subnetwork);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7455,7 +7441,6 @@ impl std::fmt::Debug for AdditionalPodNetworkConfig {
         debug_struct.field("subnetwork", &self.subnetwork);
         debug_struct.field("secondary_pod_range", &self.secondary_pod_range);
         debug_struct.field("max_pods_per_node", &self.max_pods_per_node);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7643,7 +7628,6 @@ impl std::fmt::Debug for ShieldedInstanceConfig {
             "enable_integrity_monitoring",
             &self.enable_integrity_monitoring,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7786,7 +7770,6 @@ impl std::fmt::Debug for SandboxConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SandboxConfig");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8060,7 +8043,6 @@ impl std::fmt::Debug for GcfsConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcfsConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8266,7 +8248,6 @@ impl std::fmt::Debug for ReservationAffinity {
         debug_struct.field("consume_reservation_type", &self.consume_reservation_type);
         debug_struct.field("key", &self.key);
         debug_struct.field("values", &self.values);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8623,7 +8604,6 @@ impl std::fmt::Debug for SoleTenantConfig {
         let mut debug_struct = f.debug_struct("SoleTenantConfig");
         debug_struct.field("node_affinities", &self.node_affinities);
         debug_struct.field("min_node_cpus", &self.min_node_cpus);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8835,7 +8815,6 @@ pub mod sole_tenant_config {
             debug_struct.field("key", &self.key);
             debug_struct.field("operator", &self.operator);
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9149,7 +9128,6 @@ impl std::fmt::Debug for ContainerdConfig {
             "private_registry_access_config",
             &self.private_registry_access_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9341,7 +9319,6 @@ pub mod containerd_config {
                 "certificate_authority_domain_config",
                 &self.certificate_authority_domain_config,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9580,7 +9557,6 @@ pub mod containerd_config {
                 let mut debug_struct = f.debug_struct("CertificateAuthorityDomainConfig");
                 debug_struct.field("fqdns", &self.fqdns);
                 debug_struct.field("certificate_config", &self.certificate_config);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -9752,7 +9728,6 @@ pub mod containerd_config {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("GCPSecretManagerCertificateConfig");
                     debug_struct.field("secret_uri", &self.secret_uri);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -9963,7 +9938,6 @@ impl std::fmt::Debug for NodeTaint {
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
         debug_struct.field("effect", &self.effect);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10254,7 +10228,6 @@ impl std::fmt::Debug for NodeTaints {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodeTaints");
         debug_struct.field("taints", &self.taints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10408,7 +10381,6 @@ impl std::fmt::Debug for NodeLabels {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodeLabels");
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10562,7 +10534,6 @@ impl std::fmt::Debug for ResourceLabels {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceLabels");
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10708,7 +10679,6 @@ impl std::fmt::Debug for NetworkTags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkTags");
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11027,7 +10997,6 @@ impl std::fmt::Debug for MasterAuth {
         debug_struct.field("cluster_ca_certificate", &self.cluster_ca_certificate);
         debug_struct.field("client_certificate", &self.client_certificate);
         debug_struct.field("client_key", &self.client_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11172,7 +11141,6 @@ impl std::fmt::Debug for ClientCertificateConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ClientCertificateConfig");
         debug_struct.field("issue_client_certificate", &self.issue_client_certificate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11975,7 +11943,6 @@ impl std::fmt::Debug for AddonsConfig {
             &self.high_scale_checkpointing_config,
         );
         debug_struct.field("lustre_csi_driver_config", &self.lustre_csi_driver_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12120,7 +12087,6 @@ impl std::fmt::Debug for HttpLoadBalancing {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HttpLoadBalancing");
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12266,7 +12232,6 @@ impl std::fmt::Debug for HorizontalPodAutoscaling {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HorizontalPodAutoscaling");
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12408,7 +12373,6 @@ impl std::fmt::Debug for KubernetesDashboard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("KubernetesDashboard");
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12552,7 +12516,6 @@ impl std::fmt::Debug for NetworkPolicyConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NetworkPolicyConfig");
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12694,7 +12657,6 @@ impl std::fmt::Debug for DnsCacheConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DnsCacheConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12837,7 +12799,6 @@ impl std::fmt::Debug for PrivateClusterMasterGlobalAccessConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrivateClusterMasterGlobalAccessConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13259,7 +13220,6 @@ impl std::fmt::Debug for PrivateClusterConfig {
             "private_endpoint_subnetwork",
             &self.private_endpoint_subnetwork,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13429,7 +13389,6 @@ impl std::fmt::Debug for AuthenticatorGroupsConfig {
         let mut debug_struct = f.debug_struct("AuthenticatorGroupsConfig");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("security_group", &self.security_group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13604,7 +13563,6 @@ impl std::fmt::Debug for CloudRunConfig {
         let mut debug_struct = f.debug_struct("CloudRunConfig");
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("load_balancer_type", &self.load_balancer_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13884,7 +13842,6 @@ impl std::fmt::Debug for ConfigConnectorConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConfigConnectorConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14026,7 +13983,6 @@ impl std::fmt::Debug for GcePersistentDiskCsiDriverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcePersistentDiskCsiDriverConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14168,7 +14124,6 @@ impl std::fmt::Debug for GcpFilestoreCsiDriverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcpFilestoreCsiDriverConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14310,7 +14265,6 @@ impl std::fmt::Debug for GcsFuseCsiDriverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcsFuseCsiDriverConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14453,7 +14407,6 @@ impl std::fmt::Debug for ParallelstoreCsiDriverConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ParallelstoreCsiDriverConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14596,7 +14549,6 @@ impl std::fmt::Debug for HighScaleCheckpointingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HighScaleCheckpointingConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14767,7 +14719,6 @@ impl std::fmt::Debug for LustreCsiDriverConfig {
         let mut debug_struct = f.debug_struct("LustreCsiDriverConfig");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("enable_legacy_lustre_port", &self.enable_legacy_lustre_port);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15004,7 +14955,6 @@ impl std::fmt::Debug for RayOperatorConfig {
             "ray_cluster_monitoring_config",
             &self.ray_cluster_monitoring_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15146,7 +15096,6 @@ impl std::fmt::Debug for GkeBackupAgentConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GkeBackupAgentConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15288,7 +15237,6 @@ impl std::fmt::Debug for StatefulHAConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StatefulHAConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15569,7 +15517,6 @@ impl std::fmt::Debug for MasterAuthorizedNetworksConfig {
             "private_endpoint_enforcement_enabled",
             &self.private_endpoint_enforcement_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15749,7 +15696,6 @@ pub mod master_authorized_networks_config {
             let mut debug_struct = f.debug_struct("CidrBlock");
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("cidr_block", &self.cidr_block);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15896,7 +15842,6 @@ impl std::fmt::Debug for LegacyAbac {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LegacyAbac");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16065,7 +16010,6 @@ impl std::fmt::Debug for NetworkPolicy {
         let mut debug_struct = f.debug_struct("NetworkPolicy");
         debug_struct.field("provider", &self.provider);
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16376,7 +16320,6 @@ impl std::fmt::Debug for BinaryAuthorization {
         let mut debug_struct = f.debug_struct("BinaryAuthorization");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("evaluation_mode", &self.evaluation_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16662,7 +16605,6 @@ impl std::fmt::Debug for PodCIDROverprovisionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PodCIDROverprovisionConfig");
         debug_struct.field("disable", &self.disable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17623,7 +17565,6 @@ impl std::fmt::Debug for IPAllocationPolicy {
             &self.additional_ip_ranges_configs,
         );
         debug_struct.field("auto_ipam_config", &self.auto_ipam_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20625,7 +20566,6 @@ impl std::fmt::Debug for Cluster {
             "anonymous_authentication_config",
             &self.anonymous_authentication_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21023,7 +20963,6 @@ impl std::fmt::Debug for RBACBindingConfig {
             "enable_insecure_binding_system_authenticated",
             &self.enable_insecure_binding_system_authenticated,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21415,7 +21354,6 @@ impl std::fmt::Debug for UserManagedKeysConfig {
             "gkeops_etcd_backup_encryption_key",
             &self.gkeops_etcd_backup_encryption_key,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21563,7 +21501,6 @@ impl std::fmt::Debug for AnonymousAuthenticationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AnonymousAuthenticationConfig");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21893,7 +21830,6 @@ impl std::fmt::Debug for CompliancePostureConfig {
         let mut debug_struct = f.debug_struct("CompliancePostureConfig");
         debug_struct.field("mode", &self.mode);
         debug_struct.field("compliance_standards", &self.compliance_standards);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22054,7 +21990,6 @@ pub mod compliance_posture_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ComplianceStandard");
             debug_struct.field("standard", &self.standard);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22333,7 +22268,6 @@ impl std::fmt::Debug for K8sBetaAPIConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("K8sBetaAPIConfig");
         debug_struct.field("enabled_apis", &self.enabled_apis);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22528,7 +22462,6 @@ impl std::fmt::Debug for SecurityPostureConfig {
         let mut debug_struct = f.debug_struct("SecurityPostureConfig");
         debug_struct.field("mode", &self.mode);
         debug_struct.field("vulnerability_mode", &self.vulnerability_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23089,7 +23022,6 @@ impl std::fmt::Debug for NodePoolAutoConfig {
         debug_struct.field("resource_manager_tags", &self.resource_manager_tags);
         debug_struct.field("node_kubelet_config", &self.node_kubelet_config);
         debug_struct.field("linux_node_config", &self.linux_node_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23243,7 +23175,6 @@ impl std::fmt::Debug for NodePoolDefaults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodePoolDefaults");
         debug_struct.field("node_config_defaults", &self.node_config_defaults);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23512,7 +23443,6 @@ impl std::fmt::Debug for NodeConfigDefaults {
         debug_struct.field("logging_config", &self.logging_config);
         debug_struct.field("containerd_config", &self.containerd_config);
         debug_struct.field("node_kubelet_config", &self.node_kubelet_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26925,7 +26855,6 @@ impl std::fmt::Debug for ClusterUpdate {
             &self.desired_anonymous_authentication_config,
         );
         debug_struct.field("gke_auto_upgrade_config", &self.gke_auto_upgrade_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27101,7 +27030,6 @@ impl std::fmt::Debug for AdditionalPodRangesConfig {
         let mut debug_struct = f.debug_struct("AdditionalPodRangesConfig");
         debug_struct.field("pod_range_names", &self.pod_range_names);
         debug_struct.field("pod_range_info", &self.pod_range_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27279,7 +27207,6 @@ impl std::fmt::Debug for AdditionalIPRangesConfig {
         let mut debug_struct = f.debug_struct("AdditionalIPRangesConfig");
         debug_struct.field("subnetwork", &self.subnetwork);
         debug_struct.field("pod_ipv4_range_names", &self.pod_ipv4_range_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27441,7 +27368,6 @@ impl std::fmt::Debug for DesiredAdditionalIPRangesConfig {
             "additional_ip_ranges_configs",
             &self.additional_ip_ranges_configs,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27555,7 +27481,6 @@ impl serde::ser::Serialize for AutoIpamConfig {
 impl std::fmt::Debug for AutoIpamConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutoIpamConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27741,7 +27666,6 @@ impl std::fmt::Debug for RangeInfo {
         let mut debug_struct = f.debug_struct("RangeInfo");
         debug_struct.field("range_name", &self.range_name);
         debug_struct.field("utilization", &self.utilization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27889,7 +27813,6 @@ impl std::fmt::Debug for DesiredEnterpriseConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DesiredEnterpriseConfig");
         debug_struct.field("desired_tier", &self.desired_tier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28471,7 +28394,6 @@ impl std::fmt::Debug for Operation {
         debug_struct.field("cluster_conditions", &self.cluster_conditions);
         debug_struct.field("nodepool_conditions", &self.nodepool_conditions);
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29203,7 +29125,6 @@ impl std::fmt::Debug for OperationProgress {
         debug_struct.field("status", &self.status);
         debug_struct.field("metrics", &self.metrics);
         debug_struct.field("stages", &self.stages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29562,7 +29483,6 @@ pub mod operation_progress {
             let mut debug_struct = f.debug_struct("Metric");
             debug_struct.field("name", &self.name);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29821,7 +29741,6 @@ impl std::fmt::Debug for CreateClusterRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("cluster", &self.cluster);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30053,7 +29972,6 @@ impl std::fmt::Debug for GetClusterRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30321,7 +30239,6 @@ impl std::fmt::Debug for UpdateClusterRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("update", &self.update);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31674,7 +31591,6 @@ impl std::fmt::Debug for UpdateNodePoolRequest {
         debug_struct.field("max_run_duration", &self.max_run_duration);
         debug_struct.field("flex_start", &self.flex_start);
         debug_struct.field("boot_disk", &self.boot_disk);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31972,7 +31888,6 @@ impl std::fmt::Debug for SetNodePoolAutoscalingRequest {
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("autoscaling", &self.autoscaling);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32240,7 +32155,6 @@ impl std::fmt::Debug for SetLoggingServiceRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("logging_service", &self.logging_service);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32511,7 +32425,6 @@ impl std::fmt::Debug for SetMonitoringServiceRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("monitoring_service", &self.monitoring_service);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32781,7 +32694,6 @@ impl std::fmt::Debug for SetAddonsConfigRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("addons_config", &self.addons_config);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33047,7 +32959,6 @@ impl std::fmt::Debug for SetLocationsRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("locations", &self.locations);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33314,7 +33225,6 @@ impl std::fmt::Debug for UpdateMasterRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("master_version", &self.master_version);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33612,7 +33522,6 @@ impl std::fmt::Debug for SetMasterAuthRequest {
         debug_struct.field("action", &self.action);
         debug_struct.field("update", &self.update);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33992,7 +33901,6 @@ impl std::fmt::Debug for DeleteClusterRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34196,7 +34104,6 @@ impl std::fmt::Debug for ListClustersRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("zone", &self.zone);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34372,7 +34279,6 @@ impl std::fmt::Debug for ListClustersResponse {
         let mut debug_struct = f.debug_struct("ListClustersResponse");
         debug_struct.field("clusters", &self.clusters);
         debug_struct.field("missing_zones", &self.missing_zones);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34604,7 +34510,6 @@ impl std::fmt::Debug for GetOperationRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("operation_id", &self.operation_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34808,7 +34713,6 @@ impl std::fmt::Debug for ListOperationsRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("zone", &self.zone);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35040,7 +34944,6 @@ impl std::fmt::Debug for CancelOperationRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("operation_id", &self.operation_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35215,7 +35118,6 @@ impl std::fmt::Debug for ListOperationsResponse {
         let mut debug_struct = f.debug_struct("ListOperationsResponse");
         debug_struct.field("operations", &self.operations);
         debug_struct.field("missing_zones", &self.missing_zones);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35418,7 +35320,6 @@ impl std::fmt::Debug for GetServerConfigRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("zone", &self.zone);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35714,7 +35615,6 @@ impl std::fmt::Debug for ServerConfig {
         debug_struct.field("valid_image_types", &self.valid_image_types);
         debug_struct.field("valid_master_versions", &self.valid_master_versions);
         debug_struct.field("channels", &self.channels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35954,7 +35854,6 @@ pub mod server_config {
             debug_struct.field("default_version", &self.default_version);
             debug_struct.field("valid_versions", &self.valid_versions);
             debug_struct.field("upgrade_target_version", &self.upgrade_target_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36225,7 +36124,6 @@ impl std::fmt::Debug for CreateNodePoolRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("node_pool", &self.node_pool);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36487,7 +36385,6 @@ impl std::fmt::Debug for DeleteNodePoolRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36719,7 +36616,6 @@ impl std::fmt::Debug for ListNodePoolsRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36981,7 +36877,6 @@ impl std::fmt::Debug for GetNodePoolRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37213,7 +37108,6 @@ impl std::fmt::Debug for BlueGreenSettings {
         let mut debug_struct = f.debug_struct("BlueGreenSettings");
         debug_struct.field("node_pool_soak_duration", &self.node_pool_soak_duration);
         debug_struct.field("rollout_policy", &self.rollout_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37535,7 +37429,6 @@ pub mod blue_green_settings {
             let mut debug_struct = f.debug_struct("StandardRolloutPolicy");
             debug_struct.field("batch_soak_duration", &self.batch_soak_duration);
             debug_struct.field("update_batch_size", &self.update_batch_size);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38423,7 +38316,6 @@ impl std::fmt::Debug for NodePool {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("queued_provisioning", &self.queued_provisioning);
         debug_struct.field("best_effort_provisioning", &self.best_effort_provisioning);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38761,7 +38653,6 @@ pub mod node_pool {
             debug_struct.field("max_unavailable", &self.max_unavailable);
             debug_struct.field("strategy", &self.strategy);
             debug_struct.field("blue_green_settings", &self.blue_green_settings);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38921,7 +38812,6 @@ pub mod node_pool {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UpdateInfo");
             debug_struct.field("blue_green_info", &self.blue_green_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39228,7 +39118,6 @@ pub mod node_pool {
                     &self.blue_pool_deletion_start_time,
                 );
                 debug_struct.field("green_pool_version", &self.green_pool_version);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -39613,7 +39502,6 @@ pub mod node_pool {
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("tpu_topology", &self.tpu_topology);
             debug_struct.field("policy_name", &self.policy_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39896,7 +39784,6 @@ pub mod node_pool {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QueuedProvisioning");
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -40276,7 +40163,6 @@ impl std::fmt::Debug for NodeManagement {
         debug_struct.field("auto_upgrade", &self.auto_upgrade);
         debug_struct.field("auto_repair", &self.auto_repair);
         debug_struct.field("upgrade_options", &self.upgrade_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40467,7 +40353,6 @@ impl std::fmt::Debug for BestEffortProvisioning {
         let mut debug_struct = f.debug_struct("BestEffortProvisioning");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("min_provision_nodes", &self.min_provision_nodes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40642,7 +40527,6 @@ impl std::fmt::Debug for AutoUpgradeOptions {
         let mut debug_struct = f.debug_struct("AutoUpgradeOptions");
         debug_struct.field("auto_upgrade_start_time", &self.auto_upgrade_start_time);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40829,7 +40713,6 @@ impl std::fmt::Debug for MaintenancePolicy {
         let mut debug_struct = f.debug_struct("MaintenancePolicy");
         debug_struct.field("window", &self.window);
         debug_struct.field("resource_version", &self.resource_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41120,7 +41003,6 @@ impl std::fmt::Debug for MaintenanceWindow {
         let mut debug_struct = f.debug_struct("MaintenanceWindow");
         debug_struct.field("maintenance_exclusions", &self.maintenance_exclusions);
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41408,7 +41290,6 @@ impl std::fmt::Debug for TimeWindow {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41570,7 +41451,6 @@ impl std::fmt::Debug for MaintenanceExclusionOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaintenanceExclusionOptions");
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41926,7 +41806,6 @@ impl std::fmt::Debug for RecurringTimeWindow {
         let mut debug_struct = f.debug_struct("RecurringTimeWindow");
         debug_struct.field("window", &self.window);
         debug_struct.field("recurrence", &self.recurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42099,7 +41978,6 @@ impl std::fmt::Debug for DailyMaintenanceWindow {
         let mut debug_struct = f.debug_struct("DailyMaintenanceWindow");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("duration", &self.duration);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42399,7 +42277,6 @@ impl std::fmt::Debug for SetNodePoolManagementRequest {
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("management", &self.management);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42705,7 +42582,6 @@ impl std::fmt::Debug for SetNodePoolSizeRequest {
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("node_count", &self.node_count);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42850,7 +42726,6 @@ impl std::fmt::Debug for CompleteNodePoolUpgradeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CompleteNodePoolUpgradeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43141,7 +43016,6 @@ impl std::fmt::Debug for RollbackNodePoolUpgradeRequest {
         debug_struct.field("node_pool_id", &self.node_pool_id);
         debug_struct.field("name", &self.name);
         debug_struct.field("respect_pdb", &self.respect_pdb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43287,7 +43161,6 @@ impl std::fmt::Debug for ListNodePoolsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListNodePoolsResponse");
         debug_struct.field("node_pools", &self.node_pools);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43648,7 +43521,6 @@ impl std::fmt::Debug for ClusterAutoscaling {
             "default_compute_class_config",
             &self.default_compute_class_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44302,7 +44174,6 @@ impl std::fmt::Debug for AutoprovisioningNodePoolDefaults {
             "insecure_kubelet_readonly_port_enabled",
             &self.insecure_kubelet_readonly_port_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44532,7 +44403,6 @@ impl std::fmt::Debug for ResourceLimit {
         debug_struct.field("resource_type", &self.resource_type);
         debug_struct.field("minimum", &self.minimum);
         debug_struct.field("maximum", &self.maximum);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44675,7 +44545,6 @@ impl std::fmt::Debug for DefaultComputeClassConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DefaultComputeClassConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45064,7 +44933,6 @@ impl std::fmt::Debug for NodePoolAutoscaling {
         debug_struct.field("location_policy", &self.location_policy);
         debug_struct.field("total_min_node_count", &self.total_min_node_count);
         debug_struct.field("total_max_node_count", &self.total_max_node_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45509,7 +45377,6 @@ impl std::fmt::Debug for SetLabelsRequest {
         debug_struct.field("resource_labels", &self.resource_labels);
         debug_struct.field("label_fingerprint", &self.label_fingerprint);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45767,7 +45634,6 @@ impl std::fmt::Debug for SetLegacyAbacRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46026,7 +45892,6 @@ impl std::fmt::Debug for StartIPRotationRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("name", &self.name);
         debug_struct.field("rotate_credentials", &self.rotate_credentials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46258,7 +46123,6 @@ impl std::fmt::Debug for CompleteIPRotationRequest {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46570,7 +46434,6 @@ impl std::fmt::Debug for AcceleratorConfig {
             "gpu_driver_installation_config",
             &self.gpu_driver_installation_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -46782,7 +46645,6 @@ impl std::fmt::Debug for GPUSharingConfig {
             &self.max_shared_clients_per_gpu,
         );
         debug_struct.field("gpu_sharing_strategy", &self.gpu_sharing_strategy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47077,7 +46939,6 @@ impl std::fmt::Debug for GPUDriverInstallationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GPUDriverInstallationConfig");
         debug_struct.field("gpu_driver_version", &self.gpu_driver_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47371,7 +47232,6 @@ impl std::fmt::Debug for WorkloadMetadataConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WorkloadMetadataConfig");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47783,7 +47643,6 @@ impl std::fmt::Debug for SetNetworkPolicyRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("network_policy", &self.network_policy);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48046,7 +47905,6 @@ impl std::fmt::Debug for SetMaintenancePolicyRequest {
         debug_struct.field("cluster_id", &self.cluster_id);
         debug_struct.field("maintenance_policy", &self.maintenance_policy);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48244,7 +48102,6 @@ impl std::fmt::Debug for StatusCondition {
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
         debug_struct.field("canonical_code", &self.canonical_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49224,7 +49081,6 @@ impl std::fmt::Debug for NetworkConfig {
             "disable_l4_lb_firewall_reconciliation",
             &self.disable_l4_lb_firewall_reconciliation,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49405,7 +49261,6 @@ pub mod network_config {
                 "total_egress_bandwidth_tier",
                 &self.total_egress_bandwidth_tier,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -49683,7 +49538,6 @@ impl std::fmt::Debug for GatewayAPIConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GatewayAPIConfig");
         debug_struct.field("channel", &self.channel);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49973,7 +49827,6 @@ impl std::fmt::Debug for ServiceExternalIPsConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceExternalIPsConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50117,7 +49970,6 @@ impl std::fmt::Debug for GetOpenIDConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOpenIDConfigRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50435,7 +50287,6 @@ impl std::fmt::Debug for GetOpenIDConfigResponse {
         );
         debug_struct.field("claims_supported", &self.claims_supported);
         debug_struct.field("grant_types", &self.grant_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50581,7 +50432,6 @@ impl std::fmt::Debug for GetJSONWebKeysRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJSONWebKeysRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50923,7 +50773,6 @@ impl std::fmt::Debug for Jwk {
         debug_struct.field("x", &self.x);
         debug_struct.field("y", &self.y);
         debug_struct.field("crv", &self.crv);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51069,7 +50918,6 @@ impl std::fmt::Debug for GetJSONWebKeysResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJSONWebKeysResponse");
         debug_struct.field("keys", &self.keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51213,7 +51061,6 @@ impl std::fmt::Debug for CheckAutopilotCompatibilityRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CheckAutopilotCompatibilityRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51509,7 +51356,6 @@ impl std::fmt::Debug for AutopilotCompatibilityIssue {
         debug_struct.field("subjects", &self.subjects);
         debug_struct.field("documentation_url", &self.documentation_url);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51836,7 +51682,6 @@ impl std::fmt::Debug for CheckAutopilotCompatibilityResponse {
         let mut debug_struct = f.debug_struct("CheckAutopilotCompatibilityResponse");
         debug_struct.field("issues", &self.issues);
         debug_struct.field("summary", &self.summary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51984,7 +51829,6 @@ impl std::fmt::Debug for ReleaseChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReleaseChannel");
         debug_struct.field("channel", &self.channel);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52287,7 +52131,6 @@ impl std::fmt::Debug for CostManagementConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CostManagementConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52430,7 +52273,6 @@ impl std::fmt::Debug for IntraNodeVisibilityConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IntraNodeVisibilityConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52573,7 +52415,6 @@ impl std::fmt::Debug for ILBSubsettingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ILBSubsettingConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52812,7 +52653,6 @@ impl std::fmt::Debug for DNSConfig {
             "additive_vpc_scope_dns_domain",
             &self.additive_vpc_scope_dns_domain,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53251,7 +53091,6 @@ impl std::fmt::Debug for MaxPodsConstraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MaxPodsConstraint");
         debug_struct.field("max_pods_per_node", &self.max_pods_per_node);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53395,7 +53234,6 @@ impl std::fmt::Debug for WorkloadIdentityConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WorkloadIdentityConfig");
         debug_struct.field("workload_pool", &self.workload_pool);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53538,7 +53376,6 @@ impl std::fmt::Debug for IdentityServiceConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IdentityServiceConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53702,7 +53539,6 @@ impl std::fmt::Debug for MeshCertificates {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MeshCertificates");
         debug_struct.field("enable_certificates", &self.enable_certificates);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53978,7 +53814,6 @@ impl std::fmt::Debug for DatabaseEncryption {
         debug_struct.field("current_state", &self.current_state);
         debug_struct.field("decryption_keys", &self.decryption_keys);
         debug_struct.field("last_operation_errors", &self.last_operation_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54195,7 +54030,6 @@ pub mod database_encryption {
             debug_struct.field("key_name", &self.key_name);
             debug_struct.field("error_message", &self.error_message);
             debug_struct.field("timestamp", &self.timestamp);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -54746,7 +54580,6 @@ impl std::fmt::Debug for ListUsableSubnetworksRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54939,7 +54772,6 @@ impl std::fmt::Debug for ListUsableSubnetworksResponse {
         let mut debug_struct = f.debug_struct("ListUsableSubnetworksResponse");
         debug_struct.field("subnetworks", &self.subnetworks);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55141,7 +54973,6 @@ impl std::fmt::Debug for UsableSubnetworkSecondaryRange {
         debug_struct.field("range_name", &self.range_name);
         debug_struct.field("ip_cidr_range", &self.ip_cidr_range);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55556,7 +55387,6 @@ impl std::fmt::Debug for UsableSubnetwork {
         debug_struct.field("ip_cidr_range", &self.ip_cidr_range);
         debug_struct.field("secondary_ip_ranges", &self.secondary_ip_ranges);
         debug_struct.field("status_message", &self.status_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55801,7 +55631,6 @@ impl std::fmt::Debug for ResourceUsageExportConfig {
             "consumption_metering_config",
             &self.consumption_metering_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55952,7 +55781,6 @@ pub mod resource_usage_export_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BigQueryDestination");
             debug_struct.field("dataset_id", &self.dataset_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -56099,7 +55927,6 @@ pub mod resource_usage_export_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConsumptionMeteringConfig");
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -56244,7 +56071,6 @@ impl std::fmt::Debug for VerticalPodAutoscaling {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerticalPodAutoscaling");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56387,7 +56213,6 @@ impl std::fmt::Debug for DefaultSnatStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DefaultSnatStatus");
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56529,7 +56354,6 @@ impl std::fmt::Debug for ShieldedNodes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ShieldedNodes");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56671,7 +56495,6 @@ impl std::fmt::Debug for VirtualNIC {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VirtualNIC");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56813,7 +56636,6 @@ impl std::fmt::Debug for FastSocket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FastSocket");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56966,7 +56788,6 @@ impl std::fmt::Debug for NotificationConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NotificationConfig");
         debug_struct.field("pubsub", &self.pubsub);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57181,7 +57002,6 @@ pub mod notification_config {
             debug_struct.field("enabled", &self.enabled);
             debug_struct.field("topic", &self.topic);
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -57337,7 +57157,6 @@ pub mod notification_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Filter");
             debug_struct.field("event_type", &self.event_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -57668,7 +57487,6 @@ impl std::fmt::Debug for ConfidentialNodes {
             "confidential_instance_type",
             &self.confidential_instance_type,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58102,7 +57920,6 @@ impl std::fmt::Debug for UpgradeEvent {
         debug_struct.field("current_version", &self.current_version);
         debug_struct.field("target_version", &self.target_version);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58584,7 +58401,6 @@ impl std::fmt::Debug for UpgradeInfoEvent {
         debug_struct.field("extended_support_end_time", &self.extended_support_end_time);
         debug_struct.field("description", &self.description);
         debug_struct.field("event_type", &self.event_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59115,7 +58931,6 @@ impl std::fmt::Debug for UpgradeAvailableEvent {
         debug_struct.field("resource_type", &self.resource_type);
         debug_struct.field("release_channel", &self.release_channel);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59553,7 +59368,6 @@ impl std::fmt::Debug for SecurityBulletinEvent {
         debug_struct.field("suggested_upgrade_target", &self.suggested_upgrade_target);
         debug_struct.field("manual_steps_required", &self.manual_steps_required);
         debug_struct.field("mitigated_versions", &self.mitigated_versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59732,7 +59546,6 @@ impl std::fmt::Debug for Autopilot {
         let mut debug_struct = f.debug_struct("Autopilot");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("workload_policy_config", &self.workload_policy_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59939,7 +59752,6 @@ impl std::fmt::Debug for WorkloadPolicyConfig {
             "autopilot_compatibility_auditing_enabled",
             &self.autopilot_compatibility_auditing_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60093,7 +59905,6 @@ impl std::fmt::Debug for LoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingConfig");
         debug_struct.field("component_config", &self.component_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60245,7 +60056,6 @@ impl std::fmt::Debug for LoggingComponentConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingComponentConfig");
         debug_struct.field("enable_components", &self.enable_components);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60567,7 +60377,6 @@ impl std::fmt::Debug for RayClusterLoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RayClusterLoggingConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60817,7 +60626,6 @@ impl std::fmt::Debug for MonitoringConfig {
             "advanced_datapath_observability_config",
             &self.advanced_datapath_observability_config,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61030,7 +60838,6 @@ impl std::fmt::Debug for AdvancedDatapathObservabilityConfig {
         debug_struct.field("enable_metrics", &self.enable_metrics);
         debug_struct.field("relay_mode", &self.relay_mode);
         debug_struct.field("enable_relay", &self.enable_relay);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61318,7 +61125,6 @@ impl std::fmt::Debug for RayClusterMonitoringConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RayClusterMonitoringConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61472,7 +61278,6 @@ impl std::fmt::Debug for NodePoolLoggingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NodePoolLoggingConfig");
         debug_struct.field("variant_config", &self.variant_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61619,7 +61424,6 @@ impl std::fmt::Debug for LoggingVariantConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LoggingVariantConfig");
         debug_struct.field("variant", &self.variant);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61910,7 +61714,6 @@ impl std::fmt::Debug for MonitoringComponentConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MonitoringComponentConfig");
         debug_struct.field("enable_components", &self.enable_components);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62312,7 +62115,6 @@ impl std::fmt::Debug for ManagedPrometheusConfig {
         let mut debug_struct = f.debug_struct("ManagedPrometheusConfig");
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("auto_monitoring_config", &self.auto_monitoring_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62460,7 +62262,6 @@ impl std::fmt::Debug for AutoMonitoringConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AutoMonitoringConfig");
         debug_struct.field("scope", &self.scope);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62753,7 +62554,6 @@ impl std::fmt::Debug for PodAutoscaling {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PodAutoscaling");
         debug_struct.field("hpa_profile", &self.hpa_profile);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63091,7 +62891,6 @@ impl std::fmt::Debug for Fleet {
         debug_struct.field("project", &self.project);
         debug_struct.field("membership", &self.membership);
         debug_struct.field("pre_registered", &self.pre_registered);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63286,7 +63085,6 @@ impl std::fmt::Debug for ControlPlaneEndpointsConfig {
         let mut debug_struct = f.debug_struct("ControlPlaneEndpointsConfig");
         debug_struct.field("dns_endpoint_config", &self.dns_endpoint_config);
         debug_struct.field("ip_endpoints_config", &self.ip_endpoints_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63482,7 +63280,6 @@ pub mod control_plane_endpoints_config {
             let mut debug_struct = f.debug_struct("DNSEndpointConfig");
             debug_struct.field("endpoint", &self.endpoint);
             debug_struct.field("allow_external_traffic", &self.allow_external_traffic);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -63882,7 +63679,6 @@ pub mod control_plane_endpoints_config {
                 "private_endpoint_subnetwork",
                 &self.private_endpoint_subnetwork,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -64062,7 +63858,6 @@ impl std::fmt::Debug for LocalNvmeSsdBlockConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocalNvmeSsdBlockConfig");
         debug_struct.field("local_ssd_count", &self.local_ssd_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64288,7 +64083,6 @@ impl std::fmt::Debug for EphemeralStorageLocalSsdConfig {
         let mut debug_struct = f.debug_struct("EphemeralStorageLocalSsdConfig");
         debug_struct.field("local_ssd_count", &self.local_ssd_count);
         debug_struct.field("data_cache_count", &self.data_cache_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64450,7 +64244,6 @@ impl std::fmt::Debug for ResourceManagerTags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResourceManagerTags");
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64629,7 +64422,6 @@ impl std::fmt::Debug for EnterpriseConfig {
         let mut debug_struct = f.debug_struct("EnterpriseConfig");
         debug_struct.field("cluster_tier", &self.cluster_tier);
         debug_struct.field("desired_tier", &self.desired_tier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64919,7 +64711,6 @@ impl std::fmt::Debug for SecretManagerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecretManagerConfig");
         debug_struct.field("enabled", &self.enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65200,7 +64991,6 @@ impl std::fmt::Debug for BootDisk {
         debug_struct.field("size_gb", &self.size_gb);
         debug_struct.field("provisioned_iops", &self.provisioned_iops);
         debug_struct.field("provisioned_throughput", &self.provisioned_throughput);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65370,7 +65160,6 @@ impl std::fmt::Debug for SecondaryBootDisk {
         let mut debug_struct = f.debug_struct("SecondaryBootDisk");
         debug_struct.field("mode", &self.mode);
         debug_struct.field("disk_image", &self.disk_image);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65618,7 +65407,6 @@ impl serde::ser::Serialize for SecondaryBootDiskUpdateStrategy {
 impl std::fmt::Debug for SecondaryBootDiskUpdateStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecondaryBootDiskUpdateStrategy");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65787,7 +65575,6 @@ impl std::fmt::Debug for FetchClusterUpgradeInfoRequest {
         let mut debug_struct = f.debug_struct("FetchClusterUpgradeInfoRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66181,7 +65968,6 @@ impl std::fmt::Debug for ClusterUpgradeInfo {
             "end_of_extended_support_timestamp",
             &self.end_of_extended_support_timestamp,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66806,7 +66592,6 @@ impl std::fmt::Debug for UpgradeDetails {
         debug_struct.field("initial_version", &self.initial_version);
         debug_struct.field("target_version", &self.target_version);
         debug_struct.field("start_type", &self.start_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67261,7 +67046,6 @@ impl std::fmt::Debug for FetchNodePoolUpgradeInfoRequest {
         let mut debug_struct = f.debug_struct("FetchNodePoolUpgradeInfoRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67649,7 +67433,6 @@ impl std::fmt::Debug for NodePoolUpgradeInfo {
             "end_of_extended_support_timestamp",
             &self.end_of_extended_support_timestamp,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68106,7 +67889,6 @@ impl std::fmt::Debug for GkeAutoUpgradeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GkeAutoUpgradeConfig");
         debug_struct.field("patch_mode", &self.patch_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -308,7 +308,6 @@ impl std::fmt::Debug for CommonMetadata {
         debug_struct.field("operation_type", &self.operation_type);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -692,7 +691,6 @@ impl std::fmt::Debug for Progress {
         let mut debug_struct = f.debug_struct("Progress");
         debug_struct.field("work_completed", &self.work_completed);
         debug_struct.field("work_estimated", &self.work_estimated);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -959,7 +957,6 @@ impl std::fmt::Debug for ExportEntitiesRequest {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("entity_filter", &self.entity_filter);
         debug_struct.field("output_url_prefix", &self.output_url_prefix);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1222,7 +1219,6 @@ impl std::fmt::Debug for ImportEntitiesRequest {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("input_url", &self.input_url);
         debug_struct.field("entity_filter", &self.entity_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1373,7 +1369,6 @@ impl std::fmt::Debug for ExportEntitiesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportEntitiesResponse");
         debug_struct.field("output_url", &self.output_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1674,7 +1669,6 @@ impl std::fmt::Debug for ExportEntitiesMetadata {
         debug_struct.field("progress_bytes", &self.progress_bytes);
         debug_struct.field("entity_filter", &self.entity_filter);
         debug_struct.field("output_url_prefix", &self.output_url_prefix);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1970,7 +1964,6 @@ impl std::fmt::Debug for ImportEntitiesMetadata {
         debug_struct.field("progress_bytes", &self.progress_bytes);
         debug_struct.field("entity_filter", &self.entity_filter);
         debug_struct.field("input_url", &self.input_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2168,7 +2161,6 @@ impl std::fmt::Debug for EntityFilter {
         let mut debug_struct = f.debug_struct("EntityFilter");
         debug_struct.field("kinds", &self.kinds);
         debug_struct.field("namespace_ids", &self.namespace_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2351,7 +2343,6 @@ impl std::fmt::Debug for CreateIndexRequest {
         let mut debug_struct = f.debug_struct("CreateIndexRequest");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("index", &self.index);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2523,7 +2514,6 @@ impl std::fmt::Debug for DeleteIndexRequest {
         let mut debug_struct = f.debug_struct("DeleteIndexRequest");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("index_id", &self.index_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2695,7 +2685,6 @@ impl std::fmt::Debug for GetIndexRequest {
         let mut debug_struct = f.debug_struct("GetIndexRequest");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("index_id", &self.index_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2936,7 +2925,6 @@ impl std::fmt::Debug for ListIndexesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3124,7 +3112,6 @@ impl std::fmt::Debug for ListIndexesResponse {
         let mut debug_struct = f.debug_struct("ListIndexesResponse");
         debug_struct.field("indexes", &self.indexes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3341,7 +3328,6 @@ impl std::fmt::Debug for IndexOperationMetadata {
         debug_struct.field("common", &self.common);
         debug_struct.field("progress_entities", &self.progress_entities);
         debug_struct.field("index_id", &self.index_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3525,7 +3511,6 @@ impl std::fmt::Debug for DatastoreFirestoreMigrationMetadata {
         let mut debug_struct = f.debug_struct("DatastoreFirestoreMigrationMetadata");
         debug_struct.field("migration_state", &self.migration_state);
         debug_struct.field("migration_step", &self.migration_step);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3807,7 +3792,6 @@ impl std::fmt::Debug for Index {
         debug_struct.field("ancestor", &self.ancestor);
         debug_struct.field("properties", &self.properties);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3984,7 +3968,6 @@ pub mod index {
             let mut debug_struct = f.debug_struct("IndexedProperty");
             debug_struct.field("name", &self.name);
             debug_struct.field("direction", &self.direction);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4555,7 +4538,6 @@ impl std::fmt::Debug for MigrationStateEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MigrationStateEvent");
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4846,7 +4828,6 @@ impl std::fmt::Debug for MigrationProgressEvent {
         let mut debug_struct = f.debug_struct("MigrationProgressEvent");
         debug_struct.field("step", &self.step);
         debug_struct.field("step_details", &self.step_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5005,7 +4986,6 @@ pub mod migration_progress_event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PrepareStepDetails");
             debug_struct.field("concurrency_mode", &self.concurrency_mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5158,7 +5138,6 @@ pub mod migration_progress_event {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RedirectWritesStepDetails");
             debug_struct.field("concurrency_mode", &self.concurrency_mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -319,7 +319,6 @@ impl std::fmt::Debug for AptArtifact {
         debug_struct.field("architecture", &self.architecture);
         debug_struct.field("component", &self.component);
         debug_struct.field("control_file", &self.control_file);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -628,7 +627,6 @@ impl std::fmt::Debug for ImportAptArtifactsGcsSource {
         let mut debug_struct = f.debug_struct("ImportAptArtifactsGcsSource");
         debug_struct.field("uris", &self.uris);
         debug_struct.field("use_wildcards", &self.use_wildcards);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -846,7 +844,6 @@ impl std::fmt::Debug for ImportAptArtifactsRequest {
         let mut debug_struct = f.debug_struct("ImportAptArtifactsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1091,7 +1088,6 @@ impl std::fmt::Debug for ImportAptArtifactsErrorInfo {
         let mut debug_struct = f.debug_struct("ImportAptArtifactsErrorInfo");
         debug_struct.field("error", &self.error);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1283,7 +1279,6 @@ impl std::fmt::Debug for ImportAptArtifactsResponse {
         let mut debug_struct = f.debug_struct("ImportAptArtifactsResponse");
         debug_struct.field("apt_artifacts", &self.apt_artifacts);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1397,7 +1392,6 @@ impl serde::ser::Serialize for ImportAptArtifactsMetadata {
 impl std::fmt::Debug for ImportAptArtifactsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportAptArtifactsMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1800,7 +1794,6 @@ impl std::fmt::Debug for DockerImage {
         debug_struct.field("media_type", &self.media_type);
         debug_struct.field("build_time", &self.build_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2039,7 +2032,6 @@ impl std::fmt::Debug for ListDockerImagesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2226,7 +2218,6 @@ impl std::fmt::Debug for ListDockerImagesResponse {
         let mut debug_struct = f.debug_struct("ListDockerImagesResponse");
         debug_struct.field("docker_images", &self.docker_images);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2368,7 +2359,6 @@ impl std::fmt::Debug for GetDockerImageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDockerImageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2698,7 +2688,6 @@ impl std::fmt::Debug for MavenArtifact {
         debug_struct.field("version", &self.version);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2911,7 +2900,6 @@ impl std::fmt::Debug for ListMavenArtifactsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3098,7 +3086,6 @@ impl std::fmt::Debug for ListMavenArtifactsResponse {
         let mut debug_struct = f.debug_struct("ListMavenArtifactsResponse");
         debug_struct.field("maven_artifacts", &self.maven_artifacts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3240,7 +3227,6 @@ impl std::fmt::Debug for GetMavenArtifactRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMavenArtifactRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3541,7 +3527,6 @@ impl std::fmt::Debug for NpmPackage {
         debug_struct.field("tags", &self.tags);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3754,7 +3739,6 @@ impl std::fmt::Debug for ListNpmPackagesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3941,7 +3925,6 @@ impl std::fmt::Debug for ListNpmPackagesResponse {
         let mut debug_struct = f.debug_struct("ListNpmPackagesResponse");
         debug_struct.field("npm_packages", &self.npm_packages);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4083,7 +4066,6 @@ impl std::fmt::Debug for GetNpmPackageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNpmPackageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4385,7 +4367,6 @@ impl std::fmt::Debug for PythonPackage {
         debug_struct.field("version", &self.version);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4598,7 +4579,6 @@ impl std::fmt::Debug for ListPythonPackagesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4785,7 +4765,6 @@ impl std::fmt::Debug for ListPythonPackagesResponse {
         let mut debug_struct = f.debug_struct("ListPythonPackagesResponse");
         debug_struct.field("python_packages", &self.python_packages);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4927,7 +4906,6 @@ impl std::fmt::Debug for GetPythonPackageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPythonPackageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5329,7 +5307,6 @@ impl std::fmt::Debug for Attachment {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("files", &self.files);
         debug_struct.field("oci_version_name", &self.oci_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5571,7 +5548,6 @@ impl std::fmt::Debug for ListAttachmentsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5757,7 +5733,6 @@ impl std::fmt::Debug for ListAttachmentsResponse {
         let mut debug_struct = f.debug_struct("ListAttachmentsResponse");
         debug_struct.field("attachments", &self.attachments);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5899,7 +5874,6 @@ impl std::fmt::Debug for GetAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6104,7 +6078,6 @@ impl std::fmt::Debug for CreateAttachmentRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("attachment_id", &self.attachment_id);
         debug_struct.field("attachment", &self.attachment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6246,7 +6219,6 @@ impl std::fmt::Debug for DeleteAttachmentRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAttachmentRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6431,7 +6403,6 @@ impl std::fmt::Debug for Hash {
         let mut debug_struct = f.debug_struct("Hash");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6958,7 +6929,6 @@ impl std::fmt::Debug for File {
         debug_struct.field("owner", &self.owner);
         debug_struct.field("fetch_time", &self.fetch_time);
         debug_struct.field("annotations", &self.annotations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7271,7 +7241,6 @@ impl std::fmt::Debug for ListFilesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7457,7 +7426,6 @@ impl std::fmt::Debug for ListFilesResponse {
         let mut debug_struct = f.debug_struct("ListFilesResponse");
         debug_struct.field("files", &self.files);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7599,7 +7567,6 @@ impl std::fmt::Debug for GetFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7741,7 +7708,6 @@ impl std::fmt::Debug for DeleteFileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7933,7 +7899,6 @@ impl std::fmt::Debug for UpdateFileRequest {
         let mut debug_struct = f.debug_struct("UpdateFileRequest");
         debug_struct.field("file", &self.file);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8178,7 +8143,6 @@ impl std::fmt::Debug for GenericArtifact {
         debug_struct.field("version", &self.version);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8420,7 +8384,6 @@ impl std::fmt::Debug for GoModule {
         debug_struct.field("version", &self.version);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8591,7 +8554,6 @@ impl std::fmt::Debug for KfpArtifact {
         let mut debug_struct = f.debug_struct("KfpArtifact");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8872,7 +8834,6 @@ impl std::fmt::Debug for Package {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("annotations", &self.annotations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9179,7 +9140,6 @@ impl std::fmt::Debug for ListPackagesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9365,7 +9325,6 @@ impl std::fmt::Debug for ListPackagesResponse {
         let mut debug_struct = f.debug_struct("ListPackagesResponse");
         debug_struct.field("packages", &self.packages);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9507,7 +9466,6 @@ impl std::fmt::Debug for GetPackageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPackageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9649,7 +9607,6 @@ impl std::fmt::Debug for DeletePackageRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeletePackageRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9841,7 +9798,6 @@ impl std::fmt::Debug for UpdatePackageRequest {
         let mut debug_struct = f.debug_struct("UpdatePackageRequest");
         debug_struct.field("package", &self.package);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10052,7 +10008,6 @@ impl std::fmt::Debug for UpstreamPolicy {
         debug_struct.field("id", &self.id);
         debug_struct.field("repository", &self.repository);
         debug_struct.field("priority", &self.priority);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10370,7 +10325,6 @@ impl std::fmt::Debug for CleanupPolicyCondition {
         debug_struct.field("package_name_prefixes", &self.package_name_prefixes);
         debug_struct.field("older_than", &self.older_than);
         debug_struct.field("newer_than", &self.newer_than);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10720,7 +10674,6 @@ impl std::fmt::Debug for CleanupPolicyMostRecentVersions {
         let mut debug_struct = f.debug_struct("CleanupPolicyMostRecentVersions");
         debug_struct.field("package_name_prefixes", &self.package_name_prefixes);
         debug_struct.field("keep_count", &self.keep_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11022,7 +10975,6 @@ impl std::fmt::Debug for CleanupPolicy {
         debug_struct.field("id", &self.id);
         debug_struct.field("action", &self.action);
         debug_struct.field("condition_type", &self.condition_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11321,7 +11273,6 @@ impl std::fmt::Debug for VirtualRepositoryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VirtualRepositoryConfig");
         debug_struct.field("upstream_policies", &self.upstream_policies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11978,7 +11929,6 @@ impl std::fmt::Debug for RemoteRepositoryConfig {
             &self.disable_upstream_validation,
         );
         debug_struct.field("remote_source", &self.remote_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12178,7 +12128,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("UpstreamCredentials");
             debug_struct.field("credentials", &self.credentials);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12374,7 +12323,6 @@ pub mod remote_repository_config {
                 let mut debug_struct = f.debug_struct("UsernamePasswordCredentials");
                 debug_struct.field("username", &self.username);
                 debug_struct.field("password_secret_version", &self.password_secret_version);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12648,7 +12596,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DockerRepository");
             debug_struct.field("upstream", &self.upstream);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12802,7 +12749,6 @@ pub mod remote_repository_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomRepository");
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -13213,7 +13159,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MavenRepository");
             debug_struct.field("upstream", &self.upstream);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13367,7 +13312,6 @@ pub mod remote_repository_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomRepository");
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -13778,7 +13722,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NpmRepository");
             debug_struct.field("upstream", &self.upstream);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13932,7 +13875,6 @@ pub mod remote_repository_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomRepository");
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -14343,7 +14285,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PythonRepository");
             debug_struct.field("upstream", &self.upstream);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14497,7 +14438,6 @@ pub mod remote_repository_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomRepository");
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -14911,7 +14851,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AptRepository");
             debug_struct.field("upstream", &self.upstream);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15098,7 +15037,6 @@ pub mod remote_repository_config {
                 let mut debug_struct = f.debug_struct("PublicRepository");
                 debug_struct.field("repository_base", &self.repository_base);
                 debug_struct.field("repository_path", &self.repository_path);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -15396,7 +15334,6 @@ pub mod remote_repository_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomRepository");
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -15685,7 +15622,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("YumRepository");
             debug_struct.field("upstream", &self.upstream);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15872,7 +15808,6 @@ pub mod remote_repository_config {
                 let mut debug_struct = f.debug_struct("PublicRepository");
                 debug_struct.field("repository_base", &self.repository_base);
                 debug_struct.field("repository_path", &self.repository_path);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16191,7 +16126,6 @@ pub mod remote_repository_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomRepository");
                 debug_struct.field("uri", &self.uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16356,7 +16290,6 @@ pub mod remote_repository_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CommonRemoteRepository");
             debug_struct.field("uri", &self.uri);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17299,7 +17232,6 @@ impl std::fmt::Debug for Repository {
         debug_struct.field("registry_uri", &self.registry_uri);
         debug_struct.field("format_config", &self.format_config);
         debug_struct.field("mode_config", &self.mode_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17487,7 +17419,6 @@ pub mod repository {
             let mut debug_struct = f.debug_struct("MavenRepositoryConfig");
             debug_struct.field("allow_snapshot_overwrites", &self.allow_snapshot_overwrites);
             debug_struct.field("version_policy", &self.version_policy);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17779,7 +17710,6 @@ pub mod repository {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DockerRepositoryConfig");
             debug_struct.field("immutable_tags", &self.immutable_tags);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18036,7 +17966,6 @@ pub mod repository {
             debug_struct.field("last_enable_time", &self.last_enable_time);
             debug_struct.field("enablement_state", &self.enablement_state);
             debug_struct.field("enablement_state_reason", &self.enablement_state_reason);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18946,7 +18875,6 @@ impl std::fmt::Debug for ListRepositoriesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19132,7 +19060,6 @@ impl std::fmt::Debug for ListRepositoriesResponse {
         let mut debug_struct = f.debug_struct("ListRepositoriesResponse");
         debug_struct.field("repositories", &self.repositories);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19274,7 +19201,6 @@ impl std::fmt::Debug for GetRepositoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRepositoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19479,7 +19405,6 @@ impl std::fmt::Debug for CreateRepositoryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("repository_id", &self.repository_id);
         debug_struct.field("repository", &self.repository);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19671,7 +19596,6 @@ impl std::fmt::Debug for UpdateRepositoryRequest {
         let mut debug_struct = f.debug_struct("UpdateRepositoryRequest");
         debug_struct.field("repository", &self.repository);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19813,7 +19737,6 @@ impl std::fmt::Debug for DeleteRepositoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteRepositoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20074,7 +19997,6 @@ impl std::fmt::Debug for Rule {
         debug_struct.field("operation", &self.operation);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("package_id", &self.package_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20551,7 +20473,6 @@ impl std::fmt::Debug for ListRulesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20737,7 +20658,6 @@ impl std::fmt::Debug for ListRulesResponse {
         let mut debug_struct = f.debug_struct("ListRulesResponse");
         debug_struct.field("rules", &self.rules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20879,7 +20799,6 @@ impl std::fmt::Debug for GetRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21083,7 +21002,6 @@ impl std::fmt::Debug for CreateRuleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("rule_id", &self.rule_id);
         debug_struct.field("rule", &self.rule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21275,7 +21193,6 @@ impl std::fmt::Debug for UpdateRuleRequest {
         let mut debug_struct = f.debug_struct("UpdateRuleRequest");
         debug_struct.field("rule", &self.rule);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21417,7 +21334,6 @@ impl std::fmt::Debug for DeleteRuleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteRuleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21531,7 +21447,6 @@ impl serde::ser::Serialize for OperationMetadata {
 impl std::fmt::Debug for OperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OperationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21759,7 +21674,6 @@ impl std::fmt::Debug for ProjectSettings {
         debug_struct.field("name", &self.name);
         debug_struct.field("legacy_redirection_state", &self.legacy_redirection_state);
         debug_struct.field("pull_percent", &self.pull_percent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22075,7 +21989,6 @@ impl std::fmt::Debug for GetProjectSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProjectSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22267,7 +22180,6 @@ impl std::fmt::Debug for UpdateProjectSettingsRequest {
         let mut debug_struct = f.debug_struct("UpdateProjectSettingsRequest");
         debug_struct.field("project_settings", &self.project_settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22442,7 +22354,6 @@ impl std::fmt::Debug for Tag {
         let mut debug_struct = f.debug_struct("Tag");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22707,7 +22618,6 @@ impl std::fmt::Debug for ListTagsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22893,7 +22803,6 @@ impl std::fmt::Debug for ListTagsResponse {
         let mut debug_struct = f.debug_struct("ListTagsResponse");
         debug_struct.field("tags", &self.tags);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23035,7 +22944,6 @@ impl std::fmt::Debug for GetTagRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTagRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23239,7 +23147,6 @@ impl std::fmt::Debug for CreateTagRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("tag_id", &self.tag_id);
         debug_struct.field("tag", &self.tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23431,7 +23338,6 @@ impl std::fmt::Debug for UpdateTagRequest {
         let mut debug_struct = f.debug_struct("UpdateTagRequest");
         debug_struct.field("tag", &self.tag);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23573,7 +23479,6 @@ impl std::fmt::Debug for DeleteTagRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTagRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23928,7 +23833,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("related_tags", &self.related_tags);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("annotations", &self.annotations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24260,7 +24164,6 @@ impl std::fmt::Debug for ListVersionsRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24446,7 +24349,6 @@ impl std::fmt::Debug for ListVersionsResponse {
         let mut debug_struct = f.debug_struct("ListVersionsResponse");
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24613,7 +24515,6 @@ impl std::fmt::Debug for GetVersionRequest {
         let mut debug_struct = f.debug_struct("GetVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24781,7 +24682,6 @@ impl std::fmt::Debug for DeleteVersionRequest {
         let mut debug_struct = f.debug_struct("DeleteVersionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24979,7 +24879,6 @@ impl std::fmt::Debug for BatchDeleteVersionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("names", &self.names);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25125,7 +25024,6 @@ impl std::fmt::Debug for BatchDeleteVersionsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchDeleteVersionsMetadata");
         debug_struct.field("failed_versions", &self.failed_versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25317,7 +25215,6 @@ impl std::fmt::Debug for UpdateVersionRequest {
         let mut debug_struct = f.debug_struct("UpdateVersionRequest");
         debug_struct.field("version", &self.version);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25493,7 +25390,6 @@ impl std::fmt::Debug for VPCSCConfig {
         let mut debug_struct = f.debug_struct("VPCSCConfig");
         debug_struct.field("name", &self.name);
         debug_struct.field("vpcsc_policy", &self.vpcsc_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25777,7 +25673,6 @@ impl std::fmt::Debug for GetVPCSCConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetVPCSCConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25968,7 +25863,6 @@ impl std::fmt::Debug for UpdateVPCSCConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateVPCSCConfigRequest");
         debug_struct.field("vpcsc_config", &self.vpcsc_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26188,7 +26082,6 @@ impl std::fmt::Debug for YumArtifact {
         debug_struct.field("package_name", &self.package_name);
         debug_struct.field("package_type", &self.package_type);
         debug_struct.field("architecture", &self.architecture);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26497,7 +26390,6 @@ impl std::fmt::Debug for ImportYumArtifactsGcsSource {
         let mut debug_struct = f.debug_struct("ImportYumArtifactsGcsSource");
         debug_struct.field("uris", &self.uris);
         debug_struct.field("use_wildcards", &self.use_wildcards);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26715,7 +26607,6 @@ impl std::fmt::Debug for ImportYumArtifactsRequest {
         let mut debug_struct = f.debug_struct("ImportYumArtifactsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26960,7 +26851,6 @@ impl std::fmt::Debug for ImportYumArtifactsErrorInfo {
         let mut debug_struct = f.debug_struct("ImportYumArtifactsErrorInfo");
         debug_struct.field("error", &self.error);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27152,7 +27042,6 @@ impl std::fmt::Debug for ImportYumArtifactsResponse {
         let mut debug_struct = f.debug_struct("ImportYumArtifactsResponse");
         debug_struct.field("yum_artifacts", &self.yum_artifacts);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27266,7 +27155,6 @@ impl serde::ser::Serialize for ImportYumArtifactsMetadata {
 impl std::fmt::Debug for ImportYumArtifactsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImportYumArtifactsMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -219,7 +219,6 @@ impl std::fmt::Debug for RetryBuildRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -451,7 +450,6 @@ impl std::fmt::Debug for RunBuildTriggerRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("trigger_id", &self.trigger_id);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -700,7 +698,6 @@ impl std::fmt::Debug for StorageSource {
         debug_struct.field("object", &self.object);
         debug_struct.field("generation", &self.generation);
         debug_struct.field("source_fetcher", &self.source_fetcher);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1044,7 +1041,6 @@ impl std::fmt::Debug for GitSource {
         debug_struct.field("url", &self.url);
         debug_struct.field("dir", &self.dir);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1463,7 +1459,6 @@ impl std::fmt::Debug for RepoSource {
         debug_struct.field("invert_regex", &self.invert_regex);
         debug_struct.field("substitutions", &self.substitutions);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1705,7 +1700,6 @@ impl std::fmt::Debug for StorageSourceManifest {
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("object", &self.object);
         debug_struct.field("generation", &self.generation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2048,7 +2042,6 @@ impl std::fmt::Debug for Source {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Source");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2276,7 +2269,6 @@ impl std::fmt::Debug for BuiltImage {
         debug_struct.field("name", &self.name);
         debug_struct.field("digest", &self.digest);
         debug_struct.field("push_timing", &self.push_timing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2492,7 +2484,6 @@ impl std::fmt::Debug for UploadedPythonPackage {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("file_hashes", &self.file_hashes);
         debug_struct.field("push_timing", &self.push_timing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2708,7 +2699,6 @@ impl std::fmt::Debug for UploadedMavenArtifact {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("file_hashes", &self.file_hashes);
         debug_struct.field("push_timing", &self.push_timing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2925,7 +2915,6 @@ impl std::fmt::Debug for UploadedGoModule {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("file_hashes", &self.file_hashes);
         debug_struct.field("push_timing", &self.push_timing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3142,7 +3131,6 @@ impl std::fmt::Debug for UploadedNpmPackage {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("file_hashes", &self.file_hashes);
         debug_struct.field("push_timing", &self.push_timing);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3885,7 +3873,6 @@ impl std::fmt::Debug for BuildStep {
         debug_struct.field("allow_exit_codes", &self.allow_exit_codes);
         debug_struct.field("script", &self.script);
         debug_struct.field("automap_substitutions", &self.automap_substitutions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4059,7 +4046,6 @@ impl std::fmt::Debug for Volume {
         let mut debug_struct = f.debug_struct("Volume");
         debug_struct.field("name", &self.name);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4543,7 +4529,6 @@ impl std::fmt::Debug for Results {
         debug_struct.field("maven_artifacts", &self.maven_artifacts);
         debug_struct.field("go_modules", &self.go_modules);
         debug_struct.field("npm_packages", &self.npm_packages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4717,7 +4702,6 @@ impl std::fmt::Debug for ArtifactResult {
         let mut debug_struct = f.debug_struct("ArtifactResult");
         debug_struct.field("location", &self.location);
         debug_struct.field("file_hash", &self.file_hash);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5891,7 +5875,6 @@ impl std::fmt::Debug for Build {
         debug_struct.field("git_config", &self.git_config);
         debug_struct.field("failure_info", &self.failure_info);
         debug_struct.field("dependencies", &self.dependencies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6067,7 +6050,6 @@ pub mod build {
             let mut debug_struct = f.debug_struct("Warning");
             debug_struct.field("text", &self.text);
             debug_struct.field("priority", &self.priority);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6390,7 +6372,6 @@ pub mod build {
             let mut debug_struct = f.debug_struct("FailureInfo");
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("detail", &self.detail);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6976,7 +6957,6 @@ impl std::fmt::Debug for Dependency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Dependency");
         debug_struct.field("dep", &self.dep);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7259,7 +7239,6 @@ pub mod dependency {
             debug_struct.field("recurse_submodules", &self.recurse_submodules);
             debug_struct.field("depth", &self.depth);
             debug_struct.field("dest_path", &self.dest_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7502,7 +7481,6 @@ pub mod dependency {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GitSourceRepository");
             debug_struct.field("repotype", &self.repotype);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7685,7 +7663,6 @@ impl std::fmt::Debug for GitConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GitConfig");
         debug_struct.field("http", &self.http);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7847,7 +7824,6 @@ pub mod git_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("HttpConfig");
             debug_struct.field("proxy_secret_version_name", &self.proxy_secret_version_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8202,7 +8178,6 @@ impl std::fmt::Debug for Artifacts {
         debug_struct.field("go_modules", &self.go_modules);
         debug_struct.field("python_packages", &self.python_packages);
         debug_struct.field("npm_packages", &self.npm_packages);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8422,7 +8397,6 @@ pub mod artifacts {
             debug_struct.field("location", &self.location);
             debug_struct.field("paths", &self.paths);
             debug_struct.field("timing", &self.timing);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8682,7 +8656,6 @@ pub mod artifacts {
             debug_struct.field("artifact_id", &self.artifact_id);
             debug_struct.field("group_id", &self.group_id);
             debug_struct.field("version", &self.version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8983,7 +8956,6 @@ pub mod artifacts {
             debug_struct.field("source_path", &self.source_path);
             debug_struct.field("module_path", &self.module_path);
             debug_struct.field("module_version", &self.module_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9164,7 +9136,6 @@ pub mod artifacts {
             let mut debug_struct = f.debug_struct("PythonPackage");
             debug_struct.field("repository", &self.repository);
             debug_struct.field("paths", &self.paths);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9344,7 +9315,6 @@ pub mod artifacts {
             let mut debug_struct = f.debug_struct("NpmPackage");
             debug_struct.field("repository", &self.repository);
             debug_struct.field("package_path", &self.package_path);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9536,7 +9506,6 @@ impl std::fmt::Debug for TimeSpan {
         let mut debug_struct = f.debug_struct("TimeSpan");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9689,7 +9658,6 @@ impl std::fmt::Debug for BuildOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BuildOperationMetadata");
         debug_struct.field("build", &self.build);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9981,7 +9949,6 @@ impl std::fmt::Debug for SourceProvenance {
             &self.resolved_storage_source_manifest,
         );
         debug_struct.field("file_hashes", &self.file_hashes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10128,7 +10095,6 @@ impl std::fmt::Debug for FileHashes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileHashes");
         debug_struct.field("file_hash", &self.file_hash);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10313,7 +10279,6 @@ impl std::fmt::Debug for Hash {
         let mut debug_struct = f.debug_struct("Hash");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10644,7 +10609,6 @@ impl std::fmt::Debug for Secrets {
         let mut debug_struct = f.debug_struct("Secrets");
         debug_struct.field("secret_manager", &self.secret_manager);
         debug_struct.field("inline", &self.inline);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10858,7 +10822,6 @@ impl std::fmt::Debug for InlineSecret {
         let mut debug_struct = f.debug_struct("InlineSecret");
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("env_map", &self.env_map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11029,7 +10992,6 @@ impl std::fmt::Debug for SecretManagerSecret {
         let mut debug_struct = f.debug_struct("SecretManagerSecret");
         debug_struct.field("version_name", &self.version_name);
         debug_struct.field("env", &self.env);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11245,7 +11207,6 @@ impl std::fmt::Debug for Secret {
         let mut debug_struct = f.debug_struct("Secret");
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("secret_env", &self.secret_env);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11450,7 +11411,6 @@ impl std::fmt::Debug for CreateBuildRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("build", &self.build);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11644,7 +11604,6 @@ impl std::fmt::Debug for GetBuildRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11916,7 +11875,6 @@ impl std::fmt::Debug for ListBuildsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12102,7 +12060,6 @@ impl std::fmt::Debug for ListBuildsResponse {
         let mut debug_struct = f.debug_struct("ListBuildsResponse");
         debug_struct.field("builds", &self.builds);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12296,7 +12253,6 @@ impl std::fmt::Debug for CancelBuildRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12477,7 +12433,6 @@ impl std::fmt::Debug for ApproveBuildRequest {
         let mut debug_struct = f.debug_struct("ApproveBuildRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("approval_result", &self.approval_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12695,7 +12650,6 @@ impl std::fmt::Debug for BuildApproval {
         debug_struct.field("state", &self.state);
         debug_struct.field("config", &self.config);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12992,7 +12946,6 @@ impl std::fmt::Debug for ApprovalConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ApprovalConfig");
         debug_struct.field("approval_required", &self.approval_required);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13256,7 +13209,6 @@ impl std::fmt::Debug for ApprovalResult {
         debug_struct.field("decision", &self.decision);
         debug_struct.field("comment", &self.comment);
         debug_struct.field("url", &self.url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13725,7 +13677,6 @@ impl std::fmt::Debug for GitRepoSource {
         debug_struct.field("repo_type", &self.repo_type);
         debug_struct.field("source", &self.source);
         debug_struct.field("enterprise_config", &self.enterprise_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14115,7 +14066,6 @@ impl std::fmt::Debug for GitFileSource {
         debug_struct.field("revision", &self.revision);
         debug_struct.field("source", &self.source);
         debug_struct.field("enterprise_config", &self.enterprise_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15237,7 +15187,6 @@ impl std::fmt::Debug for BuildTrigger {
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("repository_event_config", &self.repository_event_config);
         debug_struct.field("build_template", &self.build_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15570,7 +15519,6 @@ impl std::fmt::Debug for RepositoryEventConfig {
         debug_struct.field("repository", &self.repository);
         debug_struct.field("repository_type", &self.repository_type);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16070,7 +16018,6 @@ impl std::fmt::Debug for GitHubEventsConfig {
         debug_struct.field("owner", &self.owner);
         debug_struct.field("name", &self.name);
         debug_struct.field("event", &self.event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16313,7 +16260,6 @@ impl std::fmt::Debug for PubsubConfig {
         debug_struct.field("topic", &self.topic);
         debug_struct.field("service_account_email", &self.service_account_email);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16676,7 +16622,6 @@ impl std::fmt::Debug for WebhookConfig {
         let mut debug_struct = f.debug_struct("WebhookConfig");
         debug_struct.field("state", &self.state);
         debug_struct.field("auth_method", &self.auth_method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17071,7 +17016,6 @@ impl std::fmt::Debug for PullRequestFilter {
         debug_struct.field("comment_control", &self.comment_control);
         debug_struct.field("invert_regex", &self.invert_regex);
         debug_struct.field("git_ref", &self.git_ref);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17496,7 +17440,6 @@ impl std::fmt::Debug for PushFilter {
         let mut debug_struct = f.debug_struct("PushFilter");
         debug_struct.field("invert_regex", &self.invert_regex);
         debug_struct.field("git_ref", &self.git_ref);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17724,7 +17667,6 @@ impl std::fmt::Debug for CreateBuildTriggerRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("trigger", &self.trigger);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17919,7 +17861,6 @@ impl std::fmt::Debug for GetBuildTriggerRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("trigger_id", &self.trigger_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18158,7 +18099,6 @@ impl std::fmt::Debug for ListBuildTriggersRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18343,7 +18283,6 @@ impl std::fmt::Debug for ListBuildTriggersResponse {
         let mut debug_struct = f.debug_struct("ListBuildTriggersResponse");
         debug_struct.field("triggers", &self.triggers);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18538,7 +18477,6 @@ impl std::fmt::Debug for DeleteBuildTriggerRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("trigger_id", &self.trigger_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18782,7 +18720,6 @@ impl std::fmt::Debug for UpdateBuildTriggerRequest {
         debug_struct.field("trigger_id", &self.trigger_id);
         debug_struct.field("trigger", &self.trigger);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19436,7 +19373,6 @@ impl std::fmt::Debug for BuildOptions {
             &self.default_logs_bucket_behavior,
         );
         debug_struct.field("enable_structured_logging", &self.enable_structured_logging);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19594,7 +19530,6 @@ pub mod build_options {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PoolOption");
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20696,7 +20631,6 @@ impl std::fmt::Debug for ReceiveTriggerWebhookRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("trigger", &self.trigger);
         debug_struct.field("secret", &self.secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20811,7 +20745,6 @@ impl serde::ser::Serialize for ReceiveTriggerWebhookResponse {
 impl std::fmt::Debug for ReceiveTriggerWebhookResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReceiveTriggerWebhookResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21214,7 +21147,6 @@ impl std::fmt::Debug for GitHubEnterpriseConfig {
         debug_struct.field("secrets", &self.secrets);
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("ssl_ca", &self.ssl_ca);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21473,7 +21405,6 @@ impl std::fmt::Debug for GitHubEnterpriseSecrets {
             "oauth_client_id_version_name",
             &self.oauth_client_id_version_name,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21963,7 +21894,6 @@ impl std::fmt::Debug for WorkerPool {
         debug_struct.field("state", &self.state);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("config", &self.config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22362,7 +22292,6 @@ impl std::fmt::Debug for PrivatePoolV1Config {
         debug_struct.field("worker_config", &self.worker_config);
         debug_struct.field("network_config", &self.network_config);
         debug_struct.field("private_service_connect", &self.private_service_connect);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22569,7 +22498,6 @@ pub mod private_pool_v_1_config {
             let mut debug_struct = f.debug_struct("WorkerConfig");
             debug_struct.field("machine_type", &self.machine_type);
             debug_struct.field("disk_size_gb", &self.disk_size_gb);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22792,7 +22720,6 @@ pub mod private_pool_v_1_config {
             debug_struct.field("peered_network", &self.peered_network);
             debug_struct.field("egress_option", &self.egress_option);
             debug_struct.field("peered_network_ip_range", &self.peered_network_ip_range);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23162,7 +23089,6 @@ pub mod private_pool_v_1_config {
                 &self.public_ip_address_disabled,
             );
             debug_struct.field("route_all_traffic", &self.route_all_traffic);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23400,7 +23326,6 @@ impl std::fmt::Debug for CreateWorkerPoolRequest {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("worker_pool_id", &self.worker_pool_id);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23543,7 +23468,6 @@ impl std::fmt::Debug for GetWorkerPoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetWorkerPoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23767,7 +23691,6 @@ impl std::fmt::Debug for DeleteWorkerPoolRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23988,7 +23911,6 @@ impl std::fmt::Debug for UpdateWorkerPoolRequest {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24203,7 +24125,6 @@ impl std::fmt::Debug for ListWorkerPoolsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24391,7 +24312,6 @@ impl std::fmt::Debug for ListWorkerPoolsResponse {
         let mut debug_struct = f.debug_struct("ListWorkerPoolsResponse");
         debug_struct.field("worker_pools", &self.worker_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24610,7 +24530,6 @@ impl std::fmt::Debug for CreateWorkerPoolOperationMetadata {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("complete_time", &self.complete_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24829,7 +24748,6 @@ impl std::fmt::Debug for UpdateWorkerPoolOperationMetadata {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("complete_time", &self.complete_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25048,7 +24966,6 @@ impl std::fmt::Debug for DeleteWorkerPoolOperationMetadata {
         debug_struct.field("worker_pool", &self.worker_pool);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("complete_time", &self.complete_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -351,7 +351,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -676,7 +675,6 @@ impl std::fmt::Debug for RunWorkflowCustomOperationMetadata {
         debug_struct.field("api_version", &self.api_version);
         debug_struct.field("target", &self.target);
         debug_struct.field("pipeline_run_id", &self.pipeline_run_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1355,7 +1353,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("connection_config", &self.connection_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1576,7 +1573,6 @@ impl std::fmt::Debug for InstallationState {
         debug_struct.field("stage", &self.stage);
         debug_struct.field("message", &self.message);
         debug_struct.field("action_uri", &self.action_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1942,7 +1938,6 @@ impl std::fmt::Debug for FetchLinkableRepositoriesRequest {
         debug_struct.field("connection", &self.connection);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2127,7 +2122,6 @@ impl std::fmt::Debug for FetchLinkableRepositoriesResponse {
         let mut debug_struct = f.debug_struct("FetchLinkableRepositoriesResponse");
         debug_struct.field("repositories", &self.repositories);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2329,7 +2323,6 @@ impl std::fmt::Debug for GitHubConfig {
         let mut debug_struct = f.debug_struct("GitHubConfig");
         debug_struct.field("authorizer_credential", &self.authorizer_credential);
         debug_struct.field("app_installation_id", &self.app_installation_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2785,7 +2778,6 @@ impl std::fmt::Debug for GitHubEnterpriseConfig {
         debug_struct.field("service_directory_config", &self.service_directory_config);
         debug_struct.field("ssl_ca", &self.ssl_ca);
         debug_struct.field("server_version", &self.server_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3151,7 +3143,6 @@ impl std::fmt::Debug for GitLabConfig {
         debug_struct.field("service_directory_config", &self.service_directory_config);
         debug_struct.field("ssl_ca", &self.ssl_ca);
         debug_struct.field("server_version", &self.server_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3515,7 +3506,6 @@ impl std::fmt::Debug for BitbucketDataCenterConfig {
         debug_struct.field("service_directory_config", &self.service_directory_config);
         debug_struct.field("ssl_ca", &self.ssl_ca);
         debug_struct.field("server_version", &self.server_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3786,7 +3776,6 @@ impl std::fmt::Debug for BitbucketCloudConfig {
             &self.read_authorizer_credential,
         );
         debug_struct.field("authorizer_credential", &self.authorizer_credential);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3931,7 +3920,6 @@ impl std::fmt::Debug for ServiceDirectoryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceDirectoryConfig");
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4263,7 +4251,6 @@ impl std::fmt::Debug for Repository {
         debug_struct.field("annotations", &self.annotations);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("webhook_id", &self.webhook_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4443,7 +4430,6 @@ impl std::fmt::Debug for OAuthCredential {
             &self.oauth_token_secret_version,
         );
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4619,7 +4605,6 @@ impl std::fmt::Debug for UserCredential {
         let mut debug_struct = f.debug_struct("UserCredential");
         debug_struct.field("user_token_secret_version", &self.user_token_secret_version);
         debug_struct.field("username", &self.username);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4827,7 +4812,6 @@ impl std::fmt::Debug for CreateConnectionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("connection", &self.connection);
         debug_struct.field("connection_id", &self.connection_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4970,7 +4954,6 @@ impl std::fmt::Debug for GetConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5183,7 +5166,6 @@ impl std::fmt::Debug for ListConnectionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5368,7 +5350,6 @@ impl std::fmt::Debug for ListConnectionsResponse {
         let mut debug_struct = f.debug_struct("ListConnectionsResponse");
         debug_struct.field("connections", &self.connections);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5615,7 +5596,6 @@ impl std::fmt::Debug for UpdateConnectionRequest {
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("allow_missing", &self.allow_missing);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5811,7 +5791,6 @@ impl std::fmt::Debug for DeleteConnectionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6020,7 +5999,6 @@ impl std::fmt::Debug for CreateRepositoryRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("repository", &self.repository);
         debug_struct.field("repository_id", &self.repository_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6197,7 +6175,6 @@ impl std::fmt::Debug for BatchCreateRepositoriesRequest {
         let mut debug_struct = f.debug_struct("BatchCreateRepositoriesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("requests", &self.requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6342,7 +6319,6 @@ impl std::fmt::Debug for BatchCreateRepositoriesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchCreateRepositoriesResponse");
         debug_struct.field("repositories", &self.repositories);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6485,7 +6461,6 @@ impl std::fmt::Debug for GetRepositoryRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRepositoryRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6726,7 +6701,6 @@ impl std::fmt::Debug for ListRepositoriesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6911,7 +6885,6 @@ impl std::fmt::Debug for ListRepositoriesResponse {
         let mut debug_struct = f.debug_struct("ListRepositoriesResponse");
         debug_struct.field("repositories", &self.repositories);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7107,7 +7080,6 @@ impl std::fmt::Debug for DeleteRepositoryRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7250,7 +7222,6 @@ impl std::fmt::Debug for FetchReadWriteTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchReadWriteTokenRequest");
         debug_struct.field("repository", &self.repository);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7393,7 +7364,6 @@ impl std::fmt::Debug for FetchReadTokenRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchReadTokenRequest");
         debug_struct.field("repository", &self.repository);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7572,7 +7542,6 @@ impl std::fmt::Debug for FetchReadTokenResponse {
         let mut debug_struct = f.debug_struct("FetchReadTokenResponse");
         debug_struct.field("token", &self.token);
         debug_struct.field("expiration_time", &self.expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7751,7 +7720,6 @@ impl std::fmt::Debug for FetchReadWriteTokenResponse {
         let mut debug_struct = f.debug_struct("FetchReadWriteTokenResponse");
         debug_struct.field("token", &self.token);
         debug_struct.field("expiration_time", &self.expiration_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7957,7 +7925,6 @@ impl std::fmt::Debug for ProcessWebhookRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("body", &self.body);
         debug_struct.field("webhook_key", &self.webhook_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8131,7 +8098,6 @@ impl std::fmt::Debug for FetchGitRefsRequest {
         let mut debug_struct = f.debug_struct("FetchGitRefsRequest");
         debug_struct.field("repository", &self.repository);
         debug_struct.field("ref_type", &self.ref_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8415,7 +8381,6 @@ impl std::fmt::Debug for FetchGitRefsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FetchGitRefsResponse");
         debug_struct.field("ref_names", &self.ref_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/devtools/cloudprofiler/v2/src/model.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/model.rs
@@ -232,7 +232,6 @@ impl std::fmt::Debug for CreateProfileRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("deployment", &self.deployment);
         debug_struct.field("profile_type", &self.profile_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -411,7 +410,6 @@ impl std::fmt::Debug for CreateOfflineProfileRequest {
         let mut debug_struct = f.debug_struct("CreateOfflineProfileRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("profile", &self.profile);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -604,7 +602,6 @@ impl std::fmt::Debug for UpdateProfileRequest {
         let mut debug_struct = f.debug_struct("UpdateProfileRequest");
         debug_struct.field("profile", &self.profile);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -976,7 +973,6 @@ impl std::fmt::Debug for Profile {
         debug_struct.field("profile_bytes", &self.profile_bytes);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1199,7 +1195,6 @@ impl std::fmt::Debug for Deployment {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("target", &self.target);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1417,7 +1412,6 @@ impl std::fmt::Debug for ListProfilesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1652,7 +1646,6 @@ impl std::fmt::Debug for ListProfilesResponse {
         debug_struct.field("profiles", &self.profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("skipped_profiles", &self.skipped_profiles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -681,7 +681,6 @@ impl std::fmt::Debug for Span {
         );
         debug_struct.field("child_span_count", &self.child_span_count);
         debug_struct.field("span_kind", &self.span_kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -906,7 +905,6 @@ pub mod span {
             let mut debug_struct = f.debug_struct("Attributes");
             debug_struct.field("attribute_map", &self.attribute_map);
             debug_struct.field("dropped_attributes_count", &self.dropped_attributes_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1202,7 +1200,6 @@ pub mod span {
             let mut debug_struct = f.debug_struct("TimeEvent");
             debug_struct.field("time", &self.time);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1408,7 +1405,6 @@ pub mod span {
                 let mut debug_struct = f.debug_struct("Annotation");
                 debug_struct.field("description", &self.description);
                 debug_struct.field("attributes", &self.attributes);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1727,7 +1723,6 @@ pub mod span {
                 debug_struct.field("id", &self.id);
                 debug_struct.field("uncompressed_size_bytes", &self.uncompressed_size_bytes);
                 debug_struct.field("compressed_size_bytes", &self.compressed_size_bytes);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2147,7 +2142,6 @@ pub mod span {
                 "dropped_message_events_count",
                 &self.dropped_message_events_count,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2385,7 +2379,6 @@ pub mod span {
             debug_struct.field("span_id", &self.span_id);
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("attributes", &self.attributes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2726,7 +2719,6 @@ pub mod span {
             let mut debug_struct = f.debug_struct("Links");
             debug_struct.field("link", &self.link);
             debug_struct.field("dropped_links_count", &self.dropped_links_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3191,7 +3183,6 @@ impl std::fmt::Debug for AttributeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttributeValue");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3416,7 +3407,6 @@ impl std::fmt::Debug for StackTrace {
         let mut debug_struct = f.debug_struct("StackTrace");
         debug_struct.field("stack_frames", &self.stack_frames);
         debug_struct.field("stack_trace_hash_id", &self.stack_trace_hash_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3824,7 +3814,6 @@ pub mod stack_trace {
             debug_struct.field("column_number", &self.column_number);
             debug_struct.field("load_module", &self.load_module);
             debug_struct.field("source_version", &self.source_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4023,7 +4012,6 @@ pub mod stack_trace {
             let mut debug_struct = f.debug_struct("StackFrames");
             debug_struct.field("frame", &self.frame);
             debug_struct.field("dropped_frames_count", &self.dropped_frames_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4218,7 +4206,6 @@ impl std::fmt::Debug for Module {
         let mut debug_struct = f.debug_struct("Module");
         debug_struct.field("module", &self.module);
         debug_struct.field("build_id", &self.build_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4412,7 +4399,6 @@ impl std::fmt::Debug for TruncatableString {
         let mut debug_struct = f.debug_struct("TruncatableString");
         debug_struct.field("value", &self.value);
         debug_struct.field("truncated_byte_count", &self.truncated_byte_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4584,7 +4570,6 @@ impl std::fmt::Debug for BatchWriteSpansRequest {
         let mut debug_struct = f.debug_struct("BatchWriteSpansRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("spans", &self.spans);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/devtools/containeranalysis/v1/src/model.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/model.rs
@@ -250,7 +250,6 @@ impl std::fmt::Debug for ExportSBOMRequest {
         let mut debug_struct = f.debug_struct("ExportSBOMRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -373,7 +372,6 @@ pub mod export_sbom_request {
     impl std::fmt::Debug for CloudStorageLocation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudStorageLocation");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -533,7 +531,6 @@ impl std::fmt::Debug for ExportSBOMResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportSBOMResponse");
         debug_struct.field("discovery_occurrence", &self.discovery_occurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -702,7 +699,6 @@ impl std::fmt::Debug for GetVulnerabilityOccurrencesSummaryRequest {
         let mut debug_struct = f.debug_struct("GetVulnerabilityOccurrencesSummaryRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -851,7 +847,6 @@ impl std::fmt::Debug for VulnerabilityOccurrencesSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VulnerabilityOccurrencesSummary");
         debug_struct.field("counts", &self.counts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1124,7 +1119,6 @@ pub mod vulnerability_occurrences_summary {
             debug_struct.field("severity", &self.severity);
             debug_struct.field("fixable_count", &self.fixable_count);
             debug_struct.field("total_count", &self.total_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -365,7 +365,6 @@ impl std::fmt::Debug for Backup {
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("stats", &self.stats);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -626,7 +625,6 @@ pub mod backup {
             debug_struct.field("size_bytes", &self.size_bytes);
             debug_struct.field("document_count", &self.document_count);
             debug_struct.field("index_count", &self.index_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1615,7 +1613,6 @@ impl std::fmt::Debug for Database {
         debug_struct.field("free_tier", &self.free_tier);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("database_edition", &self.database_edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1815,7 +1812,6 @@ pub mod database {
             let mut debug_struct = f.debug_struct("CmekConfig");
             debug_struct.field("kms_key_name", &self.kms_key_name);
             debug_struct.field("active_key_version", &self.active_key_version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2040,7 +2036,6 @@ pub mod database {
             let mut debug_struct = f.debug_struct("SourceInfo");
             debug_struct.field("operation", &self.operation);
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2195,7 +2190,6 @@ pub mod database {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("BackupSource");
                 debug_struct.field("backup", &self.backup);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2548,7 +2542,6 @@ pub mod database {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("EncryptionConfig");
             debug_struct.field("encryption_type", &self.encryption_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2674,7 +2667,6 @@ pub mod database {
         impl std::fmt::Debug for GoogleDefaultEncryptionOptions {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("GoogleDefaultEncryptionOptions");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2795,7 +2787,6 @@ pub mod database {
         impl std::fmt::Debug for SourceEncryptionOptions {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("SourceEncryptionOptions");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2960,7 +2951,6 @@ pub mod database {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CustomerManagedEncryptionOptions");
                 debug_struct.field("kms_key_name", &self.kms_key_name);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4080,7 +4070,6 @@ impl std::fmt::Debug for Field {
         debug_struct.field("name", &self.name);
         debug_struct.field("index_config", &self.index_config);
         debug_struct.field("ttl_config", &self.ttl_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4322,7 +4311,6 @@ pub mod field {
             debug_struct.field("uses_ancestor_config", &self.uses_ancestor_config);
             debug_struct.field("ancestor_field", &self.ancestor_field);
             debug_struct.field("reverting", &self.reverting);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4475,7 +4463,6 @@ pub mod field {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TtlConfig");
             debug_struct.field("state", &self.state);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4800,7 +4787,6 @@ impl std::fmt::Debug for ListDatabasesRequest {
         let mut debug_struct = f.debug_struct("ListDatabasesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5015,7 +5001,6 @@ impl std::fmt::Debug for CreateDatabaseRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("database", &self.database);
         debug_struct.field("database_id", &self.database_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5129,7 +5114,6 @@ impl serde::ser::Serialize for CreateDatabaseMetadata {
 impl std::fmt::Debug for CreateDatabaseMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateDatabaseMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5310,7 +5294,6 @@ impl std::fmt::Debug for ListDatabasesResponse {
         let mut debug_struct = f.debug_struct("ListDatabasesResponse");
         debug_struct.field("databases", &self.databases);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5456,7 +5439,6 @@ impl std::fmt::Debug for GetDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatabaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5649,7 +5631,6 @@ impl std::fmt::Debug for UpdateDatabaseRequest {
         let mut debug_struct = f.debug_struct("UpdateDatabaseRequest");
         debug_struct.field("database", &self.database);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5763,7 +5744,6 @@ impl serde::ser::Serialize for UpdateDatabaseMetadata {
 impl std::fmt::Debug for UpdateDatabaseMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdateDatabaseMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5936,7 +5916,6 @@ impl std::fmt::Debug for DeleteDatabaseRequest {
         let mut debug_struct = f.debug_struct("DeleteDatabaseRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6050,7 +6029,6 @@ impl serde::ser::Serialize for DeleteDatabaseMetadata {
 impl std::fmt::Debug for DeleteDatabaseMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDatabaseMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6264,7 +6242,6 @@ impl std::fmt::Debug for CreateUserCredsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("user_creds", &self.user_creds);
         debug_struct.field("user_creds_id", &self.user_creds_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6410,7 +6387,6 @@ impl std::fmt::Debug for GetUserCredsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetUserCredsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6556,7 +6532,6 @@ impl std::fmt::Debug for ListUserCredsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListUserCredsRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6705,7 +6680,6 @@ impl std::fmt::Debug for ListUserCredsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListUserCredsResponse");
         debug_struct.field("user_creds", &self.user_creds);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6851,7 +6825,6 @@ impl std::fmt::Debug for EnableUserCredsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableUserCredsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6997,7 +6970,6 @@ impl std::fmt::Debug for DisableUserCredsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableUserCredsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7143,7 +7115,6 @@ impl std::fmt::Debug for ResetUserPasswordRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResetUserPasswordRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7289,7 +7260,6 @@ impl std::fmt::Debug for DeleteUserCredsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteUserCredsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7474,7 +7444,6 @@ impl std::fmt::Debug for CreateBackupScheduleRequest {
         let mut debug_struct = f.debug_struct("CreateBackupScheduleRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_schedule", &self.backup_schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7622,7 +7591,6 @@ impl std::fmt::Debug for GetBackupScheduleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupScheduleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7817,7 +7785,6 @@ impl std::fmt::Debug for UpdateBackupScheduleRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupScheduleRequest");
         debug_struct.field("backup_schedule", &self.backup_schedule);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7964,7 +7931,6 @@ impl std::fmt::Debug for ListBackupSchedulesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListBackupSchedulesRequest");
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8117,7 +8083,6 @@ impl std::fmt::Debug for ListBackupSchedulesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListBackupSchedulesResponse");
         debug_struct.field("backup_schedules", &self.backup_schedules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8262,7 +8227,6 @@ impl std::fmt::Debug for DeleteBackupScheduleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupScheduleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8444,7 +8408,6 @@ impl std::fmt::Debug for CreateIndexRequest {
         let mut debug_struct = f.debug_struct("CreateIndexRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("index", &self.index);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8689,7 +8652,6 @@ impl std::fmt::Debug for ListIndexesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8878,7 +8840,6 @@ impl std::fmt::Debug for ListIndexesResponse {
         let mut debug_struct = f.debug_struct("ListIndexesResponse");
         debug_struct.field("indexes", &self.indexes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9024,7 +8985,6 @@ impl std::fmt::Debug for GetIndexRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetIndexRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9170,7 +9130,6 @@ impl std::fmt::Debug for DeleteIndexRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteIndexRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9364,7 +9323,6 @@ impl std::fmt::Debug for UpdateFieldRequest {
         let mut debug_struct = f.debug_struct("UpdateFieldRequest");
         debug_struct.field("field", &self.field);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9510,7 +9468,6 @@ impl std::fmt::Debug for GetFieldRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFieldRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9763,7 +9720,6 @@ impl std::fmt::Debug for ListFieldsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9952,7 +9908,6 @@ impl std::fmt::Debug for ListFieldsResponse {
         let mut debug_struct = f.debug_struct("ListFieldsResponse");
         debug_struct.field("fields", &self.fields);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10243,7 +10198,6 @@ impl std::fmt::Debug for ExportDocumentsRequest {
         debug_struct.field("output_uri_prefix", &self.output_uri_prefix);
         debug_struct.field("namespace_ids", &self.namespace_ids);
         debug_struct.field("snapshot_time", &self.snapshot_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10488,7 +10442,6 @@ impl std::fmt::Debug for ImportDocumentsRequest {
         debug_struct.field("collection_ids", &self.collection_ids);
         debug_struct.field("input_uri_prefix", &self.input_uri_prefix);
         debug_struct.field("namespace_ids", &self.namespace_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10713,7 +10666,6 @@ impl std::fmt::Debug for BulkDeleteDocumentsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("collection_ids", &self.collection_ids);
         debug_struct.field("namespace_ids", &self.namespace_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10830,7 +10782,6 @@ impl serde::ser::Serialize for BulkDeleteDocumentsResponse {
 impl std::fmt::Debug for BulkDeleteDocumentsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BulkDeleteDocumentsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10977,7 +10928,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11165,7 +11115,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         let mut debug_struct = f.debug_struct("ListBackupsRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11346,7 +11295,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         let mut debug_struct = f.debug_struct("ListBackupsResponse");
         debug_struct.field("backups", &self.backups);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11493,7 +11441,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11786,7 +11733,6 @@ impl std::fmt::Debug for RestoreDatabaseRequest {
         debug_struct.field("backup", &self.backup);
         debug_struct.field("encryption_config", &self.encryption_config);
         debug_struct.field("tags", &self.tags);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12168,7 +12114,6 @@ impl std::fmt::Debug for Index {
         debug_struct.field("density", &self.density);
         debug_struct.field("multikey", &self.multikey);
         debug_struct.field("shard_count", &self.shard_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12513,7 +12458,6 @@ pub mod index {
             let mut debug_struct = f.debug_struct("IndexField");
             debug_struct.field("field_path", &self.field_path);
             debug_struct.field("value_mode", &self.value_mode);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12773,7 +12717,6 @@ pub mod index {
                 let mut debug_struct = f.debug_struct("VectorConfig");
                 debug_struct.field("dimension", &self.dimension);
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12905,7 +12848,6 @@ pub mod index {
             impl std::fmt::Debug for FlatIndex {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("FlatIndex");
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -13893,7 +13835,6 @@ impl serde::ser::Serialize for LocationMetadata {
 impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14215,7 +14156,6 @@ impl std::fmt::Debug for IndexOperationMetadata {
         debug_struct.field("state", &self.state);
         debug_struct.field("progress_documents", &self.progress_documents);
         debug_struct.field("progress_bytes", &self.progress_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14616,7 +14556,6 @@ impl std::fmt::Debug for FieldOperationMetadata {
         debug_struct.field("progress_documents", &self.progress_documents);
         debug_struct.field("progress_bytes", &self.progress_bytes);
         debug_struct.field("ttl_config_delta", &self.ttl_config_delta);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14808,7 +14747,6 @@ pub mod field_operation_metadata {
             let mut debug_struct = f.debug_struct("IndexConfigDelta");
             debug_struct.field("change_type", &self.change_type);
             debug_struct.field("index", &self.index);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15100,7 +15038,6 @@ pub mod field_operation_metadata {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TtlConfigDelta");
             debug_struct.field("change_type", &self.change_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15668,7 +15605,6 @@ impl std::fmt::Debug for ExportDocumentsMetadata {
         debug_struct.field("output_uri_prefix", &self.output_uri_prefix);
         debug_struct.field("namespace_ids", &self.namespace_ids);
         debug_struct.field("snapshot_time", &self.snapshot_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16055,7 +15991,6 @@ impl std::fmt::Debug for ImportDocumentsMetadata {
         debug_struct.field("collection_ids", &self.collection_ids);
         debug_struct.field("input_uri_prefix", &self.input_uri_prefix);
         debug_struct.field("namespace_ids", &self.namespace_ids);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16453,7 +16388,6 @@ impl std::fmt::Debug for BulkDeleteDocumentsMetadata {
         debug_struct.field("collection_ids", &self.collection_ids);
         debug_struct.field("namespace_ids", &self.namespace_ids);
         debug_struct.field("snapshot_time", &self.snapshot_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16604,7 +16538,6 @@ impl std::fmt::Debug for ExportDocumentsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExportDocumentsResponse");
         debug_struct.field("output_uri_prefix", &self.output_uri_prefix);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16914,7 +16847,6 @@ impl std::fmt::Debug for RestoreDatabaseMetadata {
         debug_struct.field("database", &self.database);
         debug_struct.field("backup", &self.backup);
         debug_struct.field("progress_percentage", &self.progress_percentage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17125,7 +17057,6 @@ impl std::fmt::Debug for Progress {
         let mut debug_struct = f.debug_struct("Progress");
         debug_struct.field("estimated_work", &self.estimated_work);
         debug_struct.field("completed_work", &self.completed_work);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17528,7 +17459,6 @@ impl std::fmt::Debug for BackupSchedule {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("retention", &self.retention);
         debug_struct.field("recurrence", &self.recurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17660,7 +17590,6 @@ impl serde::ser::Serialize for DailyRecurrence {
 impl std::fmt::Debug for DailyRecurrence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DailyRecurrence");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17806,7 +17735,6 @@ impl std::fmt::Debug for WeeklyRecurrence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WeeklyRecurrence");
         debug_struct.field("day", &self.day);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18157,7 +18085,6 @@ impl std::fmt::Debug for UserCreds {
         debug_struct.field("state", &self.state);
         debug_struct.field("secure_password", &self.secure_password);
         debug_struct.field("user_creds_identity", &self.user_creds_identity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18308,7 +18235,6 @@ pub mod user_creds {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ResourceIdentity");
             debug_struct.field("principal", &self.principal);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -183,7 +183,6 @@ impl std::fmt::Debug for AttestationNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttestationNote");
         debug_struct.field("hint", &self.hint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -344,7 +343,6 @@ pub mod attestation_note {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Hint");
             debug_struct.field("human_readable_name", &self.human_readable_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -489,7 +487,6 @@ impl std::fmt::Debug for Jwt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Jwt");
         debug_struct.field("compact_jwt", &self.compact_jwt);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -726,7 +723,6 @@ impl std::fmt::Debug for AttestationOccurrence {
         debug_struct.field("serialized_payload", &self.serialized_payload);
         debug_struct.field("signatures", &self.signatures);
         debug_struct.field("jwts", &self.jwts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -870,7 +866,6 @@ impl std::fmt::Debug for BuildNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BuildNote");
         debug_struct.field("builder_version", &self.builder_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1190,7 +1185,6 @@ impl std::fmt::Debug for BuildOccurrence {
             "in_toto_slsa_provenance_v1",
             &self.in_toto_slsa_provenance_v1,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1357,7 +1351,6 @@ impl std::fmt::Debug for RelatedUrl {
         let mut debug_struct = f.debug_struct("RelatedUrl");
         debug_struct.field("url", &self.url);
         debug_struct.field("label", &self.label);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1589,7 +1582,6 @@ impl std::fmt::Debug for Signature {
         let mut debug_struct = f.debug_struct("Signature");
         debug_struct.field("signature", &self.signature);
         debug_struct.field("public_key_id", &self.public_key_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1806,7 +1798,6 @@ impl std::fmt::Debug for Envelope {
         debug_struct.field("payload", &self.payload);
         debug_struct.field("payload_type", &self.payload_type);
         debug_struct.field("signatures", &self.signatures);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1988,7 +1979,6 @@ impl std::fmt::Debug for EnvelopeSignature {
         let mut debug_struct = f.debug_struct("EnvelopeSignature");
         debug_struct.field("sig", &self.sig);
         debug_struct.field("keyid", &self.keyid);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2170,7 +2160,6 @@ impl std::fmt::Debug for FileLocation {
         let mut debug_struct = f.debug_struct("FileLocation");
         debug_struct.field("file_path", &self.file_path);
         debug_struct.field("layer_details", &self.layer_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2381,7 +2370,6 @@ impl std::fmt::Debug for BaseImage {
         debug_struct.field("name", &self.name);
         debug_struct.field("repository", &self.repository);
         debug_struct.field("layer_count", &self.layer_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2649,7 +2637,6 @@ impl std::fmt::Debug for LayerDetails {
         debug_struct.field("chain_id", &self.chain_id);
         debug_struct.field("command", &self.command);
         debug_struct.field("base_images", &self.base_images);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2820,7 +2807,6 @@ impl std::fmt::Debug for License {
         let mut debug_struct = f.debug_struct("License");
         debug_struct.field("expression", &self.expression);
         debug_struct.field("comments", &self.comments);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3006,7 +2992,6 @@ impl std::fmt::Debug for Digest {
         let mut debug_struct = f.debug_struct("Digest");
         debug_struct.field("algo", &self.algo);
         debug_struct.field("digest_bytes", &self.digest_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3442,7 +3427,6 @@ impl std::fmt::Debug for ComplianceNote {
         debug_struct.field("scan_instructions", &self.scan_instructions);
         debug_struct.field("compliance_type", &self.compliance_type);
         debug_struct.field("potential_impact", &self.potential_impact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3635,7 +3619,6 @@ pub mod compliance_note {
             let mut debug_struct = f.debug_struct("CisBenchmark");
             debug_struct.field("profile_level", &self.profile_level);
             debug_struct.field("severity", &self.severity);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3850,7 +3833,6 @@ impl std::fmt::Debug for ComplianceVersion {
         debug_struct.field("cpe_uri", &self.cpe_uri);
         debug_struct.field("benchmark_document", &self.benchmark_document);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4065,7 +4047,6 @@ impl std::fmt::Debug for ComplianceOccurrence {
         debug_struct.field("non_compliant_files", &self.non_compliant_files);
         debug_struct.field("non_compliance_reason", &self.non_compliance_reason);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4258,7 +4239,6 @@ impl std::fmt::Debug for NonCompliantFile {
         debug_struct.field("path", &self.path);
         debug_struct.field("display_command", &self.display_command);
         debug_struct.field("reason", &self.reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4729,7 +4709,6 @@ impl std::fmt::Debug for CVSSv3 {
         debug_struct.field("confidentiality_impact", &self.confidentiality_impact);
         debug_struct.field("integrity_impact", &self.integrity_impact);
         debug_struct.field("availability_impact", &self.availability_impact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6020,7 +5999,6 @@ impl std::fmt::Debug for Cvss {
         debug_struct.field("confidentiality_impact", &self.confidentiality_impact);
         debug_struct.field("integrity_impact", &self.integrity_impact);
         debug_struct.field("availability_impact", &self.availability_impact);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7116,7 +7094,6 @@ impl std::fmt::Debug for DeploymentNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeploymentNote");
         debug_struct.field("resource_uri", &self.resource_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7443,7 +7420,6 @@ impl std::fmt::Debug for DeploymentOccurrence {
         debug_struct.field("address", &self.address);
         debug_struct.field("resource_uri", &self.resource_uri);
         debug_struct.field("platform", &self.platform);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7737,7 +7713,6 @@ impl std::fmt::Debug for DiscoveryNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryNote");
         debug_struct.field("analysis_kind", &self.analysis_kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8208,7 +8183,6 @@ impl std::fmt::Debug for DiscoveryOccurrence {
         debug_struct.field("archive_time", &self.archive_time);
         debug_struct.field("sbom_status", &self.sbom_status);
         debug_struct.field("vulnerability_attestation", &self.vulnerability_attestation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8362,7 +8336,6 @@ pub mod discovery_occurrence {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AnalysisCompleted");
             debug_struct.field("analysis_type", &self.analysis_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8541,7 +8514,6 @@ pub mod discovery_occurrence {
             let mut debug_struct = f.debug_struct("SBOMStatus");
             debug_struct.field("sbom_state", &self.sbom_state);
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8888,7 +8860,6 @@ pub mod discovery_occurrence {
             debug_struct.field("last_attempt_time", &self.last_attempt_time);
             debug_struct.field("state", &self.state);
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9477,7 +9448,6 @@ impl std::fmt::Debug for DSSEAttestationNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DSSEAttestationNote");
         debug_struct.field("hint", &self.hint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9638,7 +9608,6 @@ pub mod dsse_attestation_note {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DSSEHint");
             debug_struct.field("human_readable_name", &self.human_readable_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9866,7 +9835,6 @@ impl std::fmt::Debug for DSSEAttestationOccurrence {
         let mut debug_struct = f.debug_struct("DSSEAttestationOccurrence");
         debug_struct.field("envelope", &self.envelope);
         debug_struct.field("decoded_payload", &self.decoded_payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10891,7 +10859,6 @@ impl std::fmt::Debug for Occurrence {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("envelope", &self.envelope);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12000,7 +11967,6 @@ impl std::fmt::Debug for Note {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("related_note_names", &self.related_note_names);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12181,7 +12147,6 @@ impl std::fmt::Debug for GetOccurrenceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOccurrenceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12420,7 +12385,6 @@ impl std::fmt::Debug for ListOccurrencesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12607,7 +12571,6 @@ impl std::fmt::Debug for ListOccurrencesResponse {
         let mut debug_struct = f.debug_struct("ListOccurrencesResponse");
         debug_struct.field("occurrences", &self.occurrences);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12750,7 +12713,6 @@ impl std::fmt::Debug for DeleteOccurrenceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteOccurrenceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12929,7 +12891,6 @@ impl std::fmt::Debug for CreateOccurrenceRequest {
         let mut debug_struct = f.debug_struct("CreateOccurrenceRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("occurrence", &self.occurrence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13145,7 +13106,6 @@ impl std::fmt::Debug for UpdateOccurrenceRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("occurrence", &self.occurrence);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13288,7 +13248,6 @@ impl std::fmt::Debug for GetNoteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNoteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13431,7 +13390,6 @@ impl std::fmt::Debug for GetOccurrenceNoteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOccurrenceNoteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13670,7 +13628,6 @@ impl std::fmt::Debug for ListNotesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13857,7 +13814,6 @@ impl std::fmt::Debug for ListNotesResponse {
         let mut debug_struct = f.debug_struct("ListNotesResponse");
         debug_struct.field("notes", &self.notes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14000,7 +13956,6 @@ impl std::fmt::Debug for DeleteNoteRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteNoteRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14205,7 +14160,6 @@ impl std::fmt::Debug for CreateNoteRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("note_id", &self.note_id);
         debug_struct.field("note", &self.note);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14421,7 +14375,6 @@ impl std::fmt::Debug for UpdateNoteRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("note", &self.note);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14659,7 +14612,6 @@ impl std::fmt::Debug for ListNoteOccurrencesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14844,7 +14796,6 @@ impl std::fmt::Debug for ListNoteOccurrencesResponse {
         let mut debug_struct = f.debug_struct("ListNoteOccurrencesResponse");
         debug_struct.field("occurrences", &self.occurrences);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15023,7 +14974,6 @@ impl std::fmt::Debug for BatchCreateNotesRequest {
         let mut debug_struct = f.debug_struct("BatchCreateNotesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("notes", &self.notes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15168,7 +15118,6 @@ impl std::fmt::Debug for BatchCreateNotesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchCreateNotesResponse");
         debug_struct.field("notes", &self.notes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15339,7 +15288,6 @@ impl std::fmt::Debug for BatchCreateOccurrencesRequest {
         let mut debug_struct = f.debug_struct("BatchCreateOccurrencesRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("occurrences", &self.occurrences);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15484,7 +15432,6 @@ impl std::fmt::Debug for BatchCreateOccurrencesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BatchCreateOccurrencesResponse");
         debug_struct.field("occurrences", &self.occurrences);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15652,7 +15599,6 @@ impl std::fmt::Debug for Layer {
         let mut debug_struct = f.debug_struct("Layer");
         debug_struct.field("directive", &self.directive);
         debug_struct.field("arguments", &self.arguments);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15854,7 +15800,6 @@ impl std::fmt::Debug for Fingerprint {
         debug_struct.field("v1_name", &self.v1_name);
         debug_struct.field("v2_blob", &self.v2_blob);
         debug_struct.field("v2_name", &self.v2_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16038,7 +15983,6 @@ impl std::fmt::Debug for ImageNote {
         let mut debug_struct = f.debug_struct("ImageNote");
         debug_struct.field("resource_url", &self.resource_url);
         debug_struct.field("fingerprint", &self.fingerprint);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16298,7 +16242,6 @@ impl std::fmt::Debug for ImageOccurrence {
         debug_struct.field("distance", &self.distance);
         debug_struct.field("layer_info", &self.layer_info);
         debug_struct.field("base_resource_url", &self.base_resource_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16590,7 +16533,6 @@ impl std::fmt::Debug for Recipe {
         debug_struct.field("entry_point", &self.entry_point);
         debug_struct.field("arguments", &self.arguments);
         debug_struct.field("environment", &self.environment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16786,7 +16728,6 @@ impl std::fmt::Debug for Completeness {
         debug_struct.field("arguments", &self.arguments);
         debug_struct.field("environment", &self.environment);
         debug_struct.field("materials", &self.materials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17071,7 +17012,6 @@ impl std::fmt::Debug for Metadata {
         debug_struct.field("build_finished_on", &self.build_finished_on);
         debug_struct.field("completeness", &self.completeness);
         debug_struct.field("reproducible", &self.reproducible);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17211,7 +17151,6 @@ impl std::fmt::Debug for BuilderConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BuilderConfig");
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17468,7 +17407,6 @@ impl std::fmt::Debug for InTotoProvenance {
         debug_struct.field("recipe", &self.recipe);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("materials", &self.materials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17859,7 +17797,6 @@ impl std::fmt::Debug for InTotoStatement {
         debug_struct.field("subject", &self.subject);
         debug_struct.field("predicate_type", &self.predicate_type);
         debug_struct.field("predicate", &self.predicate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18052,7 +17989,6 @@ impl std::fmt::Debug for Subject {
         let mut debug_struct = f.debug_struct("Subject");
         debug_struct.field("name", &self.name);
         debug_struct.field("digest", &self.digest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18283,7 +18219,6 @@ impl std::fmt::Debug for InTotoSlsaProvenanceV1 {
         debug_struct.field("subject", &self.subject);
         debug_struct.field("predicate_type", &self.predicate_type);
         debug_struct.field("predicate", &self.predicate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18486,7 +18421,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             let mut debug_struct = f.debug_struct("SlsaProvenanceV1");
             debug_struct.field("build_definition", &self.build_definition);
             debug_struct.field("run_details", &self.run_details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18731,7 +18665,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             debug_struct.field("external_parameters", &self.external_parameters);
             debug_struct.field("internal_parameters", &self.internal_parameters);
             debug_struct.field("resolved_dependencies", &self.resolved_dependencies);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19065,7 +18998,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             debug_struct.field("download_location", &self.download_location);
             debug_struct.field("media_type", &self.media_type);
             debug_struct.field("annotations", &self.annotations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19285,7 +19217,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             debug_struct.field("builder", &self.builder);
             debug_struct.field("metadata", &self.metadata);
             debug_struct.field("byproducts", &self.byproducts);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19492,7 +19423,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             debug_struct.field("id", &self.id);
             debug_struct.field("version", &self.version);
             debug_struct.field("builder_dependencies", &self.builder_dependencies);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19711,7 +19641,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             debug_struct.field("invocation_id", &self.invocation_id);
             debug_struct.field("started_on", &self.started_on);
             debug_struct.field("finished_on", &self.finished_on);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19998,7 +19927,6 @@ impl std::fmt::Debug for Distribution {
         debug_struct.field("maintainer", &self.maintainer);
         debug_struct.field("url", &self.url);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20205,7 +20133,6 @@ impl std::fmt::Debug for Location {
         debug_struct.field("cpe_uri", &self.cpe_uri);
         debug_struct.field("version", &self.version);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20636,7 +20563,6 @@ impl std::fmt::Debug for PackageNote {
         debug_struct.field("description", &self.description);
         debug_struct.field("license", &self.license);
         debug_struct.field("digest", &self.digest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20963,7 +20889,6 @@ impl std::fmt::Debug for PackageOccurrence {
         debug_struct.field("architecture", &self.architecture);
         debug_struct.field("license", &self.license);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21258,7 +21183,6 @@ impl std::fmt::Debug for Version {
         debug_struct.field("inclusive", &self.inclusive);
         debug_struct.field("kind", &self.kind);
         debug_struct.field("full_name", &self.full_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21920,7 +21844,6 @@ impl std::fmt::Debug for BuildProvenance {
         debug_struct.field("trigger_id", &self.trigger_id);
         debug_struct.field("build_options", &self.build_options);
         debug_struct.field("builder_version", &self.builder_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22189,7 +22112,6 @@ impl std::fmt::Debug for Source {
         debug_struct.field("file_hashes", &self.file_hashes);
         debug_struct.field("context", &self.context);
         debug_struct.field("additional_contexts", &self.additional_contexts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22336,7 +22258,6 @@ impl std::fmt::Debug for FileHashes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileHashes");
         debug_struct.field("file_hash", &self.file_hash);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22521,7 +22442,6 @@ impl std::fmt::Debug for Hash {
         let mut debug_struct = f.debug_struct("Hash");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22801,7 +22721,6 @@ impl std::fmt::Debug for Command {
         debug_struct.field("dir", &self.dir);
         debug_struct.field("id", &self.id);
         debug_struct.field("wait_for", &self.wait_for);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23002,7 +22921,6 @@ impl std::fmt::Debug for Artifact {
         debug_struct.field("checksum", &self.checksum);
         debug_struct.field("id", &self.id);
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23331,7 +23249,6 @@ impl std::fmt::Debug for SourceContext {
         let mut debug_struct = f.debug_struct("SourceContext");
         debug_struct.field("labels", &self.labels);
         debug_struct.field("context", &self.context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23517,7 +23434,6 @@ impl std::fmt::Debug for AliasContext {
         let mut debug_struct = f.debug_struct("AliasContext");
         debug_struct.field("kind", &self.kind);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23942,7 +23858,6 @@ impl std::fmt::Debug for CloudRepoSourceContext {
         let mut debug_struct = f.debug_struct("CloudRepoSourceContext");
         debug_struct.field("repo_id", &self.repo_id);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24254,7 +24169,6 @@ impl std::fmt::Debug for GerritSourceContext {
         debug_struct.field("host_uri", &self.host_uri);
         debug_struct.field("gerrit_project", &self.gerrit_project);
         debug_struct.field("revision", &self.revision);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24440,7 +24354,6 @@ impl std::fmt::Debug for GitSourceContext {
         let mut debug_struct = f.debug_struct("GitSourceContext");
         debug_struct.field("url", &self.url);
         debug_struct.field("revision_id", &self.revision_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24670,7 +24583,6 @@ impl std::fmt::Debug for RepoId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RepoId");
         debug_struct.field("id", &self.id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24857,7 +24769,6 @@ impl std::fmt::Debug for ProjectRepoId {
         let mut debug_struct = f.debug_struct("ProjectRepoId");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("repo_name", &self.repo_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25025,7 +24936,6 @@ impl std::fmt::Debug for SBOMReferenceNote {
         let mut debug_struct = f.debug_struct("SBOMReferenceNote");
         debug_struct.field("format", &self.format);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25241,7 +25151,6 @@ impl std::fmt::Debug for SBOMReferenceOccurrence {
         debug_struct.field("payload", &self.payload);
         debug_struct.field("payload_type", &self.payload_type);
         debug_struct.field("signatures", &self.signatures);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25479,7 +25388,6 @@ impl std::fmt::Debug for SbomReferenceIntotoPayload {
         debug_struct.field("predicate_type", &self.predicate_type);
         debug_struct.field("subject", &self.subject);
         debug_struct.field("predicate", &self.predicate);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25709,7 +25617,6 @@ impl std::fmt::Debug for SbomReferenceIntotoPredicate {
         debug_struct.field("location", &self.location);
         debug_struct.field("mime_type", &self.mime_type);
         debug_struct.field("digest", &self.digest);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25823,7 +25730,6 @@ impl serde::ser::Serialize for SecretNote {
 impl std::fmt::Debug for SecretNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecretNote");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26025,7 +25931,6 @@ impl std::fmt::Debug for SecretOccurrence {
         debug_struct.field("kind", &self.kind);
         debug_struct.field("locations", &self.locations);
         debug_struct.field("statuses", &self.statuses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26216,7 +26121,6 @@ impl std::fmt::Debug for SecretLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecretLocation");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26435,7 +26339,6 @@ impl std::fmt::Debug for SecretStatus {
         debug_struct.field("status", &self.status);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26842,7 +26745,6 @@ impl std::fmt::Debug for SlsaProvenance {
         debug_struct.field("recipe", &self.recipe);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("materials", &self.materials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27154,7 +27056,6 @@ pub mod slsa_provenance {
             debug_struct.field("entry_point", &self.entry_point);
             debug_struct.field("arguments", &self.arguments);
             debug_struct.field("environment", &self.environment);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27353,7 +27254,6 @@ pub mod slsa_provenance {
             debug_struct.field("arguments", &self.arguments);
             debug_struct.field("environment", &self.environment);
             debug_struct.field("materials", &self.materials);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27642,7 +27542,6 @@ pub mod slsa_provenance {
             debug_struct.field("build_finished_on", &self.build_finished_on);
             debug_struct.field("completeness", &self.completeness);
             debug_struct.field("reproducible", &self.reproducible);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27785,7 +27684,6 @@ pub mod slsa_provenance {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SlsaBuilder");
             debug_struct.field("id", &self.id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27963,7 +27861,6 @@ pub mod slsa_provenance {
             let mut debug_struct = f.debug_struct("Material");
             debug_struct.field("uri", &self.uri);
             debug_struct.field("digest", &self.digest);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28282,7 +28179,6 @@ impl std::fmt::Debug for SlsaProvenanceZeroTwo {
         debug_struct.field("build_config", &self.build_config);
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("materials", &self.materials);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28432,7 +28328,6 @@ pub mod slsa_provenance_zero_two {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SlsaBuilder");
             debug_struct.field("id", &self.id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28612,7 +28507,6 @@ pub mod slsa_provenance_zero_two {
             let mut debug_struct = f.debug_struct("SlsaMaterial");
             debug_struct.field("uri", &self.uri);
             debug_struct.field("digest", &self.digest);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28840,7 +28734,6 @@ pub mod slsa_provenance_zero_two {
             debug_struct.field("config_source", &self.config_source);
             debug_struct.field("parameters", &self.parameters);
             debug_struct.field("environment", &self.environment);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29045,7 +28938,6 @@ pub mod slsa_provenance_zero_two {
             debug_struct.field("uri", &self.uri);
             debug_struct.field("digest", &self.digest);
             debug_struct.field("entry_point", &self.entry_point);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29326,7 +29218,6 @@ pub mod slsa_provenance_zero_two {
             debug_struct.field("build_finished_on", &self.build_finished_on);
             debug_struct.field("completeness", &self.completeness);
             debug_struct.field("reproducible", &self.reproducible);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29519,7 +29410,6 @@ pub mod slsa_provenance_zero_two {
             debug_struct.field("parameters", &self.parameters);
             debug_struct.field("environment", &self.environment);
             debug_struct.field("materials", &self.materials);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29771,7 +29661,6 @@ impl std::fmt::Debug for UpgradeNote {
         debug_struct.field("version", &self.version);
         debug_struct.field("distributions", &self.distributions);
         debug_struct.field("windows_update", &self.windows_update);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29998,7 +29887,6 @@ impl std::fmt::Debug for UpgradeDistribution {
         debug_struct.field("classification", &self.classification);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("cve", &self.cve);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30331,7 +30219,6 @@ impl std::fmt::Debug for WindowsUpdate {
         debug_struct.field("kb_article_ids", &self.kb_article_ids);
         debug_struct.field("support_url", &self.support_url);
         debug_struct.field("last_published_timestamp", &self.last_published_timestamp);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30525,7 +30412,6 @@ pub mod windows_update {
             let mut debug_struct = f.debug_struct("Identity");
             debug_struct.field("update_id", &self.update_id);
             debug_struct.field("revision", &self.revision);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30696,7 +30582,6 @@ pub mod windows_update {
             let mut debug_struct = f.debug_struct("Category");
             debug_struct.field("category_id", &self.category_id);
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -30956,7 +30841,6 @@ impl std::fmt::Debug for UpgradeOccurrence {
         debug_struct.field("parsed_version", &self.parsed_version);
         debug_struct.field("distribution", &self.distribution);
         debug_struct.field("windows_update", &self.windows_update);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31295,7 +31179,6 @@ impl std::fmt::Debug for VulnerabilityAssessmentNote {
         debug_struct.field("publisher", &self.publisher);
         debug_struct.field("product", &self.product);
         debug_struct.field("assessment", &self.assessment);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31512,7 +31395,6 @@ pub mod vulnerability_assessment_note {
             debug_struct.field("name", &self.name);
             debug_struct.field("issuing_authority", &self.issuing_authority);
             debug_struct.field("publisher_namespace", &self.publisher_namespace);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31759,7 +31641,6 @@ pub mod vulnerability_assessment_note {
             debug_struct.field("name", &self.name);
             debug_struct.field("id", &self.id);
             debug_struct.field("identifier", &self.identifier);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32178,7 +32059,6 @@ pub mod vulnerability_assessment_note {
             debug_struct.field("impacts", &self.impacts);
             debug_struct.field("justification", &self.justification);
             debug_struct.field("remediations", &self.remediations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32361,7 +32241,6 @@ pub mod vulnerability_assessment_note {
                 let mut debug_struct = f.debug_struct("Justification");
                 debug_struct.field("justification_type", &self.justification_type);
                 debug_struct.field("details", &self.details);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -32769,7 +32648,6 @@ pub mod vulnerability_assessment_note {
                 debug_struct.field("remediation_type", &self.remediation_type);
                 debug_struct.field("details", &self.details);
                 debug_struct.field("remediation_uri", &self.remediation_uri);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -33481,7 +33359,6 @@ impl std::fmt::Debug for VulnerabilityNote {
         debug_struct.field("source_update_time", &self.source_update_time);
         debug_struct.field("cvss_version", &self.cvss_version);
         debug_struct.field("cvss_v2", &self.cvss_v2);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34055,7 +33932,6 @@ pub mod vulnerability_note {
             debug_struct.field("source_update_time", &self.source_update_time);
             debug_struct.field("source", &self.source);
             debug_struct.field("vendor", &self.vendor);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34284,7 +34160,6 @@ pub mod vulnerability_note {
             debug_struct.field("name", &self.name);
             debug_struct.field("description", &self.description);
             debug_struct.field("fixing_kbs", &self.fixing_kbs);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34462,7 +34337,6 @@ pub mod vulnerability_note {
                 let mut debug_struct = f.debug_struct("KnowledgeBase");
                 debug_struct.field("name", &self.name);
                 debug_struct.field("url", &self.url);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35031,7 +34905,6 @@ impl std::fmt::Debug for VulnerabilityOccurrence {
         debug_struct.field("cvss_v2", &self.cvss_v2);
         debug_struct.field("vex_assessment", &self.vex_assessment);
         debug_struct.field("extra_details", &self.extra_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35472,7 +35345,6 @@ pub mod vulnerability_occurrence {
             debug_struct.field("package_type", &self.package_type);
             debug_struct.field("effective_severity", &self.effective_severity);
             debug_struct.field("file_location", &self.file_location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35847,7 +35719,6 @@ pub mod vulnerability_occurrence {
             debug_struct.field("impacts", &self.impacts);
             debug_struct.field("remediations", &self.remediations);
             debug_struct.field("justification", &self.justification);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -180,7 +180,6 @@ impl std::fmt::Debug for AuditData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AuditData");
         debug_struct.field("permission_delta", &self.permission_delta);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -364,7 +363,6 @@ pub mod audit_data {
             let mut debug_struct = f.debug_struct("PermissionDelta");
             debug_struct.field("added_permissions", &self.added_permissions);
             debug_struct.field("removed_permissions", &self.removed_permissions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -769,7 +767,6 @@ impl std::fmt::Debug for ServiceAccount {
         debug_struct.field("description", &self.description);
         debug_struct.field("oauth2_client_id", &self.oauth2_client_id);
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -983,7 +980,6 @@ impl std::fmt::Debug for CreateServiceAccountRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("account_id", &self.account_id);
         debug_struct.field("service_account", &self.service_account);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1206,7 +1202,6 @@ impl std::fmt::Debug for ListServiceAccountsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1399,7 +1394,6 @@ impl std::fmt::Debug for ListServiceAccountsResponse {
         let mut debug_struct = f.debug_struct("ListServiceAccountsResponse");
         debug_struct.field("accounts", &self.accounts);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1545,7 +1539,6 @@ impl std::fmt::Debug for GetServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1691,7 +1684,6 @@ impl std::fmt::Debug for DeleteServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1887,7 +1879,6 @@ impl std::fmt::Debug for PatchServiceAccountRequest {
         let mut debug_struct = f.debug_struct("PatchServiceAccountRequest");
         debug_struct.field("service_account", &self.service_account);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2032,7 +2023,6 @@ impl std::fmt::Debug for UndeleteServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteServiceAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2186,7 +2176,6 @@ impl std::fmt::Debug for UndeleteServiceAccountResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteServiceAccountResponse");
         debug_struct.field("restored_account", &self.restored_account);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2332,7 +2321,6 @@ impl std::fmt::Debug for EnableServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableServiceAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2478,7 +2466,6 @@ impl std::fmt::Debug for DisableServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableServiceAccountRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2662,7 +2649,6 @@ impl std::fmt::Debug for ListServiceAccountKeysRequest {
         let mut debug_struct = f.debug_struct("ListServiceAccountKeysRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("key_types", &self.key_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2951,7 +2937,6 @@ impl std::fmt::Debug for ListServiceAccountKeysResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListServiceAccountKeysResponse");
         debug_struct.field("keys", &self.keys);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3126,7 +3111,6 @@ impl std::fmt::Debug for GetServiceAccountKeyRequest {
         let mut debug_struct = f.debug_struct("GetServiceAccountKeyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("public_key_type", &self.public_key_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3611,7 +3595,6 @@ impl std::fmt::Debug for ServiceAccountKey {
         debug_struct.field("key_origin", &self.key_origin);
         debug_struct.field("key_type", &self.key_type);
         debug_struct.field("disabled", &self.disabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3817,7 +3800,6 @@ impl std::fmt::Debug for CreateServiceAccountKeyRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("private_key_type", &self.private_key_type);
         debug_struct.field("key_algorithm", &self.key_algorithm);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4011,7 +3993,6 @@ impl std::fmt::Debug for UploadServiceAccountKeyRequest {
         let mut debug_struct = f.debug_struct("UploadServiceAccountKeyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("public_key_data", &self.public_key_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4157,7 +4138,6 @@ impl std::fmt::Debug for DeleteServiceAccountKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceAccountKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4304,7 +4284,6 @@ impl std::fmt::Debug for DisableServiceAccountKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DisableServiceAccountKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4451,7 +4430,6 @@ impl std::fmt::Debug for EnableServiceAccountKeyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnableServiceAccountKeyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4655,7 +4633,6 @@ impl std::fmt::Debug for SignBlobRequest {
         let mut debug_struct = f.debug_struct("SignBlobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("bytes_to_sign", &self.bytes_to_sign);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4854,7 +4831,6 @@ impl std::fmt::Debug for SignBlobResponse {
         let mut debug_struct = f.debug_struct("SignBlobResponse");
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("signature", &self.signature);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5047,7 +5023,6 @@ impl std::fmt::Debug for SignJwtRequest {
         let mut debug_struct = f.debug_struct("SignJwtRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5229,7 +5204,6 @@ impl std::fmt::Debug for SignJwtResponse {
         let mut debug_struct = f.debug_struct("SignJwtResponse");
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("signed_jwt", &self.signed_jwt);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5554,7 +5528,6 @@ impl std::fmt::Debug for Role {
         debug_struct.field("stage", &self.stage);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("deleted", &self.deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5963,7 +5936,6 @@ impl std::fmt::Debug for QueryGrantableRolesRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6149,7 +6121,6 @@ impl std::fmt::Debug for QueryGrantableRolesResponse {
         let mut debug_struct = f.debug_struct("QueryGrantableRolesResponse");
         debug_struct.field("roles", &self.roles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6447,7 +6418,6 @@ impl std::fmt::Debug for ListRolesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
         debug_struct.field("show_deleted", &self.show_deleted);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6633,7 +6603,6 @@ impl std::fmt::Debug for ListRolesResponse {
         let mut debug_struct = f.debug_struct("ListRolesResponse");
         debug_struct.field("roles", &self.roles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6806,7 +6775,6 @@ impl std::fmt::Debug for GetRoleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRoleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7037,7 +7005,6 @@ impl std::fmt::Debug for CreateRoleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("role_id", &self.role_id);
         debug_struct.field("role", &self.role);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7275,7 +7242,6 @@ impl std::fmt::Debug for UpdateRoleRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("role", &self.role);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7483,7 +7449,6 @@ impl std::fmt::Debug for DeleteRoleRequest {
         let mut debug_struct = f.debug_struct("DeleteRoleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7691,7 +7656,6 @@ impl std::fmt::Debug for UndeleteRoleRequest {
         let mut debug_struct = f.debug_struct("UndeleteRoleRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8039,7 +8003,6 @@ impl std::fmt::Debug for Permission {
         );
         debug_struct.field("api_disabled", &self.api_disabled);
         debug_struct.field("primary_permission", &self.primary_permission);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8542,7 +8505,6 @@ impl std::fmt::Debug for QueryTestablePermissionsRequest {
         debug_struct.field("full_resource_name", &self.full_resource_name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8728,7 +8690,6 @@ impl std::fmt::Debug for QueryTestablePermissionsResponse {
         let mut debug_struct = f.debug_struct("QueryTestablePermissionsResponse");
         debug_struct.field("permissions", &self.permissions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8879,7 +8840,6 @@ impl std::fmt::Debug for QueryAuditableServicesRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryAuditableServicesRequest");
         debug_struct.field("full_resource_name", &self.full_resource_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9024,7 +8984,6 @@ impl std::fmt::Debug for QueryAuditableServicesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QueryAuditableServicesResponse");
         debug_struct.field("services", &self.services);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9175,7 +9134,6 @@ pub mod query_auditable_services_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AuditableService");
             debug_struct.field("name", &self.name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9402,7 +9360,6 @@ impl std::fmt::Debug for LintPolicyRequest {
         let mut debug_struct = f.debug_struct("LintPolicyRequest");
         debug_struct.field("full_resource_name", &self.full_resource_name);
         debug_struct.field("lint_object", &self.lint_object);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9720,7 +9677,6 @@ impl std::fmt::Debug for LintResult {
         debug_struct.field("field_name", &self.field_name);
         debug_struct.field("location_offset", &self.location_offset);
         debug_struct.field("debug_message", &self.debug_message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10168,7 +10124,6 @@ impl std::fmt::Debug for LintPolicyResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LintPolicyResponse");
         debug_struct.field("lint_results", &self.lint_results);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/iam/credentials/v1/src/model.rs
+++ b/src/generated/iam/credentials/v1/src/model.rs
@@ -273,7 +273,6 @@ impl std::fmt::Debug for GenerateAccessTokenRequest {
         debug_struct.field("delegates", &self.delegates);
         debug_struct.field("scope", &self.scope);
         debug_struct.field("lifetime", &self.lifetime);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -453,7 +452,6 @@ impl std::fmt::Debug for GenerateAccessTokenResponse {
         let mut debug_struct = f.debug_struct("GenerateAccessTokenResponse");
         debug_struct.field("access_token", &self.access_token);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -677,7 +675,6 @@ impl std::fmt::Debug for SignBlobRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("delegates", &self.delegates);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -863,7 +860,6 @@ impl std::fmt::Debug for SignBlobResponse {
         let mut debug_struct = f.debug_struct("SignBlobResponse");
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("signed_blob", &self.signed_blob);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1069,7 +1065,6 @@ impl std::fmt::Debug for SignJwtRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("delegates", &self.delegates);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1237,7 +1232,6 @@ impl std::fmt::Debug for SignJwtResponse {
         let mut debug_struct = f.debug_struct("SignJwtResponse");
         debug_struct.field("key_id", &self.key_id);
         debug_struct.field("signed_jwt", &self.signed_jwt);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1471,7 +1465,6 @@ impl std::fmt::Debug for GenerateIdTokenRequest {
         debug_struct.field("delegates", &self.delegates);
         debug_struct.field("audience", &self.audience);
         debug_struct.field("include_email", &self.include_email);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1612,7 +1605,6 @@ impl std::fmt::Debug for GenerateIdTokenResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GenerateIdTokenResponse");
         debug_struct.field("token", &self.token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -246,7 +246,6 @@ impl std::fmt::Debug for SetIamPolicyRequest {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("policy", &self.policy);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -427,7 +426,6 @@ impl std::fmt::Debug for GetIamPolicyRequest {
         let mut debug_struct = f.debug_struct("GetIamPolicyRequest");
         debug_struct.field("resource", &self.resource);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -601,7 +599,6 @@ impl std::fmt::Debug for TestIamPermissionsRequest {
         let mut debug_struct = f.debug_struct("TestIamPermissionsRequest");
         debug_struct.field("resource", &self.resource);
         debug_struct.field("permissions", &self.permissions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -747,7 +744,6 @@ impl std::fmt::Debug for TestIamPermissionsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TestIamPermissionsResponse");
         debug_struct.field("permissions", &self.permissions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -931,7 +927,6 @@ impl std::fmt::Debug for GetPolicyOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyOptions");
         debug_struct.field("requested_policy_version", &self.requested_policy_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1306,7 +1301,6 @@ impl std::fmt::Debug for Policy {
         debug_struct.field("bindings", &self.bindings);
         debug_struct.field("audit_configs", &self.audit_configs);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1564,7 +1558,6 @@ impl std::fmt::Debug for Binding {
         debug_struct.field("role", &self.role);
         debug_struct.field("members", &self.members);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1793,7 +1786,6 @@ impl std::fmt::Debug for AuditConfig {
         let mut debug_struct = f.debug_struct("AuditConfig");
         debug_struct.field("service", &self.service);
         debug_struct.field("audit_log_configs", &self.audit_log_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1991,7 +1983,6 @@ impl std::fmt::Debug for AuditLogConfig {
         let mut debug_struct = f.debug_struct("AuditLogConfig");
         debug_struct.field("log_type", &self.log_type);
         debug_struct.field("exempted_members", &self.exempted_members);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2316,7 +2307,6 @@ impl std::fmt::Debug for PolicyDelta {
         let mut debug_struct = f.debug_struct("PolicyDelta");
         debug_struct.field("binding_deltas", &self.binding_deltas);
         debug_struct.field("audit_config_deltas", &self.audit_config_deltas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2551,7 +2541,6 @@ impl std::fmt::Debug for BindingDelta {
         debug_struct.field("role", &self.role);
         debug_struct.field("member", &self.member);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2918,7 +2907,6 @@ impl std::fmt::Debug for AuditConfigDelta {
         debug_struct.field("service", &self.service);
         debug_struct.field("exempted_member", &self.exempted_member);
         debug_struct.field("log_type", &self.log_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3248,7 +3236,6 @@ impl std::fmt::Debug for ResourcePolicyMember {
         let mut debug_struct = f.debug_struct("ResourcePolicyMember");
         debug_struct.field("iam_policy_name_principal", &self.iam_policy_name_principal);
         debug_struct.field("iam_policy_uid_principal", &self.iam_policy_uid_principal);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -361,7 +361,6 @@ impl std::fmt::Debug for DenyRule {
         debug_struct.field("denied_permissions", &self.denied_permissions);
         debug_struct.field("exception_permissions", &self.exception_permissions);
         debug_struct.field("denial_condition", &self.denial_condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -828,7 +827,6 @@ impl std::fmt::Debug for Policy {
         debug_struct.field("delete_time", &self.delete_time);
         debug_struct.field("rules", &self.rules);
         debug_struct.field("managing_authority", &self.managing_authority);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1036,7 +1034,6 @@ impl std::fmt::Debug for PolicyRule {
         let mut debug_struct = f.debug_struct("PolicyRule");
         debug_struct.field("description", &self.description);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1275,7 +1272,6 @@ impl std::fmt::Debug for ListPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1463,7 +1459,6 @@ impl std::fmt::Debug for ListPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListPoliciesResponse");
         debug_struct.field("policies", &self.policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1613,7 +1608,6 @@ impl std::fmt::Debug for GetPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1829,7 +1823,6 @@ impl std::fmt::Debug for CreatePolicyRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("policy", &self.policy);
         debug_struct.field("policy_id", &self.policy_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1986,7 +1979,6 @@ impl std::fmt::Debug for UpdatePolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UpdatePolicyRequest");
         debug_struct.field("policy", &self.policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2166,7 +2158,6 @@ impl std::fmt::Debug for DeletePolicyRequest {
         let mut debug_struct = f.debug_struct("DeletePolicyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2320,7 +2311,6 @@ impl std::fmt::Debug for PolicyOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PolicyOperationMetadata");
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -350,7 +350,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("status_message", &self.status_message);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("api_version", &self.api_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -884,7 +883,6 @@ impl std::fmt::Debug for PolicyBinding {
         debug_struct.field("condition", &self.condition);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1081,7 +1079,6 @@ pub mod policy_binding {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Target");
             debug_struct.field("target", &self.target);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1494,7 +1491,6 @@ impl std::fmt::Debug for CreatePolicyBindingRequest {
         debug_struct.field("policy_binding_id", &self.policy_binding_id);
         debug_struct.field("policy_binding", &self.policy_binding);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1643,7 +1639,6 @@ impl std::fmt::Debug for GetPolicyBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPolicyBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1864,7 +1859,6 @@ impl std::fmt::Debug for UpdatePolicyBindingRequest {
         debug_struct.field("policy_binding", &self.policy_binding);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2066,7 +2060,6 @@ impl std::fmt::Debug for DeletePolicyBindingRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2329,7 +2322,6 @@ impl std::fmt::Debug for ListPolicyBindingsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2516,7 +2508,6 @@ impl std::fmt::Debug for ListPolicyBindingsResponse {
         let mut debug_struct = f.debug_struct("ListPolicyBindingsResponse");
         debug_struct.field("policy_bindings", &self.policy_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2781,7 +2772,6 @@ impl std::fmt::Debug for SearchTargetPolicyBindingsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("parent", &self.parent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2968,7 +2958,6 @@ impl std::fmt::Debug for SearchTargetPolicyBindingsResponse {
         let mut debug_struct = f.debug_struct("SearchTargetPolicyBindingsResponse");
         debug_struct.field("policy_bindings", &self.policy_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3241,7 +3230,6 @@ impl std::fmt::Debug for CreatePrincipalAccessBoundaryPolicyRequest {
             &self.principal_access_boundary_policy,
         );
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3387,7 +3375,6 @@ impl std::fmt::Debug for GetPrincipalAccessBoundaryPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetPrincipalAccessBoundaryPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3626,7 +3613,6 @@ impl std::fmt::Debug for UpdatePrincipalAccessBoundaryPolicyRequest {
         );
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3852,7 +3838,6 @@ impl std::fmt::Debug for DeletePrincipalAccessBoundaryPolicyRequest {
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4081,7 +4066,6 @@ impl std::fmt::Debug for ListPrincipalAccessBoundaryPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4285,7 +4269,6 @@ impl std::fmt::Debug for ListPrincipalAccessBoundaryPoliciesResponse {
             &self.principal_access_boundary_policies,
         );
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4511,7 +4494,6 @@ impl std::fmt::Debug for SearchPrincipalAccessBoundaryPolicyBindingsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4703,7 +4685,6 @@ impl std::fmt::Debug for SearchPrincipalAccessBoundaryPolicyBindingsResponse {
             f.debug_struct("SearchPrincipalAccessBoundaryPolicyBindingsResponse");
         debug_struct.field("policy_bindings", &self.policy_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5078,7 +5059,6 @@ impl std::fmt::Debug for PrincipalAccessBoundaryPolicy {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5261,7 +5241,6 @@ impl std::fmt::Debug for PrincipalAccessBoundaryPolicyDetails {
         let mut debug_struct = f.debug_struct("PrincipalAccessBoundaryPolicyDetails");
         debug_struct.field("rules", &self.rules);
         debug_struct.field("enforcement_version", &self.enforcement_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5476,7 +5455,6 @@ impl std::fmt::Debug for PrincipalAccessBoundaryPolicyRule {
         debug_struct.field("description", &self.description);
         debug_struct.field("resources", &self.resources);
         debug_struct.field("effect", &self.effect);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -244,7 +244,6 @@ impl std::fmt::Debug for ListAccessPoliciesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -431,7 +430,6 @@ impl std::fmt::Debug for ListAccessPoliciesResponse {
         let mut debug_struct = f.debug_struct("ListAccessPoliciesResponse");
         debug_struct.field("access_policies", &self.access_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -575,7 +573,6 @@ impl std::fmt::Debug for GetAccessPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAccessPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -765,7 +762,6 @@ impl std::fmt::Debug for UpdateAccessPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateAccessPolicyRequest");
         debug_struct.field("policy", &self.policy);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -909,7 +905,6 @@ impl std::fmt::Debug for DeleteAccessPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAccessPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1160,7 +1155,6 @@ impl std::fmt::Debug for ListAccessLevelsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("access_level_format", &self.access_level_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1348,7 +1342,6 @@ impl std::fmt::Debug for ListAccessLevelsResponse {
         let mut debug_struct = f.debug_struct("ListAccessLevelsResponse");
         debug_struct.field("access_levels", &self.access_levels);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1530,7 +1523,6 @@ impl std::fmt::Debug for GetAccessLevelRequest {
         let mut debug_struct = f.debug_struct("GetAccessLevelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("access_level_format", &self.access_level_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1716,7 +1708,6 @@ impl std::fmt::Debug for CreateAccessLevelRequest {
         let mut debug_struct = f.debug_struct("CreateAccessLevelRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("access_level", &self.access_level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1911,7 +1902,6 @@ impl std::fmt::Debug for UpdateAccessLevelRequest {
         let mut debug_struct = f.debug_struct("UpdateAccessLevelRequest");
         debug_struct.field("access_level", &self.access_level);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2057,7 +2047,6 @@ impl std::fmt::Debug for DeleteAccessLevelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAccessLevelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2269,7 +2258,6 @@ impl std::fmt::Debug for ReplaceAccessLevelsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("access_levels", &self.access_levels);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2417,7 +2405,6 @@ impl std::fmt::Debug for ReplaceAccessLevelsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplaceAccessLevelsResponse");
         debug_struct.field("access_levels", &self.access_levels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2637,7 +2624,6 @@ impl std::fmt::Debug for ListServicePerimetersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2829,7 +2815,6 @@ impl std::fmt::Debug for ListServicePerimetersResponse {
         let mut debug_struct = f.debug_struct("ListServicePerimetersResponse");
         debug_struct.field("service_perimeters", &self.service_perimeters);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2975,7 +2960,6 @@ impl std::fmt::Debug for GetServicePerimeterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServicePerimeterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3162,7 +3146,6 @@ impl std::fmt::Debug for CreateServicePerimeterRequest {
         let mut debug_struct = f.debug_struct("CreateServicePerimeterRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_perimeter", &self.service_perimeter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3355,7 +3338,6 @@ impl std::fmt::Debug for UpdateServicePerimeterRequest {
         let mut debug_struct = f.debug_struct("UpdateServicePerimeterRequest");
         debug_struct.field("service_perimeter", &self.service_perimeter);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3501,7 +3483,6 @@ impl std::fmt::Debug for DeleteServicePerimeterRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServicePerimeterRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3717,7 +3698,6 @@ impl std::fmt::Debug for ReplaceServicePerimetersRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_perimeters", &self.service_perimeters);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3869,7 +3849,6 @@ impl std::fmt::Debug for ReplaceServicePerimetersResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplaceServicePerimetersResponse");
         debug_struct.field("service_perimeters", &self.service_perimeters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4052,7 +4031,6 @@ impl std::fmt::Debug for CommitServicePerimetersRequest {
         let mut debug_struct = f.debug_struct("CommitServicePerimetersRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4206,7 +4184,6 @@ impl std::fmt::Debug for CommitServicePerimetersResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CommitServicePerimetersResponse");
         debug_struct.field("service_perimeters", &self.service_perimeters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4423,7 +4400,6 @@ impl std::fmt::Debug for ListGcpUserAccessBindingsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4617,7 +4593,6 @@ impl std::fmt::Debug for ListGcpUserAccessBindingsResponse {
         let mut debug_struct = f.debug_struct("ListGcpUserAccessBindingsResponse");
         debug_struct.field("gcp_user_access_bindings", &self.gcp_user_access_bindings);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4760,7 +4735,6 @@ impl std::fmt::Debug for GetGcpUserAccessBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGcpUserAccessBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4941,7 +4915,6 @@ impl std::fmt::Debug for CreateGcpUserAccessBindingRequest {
         let mut debug_struct = f.debug_struct("CreateGcpUserAccessBindingRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("gcp_user_access_binding", &self.gcp_user_access_binding);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5139,7 +5112,6 @@ impl std::fmt::Debug for UpdateGcpUserAccessBindingRequest {
         let mut debug_struct = f.debug_struct("UpdateGcpUserAccessBindingRequest");
         debug_struct.field("gcp_user_access_binding", &self.gcp_user_access_binding);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5282,7 +5254,6 @@ impl std::fmt::Debug for DeleteGcpUserAccessBindingRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteGcpUserAccessBindingRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5399,7 +5370,6 @@ impl serde::ser::Serialize for GcpUserAccessBindingOperationMetadata {
 impl std::fmt::Debug for GcpUserAccessBindingOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GcpUserAccessBindingOperationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5514,7 +5484,6 @@ impl serde::ser::Serialize for AccessContextManagerOperationMetadata {
 impl std::fmt::Debug for AccessContextManagerOperationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AccessContextManagerOperationMetadata");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5901,7 +5870,6 @@ impl std::fmt::Debug for AccessLevel {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("level", &self.level);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6099,7 +6067,6 @@ impl std::fmt::Debug for BasicLevel {
         let mut debug_struct = f.debug_struct("BasicLevel");
         debug_struct.field("conditions", &self.conditions);
         debug_struct.field("combining_function", &self.combining_function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6547,7 +6514,6 @@ impl std::fmt::Debug for Condition {
         debug_struct.field("negate", &self.negate);
         debug_struct.field("members", &self.members);
         debug_struct.field("regions", &self.regions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6702,7 +6668,6 @@ impl std::fmt::Debug for CustomLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomLevel");
         debug_struct.field("expr", &self.expr);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7028,7 +6993,6 @@ impl std::fmt::Debug for DevicePolicy {
         );
         debug_struct.field("require_admin_approval", &self.require_admin_approval);
         debug_struct.field("require_corp_owned", &self.require_corp_owned);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7236,7 +7200,6 @@ impl std::fmt::Debug for OsConstraint {
             "require_verified_chrome_os",
             &self.require_verified_chrome_os,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7579,7 +7542,6 @@ impl std::fmt::Debug for AccessPolicy {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7790,7 +7752,6 @@ impl std::fmt::Debug for GcpUserAccessBinding {
         debug_struct.field("name", &self.name);
         debug_struct.field("group_key", &self.group_key);
         debug_struct.field("access_levels", &self.access_levels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8221,7 +8182,6 @@ impl std::fmt::Debug for ServicePerimeter {
         debug_struct.field("status", &self.status);
         debug_struct.field("spec", &self.spec);
         debug_struct.field("use_explicit_dry_run_spec", &self.use_explicit_dry_run_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8704,7 +8664,6 @@ impl std::fmt::Debug for ServicePerimeterConfig {
         debug_struct.field("vpc_accessible_services", &self.vpc_accessible_services);
         debug_struct.field("ingress_policies", &self.ingress_policies);
         debug_struct.field("egress_policies", &self.egress_policies);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8889,7 +8848,6 @@ pub mod service_perimeter_config {
             let mut debug_struct = f.debug_struct("VpcAccessibleServices");
             debug_struct.field("enable_restriction", &self.enable_restriction);
             debug_struct.field("allowed_services", &self.allowed_services);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9127,7 +9085,6 @@ pub mod service_perimeter_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MethodSelector");
             debug_struct.field("kind", &self.kind);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9344,7 +9301,6 @@ pub mod service_perimeter_config {
             let mut debug_struct = f.debug_struct("ApiOperation");
             debug_struct.field("service_name", &self.service_name);
             debug_struct.field("method_selectors", &self.method_selectors);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9591,7 +9547,6 @@ pub mod service_perimeter_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("IngressSource");
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9857,7 +9812,6 @@ pub mod service_perimeter_config {
             debug_struct.field("sources", &self.sources);
             debug_struct.field("identities", &self.identities);
             debug_struct.field("identity_type", &self.identity_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10059,7 +10013,6 @@ pub mod service_perimeter_config {
             let mut debug_struct = f.debug_struct("IngressTo");
             debug_struct.field("operations", &self.operations);
             debug_struct.field("resources", &self.resources);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10281,7 +10234,6 @@ pub mod service_perimeter_config {
             let mut debug_struct = f.debug_struct("IngressPolicy");
             debug_struct.field("ingress_from", &self.ingress_from);
             debug_struct.field("ingress_to", &self.ingress_to);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10476,7 +10428,6 @@ pub mod service_perimeter_config {
             let mut debug_struct = f.debug_struct("EgressFrom");
             debug_struct.field("identities", &self.identities);
             debug_struct.field("identity_type", &self.identity_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10718,7 +10669,6 @@ pub mod service_perimeter_config {
             debug_struct.field("resources", &self.resources);
             debug_struct.field("operations", &self.operations);
             debug_struct.field("external_resources", &self.external_resources);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10947,7 +10897,6 @@ pub mod service_perimeter_config {
             let mut debug_struct = f.debug_struct("EgressPolicy");
             debug_struct.field("egress_from", &self.egress_from);
             debug_struct.field("egress_to", &self.egress_to);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/logging/type/src/model.rs
+++ b/src/generated/logging/type/src/model.rs
@@ -637,7 +637,6 @@ impl std::fmt::Debug for HttpRequest {
         );
         debug_struct.field("cache_fill_bytes", &self.cache_fill_bytes);
         debug_struct.field("protocol", &self.protocol);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -862,7 +862,6 @@ impl std::fmt::Debug for LogEntry {
         debug_struct.field("source_location", &self.source_location);
         debug_struct.field("split", &self.split);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1109,7 +1108,6 @@ impl std::fmt::Debug for LogEntryOperation {
         debug_struct.field("producer", &self.producer);
         debug_struct.field("first", &self.first);
         debug_struct.field("last", &self.last);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1327,7 +1325,6 @@ impl std::fmt::Debug for LogEntrySourceLocation {
         debug_struct.field("file", &self.file);
         debug_struct.field("line", &self.line);
         debug_struct.field("function", &self.function);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1562,7 +1559,6 @@ impl std::fmt::Debug for LogSplit {
         debug_struct.field("uid", &self.uid);
         debug_struct.field("index", &self.index);
         debug_struct.field("total_splits", &self.total_splits);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1719,7 +1715,6 @@ impl std::fmt::Debug for DeleteLogRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteLogRequest");
         debug_struct.field("log_name", &self.log_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2082,7 +2077,6 @@ impl std::fmt::Debug for WriteLogEntriesRequest {
         debug_struct.field("entries", &self.entries);
         debug_struct.field("partial_success", &self.partial_success);
         debug_struct.field("dry_run", &self.dry_run);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2196,7 +2190,6 @@ impl serde::ser::Serialize for WriteLogEntriesResponse {
 impl std::fmt::Debug for WriteLogEntriesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WriteLogEntriesResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2381,7 +2374,6 @@ impl std::fmt::Debug for WriteLogEntriesPartialErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WriteLogEntriesPartialErrors");
         debug_struct.field("log_entry_errors", &self.log_entry_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2679,7 +2671,6 @@ impl std::fmt::Debug for ListLogEntriesRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2875,7 +2866,6 @@ impl std::fmt::Debug for ListLogEntriesResponse {
         let mut debug_struct = f.debug_struct("ListLogEntriesResponse");
         debug_struct.field("entries", &self.entries);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3068,7 +3058,6 @@ impl std::fmt::Debug for ListMonitoredResourceDescriptorsRequest {
         let mut debug_struct = f.debug_struct("ListMonitoredResourceDescriptorsRequest");
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3261,7 +3250,6 @@ impl std::fmt::Debug for ListMonitoredResourceDescriptorsResponse {
         let mut debug_struct = f.debug_struct("ListMonitoredResourceDescriptorsResponse");
         debug_struct.field("resource_descriptors", &self.resource_descriptors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3526,7 +3514,6 @@ impl std::fmt::Debug for ListLogsRequest {
         debug_struct.field("resource_names", &self.resource_names);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3702,7 +3689,6 @@ impl std::fmt::Debug for ListLogsResponse {
         let mut debug_struct = f.debug_struct("ListLogsResponse");
         debug_struct.field("log_names", &self.log_names);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3929,7 +3915,6 @@ impl std::fmt::Debug for TailLogEntriesRequest {
         debug_struct.field("resource_names", &self.resource_names);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("buffer_window", &self.buffer_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4115,7 +4100,6 @@ impl std::fmt::Debug for TailLogEntriesResponse {
         let mut debug_struct = f.debug_struct("TailLogEntriesResponse");
         debug_struct.field("entries", &self.entries);
         debug_struct.field("suppression_info", &self.suppression_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4313,7 +4297,6 @@ pub mod tail_log_entries_response {
             let mut debug_struct = f.debug_struct("SuppressionInfo");
             debug_struct.field("reason", &self.reason);
             debug_struct.field("suppressed_count", &self.suppressed_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4674,7 +4657,6 @@ impl std::fmt::Debug for IndexConfig {
         debug_struct.field("field_path", &self.field_path);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5166,7 +5148,6 @@ impl std::fmt::Debug for LogBucket {
         debug_struct.field("restricted_fields", &self.restricted_fields);
         debug_struct.field("index_configs", &self.index_configs);
         debug_struct.field("cmek_settings", &self.cmek_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5449,7 +5430,6 @@ impl std::fmt::Debug for LogView {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6024,7 +6004,6 @@ impl std::fmt::Debug for LogSink {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6319,7 +6298,6 @@ impl std::fmt::Debug for BigQueryDataset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryDataset");
         debug_struct.field("dataset_id", &self.dataset_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6608,7 +6586,6 @@ impl std::fmt::Debug for Link {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("lifecycle_state", &self.lifecycle_state);
         debug_struct.field("bigquery_dataset", &self.bigquery_dataset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6803,7 +6780,6 @@ impl std::fmt::Debug for BigQueryOptions {
             "uses_timestamp_column_partitioning",
             &self.uses_timestamp_column_partitioning,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7031,7 +7007,6 @@ impl std::fmt::Debug for ListBucketsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7218,7 +7193,6 @@ impl std::fmt::Debug for ListBucketsResponse {
         let mut debug_struct = f.debug_struct("ListBucketsResponse");
         debug_struct.field("buckets", &self.buckets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7434,7 +7408,6 @@ impl std::fmt::Debug for CreateBucketRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("bucket_id", &self.bucket_id);
         debug_struct.field("bucket", &self.bucket);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7667,7 +7640,6 @@ impl std::fmt::Debug for UpdateBucketRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7820,7 +7792,6 @@ impl std::fmt::Debug for GetBucketRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBucketRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7973,7 +7944,6 @@ impl std::fmt::Debug for DeleteBucketRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBucketRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8126,7 +8096,6 @@ impl std::fmt::Debug for UndeleteBucketRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UndeleteBucketRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8348,7 +8317,6 @@ impl std::fmt::Debug for ListViewsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8535,7 +8503,6 @@ impl std::fmt::Debug for ListViewsResponse {
         let mut debug_struct = f.debug_struct("ListViewsResponse");
         debug_struct.field("views", &self.views);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8749,7 +8716,6 @@ impl std::fmt::Debug for CreateViewRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("view_id", &self.view_id);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8979,7 +8945,6 @@ impl std::fmt::Debug for UpdateViewRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9129,7 +9094,6 @@ impl std::fmt::Debug for GetViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9279,7 +9243,6 @@ impl std::fmt::Debug for DeleteViewRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteViewRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9503,7 +9466,6 @@ impl std::fmt::Debug for ListSinksRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9690,7 +9652,6 @@ impl std::fmt::Debug for ListSinksResponse {
         let mut debug_struct = f.debug_struct("ListSinksResponse");
         debug_struct.field("sinks", &self.sinks);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9844,7 +9805,6 @@ impl std::fmt::Debug for GetSinkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSinkRequest");
         debug_struct.field("sink_name", &self.sink_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10074,7 +10034,6 @@ impl std::fmt::Debug for CreateSinkRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("sink", &self.sink);
         debug_struct.field("unique_writer_identity", &self.unique_writer_identity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10356,7 +10315,6 @@ impl std::fmt::Debug for UpdateSinkRequest {
         debug_struct.field("sink", &self.sink);
         debug_struct.field("unique_writer_identity", &self.unique_writer_identity);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10511,7 +10469,6 @@ impl std::fmt::Debug for DeleteSinkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSinkRequest");
         debug_struct.field("sink_name", &self.sink_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10724,7 +10681,6 @@ impl std::fmt::Debug for CreateLinkRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("link", &self.link);
         debug_struct.field("link_id", &self.link_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10871,7 +10827,6 @@ impl std::fmt::Debug for DeleteLinkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteLinkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11090,7 +11045,6 @@ impl std::fmt::Debug for ListLinksRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11277,7 +11231,6 @@ impl std::fmt::Debug for ListLinksResponse {
         let mut debug_struct = f.debug_struct("ListLinksResponse");
         debug_struct.field("links", &self.links);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11424,7 +11377,6 @@ impl std::fmt::Debug for GetLinkRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLinkRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11740,7 +11692,6 @@ impl std::fmt::Debug for LogExclusion {
         debug_struct.field("disabled", &self.disabled);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11964,7 +11915,6 @@ impl std::fmt::Debug for ListExclusionsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12151,7 +12101,6 @@ impl std::fmt::Debug for ListExclusionsResponse {
         let mut debug_struct = f.debug_struct("ListExclusionsResponse");
         debug_struct.field("exclusions", &self.exclusions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12304,7 +12253,6 @@ impl std::fmt::Debug for GetExclusionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetExclusionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12495,7 +12443,6 @@ impl std::fmt::Debug for CreateExclusionRequest {
         let mut debug_struct = f.debug_struct("CreateExclusionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("exclusion", &self.exclusion);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12731,7 +12678,6 @@ impl std::fmt::Debug for UpdateExclusionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("exclusion", &self.exclusion);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12884,7 +12830,6 @@ impl std::fmt::Debug for DeleteExclusionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteExclusionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13049,7 +12994,6 @@ impl std::fmt::Debug for GetCmekSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetCmekSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13299,7 +13243,6 @@ impl std::fmt::Debug for UpdateCmekSettingsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("cmek_settings", &self.cmek_settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13592,7 +13535,6 @@ impl std::fmt::Debug for CmekSettings {
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
         debug_struct.field("service_account_id", &self.service_account_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13757,7 +13699,6 @@ impl std::fmt::Debug for GetSettingsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSettingsRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14003,7 +13944,6 @@ impl std::fmt::Debug for UpdateSettingsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("settings", &self.settings);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14300,7 +14240,6 @@ impl std::fmt::Debug for Settings {
         debug_struct.field("kms_service_account_id", &self.kms_service_account_id);
         debug_struct.field("storage_location", &self.storage_location);
         debug_struct.field("disable_default_sink", &self.disable_default_sink);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14497,7 +14436,6 @@ impl std::fmt::Debug for CopyLogEntriesRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("destination", &self.destination);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14850,7 +14788,6 @@ impl std::fmt::Debug for CopyLogEntriesMetadata {
         debug_struct.field("request", &self.request);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("writer_identity", &self.writer_identity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15017,7 +14954,6 @@ impl std::fmt::Debug for CopyLogEntriesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CopyLogEntriesResponse");
         debug_struct.field("log_entries_copied_count", &self.log_entries_copied_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15366,7 +15302,6 @@ impl std::fmt::Debug for BucketMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("state", &self.state);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15730,7 +15665,6 @@ impl std::fmt::Debug for LinkMetadata {
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("state", &self.state);
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15889,7 +15823,6 @@ impl std::fmt::Debug for LocationMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LocationMetadata");
         debug_struct.field("log_analytics_enabled", &self.log_analytics_enabled);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16467,7 +16400,6 @@ impl std::fmt::Debug for LogMetric {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16819,7 +16751,6 @@ impl std::fmt::Debug for ListLogMetricsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17006,7 +16937,6 @@ impl std::fmt::Debug for ListLogMetricsResponse {
         let mut debug_struct = f.debug_struct("ListLogMetricsResponse");
         debug_struct.field("metrics", &self.metrics);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17153,7 +17083,6 @@ impl std::fmt::Debug for GetLogMetricRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetLogMetricRequest");
         debug_struct.field("metric_name", &self.metric_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17338,7 +17267,6 @@ impl std::fmt::Debug for CreateLogMetricRequest {
         let mut debug_struct = f.debug_struct("CreateLogMetricRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("metric", &self.metric);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17525,7 +17453,6 @@ impl std::fmt::Debug for UpdateLogMetricRequest {
         let mut debug_struct = f.debug_struct("UpdateLogMetricRequest");
         debug_struct.field("metric_name", &self.metric_name);
         debug_struct.field("metric", &self.metric);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17672,7 +17599,6 @@ impl std::fmt::Debug for DeleteLogMetricRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteLogMetricRequest");
         debug_struct.field("metric_name", &self.metric_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -348,7 +348,6 @@ impl std::fmt::Debug for Operation {
         debug_struct.field("metadata", &self.metadata);
         debug_struct.field("done", &self.done);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -519,7 +518,6 @@ impl std::fmt::Debug for GetOperationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOperationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -759,7 +757,6 @@ impl std::fmt::Debug for ListOperationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -947,7 +944,6 @@ impl std::fmt::Debug for ListOperationsResponse {
         let mut debug_struct = f.debug_struct("ListOperationsResponse");
         debug_struct.field("operations", &self.operations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1092,7 +1088,6 @@ impl std::fmt::Debug for CancelOperationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelOperationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1237,7 +1232,6 @@ impl std::fmt::Debug for DeleteOperationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteOperationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1418,7 +1412,6 @@ impl std::fmt::Debug for WaitOperationRequest {
         let mut debug_struct = f.debug_struct("WaitOperationRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("timeout", &self.timeout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1611,7 +1604,6 @@ impl std::fmt::Debug for OperationInfo {
         let mut debug_struct = f.debug_struct("OperationInfo");
         debug_struct.field("response_type", &self.response_type);
         debug_struct.field("metadata_type", &self.metadata_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -170,7 +170,6 @@ impl std::fmt::Debug for AlertChart {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AlertChart");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -313,7 +312,6 @@ impl std::fmt::Debug for CollapsibleGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CollapsibleGroup");
         debug_struct.field("collapsed", &self.collapsed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -627,7 +625,6 @@ impl std::fmt::Debug for Aggregation {
         debug_struct.field("per_series_aligner", &self.per_series_aligner);
         debug_struct.field("cross_series_reducer", &self.cross_series_reducer);
         debug_struct.field("group_by_fields", &self.group_by_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1506,7 +1503,6 @@ impl std::fmt::Debug for PickTimeSeriesFilter {
         debug_struct.field("num_time_series", &self.num_time_series);
         debug_struct.field("direction", &self.direction);
         debug_struct.field("interval", &self.interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2000,7 +1996,6 @@ impl std::fmt::Debug for StatisticalTimeSeriesFilter {
         let mut debug_struct = f.debug_struct("StatisticalTimeSeriesFilter");
         debug_struct.field("ranking_method", &self.ranking_method);
         debug_struct.field("num_time_series", &self.num_time_series);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2626,7 +2621,6 @@ impl std::fmt::Debug for Dashboard {
         debug_struct.field("dashboard_filters", &self.dashboard_filters);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("layout", &self.layout);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2918,7 +2912,6 @@ impl std::fmt::Debug for DashboardFilter {
         debug_struct.field("template_variable", &self.template_variable);
         debug_struct.field("filter_type", &self.filter_type);
         debug_struct.field("default_value", &self.default_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3296,7 +3289,6 @@ impl std::fmt::Debug for CreateDashboardRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("dashboard", &self.dashboard);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3516,7 +3508,6 @@ impl std::fmt::Debug for ListDashboardsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3703,7 +3694,6 @@ impl std::fmt::Debug for ListDashboardsResponse {
         let mut debug_struct = f.debug_struct("ListDashboardsResponse");
         debug_struct.field("dashboards", &self.dashboards);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3849,7 +3839,6 @@ impl std::fmt::Debug for GetDashboardRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDashboardRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3995,7 +3984,6 @@ impl std::fmt::Debug for DeleteDashboardRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDashboardRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4175,7 +4163,6 @@ impl std::fmt::Debug for UpdateDashboardRequest {
         let mut debug_struct = f.debug_struct("UpdateDashboardRequest");
         debug_struct.field("dashboard", &self.dashboard);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4391,7 +4378,6 @@ impl std::fmt::Debug for ErrorReportingPanel {
         debug_struct.field("project_names", &self.project_names);
         debug_struct.field("services", &self.services);
         debug_struct.field("versions", &self.versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4575,7 +4561,6 @@ impl std::fmt::Debug for IncidentList {
         let mut debug_struct = f.debug_struct("IncidentList");
         debug_struct.field("monitored_resources", &self.monitored_resources);
         debug_struct.field("policy_names", &self.policy_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4765,7 +4750,6 @@ impl std::fmt::Debug for GridLayout {
         let mut debug_struct = f.debug_struct("GridLayout");
         debug_struct.field("columns", &self.columns);
         debug_struct.field("widgets", &self.widgets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4960,7 +4944,6 @@ impl std::fmt::Debug for MosaicLayout {
         let mut debug_struct = f.debug_struct("MosaicLayout");
         debug_struct.field("columns", &self.columns);
         debug_struct.field("tiles", &self.tiles);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5301,7 +5284,6 @@ pub mod mosaic_layout {
             debug_struct.field("width", &self.width);
             debug_struct.field("height", &self.height);
             debug_struct.field("widget", &self.widget);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5452,7 +5434,6 @@ impl std::fmt::Debug for RowLayout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RowLayout");
         debug_struct.field("rows", &self.rows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5651,7 +5632,6 @@ pub mod row_layout {
             let mut debug_struct = f.debug_struct("Row");
             debug_struct.field("weight", &self.weight);
             debug_struct.field("widgets", &self.widgets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5802,7 +5782,6 @@ impl std::fmt::Debug for ColumnLayout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ColumnLayout");
         debug_struct.field("columns", &self.columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6001,7 +5980,6 @@ pub mod column_layout {
             let mut debug_struct = f.debug_struct("Column");
             debug_struct.field("weight", &self.weight);
             debug_struct.field("widgets", &self.widgets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6177,7 +6155,6 @@ impl std::fmt::Debug for LogsPanel {
         let mut debug_struct = f.debug_struct("LogsPanel");
         debug_struct.field("filter", &self.filter);
         debug_struct.field("resource_names", &self.resource_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6602,7 +6579,6 @@ impl std::fmt::Debug for TimeSeriesQuery {
         debug_struct.field("unit_override", &self.unit_override);
         debug_struct.field("output_full_duration", &self.output_full_duration);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6978,7 +6954,6 @@ impl std::fmt::Debug for TimeSeriesFilter {
         debug_struct.field("aggregation", &self.aggregation);
         debug_struct.field("secondary_aggregation", &self.secondary_aggregation);
         debug_struct.field("output_filter", &self.output_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7365,7 +7340,6 @@ impl std::fmt::Debug for TimeSeriesFilterRatio {
         debug_struct.field("denominator", &self.denominator);
         debug_struct.field("secondary_aggregation", &self.secondary_aggregation);
         debug_struct.field("output_filter", &self.output_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7557,7 +7531,6 @@ pub mod time_series_filter_ratio {
             let mut debug_struct = f.debug_struct("RatioPart");
             debug_struct.field("filter", &self.filter);
             debug_struct.field("aggregation", &self.aggregation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7841,7 +7814,6 @@ impl std::fmt::Debug for Threshold {
         debug_struct.field("color", &self.color);
         debug_struct.field("direction", &self.direction);
         debug_struct.field("target_axis", &self.target_axis);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8451,7 +8423,6 @@ impl std::fmt::Debug for PieChart {
         debug_struct.field("data_sets", &self.data_sets);
         debug_struct.field("chart_type", &self.chart_type);
         debug_struct.field("show_labels", &self.show_labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8689,7 +8660,6 @@ pub mod pie_chart {
             debug_struct.field("time_series_query", &self.time_series_query);
             debug_struct.field("slice_name_template", &self.slice_name_template);
             debug_struct.field("min_alignment_period", &self.min_alignment_period);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9221,7 +9191,6 @@ impl std::fmt::Debug for Scorecard {
         debug_struct.field("time_series_query", &self.time_series_query);
         debug_struct.field("thresholds", &self.thresholds);
         debug_struct.field("data_view", &self.data_view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9440,7 +9409,6 @@ pub mod scorecard {
             let mut debug_struct = f.debug_struct("GaugeView");
             debug_struct.field("lower_bound", &self.lower_bound);
             debug_struct.field("upper_bound", &self.upper_bound);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9631,7 +9599,6 @@ pub mod scorecard {
             let mut debug_struct = f.debug_struct("SparkChartView");
             debug_struct.field("spark_chart_type", &self.spark_chart_type);
             debug_struct.field("min_alignment_period", &self.min_alignment_period);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9815,7 +9782,6 @@ impl std::fmt::Debug for SectionHeader {
         let mut debug_struct = f.debug_struct("SectionHeader");
         debug_struct.field("subtitle", &self.subtitle);
         debug_struct.field("divider_below", &self.divider_below);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9931,7 +9897,6 @@ impl serde::ser::Serialize for SingleViewGroup {
 impl std::fmt::Debug for SingleViewGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SingleViewGroup");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10147,7 +10112,6 @@ impl std::fmt::Debug for TimeSeriesTable {
         debug_struct.field("data_sets", &self.data_sets);
         debug_struct.field("metric_visualization", &self.metric_visualization);
         debug_struct.field("column_settings", &self.column_settings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10421,7 +10385,6 @@ pub mod time_series_table {
             debug_struct.field("table_template", &self.table_template);
             debug_struct.field("min_alignment_period", &self.min_alignment_period);
             debug_struct.field("table_display_options", &self.table_display_options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10591,7 +10554,6 @@ pub mod time_series_table {
             let mut debug_struct = f.debug_struct("ColumnSettings");
             debug_struct.field("column", &self.column);
             debug_struct.field("visible", &self.visible);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10873,7 +10835,6 @@ impl std::fmt::Debug for TableDisplayOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TableDisplayOptions");
         debug_struct.field("shown_columns", &self.shown_columns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11077,7 +11038,6 @@ impl std::fmt::Debug for Text {
         debug_struct.field("content", &self.content);
         debug_struct.field("format", &self.format);
         debug_struct.field("style", &self.style);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11418,7 +11378,6 @@ pub mod text {
             debug_struct.field("padding", &self.padding);
             debug_struct.field("font_size", &self.font_size);
             debug_struct.field("pointer_location", &self.pointer_location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13225,7 +13184,6 @@ impl std::fmt::Debug for Widget {
         debug_struct.field("title", &self.title);
         debug_struct.field("id", &self.id);
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13635,7 +13593,6 @@ impl std::fmt::Debug for XyChart {
         debug_struct.field("y_axis", &self.y_axis);
         debug_struct.field("y2_axis", &self.y2_axis);
         debug_struct.field("chart_options", &self.chart_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13934,7 +13891,6 @@ pub mod xy_chart {
             debug_struct.field("legend_template", &self.legend_template);
             debug_struct.field("min_alignment_period", &self.min_alignment_period);
             debug_struct.field("target_axis", &self.target_axis);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14404,7 +14360,6 @@ pub mod xy_chart {
             let mut debug_struct = f.debug_struct("Axis");
             debug_struct.field("label", &self.label);
             debug_struct.field("scale", &self.scale);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14689,7 +14644,6 @@ impl std::fmt::Debug for ChartOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ChartOptions");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/monitoring/metricsscope/v1/src/model.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/model.rs
@@ -281,7 +281,6 @@ impl std::fmt::Debug for MetricsScope {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("monitored_projects", &self.monitored_projects);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -466,7 +465,6 @@ impl std::fmt::Debug for MonitoredProject {
         let mut debug_struct = f.debug_struct("MonitoredProject");
         debug_struct.field("name", &self.name);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -610,7 +608,6 @@ impl std::fmt::Debug for GetMetricsScopeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMetricsScopeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -770,7 +767,6 @@ impl std::fmt::Debug for ListMetricsScopesByMonitoredProjectRequest {
             "monitored_resource_container",
             &self.monitored_resource_container,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -919,7 +915,6 @@ impl std::fmt::Debug for ListMetricsScopesByMonitoredProjectResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListMetricsScopesByMonitoredProjectResponse");
         debug_struct.field("metrics_scopes", &self.metrics_scopes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1105,7 +1100,6 @@ impl std::fmt::Debug for CreateMonitoredProjectRequest {
         let mut debug_struct = f.debug_struct("CreateMonitoredProjectRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("monitored_project", &self.monitored_project);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1253,7 +1247,6 @@ impl std::fmt::Debug for DeleteMonitoredProjectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteMonitoredProjectRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1471,7 +1464,6 @@ impl std::fmt::Debug for OperationMetadata {
         debug_struct.field("state", &self.state);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -645,7 +645,6 @@ impl std::fmt::Debug for AlertPolicy {
         debug_struct.field("mutation_record", &self.mutation_record);
         debug_struct.field("alert_strategy", &self.alert_strategy);
         debug_struct.field("severity", &self.severity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -900,7 +899,6 @@ pub mod alert_policy {
             debug_struct.field("mime_type", &self.mime_type);
             debug_struct.field("subject", &self.subject);
             debug_struct.field("links", &self.links);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1089,7 +1087,6 @@ pub mod alert_policy {
                 let mut debug_struct = f.debug_struct("Link");
                 debug_struct.field("display_name", &self.display_name);
                 debug_struct.field("url", &self.url);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -1691,7 +1688,6 @@ pub mod alert_policy {
             debug_struct.field("name", &self.name);
             debug_struct.field("display_name", &self.display_name);
             debug_struct.field("condition", &self.condition);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1986,7 +1982,6 @@ pub mod alert_policy {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("Trigger");
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2559,7 +2554,6 @@ pub mod alert_policy {
                 debug_struct.field("duration", &self.duration);
                 debug_struct.field("trigger", &self.trigger);
                 debug_struct.field("evaluation_missing_data", &self.evaluation_missing_data);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2738,7 +2732,6 @@ pub mod alert_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("ForecastOptions");
                     debug_struct.field("forecast_horizon", &self.forecast_horizon);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -3031,7 +3024,6 @@ pub mod alert_policy {
                 debug_struct.field("aggregations", &self.aggregations);
                 debug_struct.field("duration", &self.duration);
                 debug_struct.field("trigger", &self.trigger);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3234,7 +3226,6 @@ pub mod alert_policy {
                 let mut debug_struct = f.debug_struct("LogMatch");
                 debug_struct.field("filter", &self.filter);
                 debug_struct.field("label_extractors", &self.label_extractors);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3514,7 +3505,6 @@ pub mod alert_policy {
                 debug_struct.field("duration", &self.duration);
                 debug_struct.field("trigger", &self.trigger);
                 debug_struct.field("evaluation_missing_data", &self.evaluation_missing_data);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3955,7 +3945,6 @@ pub mod alert_policy {
                 debug_struct.field("rule_group", &self.rule_group);
                 debug_struct.field("alert_rule", &self.alert_rule);
                 debug_struct.field("disable_metric_validation", &self.disable_metric_validation);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4493,7 +4482,6 @@ pub mod alert_policy {
                 debug_struct.field("query", &self.query);
                 debug_struct.field("schedule", &self.schedule);
                 debug_struct.field("evaluate", &self.evaluate);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4683,7 +4671,6 @@ pub mod alert_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("Minutes");
                     debug_struct.field("periodicity", &self.periodicity);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -4938,7 +4925,6 @@ pub mod alert_policy {
                     let mut debug_struct = f.debug_struct("Hourly");
                     debug_struct.field("periodicity", &self.periodicity);
                     debug_struct.field("minute_offset", &self.minute_offset);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -5163,7 +5149,6 @@ pub mod alert_policy {
                     let mut debug_struct = f.debug_struct("Daily");
                     debug_struct.field("periodicity", &self.periodicity);
                     debug_struct.field("execution_time", &self.execution_time);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -5376,7 +5361,6 @@ pub mod alert_policy {
                     let mut debug_struct = f.debug_struct("RowCountTest");
                     debug_struct.field("comparison", &self.comparison);
                     debug_struct.field("threshold", &self.threshold);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -5538,7 +5522,6 @@ pub mod alert_policy {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     let mut debug_struct = f.debug_struct("BooleanTest");
                     debug_struct.field("column", &self.column);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -6039,7 +6022,6 @@ pub mod alert_policy {
                 "notification_channel_strategy",
                 &self.notification_channel_strategy,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6204,7 +6186,6 @@ pub mod alert_policy {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("NotificationRateLimit");
                 debug_struct.field("period", &self.period);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -6417,7 +6398,6 @@ pub mod alert_policy {
                     &self.notification_channel_names,
                 );
                 debug_struct.field("renotify_interval", &self.renotify_interval);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -7041,7 +7021,6 @@ impl std::fmt::Debug for CreateAlertPolicyRequest {
         let mut debug_struct = f.debug_struct("CreateAlertPolicyRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("alert_policy", &self.alert_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7187,7 +7166,6 @@ impl std::fmt::Debug for GetAlertPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAlertPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7476,7 +7454,6 @@ impl std::fmt::Debug for ListAlertPoliciesRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7709,7 +7686,6 @@ impl std::fmt::Debug for ListAlertPoliciesResponse {
         debug_struct.field("alert_policies", &self.alert_policies);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7923,7 +7899,6 @@ impl std::fmt::Debug for UpdateAlertPolicyRequest {
         let mut debug_struct = f.debug_struct("UpdateAlertPolicyRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("alert_policy", &self.alert_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8073,7 +8048,6 @@ impl std::fmt::Debug for DeleteAlertPolicyRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAlertPolicyRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8486,7 +8460,6 @@ impl std::fmt::Debug for TypedValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TypedValue");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8740,7 +8713,6 @@ impl std::fmt::Debug for TimeInterval {
         let mut debug_struct = f.debug_struct("TimeInterval");
         debug_struct.field("end_time", &self.end_time);
         debug_struct.field("start_time", &self.start_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9057,7 +9029,6 @@ impl std::fmt::Debug for Aggregation {
         debug_struct.field("per_series_aligner", &self.per_series_aligner);
         debug_struct.field("cross_series_reducer", &self.cross_series_reducer);
         debug_struct.field("group_by_fields", &self.group_by_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9840,7 +9811,6 @@ impl std::fmt::Debug for DroppedLabels {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DroppedLabels");
         debug_struct.field("label", &self.label);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10126,7 +10096,6 @@ impl std::fmt::Debug for Group {
         debug_struct.field("parent_name", &self.parent_name);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("is_cluster", &self.is_cluster);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10522,7 +10491,6 @@ impl std::fmt::Debug for ListGroupsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10753,7 +10721,6 @@ impl std::fmt::Debug for ListGroupsResponse {
         let mut debug_struct = f.debug_struct("ListGroupsResponse");
         debug_struct.field("group", &self.group);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10899,7 +10866,6 @@ impl std::fmt::Debug for GetGroupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGroupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11110,7 +11076,6 @@ impl std::fmt::Debug for CreateGroupRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("group", &self.group);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11291,7 +11256,6 @@ impl std::fmt::Debug for UpdateGroupRequest {
         let mut debug_struct = f.debug_struct("UpdateGroupRequest");
         debug_struct.field("group", &self.group);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11465,7 +11429,6 @@ impl std::fmt::Debug for DeleteGroupRequest {
         let mut debug_struct = f.debug_struct("DeleteGroupRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("recursive", &self.recursive);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11756,7 +11719,6 @@ impl std::fmt::Debug for ListGroupMembersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("interval", &self.interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11991,7 +11953,6 @@ impl std::fmt::Debug for ListGroupMembersResponse {
         debug_struct.field("members", &self.members);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12188,7 +12149,6 @@ impl std::fmt::Debug for Point {
         let mut debug_struct = f.debug_struct("Point");
         debug_struct.field("interval", &self.interval);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12583,7 +12543,6 @@ impl std::fmt::Debug for TimeSeries {
         debug_struct.field("points", &self.points);
         debug_struct.field("unit", &self.unit);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12764,7 +12723,6 @@ impl std::fmt::Debug for TimeSeriesDescriptor {
         let mut debug_struct = f.debug_struct("TimeSeriesDescriptor");
         debug_struct.field("label_descriptors", &self.label_descriptors);
         debug_struct.field("point_descriptors", &self.point_descriptors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13004,7 +12962,6 @@ pub mod time_series_descriptor {
             debug_struct.field("value_type", &self.value_type);
             debug_struct.field("metric_kind", &self.metric_kind);
             debug_struct.field("unit", &self.unit);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13188,7 +13145,6 @@ impl std::fmt::Debug for TimeSeriesData {
         let mut debug_struct = f.debug_struct("TimeSeriesData");
         debug_struct.field("label_values", &self.label_values);
         debug_struct.field("point_data", &self.point_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13385,7 +13341,6 @@ pub mod time_series_data {
             let mut debug_struct = f.debug_struct("PointData");
             debug_struct.field("values", &self.values);
             debug_struct.field("time_interval", &self.time_interval);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13678,7 +13633,6 @@ impl std::fmt::Debug for LabelValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LabelValue");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13875,7 +13829,6 @@ impl std::fmt::Debug for QueryError {
         let mut debug_struct = f.debug_struct("QueryError");
         debug_struct.field("locator", &self.locator);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14187,7 +14140,6 @@ impl std::fmt::Debug for TextLocator {
         debug_struct.field("end_position", &self.end_position);
         debug_struct.field("nested_locator", &self.nested_locator);
         debug_struct.field("nesting_reason", &self.nesting_reason);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14399,7 +14351,6 @@ pub mod text_locator {
             let mut debug_struct = f.debug_struct("Position");
             debug_struct.field("line", &self.line);
             debug_struct.field("column", &self.column);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14653,7 +14604,6 @@ impl std::fmt::Debug for ListMonitoredResourceDescriptorsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14847,7 +14797,6 @@ impl std::fmt::Debug for ListMonitoredResourceDescriptorsResponse {
         let mut debug_struct = f.debug_struct("ListMonitoredResourceDescriptorsResponse");
         debug_struct.field("resource_descriptors", &self.resource_descriptors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14997,7 +14946,6 @@ impl std::fmt::Debug for GetMonitoredResourceDescriptorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMonitoredResourceDescriptorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15290,7 +15238,6 @@ impl std::fmt::Debug for ListMetricDescriptorsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("active_only", &self.active_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15483,7 +15430,6 @@ impl std::fmt::Debug for ListMetricDescriptorsResponse {
         let mut debug_struct = f.debug_struct("ListMetricDescriptorsResponse");
         debug_struct.field("metric_descriptors", &self.metric_descriptors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15633,7 +15579,6 @@ impl std::fmt::Debug for GetMetricDescriptorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetMetricDescriptorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15818,7 +15763,6 @@ impl std::fmt::Debug for CreateMetricDescriptorRequest {
         let mut debug_struct = f.debug_struct("CreateMetricDescriptorRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("metric_descriptor", &self.metric_descriptor);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15968,7 +15912,6 @@ impl std::fmt::Debug for DeleteMetricDescriptorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteMetricDescriptorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16403,7 +16346,6 @@ impl std::fmt::Debug for ListTimeSeriesRequest {
         debug_struct.field("view", &self.view);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16784,7 +16726,6 @@ impl std::fmt::Debug for ListTimeSeriesResponse {
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("execution_errors", &self.execution_errors);
         debug_struct.field("unit", &self.unit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16967,7 +16908,6 @@ impl std::fmt::Debug for CreateTimeSeriesRequest {
         let mut debug_struct = f.debug_struct("CreateTimeSeriesRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("time_series", &self.time_series);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17163,7 +17103,6 @@ impl std::fmt::Debug for CreateTimeSeriesError {
         let mut debug_struct = f.debug_struct("CreateTimeSeriesError");
         debug_struct.field("time_series", &self.time_series);
         debug_struct.field("status", &self.status);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17402,7 +17341,6 @@ impl std::fmt::Debug for CreateTimeSeriesSummary {
         debug_struct.field("total_point_count", &self.total_point_count);
         debug_struct.field("success_point_count", &self.success_point_count);
         debug_struct.field("errors", &self.errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17608,7 +17546,6 @@ pub mod create_time_series_summary {
             let mut debug_struct = f.debug_struct("Error");
             debug_struct.field("status", &self.status);
             debug_struct.field("point_count", &self.point_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17859,7 +17796,6 @@ impl std::fmt::Debug for QueryTimeSeriesRequest {
         debug_struct.field("query", &self.query);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18122,7 +18058,6 @@ impl std::fmt::Debug for QueryTimeSeriesResponse {
         debug_struct.field("time_series_data", &self.time_series_data);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("partial_errors", &self.partial_errors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18294,7 +18229,6 @@ impl std::fmt::Debug for QueryErrorList {
         let mut debug_struct = f.debug_struct("QueryErrorList");
         debug_struct.field("errors", &self.errors);
         debug_struct.field("error_summary", &self.error_summary);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18474,7 +18408,6 @@ impl std::fmt::Debug for MutationRecord {
         let mut debug_struct = f.debug_struct("MutationRecord");
         debug_struct.field("mutate_time", &self.mutate_time);
         debug_struct.field("mutated_by", &self.mutated_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18798,7 +18731,6 @@ impl std::fmt::Debug for NotificationChannelDescriptor {
         debug_struct.field("labels", &self.labels);
         debug_struct.field("supported_tiers", &self.supported_tiers);
         debug_struct.field("launch_stage", &self.launch_stage);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19290,7 +19222,6 @@ impl std::fmt::Debug for NotificationChannel {
         debug_struct.field("enabled", &self.enabled);
         debug_struct.field("creation_record", &self.creation_record);
         debug_struct.field("mutation_records", &self.mutation_records);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19674,7 +19605,6 @@ impl std::fmt::Debug for ListNotificationChannelDescriptorsRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19870,7 +19800,6 @@ impl std::fmt::Debug for ListNotificationChannelDescriptorsResponse {
         let mut debug_struct = f.debug_struct("ListNotificationChannelDescriptorsResponse");
         debug_struct.field("channel_descriptors", &self.channel_descriptors);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20017,7 +19946,6 @@ impl std::fmt::Debug for GetNotificationChannelDescriptorRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNotificationChannelDescriptorRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20207,7 +20135,6 @@ impl std::fmt::Debug for CreateNotificationChannelRequest {
         let mut debug_struct = f.debug_struct("CreateNotificationChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("notification_channel", &self.notification_channel);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20498,7 +20425,6 @@ impl std::fmt::Debug for ListNotificationChannelsRequest {
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20736,7 +20662,6 @@ impl std::fmt::Debug for ListNotificationChannelsResponse {
         debug_struct.field("notification_channels", &self.notification_channels);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20882,7 +20807,6 @@ impl std::fmt::Debug for GetNotificationChannelRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetNotificationChannelRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21076,7 +21000,6 @@ impl std::fmt::Debug for UpdateNotificationChannelRequest {
         let mut debug_struct = f.debug_struct("UpdateNotificationChannelRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("notification_channel", &self.notification_channel);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21250,7 +21173,6 @@ impl std::fmt::Debug for DeleteNotificationChannelRequest {
         let mut debug_struct = f.debug_struct("DeleteNotificationChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("force", &self.force);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21394,7 +21316,6 @@ impl std::fmt::Debug for SendNotificationChannelVerificationCodeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SendNotificationChannelVerificationCodeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21585,7 +21506,6 @@ impl std::fmt::Debug for GetNotificationChannelVerificationCodeRequest {
         let mut debug_struct = f.debug_struct("GetNotificationChannelVerificationCodeRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21771,7 +21691,6 @@ impl std::fmt::Debug for GetNotificationChannelVerificationCodeResponse {
         let mut debug_struct = f.debug_struct("GetNotificationChannelVerificationCodeResponse");
         debug_struct.field("code", &self.code);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -21944,7 +21863,6 @@ impl std::fmt::Debug for VerifyNotificationChannelRequest {
         let mut debug_struct = f.debug_struct("VerifyNotificationChannelRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("code", &self.code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22806,7 +22724,6 @@ impl std::fmt::Debug for Service {
         debug_struct.field("telemetry", &self.telemetry);
         debug_struct.field("user_labels", &self.user_labels);
         debug_struct.field("identifier", &self.identifier);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -22930,7 +22847,6 @@ pub mod service {
     impl std::fmt::Debug for Custom {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Custom");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23078,7 +22994,6 @@ pub mod service {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AppEngine");
             debug_struct.field("module_id", &self.module_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23225,7 +23140,6 @@ pub mod service {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CloudEndpoints");
             debug_struct.field("service", &self.service);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23465,7 +23379,6 @@ pub mod service {
             debug_struct.field("cluster_name", &self.cluster_name);
             debug_struct.field("service_namespace", &self.service_namespace);
             debug_struct.field("service_name", &self.service_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23673,7 +23586,6 @@ pub mod service {
             debug_struct.field("mesh_uid", &self.mesh_uid);
             debug_struct.field("service_namespace", &self.service_namespace);
             debug_struct.field("service_name", &self.service_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -23896,7 +23808,6 @@ pub mod service {
                 &self.canonical_service_namespace,
             );
             debug_struct.field("canonical_service", &self.canonical_service);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24074,7 +23985,6 @@ pub mod service {
             let mut debug_struct = f.debug_struct("CloudRun");
             debug_struct.field("service_name", &self.service_name);
             debug_struct.field("location", &self.location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24307,7 +24217,6 @@ pub mod service {
             debug_struct.field("location", &self.location);
             debug_struct.field("cluster_name", &self.cluster_name);
             debug_struct.field("namespace_name", &self.namespace_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24606,7 +24515,6 @@ pub mod service {
             debug_struct.field("namespace_name", &self.namespace_name);
             debug_struct.field("top_level_controller_type", &self.top_level_controller_type);
             debug_struct.field("top_level_controller_name", &self.top_level_controller_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24871,7 +24779,6 @@ pub mod service {
             debug_struct.field("cluster_name", &self.cluster_name);
             debug_struct.field("namespace_name", &self.namespace_name);
             debug_struct.field("service_name", &self.service_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25065,7 +24972,6 @@ pub mod service {
             let mut debug_struct = f.debug_struct("BasicService");
             debug_struct.field("service_type", &self.service_type);
             debug_struct.field("service_labels", &self.service_labels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25215,7 +25121,6 @@ pub mod service {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Telemetry");
             debug_struct.field("resource_name", &self.resource_name);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25666,7 +25571,6 @@ impl std::fmt::Debug for ServiceLevelObjective {
         debug_struct.field("goal", &self.goal);
         debug_struct.field("user_labels", &self.user_labels);
         debug_struct.field("period", &self.period);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26143,7 +26047,6 @@ impl std::fmt::Debug for ServiceLevelIndicator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ServiceLevelIndicator");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26509,7 +26412,6 @@ impl std::fmt::Debug for BasicSli {
         debug_struct.field("location", &self.location);
         debug_struct.field("version", &self.version);
         debug_struct.field("sli_criteria", &self.sli_criteria);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26631,7 +26533,6 @@ pub mod basic_sli {
     impl std::fmt::Debug for AvailabilityCriteria {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AvailabilityCriteria");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26788,7 +26689,6 @@ pub mod basic_sli {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LatencyCriteria");
             debug_struct.field("threshold", &self.threshold);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -27004,7 +26904,6 @@ impl std::fmt::Debug for Range {
         let mut debug_struct = f.debug_struct("Range");
         debug_struct.field("min", &self.min);
         debug_struct.field("max", &self.max);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27256,7 +27155,6 @@ impl std::fmt::Debug for RequestBasedSli {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RequestBasedSli");
         debug_struct.field("method", &self.method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27495,7 +27393,6 @@ impl std::fmt::Debug for TimeSeriesRatio {
         debug_struct.field("good_service_filter", &self.good_service_filter);
         debug_struct.field("bad_service_filter", &self.bad_service_filter);
         debug_struct.field("total_service_filter", &self.total_service_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27684,7 +27581,6 @@ impl std::fmt::Debug for DistributionCut {
         let mut debug_struct = f.debug_struct("DistributionCut");
         debug_struct.field("distribution_filter", &self.distribution_filter);
         debug_struct.field("range", &self.range);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28090,7 +27986,6 @@ impl std::fmt::Debug for WindowsBasedSli {
         let mut debug_struct = f.debug_struct("WindowsBasedSli");
         debug_struct.field("window_period", &self.window_period);
         debug_struct.field("window_criterion", &self.window_criterion);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28393,7 +28288,6 @@ pub mod windows_based_sli {
             let mut debug_struct = f.debug_struct("PerformanceThreshold");
             debug_struct.field("threshold", &self.threshold);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28597,7 +28491,6 @@ pub mod windows_based_sli {
             let mut debug_struct = f.debug_struct("MetricRange");
             debug_struct.field("time_series", &self.time_series);
             debug_struct.field("range", &self.range);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -28829,7 +28722,6 @@ impl std::fmt::Debug for CreateServiceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("service_id", &self.service_id);
         debug_struct.field("service", &self.service);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28975,7 +28867,6 @@ impl std::fmt::Debug for GetServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29239,7 +29130,6 @@ impl std::fmt::Debug for ListServicesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29426,7 +29316,6 @@ impl std::fmt::Debug for ListServicesResponse {
         let mut debug_struct = f.debug_struct("ListServicesResponse");
         debug_struct.field("services", &self.services);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29617,7 +29506,6 @@ impl std::fmt::Debug for UpdateServiceRequest {
         let mut debug_struct = f.debug_struct("UpdateServiceRequest");
         debug_struct.field("service", &self.service);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29763,7 +29651,6 @@ impl std::fmt::Debug for DeleteServiceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29986,7 +29873,6 @@ impl std::fmt::Debug for CreateServiceLevelObjectiveRequest {
             &self.service_level_objective_id,
         );
         debug_struct.field("service_level_objective", &self.service_level_objective);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30166,7 +30052,6 @@ impl std::fmt::Debug for GetServiceLevelObjectiveRequest {
         let mut debug_struct = f.debug_struct("GetServiceLevelObjectiveRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30445,7 +30330,6 @@ impl std::fmt::Debug for ListServiceLevelObjectivesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("view", &self.view);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30639,7 +30523,6 @@ impl std::fmt::Debug for ListServiceLevelObjectivesResponse {
         let mut debug_struct = f.debug_struct("ListServiceLevelObjectivesResponse");
         debug_struct.field("service_level_objectives", &self.service_level_objectives);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30831,7 +30714,6 @@ impl std::fmt::Debug for UpdateServiceLevelObjectiveRequest {
         let mut debug_struct = f.debug_struct("UpdateServiceLevelObjectiveRequest");
         debug_struct.field("service_level_objective", &self.service_level_objective);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30978,7 +30860,6 @@ impl std::fmt::Debug for DeleteServiceLevelObjectiveRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteServiceLevelObjectiveRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31234,7 +31115,6 @@ impl std::fmt::Debug for Snooze {
         debug_struct.field("criteria", &self.criteria);
         debug_struct.field("interval", &self.interval);
         debug_struct.field("display_name", &self.display_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31439,7 +31319,6 @@ pub mod snooze {
             let mut debug_struct = f.debug_struct("Criteria");
             debug_struct.field("policies", &self.policies);
             debug_struct.field("filter", &self.filter);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31626,7 +31505,6 @@ impl std::fmt::Debug for CreateSnoozeRequest {
         let mut debug_struct = f.debug_struct("CreateSnoozeRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("snooze", &self.snooze);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31886,7 +31764,6 @@ impl std::fmt::Debug for ListSnoozesRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32073,7 +31950,6 @@ impl std::fmt::Debug for ListSnoozesResponse {
         let mut debug_struct = f.debug_struct("ListSnoozesResponse");
         debug_struct.field("snoozes", &self.snoozes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32220,7 +32096,6 @@ impl std::fmt::Debug for GetSnoozeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSnoozeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32443,7 +32318,6 @@ impl std::fmt::Debug for UpdateSnoozeRequest {
         let mut debug_struct = f.debug_struct("UpdateSnoozeRequest");
         debug_struct.field("snooze", &self.snooze);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32607,7 +32481,6 @@ impl std::fmt::Debug for SpanContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SpanContext");
         debug_struct.field("span_name", &self.span_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32892,7 +32765,6 @@ impl std::fmt::Debug for InternalChecker {
         debug_struct.field("gcp_zone", &self.gcp_zone);
         debug_struct.field("peer_project_id", &self.peer_project_id);
         debug_struct.field("state", &self.state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33234,7 +33106,6 @@ impl std::fmt::Debug for SyntheticMonitorTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SyntheticMonitorTarget");
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33426,7 +33297,6 @@ pub mod synthetic_monitor_target {
             let mut debug_struct = f.debug_struct("CloudFunctionV2Target");
             debug_struct.field("name", &self.name);
             debug_struct.field("cloud_run_revision", &self.cloud_run_revision);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34253,7 +34123,6 @@ impl std::fmt::Debug for UptimeCheckConfig {
         debug_struct.field("user_labels", &self.user_labels);
         debug_struct.field("resource", &self.resource);
         debug_struct.field("check_request_type", &self.check_request_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34434,7 +34303,6 @@ pub mod uptime_check_config {
             let mut debug_struct = f.debug_struct("ResourceGroup");
             debug_struct.field("group_id", &self.group_id);
             debug_struct.field("resource_type", &self.resource_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34601,7 +34469,6 @@ pub mod uptime_check_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PingConfig");
             debug_struct.field("pings_count", &self.pings_count);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35303,7 +35170,6 @@ pub mod uptime_check_config {
             );
             debug_struct.field("ping_config", &self.ping_config);
             debug_struct.field("auth_method", &self.auth_method);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -35494,7 +35360,6 @@ pub mod uptime_check_config {
                 let mut debug_struct = f.debug_struct("BasicAuthentication");
                 debug_struct.field("username", &self.username);
                 debug_struct.field("password", &self.password);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -35765,7 +35630,6 @@ pub mod uptime_check_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ResponseStatusCode");
                 debug_struct.field("status_code", &self.status_code);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -36095,7 +35959,6 @@ pub mod uptime_check_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ServiceAgentAuthentication");
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -36723,7 +36586,6 @@ pub mod uptime_check_config {
             let mut debug_struct = f.debug_struct("TcpCheck");
             debug_struct.field("port", &self.port);
             debug_struct.field("ping_config", &self.ping_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -36991,7 +36853,6 @@ pub mod uptime_check_config {
             debug_struct.field("content", &self.content);
             debug_struct.field("matcher", &self.matcher);
             debug_struct.field("additional_matcher_info", &self.additional_matcher_info);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -37181,7 +37042,6 @@ pub mod uptime_check_config {
                 let mut debug_struct = f.debug_struct("JsonPathMatcher");
                 debug_struct.field("json_path", &self.json_path);
                 debug_struct.field("json_matcher", &self.json_matcher);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -37896,7 +37756,6 @@ impl std::fmt::Debug for UptimeCheckIp {
         debug_struct.field("region", &self.region);
         debug_struct.field("location", &self.location);
         debug_struct.field("ip_address", &self.ip_address);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38148,7 +38007,6 @@ impl std::fmt::Debug for ListUptimeCheckConfigsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38387,7 +38245,6 @@ impl std::fmt::Debug for ListUptimeCheckConfigsResponse {
         debug_struct.field("uptime_check_configs", &self.uptime_check_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38533,7 +38390,6 @@ impl std::fmt::Debug for GetUptimeCheckConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetUptimeCheckConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38719,7 +38575,6 @@ impl std::fmt::Debug for CreateUptimeCheckConfigRequest {
         let mut debug_struct = f.debug_struct("CreateUptimeCheckConfigRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("uptime_check_config", &self.uptime_check_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38924,7 +38779,6 @@ impl std::fmt::Debug for UpdateUptimeCheckConfigRequest {
         let mut debug_struct = f.debug_struct("UpdateUptimeCheckConfigRequest");
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("uptime_check_config", &self.uptime_check_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39070,7 +38924,6 @@ impl std::fmt::Debug for DeleteUptimeCheckConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteUptimeCheckConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39264,7 +39117,6 @@ impl std::fmt::Debug for ListUptimeCheckIpsRequest {
         let mut debug_struct = f.debug_struct("ListUptimeCheckIpsRequest");
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -39456,7 +39308,6 @@ impl std::fmt::Debug for ListUptimeCheckIpsResponse {
         let mut debug_struct = f.debug_struct("ListUptimeCheckIpsResponse");
         debug_struct.field("uptime_check_ips", &self.uptime_check_ips);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/openapi-validation/src/model.rs
+++ b/src/generated/openapi-validation/src/model.rs
@@ -217,7 +217,6 @@ impl std::fmt::Debug for ListLocationsResponse {
         let mut debug_struct = f.debug_struct("ListLocationsResponse");
         debug_struct.field("locations", &self.locations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -520,7 +519,6 @@ impl std::fmt::Debug for Location {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("labels", &self.labels);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -775,7 +773,6 @@ impl std::fmt::Debug for ListSecretsResponse {
         debug_struct.field("secrets", &self.secrets);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1435,7 +1432,6 @@ impl std::fmt::Debug for Secret {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1624,7 +1620,6 @@ impl std::fmt::Debug for Replication {
         let mut debug_struct = f.debug_struct("Replication");
         debug_struct.field("automatic", &self.automatic);
         debug_struct.field("user_managed", &self.user_managed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1791,7 +1786,6 @@ impl std::fmt::Debug for Automatic {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1944,7 +1938,6 @@ impl std::fmt::Debug for CustomerManagedEncryption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomerManagedEncryption");
         debug_struct.field("kms_key_name", &self.kms_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2092,7 +2085,6 @@ impl std::fmt::Debug for UserManaged {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserManaged");
         debug_struct.field("replicas", &self.replicas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2296,7 +2288,6 @@ impl std::fmt::Debug for Replica {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2443,7 +2434,6 @@ impl std::fmt::Debug for Topic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Topic");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2643,7 +2633,6 @@ impl std::fmt::Debug for Rotation {
         let mut debug_struct = f.debug_struct("Rotation");
         debug_struct.field("next_rotation_time", &self.next_rotation_time);
         debug_struct.field("rotation_period", &self.rotation_period);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2862,7 +2851,6 @@ impl std::fmt::Debug for AddSecretVersionRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3103,7 +3091,6 @@ impl std::fmt::Debug for SecretPayload {
         let mut debug_struct = f.debug_struct("SecretPayload");
         debug_struct.field("data", &self.data);
         debug_struct.field("data_crc_32_c", &self.data_crc_32_c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3581,7 +3568,6 @@ impl std::fmt::Debug for SecretVersion {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3780,7 +3766,6 @@ impl std::fmt::Debug for ReplicationStatus {
         let mut debug_struct = f.debug_struct("ReplicationStatus");
         debug_struct.field("automatic", &self.automatic);
         debug_struct.field("user_managed", &self.user_managed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3948,7 +3933,6 @@ impl std::fmt::Debug for AutomaticStatus {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4095,7 +4079,6 @@ impl std::fmt::Debug for CustomerManagedEncryptionStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CustomerManagedEncryptionStatus");
         debug_struct.field("kms_key_version_name", &self.kms_key_version_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4244,7 +4227,6 @@ impl std::fmt::Debug for UserManagedStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UserManagedStatus");
         debug_struct.field("replicas", &self.replicas);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4446,7 +4428,6 @@ impl std::fmt::Debug for ReplicaStatus {
             "customer_managed_encryption",
             &self.customer_managed_encryption,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4568,7 +4549,6 @@ impl serde::ser::Serialize for Empty {
 impl std::fmt::Debug for Empty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Empty");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4823,7 +4803,6 @@ impl std::fmt::Debug for ListSecretVersionsResponse {
         debug_struct.field("versions", &self.versions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("total_size", &self.total_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5014,7 +4993,6 @@ impl std::fmt::Debug for AccessSecretVersionResponse {
         let mut debug_struct = f.debug_struct("AccessSecretVersionResponse");
         debug_struct.field("name", &self.name);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5259,7 +5237,6 @@ impl std::fmt::Debug for DisableSecretVersionRequest {
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5504,7 +5481,6 @@ impl std::fmt::Debug for EnableSecretVersionRequest {
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5749,7 +5725,6 @@ impl std::fmt::Debug for DestroySecretVersionRequest {
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6011,7 +5986,6 @@ impl std::fmt::Debug for SetIamPolicyRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6410,7 +6384,6 @@ impl std::fmt::Debug for Policy {
         debug_struct.field("bindings", &self.bindings);
         debug_struct.field("audit_configs", &self.audit_configs);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6721,7 +6694,6 @@ impl std::fmt::Debug for Binding {
         debug_struct.field("role", &self.role);
         debug_struct.field("members", &self.members);
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7025,7 +6997,6 @@ impl std::fmt::Debug for Expr {
         debug_struct.field("title", &self.title);
         debug_struct.field("description", &self.description);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7264,7 +7235,6 @@ impl std::fmt::Debug for AuditConfig {
         let mut debug_struct = f.debug_struct("AuditConfig");
         debug_struct.field("service", &self.service);
         debug_struct.field("audit_log_configs", &self.audit_log_configs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7467,7 +7437,6 @@ impl std::fmt::Debug for AuditLogConfig {
         let mut debug_struct = f.debug_struct("AuditLogConfig");
         debug_struct.field("log_type", &self.log_type);
         debug_struct.field("exempted_members", &self.exempted_members);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7681,7 +7650,6 @@ impl std::fmt::Debug for TestIamPermissionsRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7827,7 +7795,6 @@ impl std::fmt::Debug for TestIamPermissionsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TestIamPermissionsResponse");
         debug_struct.field("permissions", &self.permissions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8075,7 +8042,6 @@ impl std::fmt::Debug for ListLocationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8234,7 +8200,6 @@ impl std::fmt::Debug for GetLocationRequest {
         let mut debug_struct = f.debug_struct("GetLocationRequest");
         debug_struct.field("project", &self.project);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8485,7 +8450,6 @@ impl std::fmt::Debug for ListSecretsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8682,7 +8646,6 @@ impl std::fmt::Debug for CreateSecretRequest {
         debug_struct.field("request_body", &self.request_body);
         debug_struct.field("project", &self.project);
         debug_struct.field("secret_id", &self.secret_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8958,7 +8921,6 @@ impl std::fmt::Debug for ListSecretsByProjectAndLocationRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9180,7 +9142,6 @@ impl std::fmt::Debug for CreateSecretByProjectAndLocationRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("location", &self.location);
         debug_struct.field("secret_id", &self.secret_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9339,7 +9300,6 @@ impl std::fmt::Debug for GetSecretRequest {
         let mut debug_struct = f.debug_struct("GetSecretRequest");
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9533,7 +9493,6 @@ impl std::fmt::Debug for DeleteSecretRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9750,7 +9709,6 @@ impl std::fmt::Debug for UpdateSecretRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9935,7 +9893,6 @@ impl std::fmt::Debug for GetSecretByProjectAndLocationAndSecretRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("location", &self.location);
         debug_struct.field("secret", &self.secret);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10155,7 +10112,6 @@ impl std::fmt::Debug for DeleteSecretByProjectAndLocationAndSecretRequest {
         debug_struct.field("location", &self.location);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10398,7 +10354,6 @@ impl std::fmt::Debug for UpdateSecretByProjectAndLocationAndSecretRequest {
         debug_struct.field("location", &self.location);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10673,7 +10628,6 @@ impl std::fmt::Debug for ListSecretVersionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10973,7 +10927,6 @@ impl std::fmt::Debug for ListSecretVersionsByProjectAndLocationAndSecretRequest 
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11156,7 +11109,6 @@ impl std::fmt::Debug for GetSecretVersionRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11368,7 +11320,6 @@ impl std::fmt::Debug for GetSecretVersionByProjectAndLocationAndSecretAndVersion
         debug_struct.field("location", &self.location);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11551,7 +11502,6 @@ impl std::fmt::Debug for AccessSecretVersionRequest {
         debug_struct.field("project", &self.project);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11763,7 +11713,6 @@ impl std::fmt::Debug for AccessSecretVersionByProjectAndLocationAndSecretAndVers
         debug_struct.field("location", &self.location);
         debug_struct.field("secret", &self.secret);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11990,7 +11939,6 @@ impl std::fmt::Debug for GetIamPolicyRequest {
             "options_requested_policy_version",
             &self.options_requested_policy_version,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12243,7 +12191,6 @@ impl std::fmt::Debug for GetIamPolicyByProjectAndLocationAndSecretRequest {
             "options_requested_policy_version",
             &self.options_requested_policy_version,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/oslogin/common/src/model.rs
+++ b/src/generated/oslogin/common/src/model.rs
@@ -450,7 +450,6 @@ impl std::fmt::Debug for PosixAccount {
         debug_struct.field("account_id", &self.account_id);
         debug_struct.field("operating_system_type", &self.operating_system_type);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -688,7 +687,6 @@ impl std::fmt::Debug for SshPublicKey {
         debug_struct.field("expiration_time_usec", &self.expiration_time_usec);
         debug_struct.field("fingerprint", &self.fingerprint);
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -177,7 +177,6 @@ impl std::fmt::Debug for ExcludeInfoTypes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ExcludeInfoTypes");
         debug_struct.field("info_types", &self.info_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -374,7 +373,6 @@ impl std::fmt::Debug for ExcludeByHotword {
         let mut debug_struct = f.debug_struct("ExcludeByHotword");
         debug_struct.field("hotword_regex", &self.hotword_regex);
         debug_struct.field("proximity", &self.proximity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -759,7 +757,6 @@ impl std::fmt::Debug for ExclusionRule {
         let mut debug_struct = f.debug_struct("ExclusionRule");
         debug_struct.field("matching_type", &self.matching_type);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1027,7 +1024,6 @@ impl std::fmt::Debug for InspectionRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InspectionRule");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1222,7 +1218,6 @@ impl std::fmt::Debug for InspectionRuleSet {
         let mut debug_struct = f.debug_struct("InspectionRuleSet");
         debug_struct.field("info_types", &self.info_types);
         debug_struct.field("rules", &self.rules);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1674,7 +1669,6 @@ impl std::fmt::Debug for InspectConfig {
         debug_struct.field("custom_info_types", &self.custom_info_types);
         debug_struct.field("content_options", &self.content_options);
         debug_struct.field("rule_set", &self.rule_set);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1872,7 +1866,6 @@ pub mod inspect_config {
             let mut debug_struct = f.debug_struct("InfoTypeLikelihood");
             debug_struct.field("info_type", &self.info_type);
             debug_struct.field("min_likelihood", &self.min_likelihood);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2160,7 +2153,6 @@ pub mod inspect_config {
                 "max_findings_per_info_type",
                 &self.max_findings_per_info_type,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2382,7 +2374,6 @@ pub mod inspect_config {
                 let mut debug_struct = f.debug_struct("InfoTypeLimit");
                 debug_struct.field("info_type", &self.info_type);
                 debug_struct.field("max_findings", &self.max_findings);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -2570,7 +2561,6 @@ impl std::fmt::Debug for ByteContentItem {
         let mut debug_struct = f.debug_struct("ByteContentItem");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("data", &self.data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3102,7 +3092,6 @@ impl std::fmt::Debug for ContentItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ContentItem");
         debug_struct.field("data_item", &self.data_item);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3297,7 +3286,6 @@ impl std::fmt::Debug for Table {
         let mut debug_struct = f.debug_struct("Table");
         debug_struct.field("headers", &self.headers);
         debug_struct.field("rows", &self.rows);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3450,7 +3438,6 @@ pub mod table {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Row");
             debug_struct.field("values", &self.values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3627,7 +3614,6 @@ impl std::fmt::Debug for InspectResult {
         let mut debug_struct = f.debug_struct("InspectResult");
         debug_struct.field("findings", &self.findings);
         debug_struct.field("findings_truncated", &self.findings_truncated);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4165,7 +4151,6 @@ impl std::fmt::Debug for Finding {
         debug_struct.field("job_create_time", &self.job_create_time);
         debug_struct.field("job_name", &self.job_name);
         debug_struct.field("finding_id", &self.finding_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4432,7 +4417,6 @@ impl std::fmt::Debug for Location {
         debug_struct.field("codepoint_range", &self.codepoint_range);
         debug_struct.field("content_locations", &self.content_locations);
         debug_struct.field("container", &self.container);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4905,7 +4889,6 @@ impl std::fmt::Debug for ContentLocation {
         debug_struct.field("container_timestamp", &self.container_timestamp);
         debug_struct.field("container_version", &self.container_version);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5142,7 +5125,6 @@ impl std::fmt::Debug for MetadataLocation {
         let mut debug_struct = f.debug_struct("MetadataLocation");
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("label", &self.label);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5299,7 +5281,6 @@ impl std::fmt::Debug for StorageMetadataLabel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StorageMetadataLabel");
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5461,7 +5442,6 @@ impl std::fmt::Debug for DocumentLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DocumentLocation");
         debug_struct.field("file_offset", &self.file_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5689,7 +5669,6 @@ impl std::fmt::Debug for RecordLocation {
         debug_struct.field("record_key", &self.record_key);
         debug_struct.field("field_id", &self.field_id);
         debug_struct.field("table_location", &self.table_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5855,7 +5834,6 @@ impl std::fmt::Debug for TableLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TableLocation");
         debug_struct.field("row_index", &self.row_index);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6185,7 +6163,6 @@ impl std::fmt::Debug for Container {
         debug_struct.field("relative_path", &self.relative_path);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6388,7 +6365,6 @@ impl std::fmt::Debug for Range {
         let mut debug_struct = f.debug_struct("Range");
         debug_struct.field("start", &self.start);
         debug_struct.field("end", &self.end);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6534,7 +6510,6 @@ impl std::fmt::Debug for ImageLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImageLocation");
         debug_struct.field("bounding_boxes", &self.bounding_boxes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6823,7 +6798,6 @@ impl std::fmt::Debug for BoundingBox {
         debug_struct.field("left", &self.left);
         debug_struct.field("width", &self.width);
         debug_struct.field("height", &self.height);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7147,7 +7121,6 @@ impl std::fmt::Debug for RedactImageRequest {
         debug_struct.field("image_redaction_configs", &self.image_redaction_configs);
         debug_struct.field("include_findings", &self.include_findings);
         debug_struct.field("byte_item", &self.byte_item);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7434,7 +7407,6 @@ pub mod redact_image_request {
             let mut debug_struct = f.debug_struct("ImageRedactionConfig");
             debug_struct.field("redaction_color", &self.redaction_color);
             debug_struct.field("target", &self.target);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7701,7 +7673,6 @@ impl std::fmt::Debug for Color {
         debug_struct.field("red", &self.red);
         debug_struct.field("green", &self.green);
         debug_struct.field("blue", &self.blue);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7928,7 +7899,6 @@ impl std::fmt::Debug for RedactImageResponse {
         debug_struct.field("redacted_image", &self.redacted_image);
         debug_struct.field("extracted_text", &self.extracted_text);
         debug_struct.field("inspect_result", &self.inspect_result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8307,7 +8277,6 @@ impl std::fmt::Debug for DeidentifyContentRequest {
         debug_struct.field("inspect_template_name", &self.inspect_template_name);
         debug_struct.field("deidentify_template_name", &self.deidentify_template_name);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8496,7 +8465,6 @@ impl std::fmt::Debug for DeidentifyContentResponse {
         let mut debug_struct = f.debug_struct("DeidentifyContentResponse");
         debug_struct.field("item", &self.item);
         debug_struct.field("overview", &self.overview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8871,7 +8839,6 @@ impl std::fmt::Debug for ReidentifyContentRequest {
         debug_struct.field("inspect_template_name", &self.inspect_template_name);
         debug_struct.field("reidentify_template_name", &self.reidentify_template_name);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9060,7 +9027,6 @@ impl std::fmt::Debug for ReidentifyContentResponse {
         let mut debug_struct = f.debug_struct("ReidentifyContentResponse");
         debug_struct.field("item", &self.item);
         debug_struct.field("overview", &self.overview);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9352,7 +9318,6 @@ impl std::fmt::Debug for InspectContentRequest {
         debug_struct.field("item", &self.item);
         debug_struct.field("inspect_template_name", &self.inspect_template_name);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9505,7 +9470,6 @@ impl std::fmt::Debug for InspectContentResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InspectContentResponse");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9732,7 +9696,6 @@ impl std::fmt::Debug for OutputStorageConfig {
         let mut debug_struct = f.debug_struct("OutputStorageConfig");
         debug_struct.field("output_schema", &self.output_schema);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10111,7 +10074,6 @@ impl std::fmt::Debug for InfoTypeStats {
         let mut debug_struct = f.debug_struct("InfoTypeStats");
         debug_struct.field("info_type", &self.info_type);
         debug_struct.field("count", &self.count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10304,7 +10266,6 @@ impl std::fmt::Debug for InspectDataSourceDetails {
         let mut debug_struct = f.debug_struct("InspectDataSourceDetails");
         debug_struct.field("requested_options", &self.requested_options);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10512,7 +10473,6 @@ pub mod inspect_data_source_details {
             let mut debug_struct = f.debug_struct("RequestedOptions");
             debug_struct.field("snapshot_inspect_template", &self.snapshot_inspect_template);
             debug_struct.field("job_config", &self.job_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10840,7 +10800,6 @@ pub mod inspect_data_source_details {
             debug_struct.field("info_type_stats", &self.info_type_stats);
             debug_struct.field("num_rows_processed", &self.num_rows_processed);
             debug_struct.field("hybrid_stats", &self.hybrid_stats);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11147,7 +11106,6 @@ impl std::fmt::Debug for DataProfileBigQueryRowSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataProfileBigQueryRowSchema");
         debug_struct.field("data_profile", &self.data_profile);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11422,7 +11380,6 @@ impl std::fmt::Debug for HybridInspectStatistics {
         debug_struct.field("processed_count", &self.processed_count);
         debug_struct.field("aborted_count", &self.aborted_count);
         debug_struct.field("pending_count", &self.pending_count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11617,7 +11574,6 @@ impl std::fmt::Debug for ActionDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ActionDetails");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11893,7 +11849,6 @@ impl std::fmt::Debug for DeidentifyDataSourceStats {
             "transformation_error_count",
             &self.transformation_error_count,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12093,7 +12048,6 @@ impl std::fmt::Debug for DeidentifyDataSourceDetails {
         let mut debug_struct = f.debug_struct("DeidentifyDataSourceDetails");
         debug_struct.field("requested_options", &self.requested_options);
         debug_struct.field("deidentify_stats", &self.deidentify_stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12377,7 +12331,6 @@ pub mod deidentify_data_source_details {
                 "snapshot_image_redact_template",
                 &self.snapshot_image_redact_template,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12765,7 +12718,6 @@ impl std::fmt::Debug for InfoTypeDescription {
         debug_struct.field("categories", &self.categories);
         debug_struct.field("sensitivity_score", &self.sensitivity_score);
         debug_struct.field("specific_info_types", &self.specific_info_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13075,7 +13027,6 @@ impl std::fmt::Debug for InfoTypeCategory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InfoTypeCategory");
         debug_struct.field("category", &self.category);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14057,7 +14008,6 @@ impl std::fmt::Debug for VersionDescription {
         let mut debug_struct = f.debug_struct("VersionDescription");
         debug_struct.field("version", &self.version);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14285,7 +14235,6 @@ impl std::fmt::Debug for ListInfoTypesRequest {
         debug_struct.field("language_code", &self.language_code);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14435,7 +14384,6 @@ impl std::fmt::Debug for ListInfoTypesResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ListInfoTypesResponse");
         debug_struct.field("info_types", &self.info_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14657,7 +14605,6 @@ impl std::fmt::Debug for RiskAnalysisJobConfig {
         debug_struct.field("privacy_metric", &self.privacy_metric);
         debug_struct.field("source_table", &self.source_table);
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14967,7 +14914,6 @@ impl std::fmt::Debug for QuasiId {
         let mut debug_struct = f.debug_struct("QuasiId");
         debug_struct.field("field", &self.field);
         debug_struct.field("tag", &self.tag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15226,7 +15172,6 @@ impl std::fmt::Debug for StatisticalTable {
         debug_struct.field("table", &self.table);
         debug_struct.field("quasi_ids", &self.quasi_ids);
         debug_struct.field("relative_frequency", &self.relative_frequency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15416,7 +15361,6 @@ pub mod statistical_table {
             let mut debug_struct = f.debug_struct("QuasiIdentifierField");
             debug_struct.field("field", &self.field);
             debug_struct.field("custom_tag", &self.custom_tag);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15916,7 +15860,6 @@ impl std::fmt::Debug for PrivacyMetric {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrivacyMetric");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16079,7 +16022,6 @@ pub mod privacy_metric {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NumericalStatsConfig");
             debug_struct.field("field", &self.field);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16239,7 +16181,6 @@ pub mod privacy_metric {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CategoricalStatsConfig");
             debug_struct.field("field", &self.field);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16438,7 +16379,6 @@ pub mod privacy_metric {
             let mut debug_struct = f.debug_struct("KAnonymityConfig");
             debug_struct.field("quasi_ids", &self.quasi_ids);
             debug_struct.field("entity_id", &self.entity_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16626,7 +16566,6 @@ pub mod privacy_metric {
             let mut debug_struct = f.debug_struct("LDiversityConfig");
             debug_struct.field("quasi_ids", &self.quasi_ids);
             debug_struct.field("sensitive_attribute", &self.sensitive_attribute);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16846,7 +16785,6 @@ pub mod privacy_metric {
             debug_struct.field("quasi_ids", &self.quasi_ids);
             debug_struct.field("region_code", &self.region_code);
             debug_struct.field("auxiliary_tables", &self.auxiliary_tables);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -17195,7 +17133,6 @@ pub mod privacy_metric {
                 let mut debug_struct = f.debug_struct("TaggedField");
                 debug_struct.field("field", &self.field);
                 debug_struct.field("tag", &self.tag);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17460,7 +17397,6 @@ pub mod privacy_metric {
                 debug_struct.field("table", &self.table);
                 debug_struct.field("quasi_ids", &self.quasi_ids);
                 debug_struct.field("relative_frequency", &self.relative_frequency);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -17665,7 +17601,6 @@ pub mod privacy_metric {
                     let mut debug_struct = f.debug_struct("QuasiIdField");
                     debug_struct.field("field", &self.field);
                     debug_struct.field("custom_tag", &self.custom_tag);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -17883,7 +17818,6 @@ pub mod privacy_metric {
             debug_struct.field("quasi_ids", &self.quasi_ids);
             debug_struct.field("region_code", &self.region_code);
             debug_struct.field("auxiliary_tables", &self.auxiliary_tables);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18534,7 +18468,6 @@ impl std::fmt::Debug for AnalyzeDataSourceRiskDetails {
         debug_struct.field("requested_source_table", &self.requested_source_table);
         debug_struct.field("requested_options", &self.requested_options);
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18763,7 +18696,6 @@ pub mod analyze_data_source_risk_details {
             debug_struct.field("min_value", &self.min_value);
             debug_struct.field("max_value", &self.max_value);
             debug_struct.field("quantile_values", &self.quantile_values);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -18923,7 +18855,6 @@ pub mod analyze_data_source_risk_details {
                 "value_frequency_histogram_buckets",
                 &self.value_frequency_histogram_buckets,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19314,7 +19245,6 @@ pub mod analyze_data_source_risk_details {
                 debug_struct.field("bucket_size", &self.bucket_size);
                 debug_struct.field("bucket_values", &self.bucket_values);
                 debug_struct.field("bucket_value_count", &self.bucket_value_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -19476,7 +19406,6 @@ pub mod analyze_data_source_risk_details {
                 "equivalence_class_histogram_buckets",
                 &self.equivalence_class_histogram_buckets,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19695,7 +19624,6 @@ pub mod analyze_data_source_risk_details {
                 let mut debug_struct = f.debug_struct("KAnonymityEquivalenceClass");
                 debug_struct.field("quasi_ids_values", &self.quasi_ids_values);
                 debug_struct.field("equivalence_class_size", &self.equivalence_class_size);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -20081,7 +20009,6 @@ pub mod analyze_data_source_risk_details {
                 debug_struct.field("bucket_size", &self.bucket_size);
                 debug_struct.field("bucket_values", &self.bucket_values);
                 debug_struct.field("bucket_value_count", &self.bucket_value_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -20245,7 +20172,6 @@ pub mod analyze_data_source_risk_details {
                 "sensitive_value_frequency_histogram_buckets",
                 &self.sensitive_value_frequency_histogram_buckets,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -20562,7 +20488,6 @@ pub mod analyze_data_source_risk_details {
                     &self.num_distinct_sensitive_values,
                 );
                 debug_struct.field("top_sensitive_values", &self.top_sensitive_values);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -20950,7 +20875,6 @@ pub mod analyze_data_source_risk_details {
                 debug_struct.field("bucket_size", &self.bucket_size);
                 debug_struct.field("bucket_values", &self.bucket_values);
                 debug_struct.field("bucket_value_count", &self.bucket_value_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -21117,7 +21041,6 @@ pub mod analyze_data_source_risk_details {
                 "k_map_estimation_histogram",
                 &self.k_map_estimation_histogram,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -21329,7 +21252,6 @@ pub mod analyze_data_source_risk_details {
                 let mut debug_struct = f.debug_struct("KMapEstimationQuasiIdValues");
                 debug_struct.field("quasi_ids_values", &self.quasi_ids_values);
                 debug_struct.field("estimated_anonymity", &self.estimated_anonymity);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -21693,7 +21615,6 @@ pub mod analyze_data_source_risk_details {
                 debug_struct.field("bucket_size", &self.bucket_size);
                 debug_struct.field("bucket_values", &self.bucket_values);
                 debug_struct.field("bucket_value_count", &self.bucket_value_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -21863,7 +21784,6 @@ pub mod analyze_data_source_risk_details {
                 "delta_presence_estimation_histogram",
                 &self.delta_presence_estimation_histogram,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22088,7 +22008,6 @@ pub mod analyze_data_source_risk_details {
                 let mut debug_struct = f.debug_struct("DeltaPresenceEstimationQuasiIdValues");
                 debug_struct.field("quasi_ids_values", &self.quasi_ids_values);
                 debug_struct.field("estimated_probability", &self.estimated_probability);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -22454,7 +22373,6 @@ pub mod analyze_data_source_risk_details {
                 debug_struct.field("bucket_size", &self.bucket_size);
                 debug_struct.field("bucket_values", &self.bucket_values);
                 debug_struct.field("bucket_value_count", &self.bucket_value_count);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -22612,7 +22530,6 @@ pub mod analyze_data_source_risk_details {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("RequestedRiskAnalysisOptions");
             debug_struct.field("job_config", &self.job_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -22841,7 +22758,6 @@ impl std::fmt::Debug for ValueFrequency {
         let mut debug_struct = f.debug_struct("ValueFrequency");
         debug_struct.field("value", &self.value);
         debug_struct.field("count", &self.count);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23391,7 +23307,6 @@ impl std::fmt::Debug for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Value");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23605,7 +23520,6 @@ impl std::fmt::Debug for QuoteInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QuoteInfo");
         debug_struct.field("parsed_quote", &self.parsed_quote);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -23873,7 +23787,6 @@ impl std::fmt::Debug for DateTime {
         debug_struct.field("day_of_week", &self.day_of_week);
         debug_struct.field("time", &self.time);
         debug_struct.field("time_zone", &self.time_zone);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24044,7 +23957,6 @@ pub mod date_time {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TimeZone");
             debug_struct.field("offset_minutes", &self.offset_minutes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -24401,7 +24313,6 @@ impl std::fmt::Debug for DeidentifyConfig {
             &self.transformation_error_handling,
         );
         debug_struct.field("transformation", &self.transformation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24573,7 +24484,6 @@ impl std::fmt::Debug for ImageTransformations {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ImageTransformations");
         debug_struct.field("transforms", &self.transforms);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -24941,7 +24851,6 @@ pub mod image_transformations {
             let mut debug_struct = f.debug_struct("ImageTransformation");
             debug_struct.field("redaction_color", &self.redaction_color);
             debug_struct.field("target", &self.target);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25105,7 +25014,6 @@ pub mod image_transformations {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("SelectedInfoTypes");
                 debug_struct.field("info_types", &self.info_types);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25225,7 +25133,6 @@ pub mod image_transformations {
         impl std::fmt::Debug for AllInfoTypes {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("AllInfoTypes");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25345,7 +25252,6 @@ pub mod image_transformations {
         impl std::fmt::Debug for AllText {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("AllText");
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -25637,7 +25543,6 @@ impl std::fmt::Debug for TransformationErrorHandling {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TransformationErrorHandling");
         debug_struct.field("mode", &self.mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -25759,7 +25664,6 @@ pub mod transformation_error_handling {
     impl std::fmt::Debug for ThrowError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ThrowError");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -25879,7 +25783,6 @@ pub mod transformation_error_handling {
     impl std::fmt::Debug for LeaveUntransformed {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("LeaveUntransformed");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -26717,7 +26620,6 @@ impl std::fmt::Debug for PrimitiveTransformation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PrimitiveTransformation");
         debug_struct.field("transformation", &self.transformation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -26899,7 +26801,6 @@ impl std::fmt::Debug for TimePartConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TimePartConfig");
         debug_struct.field("part_to_extract", &self.part_to_extract);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27226,7 +27127,6 @@ impl std::fmt::Debug for CryptoHashConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CryptoHashConfig");
         debug_struct.field("crypto_key", &self.crypto_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27505,7 +27405,6 @@ impl std::fmt::Debug for CryptoDeterministicConfig {
         debug_struct.field("crypto_key", &self.crypto_key);
         debug_struct.field("surrogate_info_type", &self.surrogate_info_type);
         debug_struct.field("context", &self.context);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27659,7 +27558,6 @@ impl std::fmt::Debug for ReplaceValueConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplaceValueConfig");
         debug_struct.field("new_value", &self.new_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27855,7 +27753,6 @@ impl std::fmt::Debug for ReplaceDictionaryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplaceDictionaryConfig");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -27985,7 +27882,6 @@ impl serde::ser::Serialize for ReplaceWithInfoTypeConfig {
 impl std::fmt::Debug for ReplaceWithInfoTypeConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplaceWithInfoTypeConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28101,7 +27997,6 @@ impl serde::ser::Serialize for RedactConfig {
 impl std::fmt::Debug for RedactConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RedactConfig");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28351,7 +28246,6 @@ impl std::fmt::Debug for CharsToIgnore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CharsToIgnore");
         debug_struct.field("characters", &self.characters);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -28800,7 +28694,6 @@ impl std::fmt::Debug for CharacterMaskConfig {
         debug_struct.field("number_to_mask", &self.number_to_mask);
         debug_struct.field("reverse_order", &self.reverse_order);
         debug_struct.field("characters_to_ignore", &self.characters_to_ignore);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29059,7 +28952,6 @@ impl std::fmt::Debug for FixedSizeBucketingConfig {
         debug_struct.field("lower_bound", &self.lower_bound);
         debug_struct.field("upper_bound", &self.upper_bound);
         debug_struct.field("bucket_size", &self.bucket_size);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29219,7 +29111,6 @@ impl std::fmt::Debug for BucketingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BucketingConfig");
         debug_struct.field("buckets", &self.buckets);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -29454,7 +29345,6 @@ pub mod bucketing_config {
             debug_struct.field("min", &self.min);
             debug_struct.field("max", &self.max);
             debug_struct.field("replacement_value", &self.replacement_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -29929,7 +29819,6 @@ impl std::fmt::Debug for CryptoReplaceFfxFpeConfig {
         debug_struct.field("context", &self.context);
         debug_struct.field("surrogate_info_type", &self.surrogate_info_type);
         debug_struct.field("alphabet", &self.alphabet);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30412,7 +30301,6 @@ impl std::fmt::Debug for CryptoKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CryptoKey");
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30578,7 +30466,6 @@ impl std::fmt::Debug for TransientCryptoKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TransientCryptoKey");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30739,7 +30626,6 @@ impl std::fmt::Debug for UnwrappedCryptoKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("UnwrappedCryptoKey");
         debug_struct.field("key", &self.key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -30936,7 +30822,6 @@ impl std::fmt::Debug for KmsWrappedCryptoKey {
         let mut debug_struct = f.debug_struct("KmsWrappedCryptoKey");
         debug_struct.field("wrapped_key", &self.wrapped_key);
         debug_struct.field("crypto_key_name", &self.crypto_key_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31259,7 +31144,6 @@ impl std::fmt::Debug for DateShiftConfig {
         debug_struct.field("lower_bound_days", &self.lower_bound_days);
         debug_struct.field("context", &self.context);
         debug_struct.field("method", &self.method);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31426,7 +31310,6 @@ impl std::fmt::Debug for InfoTypeTransformations {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("InfoTypeTransformations");
         debug_struct.field("transformations", &self.transformations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -31624,7 +31507,6 @@ pub mod info_type_transformations {
             let mut debug_struct = f.debug_struct("InfoTypeTransformation");
             debug_struct.field("info_types", &self.info_types);
             debug_struct.field("primitive_transformation", &self.primitive_transformation);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -31952,7 +31834,6 @@ impl std::fmt::Debug for FieldTransformation {
         debug_struct.field("fields", &self.fields);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("transformation", &self.transformation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32154,7 +32035,6 @@ impl std::fmt::Debug for RecordTransformations {
         let mut debug_struct = f.debug_struct("RecordTransformations");
         debug_struct.field("field_transformations", &self.field_transformations);
         debug_struct.field("record_suppressions", &self.record_suppressions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32310,7 +32190,6 @@ impl std::fmt::Debug for RecordSuppression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RecordSuppression");
         debug_struct.field("condition", &self.condition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32466,7 +32345,6 @@ impl std::fmt::Debug for RecordCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RecordCondition");
         debug_struct.field("expressions", &self.expressions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -32707,7 +32585,6 @@ pub mod record_condition {
             debug_struct.field("field", &self.field);
             debug_struct.field("operator", &self.operator);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -32859,7 +32736,6 @@ pub mod record_condition {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Conditions");
             debug_struct.field("conditions", &self.conditions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33089,7 +32965,6 @@ pub mod record_condition {
             let mut debug_struct = f.debug_struct("Expressions");
             debug_struct.field("logical_operator", &self.logical_operator);
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -33429,7 +33304,6 @@ impl std::fmt::Debug for TransformationOverview {
         let mut debug_struct = f.debug_struct("TransformationOverview");
         debug_struct.field("transformed_bytes", &self.transformed_bytes);
         debug_struct.field("transformation_summaries", &self.transformation_summaries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -33809,7 +33683,6 @@ impl std::fmt::Debug for TransformationSummary {
         debug_struct.field("record_suppress", &self.record_suppress);
         debug_struct.field("results", &self.results);
         debug_struct.field("transformed_bytes", &self.transformed_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34032,7 +33905,6 @@ pub mod transformation_summary {
             debug_struct.field("count", &self.count);
             debug_struct.field("code", &self.code);
             debug_struct.field("details", &self.details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -34412,7 +34284,6 @@ impl std::fmt::Debug for TransformationDescription {
         debug_struct.field("description", &self.description);
         debug_struct.field("condition", &self.condition);
         debug_struct.field("info_type", &self.info_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -34744,7 +34615,6 @@ impl std::fmt::Debug for TransformationDetails {
         debug_struct.field("status_details", &self.status_details);
         debug_struct.field("transformed_bytes", &self.transformed_bytes);
         debug_struct.field("transformation_location", &self.transformation_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35013,7 +34883,6 @@ impl std::fmt::Debug for TransformationLocation {
         let mut debug_struct = f.debug_struct("TransformationLocation");
         debug_struct.field("container_type", &self.container_type);
         debug_struct.field("location_type", &self.location_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35253,7 +35122,6 @@ impl std::fmt::Debug for RecordTransformation {
         debug_struct.field("field_id", &self.field_id);
         debug_struct.field("container_timestamp", &self.container_timestamp);
         debug_struct.field("container_version", &self.container_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35440,7 +35308,6 @@ impl std::fmt::Debug for TransformationResultStatus {
         let mut debug_struct = f.debug_struct("TransformationResultStatus");
         debug_struct.field("result_status_type", &self.result_status_type);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35630,7 +35497,6 @@ impl std::fmt::Debug for TransformationDetailsStorageConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TransformationDetailsStorageConfig");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35841,7 +35707,6 @@ impl std::fmt::Debug for Schedule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Schedule");
         debug_struct.field("option", &self.option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -35977,7 +35842,6 @@ impl serde::ser::Serialize for Manual {
 impl std::fmt::Debug for Manual {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Manual");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36289,7 +36153,6 @@ impl std::fmt::Debug for InspectTemplate {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("inspect_config", &self.inspect_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36601,7 +36464,6 @@ impl std::fmt::Debug for DeidentifyTemplate {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("deidentify_config", &self.deidentify_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -36813,7 +36675,6 @@ impl std::fmt::Debug for Error {
         debug_struct.field("details", &self.details);
         debug_struct.field("timestamps", &self.timestamps);
         debug_struct.field("extra_info", &self.extra_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37425,7 +37286,6 @@ impl std::fmt::Debug for JobTrigger {
         debug_struct.field("last_run_time", &self.last_run_time);
         debug_struct.field("status", &self.status);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -37674,7 +37534,6 @@ pub mod job_trigger {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Trigger");
             debug_struct.field("trigger", &self.trigger);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38374,7 +38233,6 @@ impl std::fmt::Debug for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Action");
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -38539,7 +38397,6 @@ pub mod action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SaveFindings");
             debug_struct.field("output_config", &self.output_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38691,7 +38548,6 @@ pub mod action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishToPubSub");
             debug_struct.field("topic", &self.topic);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38815,7 +38671,6 @@ pub mod action {
     impl std::fmt::Debug for PublishSummaryToCscc {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishSummaryToCscc");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -38952,7 +38807,6 @@ pub mod action {
     impl std::fmt::Debug for PublishFindingsToCloudDataCatalog {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishFindingsToCloudDataCatalog");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39339,7 +39193,6 @@ pub mod action {
             );
             debug_struct.field("file_types_to_transform", &self.file_types_to_transform);
             debug_struct.field("output", &self.output);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39478,7 +39331,6 @@ pub mod action {
     impl std::fmt::Debug for JobNotificationEmails {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("JobNotificationEmails");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39598,7 +39450,6 @@ pub mod action {
     impl std::fmt::Debug for PublishToStackdriver {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishToStackdriver");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -39853,7 +39704,6 @@ impl std::fmt::Debug for TransformationConfig {
             &self.structured_deidentify_template,
         );
         debug_struct.field("image_redact_template", &self.image_redact_template);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40109,7 +39959,6 @@ impl std::fmt::Debug for CreateInspectTemplateRequest {
         debug_struct.field("inspect_template", &self.inspect_template);
         debug_struct.field("template_id", &self.template_id);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40328,7 +40177,6 @@ impl std::fmt::Debug for UpdateInspectTemplateRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("inspect_template", &self.inspect_template);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40472,7 +40320,6 @@ impl std::fmt::Debug for GetInspectTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInspectTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40771,7 +40618,6 @@ impl std::fmt::Debug for ListInspectTemplatesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -40962,7 +40808,6 @@ impl std::fmt::Debug for ListInspectTemplatesResponse {
         let mut debug_struct = f.debug_struct("ListInspectTemplatesResponse");
         debug_struct.field("inspect_templates", &self.inspect_templates);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41106,7 +40951,6 @@ impl std::fmt::Debug for DeleteInspectTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInspectTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41357,7 +41201,6 @@ impl std::fmt::Debug for CreateJobTriggerRequest {
         debug_struct.field("job_trigger", &self.job_trigger);
         debug_struct.field("trigger_id", &self.trigger_id);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41500,7 +41343,6 @@ impl std::fmt::Debug for ActivateJobTriggerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ActivateJobTriggerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41717,7 +41559,6 @@ impl std::fmt::Debug for UpdateJobTriggerRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("job_trigger", &self.job_trigger);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -41860,7 +41701,6 @@ impl std::fmt::Debug for GetJobTriggerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetJobTriggerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42085,7 +41925,6 @@ impl std::fmt::Debug for CreateDiscoveryConfigRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("discovery_config", &self.discovery_config);
         debug_struct.field("config_id", &self.config_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42303,7 +42142,6 @@ impl std::fmt::Debug for UpdateDiscoveryConfigRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("discovery_config", &self.discovery_config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42446,7 +42284,6 @@ impl std::fmt::Debug for GetDiscoveryConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDiscoveryConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42708,7 +42545,6 @@ impl std::fmt::Debug for ListDiscoveryConfigsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -42899,7 +42735,6 @@ impl std::fmt::Debug for ListDiscoveryConfigsResponse {
         let mut debug_struct = f.debug_struct("ListDiscoveryConfigsResponse");
         debug_struct.field("discovery_configs", &self.discovery_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43042,7 +42877,6 @@ impl std::fmt::Debug for DeleteDiscoveryConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDiscoveryConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43389,7 +43223,6 @@ impl std::fmt::Debug for CreateDlpJobRequest {
         debug_struct.field("job_id", &self.job_id);
         debug_struct.field("location_id", &self.location_id);
         debug_struct.field("job", &self.job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43776,7 +43609,6 @@ impl std::fmt::Debug for ListJobTriggersRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -43963,7 +43795,6 @@ impl std::fmt::Debug for ListJobTriggersResponse {
         let mut debug_struct = f.debug_struct("ListJobTriggersResponse");
         debug_struct.field("job_triggers", &self.job_triggers);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44106,7 +43937,6 @@ impl std::fmt::Debug for DeleteJobTriggerRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteJobTriggerRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44356,7 +44186,6 @@ impl std::fmt::Debug for InspectJobConfig {
         debug_struct.field("inspect_config", &self.inspect_config);
         debug_struct.field("inspect_template_name", &self.inspect_template_name);
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -44854,7 +44683,6 @@ impl std::fmt::Debug for DataProfileAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataProfileAction");
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -45089,7 +44917,6 @@ pub mod data_profile_action {
             let mut debug_struct = f.debug_struct("Export");
             debug_struct.field("profile_table", &self.profile_table);
             debug_struct.field("sample_findings_table", &self.sample_findings_table);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45341,7 +45168,6 @@ pub mod data_profile_action {
             debug_struct.field("event", &self.event);
             debug_struct.field("pubsub_condition", &self.pubsub_condition);
             debug_struct.field("detail_of_message", &self.detail_of_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45606,7 +45432,6 @@ pub mod data_profile_action {
     impl std::fmt::Debug for PublishToChronicle {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishToChronicle");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45724,7 +45549,6 @@ pub mod data_profile_action {
     impl std::fmt::Debug for PublishToSecurityCommandCenter {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishToSecurityCommandCenter");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -45878,7 +45702,6 @@ pub mod data_profile_action {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PublishToDataplexCatalog");
             debug_struct.field("lower_data_risk_to_low", &self.lower_data_risk_to_low);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46114,7 +45937,6 @@ pub mod data_profile_action {
                 &self.profile_generations_to_tag,
             );
             debug_struct.field("lower_data_risk_to_low", &self.lower_data_risk_to_low);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -46364,7 +46186,6 @@ pub mod data_profile_action {
                 let mut debug_struct = f.debug_struct("TagCondition");
                 debug_struct.field("tag", &self.tag);
                 debug_struct.field("r#type", &self.r#type);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -46581,7 +46402,6 @@ pub mod data_profile_action {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("TagValue");
                 debug_struct.field("format", &self.format);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -47224,7 +47044,6 @@ impl std::fmt::Debug for DataProfileFinding {
         debug_struct.field("resource_visibility", &self.resource_visibility);
         debug_struct.field("full_resource_name", &self.full_resource_name);
         debug_struct.field("data_source_type", &self.data_source_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47456,7 +47275,6 @@ impl std::fmt::Debug for DataProfileFindingLocation {
         let mut debug_struct = f.debug_struct("DataProfileFindingLocation");
         debug_struct.field("container_name", &self.container_name);
         debug_struct.field("location_extra_details", &self.location_extra_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47628,7 +47446,6 @@ impl std::fmt::Debug for DataProfileFindingRecordLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataProfileFindingRecordLocation");
         debug_struct.field("field", &self.field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -47945,7 +47762,6 @@ impl std::fmt::Debug for DataProfileJobConfig {
         );
         debug_struct.field("inspect_templates", &self.inspect_templates);
         debug_struct.field("data_profile_actions", &self.data_profile_actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48151,7 +47967,6 @@ impl std::fmt::Debug for BigQueryRegex {
         debug_struct.field("project_id_regex", &self.project_id_regex);
         debug_struct.field("dataset_id_regex", &self.dataset_id_regex);
         debug_struct.field("table_id_regex", &self.table_id_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48298,7 +48113,6 @@ impl std::fmt::Debug for BigQueryRegexes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryRegexes");
         debug_struct.field("patterns", &self.patterns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48447,7 +48261,6 @@ impl std::fmt::Debug for BigQueryTableTypes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryTableTypes");
         debug_struct.field("types", &self.types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48561,7 +48374,6 @@ impl serde::ser::Serialize for Disabled {
 impl std::fmt::Debug for Disabled {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Disabled");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -48832,7 +48644,6 @@ impl std::fmt::Debug for DataProfileLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataProfileLocation");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49429,7 +49240,6 @@ impl std::fmt::Debug for DiscoveryConfig {
         debug_struct.field("last_run_time", &self.last_run_time);
         debug_struct.field("status", &self.status);
         debug_struct.field("processing_location", &self.processing_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -49620,7 +49430,6 @@ pub mod discovery_config {
             let mut debug_struct = f.debug_struct("OrgConfig");
             debug_struct.field("location", &self.location);
             debug_struct.field("project_id", &self.project_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -50237,7 +50046,6 @@ impl std::fmt::Debug for DiscoveryTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryTarget");
         debug_struct.field("target", &self.target);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50597,7 +50405,6 @@ impl std::fmt::Debug for BigQueryDiscoveryTarget {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("conditions", &self.conditions);
         debug_struct.field("frequency", &self.frequency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -50931,7 +50738,6 @@ impl std::fmt::Debug for DiscoveryBigQueryFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryBigQueryFilter");
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51055,7 +50861,6 @@ pub mod discovery_big_query_filter {
     impl std::fmt::Debug for AllOtherBigQueryTables {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AllOtherBigQueryTables");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -51275,7 +51080,6 @@ impl std::fmt::Debug for BigQueryTableCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BigQueryTableCollection");
         debug_struct.field("pattern", &self.pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51617,7 +51421,6 @@ impl std::fmt::Debug for DiscoveryBigQueryConditions {
         debug_struct.field("created_after", &self.created_after);
         debug_struct.field("or_conditions", &self.or_conditions);
         debug_struct.field("included_types", &self.included_types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -51827,7 +51630,6 @@ pub mod discovery_big_query_conditions {
             let mut debug_struct = f.debug_struct("OrConditions");
             debug_struct.field("min_row_count", &self.min_row_count);
             debug_struct.field("min_age", &self.min_age);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -52123,7 +51925,6 @@ impl std::fmt::Debug for DiscoveryGenerationCadence {
             &self.inspect_template_modified_cadence,
         );
         debug_struct.field("refresh_frequency", &self.refresh_frequency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52301,7 +52102,6 @@ impl std::fmt::Debug for DiscoveryTableModifiedCadence {
         let mut debug_struct = f.debug_struct("DiscoveryTableModifiedCadence");
         debug_struct.field("types", &self.types);
         debug_struct.field("frequency", &self.frequency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52479,7 +52279,6 @@ impl std::fmt::Debug for DiscoverySchemaModifiedCadence {
         let mut debug_struct = f.debug_struct("DiscoverySchemaModifiedCadence");
         debug_struct.field("types", &self.types);
         debug_struct.field("frequency", &self.frequency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52625,7 +52424,6 @@ impl std::fmt::Debug for DiscoveryInspectTemplateModifiedCadence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryInspectTemplateModifiedCadence");
         debug_struct.field("frequency", &self.frequency);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -52943,7 +52741,6 @@ impl std::fmt::Debug for CloudSqlDiscoveryTarget {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("conditions", &self.conditions);
         debug_struct.field("cadence", &self.cadence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53274,7 +53071,6 @@ impl std::fmt::Debug for DiscoveryCloudSqlFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryCloudSqlFilter");
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53496,7 +53292,6 @@ impl std::fmt::Debug for DatabaseResourceCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseResourceCollection");
         debug_struct.field("pattern", &self.pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53664,7 +53459,6 @@ impl std::fmt::Debug for DatabaseResourceRegexes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseResourceRegexes");
         debug_struct.field("patterns", &self.patterns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -53908,7 +53702,6 @@ impl std::fmt::Debug for DatabaseResourceRegex {
             "database_resource_name_regex",
             &self.database_resource_name_regex,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54022,7 +53815,6 @@ impl serde::ser::Serialize for AllOtherDatabaseResources {
 impl std::fmt::Debug for AllOtherDatabaseResources {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AllOtherDatabaseResources");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54247,7 +54039,6 @@ impl std::fmt::Debug for DatabaseResourceReference {
         debug_struct.field("instance", &self.instance);
         debug_struct.field("database", &self.database);
         debug_struct.field("database_resource", &self.database_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54426,7 +54217,6 @@ impl std::fmt::Debug for DiscoveryCloudSqlConditions {
         let mut debug_struct = f.debug_struct("DiscoveryCloudSqlConditions");
         debug_struct.field("database_engines", &self.database_engines);
         debug_struct.field("types", &self.types);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -54958,7 +54748,6 @@ impl std::fmt::Debug for DiscoveryCloudSqlGenerationCadence {
             "inspect_template_modified_cadence",
             &self.inspect_template_modified_cadence,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55144,7 +54933,6 @@ pub mod discovery_cloud_sql_generation_cadence {
             let mut debug_struct = f.debug_struct("SchemaModifiedCadence");
             debug_struct.field("types", &self.types);
             debug_struct.field("frequency", &self.frequency);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -55412,7 +55200,6 @@ impl serde::ser::Serialize for SecretsDiscoveryTarget {
 impl std::fmt::Debug for SecretsDiscoveryTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SecretsDiscoveryTarget");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -55732,7 +55519,6 @@ impl std::fmt::Debug for CloudStorageDiscoveryTarget {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("conditions", &self.conditions);
         debug_struct.field("cadence", &self.cadence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56063,7 +55849,6 @@ impl std::fmt::Debug for DiscoveryCloudStorageFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryCloudStorageFilter");
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56284,7 +56069,6 @@ impl std::fmt::Debug for FileStoreCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileStoreCollection");
         debug_struct.field("pattern", &self.pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56452,7 +56236,6 @@ impl std::fmt::Debug for FileStoreRegexes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileStoreRegexes");
         debug_struct.field("patterns", &self.patterns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56645,7 +56428,6 @@ impl std::fmt::Debug for FileStoreRegex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileStoreRegex");
         debug_struct.field("resource_regex", &self.resource_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -56839,7 +56621,6 @@ impl std::fmt::Debug for CloudStorageRegex {
         let mut debug_struct = f.debug_struct("CloudStorageRegex");
         debug_struct.field("project_id_regex", &self.project_id_regex);
         debug_struct.field("bucket_name_regex", &self.bucket_name_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57009,7 +56790,6 @@ impl std::fmt::Debug for CloudStorageResourceReference {
         let mut debug_struct = f.debug_struct("CloudStorageResourceReference");
         debug_struct.field("bucket_name", &self.bucket_name);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57215,7 +56995,6 @@ impl std::fmt::Debug for DiscoveryCloudStorageGenerationCadence {
             "inspect_template_modified_cadence",
             &self.inspect_template_modified_cadence,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -57419,7 +57198,6 @@ impl std::fmt::Debug for DiscoveryCloudStorageConditions {
             "included_bucket_attributes",
             &self.included_bucket_attributes,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58027,7 +57805,6 @@ impl std::fmt::Debug for DiscoveryFileStoreConditions {
         debug_struct.field("created_after", &self.created_after);
         debug_struct.field("min_age", &self.min_age);
         debug_struct.field("conditions", &self.conditions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58407,7 +58184,6 @@ impl std::fmt::Debug for OtherCloudDiscoveryTarget {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("conditions", &self.conditions);
         debug_struct.field("cadence", &self.cadence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58734,7 +58510,6 @@ impl std::fmt::Debug for DiscoveryOtherCloudFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryOtherCloudFilter");
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -58950,7 +58725,6 @@ impl std::fmt::Debug for OtherCloudResourceCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OtherCloudResourceCollection");
         debug_struct.field("pattern", &self.pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59117,7 +58891,6 @@ impl std::fmt::Debug for OtherCloudResourceRegexes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OtherCloudResourceRegexes");
         debug_struct.field("patterns", &self.patterns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59313,7 +59086,6 @@ impl std::fmt::Debug for OtherCloudResourceRegex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OtherCloudResourceRegex");
         debug_struct.field("resource_regex", &self.resource_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59474,7 +59246,6 @@ impl std::fmt::Debug for AwsAccountRegex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsAccountRegex");
         debug_struct.field("account_id_regex", &self.account_id_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59659,7 +59430,6 @@ impl std::fmt::Debug for AmazonS3BucketRegex {
         let mut debug_struct = f.debug_struct("AmazonS3BucketRegex");
         debug_struct.field("aws_account_regex", &self.aws_account_regex);
         debug_struct.field("bucket_name_regex", &self.bucket_name_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -59852,7 +59622,6 @@ impl std::fmt::Debug for OtherCloudSingleResourceReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OtherCloudSingleResourceReference");
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60009,7 +59778,6 @@ impl std::fmt::Debug for AwsAccount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AwsAccount");
         debug_struct.field("account_id", &self.account_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60189,7 +59957,6 @@ impl std::fmt::Debug for AmazonS3Bucket {
         let mut debug_struct = f.debug_struct("AmazonS3Bucket");
         debug_struct.field("aws_account", &self.aws_account);
         debug_struct.field("bucket_name", &self.bucket_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60424,7 +60191,6 @@ impl std::fmt::Debug for DiscoveryOtherCloudConditions {
         let mut debug_struct = f.debug_struct("DiscoveryOtherCloudConditions");
         debug_struct.field("min_age", &self.min_age);
         debug_struct.field("conditions", &self.conditions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -60622,7 +60388,6 @@ impl std::fmt::Debug for AmazonS3BucketConditions {
         let mut debug_struct = f.debug_struct("AmazonS3BucketConditions");
         debug_struct.field("bucket_types", &self.bucket_types);
         debug_struct.field("object_storage_classes", &self.object_storage_classes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61123,7 +60888,6 @@ impl std::fmt::Debug for DiscoveryOtherCloudGenerationCadence {
             "inspect_template_modified_cadence",
             &self.inspect_template_modified_cadence,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61397,7 +61161,6 @@ impl std::fmt::Debug for DiscoveryStartingLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryStartingLocation");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61607,7 +61370,6 @@ impl std::fmt::Debug for OtherCloudDiscoveryStartingLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("OtherCloudDiscoveryStartingLocation");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -61847,7 +61609,6 @@ pub mod other_cloud_discovery_starting_location {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("AwsDiscoveryStartingLocation");
             debug_struct.field("scope", &self.scope);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -61994,7 +61755,6 @@ impl serde::ser::Serialize for AllOtherResources {
 impl std::fmt::Debug for AllOtherResources {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AllOtherResources");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62315,7 +62075,6 @@ impl std::fmt::Debug for VertexDatasetDiscoveryTarget {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("conditions", &self.conditions);
         debug_struct.field("cadence", &self.cadence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62644,7 +62403,6 @@ impl std::fmt::Debug for DiscoveryVertexDatasetFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DiscoveryVertexDatasetFilter");
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -62861,7 +62619,6 @@ impl std::fmt::Debug for VertexDatasetCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VertexDatasetCollection");
         debug_struct.field("pattern", &self.pattern);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63027,7 +62784,6 @@ impl std::fmt::Debug for VertexDatasetRegexes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VertexDatasetRegexes");
         debug_struct.field("patterns", &self.patterns);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63174,7 +62930,6 @@ impl std::fmt::Debug for VertexDatasetRegex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VertexDatasetRegex");
         debug_struct.field("project_id_regex", &self.project_id_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63321,7 +63076,6 @@ impl std::fmt::Debug for VertexDatasetResourceReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VertexDatasetResourceReference");
         debug_struct.field("dataset_resource_name", &self.dataset_resource_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63515,7 +63269,6 @@ impl std::fmt::Debug for DiscoveryVertexDatasetConditions {
         let mut debug_struct = f.debug_struct("DiscoveryVertexDatasetConditions");
         debug_struct.field("created_after", &self.created_after);
         debug_struct.field("min_age", &self.min_age);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -63722,7 +63475,6 @@ impl std::fmt::Debug for DiscoveryVertexDatasetGenerationCadence {
             "inspect_template_modified_cadence",
             &self.inspect_template_modified_cadence,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64281,7 +64033,6 @@ impl std::fmt::Debug for DlpJob {
         debug_struct.field("errors", &self.errors);
         debug_struct.field("action_details", &self.action_details);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64606,7 +64357,6 @@ impl std::fmt::Debug for GetDlpJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDlpJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -64976,7 +64726,6 @@ impl std::fmt::Debug for ListDlpJobsRequest {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65161,7 +64910,6 @@ impl std::fmt::Debug for ListDlpJobsResponse {
         let mut debug_struct = f.debug_struct("ListDlpJobsResponse");
         debug_struct.field("jobs", &self.jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65303,7 +65051,6 @@ impl std::fmt::Debug for CancelDlpJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CancelDlpJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65445,7 +65192,6 @@ impl std::fmt::Debug for FinishDlpJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FinishDlpJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65587,7 +65333,6 @@ impl std::fmt::Debug for DeleteDlpJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDlpJobRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -65842,7 +65587,6 @@ impl std::fmt::Debug for CreateDeidentifyTemplateRequest {
         debug_struct.field("deidentify_template", &self.deidentify_template);
         debug_struct.field("template_id", &self.template_id);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66061,7 +65805,6 @@ impl std::fmt::Debug for UpdateDeidentifyTemplateRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("deidentify_template", &self.deidentify_template);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66205,7 +65948,6 @@ impl std::fmt::Debug for GetDeidentifyTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDeidentifyTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66504,7 +66246,6 @@ impl std::fmt::Debug for ListDeidentifyTemplatesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66696,7 +66437,6 @@ impl std::fmt::Debug for ListDeidentifyTemplatesResponse {
         let mut debug_struct = f.debug_struct("ListDeidentifyTemplatesResponse");
         debug_struct.field("deidentify_templates", &self.deidentify_templates);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -66841,7 +66581,6 @@ impl std::fmt::Debug for DeleteDeidentifyTemplateRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteDeidentifyTemplateRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67137,7 +66876,6 @@ impl std::fmt::Debug for LargeCustomDictionaryConfig {
         let mut debug_struct = f.debug_struct("LargeCustomDictionaryConfig");
         debug_struct.field("output_path", &self.output_path);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67315,7 +67053,6 @@ impl std::fmt::Debug for LargeCustomDictionaryStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("LargeCustomDictionaryStats");
         debug_struct.field("approx_num_phrases", &self.approx_num_phrases);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67672,7 +67409,6 @@ impl std::fmt::Debug for StoredInfoTypeConfig {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("description", &self.description);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -67883,7 +67619,6 @@ impl std::fmt::Debug for StoredInfoTypeStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("StoredInfoTypeStats");
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68192,7 +67927,6 @@ impl std::fmt::Debug for StoredInfoTypeVersion {
         debug_struct.field("state", &self.state);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("stats", &self.stats);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68406,7 +68140,6 @@ impl std::fmt::Debug for StoredInfoType {
         debug_struct.field("name", &self.name);
         debug_struct.field("current_version", &self.current_version);
         debug_struct.field("pending_versions", &self.pending_versions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68663,7 +68396,6 @@ impl std::fmt::Debug for CreateStoredInfoTypeRequest {
         debug_struct.field("config", &self.config);
         debug_struct.field("stored_info_type_id", &self.stored_info_type_id);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -68882,7 +68614,6 @@ impl std::fmt::Debug for UpdateStoredInfoTypeRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("config", &self.config);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69026,7 +68757,6 @@ impl std::fmt::Debug for GetStoredInfoTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStoredInfoTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69322,7 +69052,6 @@ impl std::fmt::Debug for ListStoredInfoTypesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("location_id", &self.location_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69513,7 +69242,6 @@ impl std::fmt::Debug for ListStoredInfoTypesResponse {
         let mut debug_struct = f.debug_struct("ListStoredInfoTypesResponse");
         debug_struct.field("stored_info_types", &self.stored_info_types);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69657,7 +69385,6 @@ impl std::fmt::Debug for DeleteStoredInfoTypeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteStoredInfoTypeRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -69838,7 +69565,6 @@ impl std::fmt::Debug for HybridInspectJobTriggerRequest {
         let mut debug_struct = f.debug_struct("HybridInspectJobTriggerRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("hybrid_item", &self.hybrid_item);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70019,7 +69745,6 @@ impl std::fmt::Debug for HybridInspectDlpJobRequest {
         let mut debug_struct = f.debug_struct("HybridInspectDlpJobRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("hybrid_item", &self.hybrid_item);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70210,7 +69935,6 @@ impl std::fmt::Debug for HybridContentItem {
         let mut debug_struct = f.debug_struct("HybridContentItem");
         debug_struct.field("item", &self.item);
         debug_struct.field("finding_details", &self.finding_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70550,7 +70274,6 @@ impl std::fmt::Debug for HybridFindingDetails {
         debug_struct.field("row_offset", &self.row_offset);
         debug_struct.field("table_options", &self.table_options);
         debug_struct.field("labels", &self.labels);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70664,7 +70387,6 @@ impl serde::ser::Serialize for HybridInspectResponse {
 impl std::fmt::Debug for HybridInspectResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HybridInspectResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -70964,7 +70686,6 @@ impl std::fmt::Debug for ListProjectDataProfilesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71154,7 +70875,6 @@ impl std::fmt::Debug for ListProjectDataProfilesResponse {
         let mut debug_struct = f.debug_struct("ListProjectDataProfilesResponse");
         debug_struct.field("project_data_profiles", &self.project_data_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71467,7 +71187,6 @@ impl std::fmt::Debug for ListTableDataProfilesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71657,7 +71376,6 @@ impl std::fmt::Debug for ListTableDataProfilesResponse {
         let mut debug_struct = f.debug_struct("ListTableDataProfilesResponse");
         debug_struct.field("table_data_profiles", &self.table_data_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -71971,7 +71689,6 @@ impl std::fmt::Debug for ListColumnDataProfilesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72161,7 +71878,6 @@ impl std::fmt::Debug for ListColumnDataProfilesResponse {
         let mut debug_struct = f.debug_struct("ListColumnDataProfilesResponse");
         debug_struct.field("column_data_profiles", &self.column_data_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72309,7 +72025,6 @@ impl std::fmt::Debug for DataRiskLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataRiskLevel");
         debug_struct.field("score", &self.score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -72890,7 +72605,6 @@ impl std::fmt::Debug for ProjectDataProfile {
             "file_store_data_profile_count",
             &self.file_store_data_profile_count,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -73206,7 +72920,6 @@ impl std::fmt::Debug for DataProfileConfigSnapshot {
             "inspect_template_modified_time",
             &self.inspect_template_modified_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74319,7 +74032,6 @@ impl std::fmt::Debug for TableDataProfile {
         debug_struct.field("sample_findings_table", &self.sample_findings_table);
         debug_struct.field("tags", &self.tags);
         debug_struct.field("related_resources", &self.related_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74650,7 +74362,6 @@ impl std::fmt::Debug for ProfileStatus {
         let mut debug_struct = f.debug_struct("ProfileStatus");
         debug_struct.field("status", &self.status);
         debug_struct.field("timestamp", &self.timestamp);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -74851,7 +74562,6 @@ impl std::fmt::Debug for InfoTypeSummary {
         let mut debug_struct = f.debug_struct("InfoTypeSummary");
         debug_struct.field("info_type", &self.info_type);
         debug_struct.field("estimated_prevalence", &self.estimated_prevalence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75078,7 +74788,6 @@ impl std::fmt::Debug for OtherInfoTypeSummary {
         debug_struct.field("info_type", &self.info_type);
         debug_struct.field("estimated_prevalence", &self.estimated_prevalence);
         debug_struct.field("excluded_from_analysis", &self.excluded_from_analysis);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -75847,7 +75556,6 @@ impl std::fmt::Debug for ColumnDataProfile {
         debug_struct.field("free_text_score", &self.free_text_score);
         debug_struct.field("column_type", &self.column_type);
         debug_struct.field("policy_state", &self.policy_state);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77352,7 +77060,6 @@ impl std::fmt::Debug for FileStoreDataProfile {
         debug_struct.field("file_store_is_empty", &self.file_store_is_empty);
         debug_struct.field("tags", &self.tags);
         debug_struct.field("related_resources", &self.related_resources);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77694,7 +77401,6 @@ impl std::fmt::Debug for Tag {
         debug_struct.field("namespaced_tag_value", &self.namespaced_tag_value);
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77841,7 +77547,6 @@ impl std::fmt::Debug for RelatedResource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RelatedResource");
         debug_struct.field("full_resource", &self.full_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -77995,7 +77700,6 @@ impl std::fmt::Debug for FileStoreInfoTypeSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileStoreInfoTypeSummary");
         debug_struct.field("info_type", &self.info_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78138,7 +77842,6 @@ impl std::fmt::Debug for FileExtensionInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileExtensionInfo");
         debug_struct.field("file_extension", &self.file_extension);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78539,7 +78242,6 @@ impl std::fmt::Debug for FileClusterSummary {
         debug_struct.field("file_extensions_scanned", &self.file_extensions_scanned);
         debug_struct.field("file_extensions_seen", &self.file_extensions_seen);
         debug_struct.field("no_files_exist", &self.no_files_exist);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78682,7 +78384,6 @@ impl std::fmt::Debug for GetProjectDataProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProjectDataProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -78825,7 +78526,6 @@ impl std::fmt::Debug for GetFileStoreDataProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFileStoreDataProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79143,7 +78843,6 @@ impl std::fmt::Debug for ListFileStoreDataProfilesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("order_by", &self.order_by);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79336,7 +79035,6 @@ impl std::fmt::Debug for ListFileStoreDataProfilesResponse {
         let mut debug_struct = f.debug_struct("ListFileStoreDataProfilesResponse");
         debug_struct.field("file_store_data_profiles", &self.file_store_data_profiles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79478,7 +79176,6 @@ impl std::fmt::Debug for DeleteFileStoreDataProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteFileStoreDataProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79621,7 +79318,6 @@ impl std::fmt::Debug for GetTableDataProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetTableDataProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79764,7 +79460,6 @@ impl std::fmt::Debug for GetColumnDataProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetColumnDataProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -79919,7 +79614,6 @@ impl std::fmt::Debug for DataProfilePubSubCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataProfilePubSubCondition");
         debug_struct.field("expressions", &self.expressions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -80184,7 +79878,6 @@ pub mod data_profile_pub_sub_condition {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("PubSubCondition");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -80375,7 +80068,6 @@ pub mod data_profile_pub_sub_condition {
             let mut debug_struct = f.debug_struct("PubSubExpressions");
             debug_struct.field("logical_operator", &self.logical_operator);
             debug_struct.field("conditions", &self.conditions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -80877,7 +80569,6 @@ impl std::fmt::Debug for DataProfilePubSubMessage {
         debug_struct.field("profile", &self.profile);
         debug_struct.field("file_store_profile", &self.file_store_profile);
         debug_struct.field("event", &self.event);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81063,7 +80754,6 @@ impl std::fmt::Debug for CreateConnectionRequest {
         let mut debug_struct = f.debug_struct("CreateConnectionRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("connection", &self.connection);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81206,7 +80896,6 @@ impl std::fmt::Debug for GetConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81446,7 +81135,6 @@ impl std::fmt::Debug for ListConnectionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81686,7 +81374,6 @@ impl std::fmt::Debug for SearchConnectionsRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -81872,7 +81559,6 @@ impl std::fmt::Debug for ListConnectionsResponse {
         let mut debug_struct = f.debug_struct("ListConnectionsResponse");
         debug_struct.field("connections", &self.connections);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82060,7 +81746,6 @@ impl std::fmt::Debug for SearchConnectionsResponse {
         let mut debug_struct = f.debug_struct("SearchConnectionsResponse");
         debug_struct.field("connections", &self.connections);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82276,7 +81961,6 @@ impl std::fmt::Debug for UpdateConnectionRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("connection", &self.connection);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82419,7 +82103,6 @@ impl std::fmt::Debug for DeleteConnectionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteConnectionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82690,7 +82373,6 @@ impl std::fmt::Debug for Connection {
         debug_struct.field("state", &self.state);
         debug_struct.field("errors", &self.errors);
         debug_struct.field("properties", &self.properties);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -82889,7 +82571,6 @@ impl std::fmt::Debug for SecretManagerCredential {
             "password_secret_version_name",
             &self.password_secret_version_name,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83006,7 +82687,6 @@ impl serde::ser::Serialize for CloudSqlIamCredential {
 impl std::fmt::Debug for CloudSqlIamCredential {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudSqlIamCredential");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83372,7 +83052,6 @@ impl std::fmt::Debug for CloudSqlProperties {
         debug_struct.field("max_connections", &self.max_connections);
         debug_struct.field("database_engine", &self.database_engine);
         debug_struct.field("credential", &self.credential);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83663,7 +83342,6 @@ impl std::fmt::Debug for DeleteTableDataProfileRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTableDataProfileRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -83812,7 +83490,6 @@ impl std::fmt::Debug for DataSourceType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DataSourceType");
         debug_struct.field("data_source", &self.data_source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84000,7 +83677,6 @@ impl std::fmt::Debug for FileClusterType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileClusterType");
         debug_struct.field("file_cluster_type", &self.file_cluster_type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84361,7 +84037,6 @@ impl std::fmt::Debug for ProcessingLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ProcessingLocation");
         debug_struct.field("image_fallback_location", &self.image_fallback_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -84484,7 +84159,6 @@ pub mod processing_location {
     impl std::fmt::Debug for MultiRegionProcessing {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MultiRegionProcessing");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -84601,7 +84275,6 @@ pub mod processing_location {
     impl std::fmt::Debug for GlobalProcessing {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("GlobalProcessing");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -84807,7 +84480,6 @@ pub mod processing_location {
             let mut debug_struct = f.debug_struct("ImageFallbackLocation");
             debug_struct.field("multi_region_processing", &self.multi_region_processing);
             debug_struct.field("global_processing", &self.global_processing);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -84955,7 +84627,6 @@ impl std::fmt::Debug for SaveToGcsFindingsOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SaveToGcsFindingsOutput");
         debug_struct.field("findings", &self.findings);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85167,7 +84838,6 @@ impl std::fmt::Debug for InfoType {
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
         debug_struct.field("sensitivity_score", &self.sensitivity_score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85317,7 +84987,6 @@ impl std::fmt::Debug for SensitivityScore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SensitivityScore");
         debug_struct.field("score", &self.score);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -85660,7 +85329,6 @@ impl std::fmt::Debug for StoredType {
         let mut debug_struct = f.debug_struct("StoredType");
         debug_struct.field("name", &self.name);
         debug_struct.field("create_time", &self.create_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86193,7 +85861,6 @@ impl std::fmt::Debug for CustomInfoType {
         debug_struct.field("exclusion_type", &self.exclusion_type);
         debug_struct.field("sensitivity_score", &self.sensitivity_score);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -86474,7 +86141,6 @@ pub mod custom_info_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Dictionary");
             debug_struct.field("source", &self.source);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -86632,7 +86298,6 @@ pub mod custom_info_type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("WordList");
                 debug_struct.field("words", &self.words);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -86849,7 +86514,6 @@ pub mod custom_info_type {
             let mut debug_struct = f.debug_struct("Regex");
             debug_struct.field("pattern", &self.pattern);
             debug_struct.field("group_indexes", &self.group_indexes);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -86973,7 +86637,6 @@ pub mod custom_info_type {
     impl std::fmt::Debug for SurrogateType {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SurrogateType");
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -87175,7 +86838,6 @@ pub mod custom_info_type {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("DetectionRule");
             debug_struct.field("r#type", &self.r#type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -87408,7 +87070,6 @@ pub mod custom_info_type {
                 let mut debug_struct = f.debug_struct("Proximity");
                 debug_struct.field("window_before", &self.window_before);
                 debug_struct.field("window_after", &self.window_after);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -87678,7 +87339,6 @@ pub mod custom_info_type {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("LikelihoodAdjustment");
                 debug_struct.field("adjustment", &self.adjustment);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -87971,7 +87631,6 @@ pub mod custom_info_type {
                 debug_struct.field("hotword_regex", &self.hotword_regex);
                 debug_struct.field("proximity", &self.proximity);
                 debug_struct.field("likelihood_adjustment", &self.likelihood_adjustment);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -88267,7 +87926,6 @@ impl std::fmt::Debug for FieldId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FieldId");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88441,7 +88099,6 @@ impl std::fmt::Debug for PartitionId {
         let mut debug_struct = f.debug_struct("PartitionId");
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("namespace_id", &self.namespace_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88583,7 +88240,6 @@ impl std::fmt::Debug for KindExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("KindExpression");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -88775,7 +88431,6 @@ impl std::fmt::Debug for DatastoreOptions {
         let mut debug_struct = f.debug_struct("DatastoreOptions");
         debug_struct.field("partition_id", &self.partition_id);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -89021,7 +88676,6 @@ impl std::fmt::Debug for CloudStorageRegexFileSet {
         debug_struct.field("bucket_name", &self.bucket_name);
         debug_struct.field("include_regex", &self.include_regex);
         debug_struct.field("exclude_regex", &self.exclude_regex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -89406,7 +89060,6 @@ impl std::fmt::Debug for CloudStorageOptions {
         debug_struct.field("file_types", &self.file_types);
         debug_struct.field("sample_method", &self.sample_method);
         debug_struct.field("files_limit_percent", &self.files_limit_percent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -89603,7 +89256,6 @@ pub mod cloud_storage_options {
             let mut debug_struct = f.debug_struct("FileSet");
             debug_struct.field("url", &self.url);
             debug_struct.field("regex_file_set", &self.regex_file_set);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -89882,7 +89534,6 @@ impl std::fmt::Debug for CloudStorageFileSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudStorageFileSet");
         debug_struct.field("url", &self.url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90025,7 +89676,6 @@ impl std::fmt::Debug for CloudStoragePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CloudStoragePath");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90411,7 +90061,6 @@ impl std::fmt::Debug for BigQueryOptions {
         debug_struct.field("sample_method", &self.sample_method);
         debug_struct.field("excluded_fields", &self.excluded_fields);
         debug_struct.field("included_fields", &self.included_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -90952,7 +90601,6 @@ impl std::fmt::Debug for StorageConfig {
         let mut debug_struct = f.debug_struct("StorageConfig");
         debug_struct.field("timespan_config", &self.timespan_config);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91279,7 +90927,6 @@ pub mod storage_config {
                 "enable_auto_population_of_timespan_config",
                 &self.enable_auto_population_of_timespan_config,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -91571,7 +91218,6 @@ impl std::fmt::Debug for HybridOptions {
         );
         debug_struct.field("labels", &self.labels);
         debug_struct.field("table_options", &self.table_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91773,7 +91419,6 @@ impl std::fmt::Debug for BigQueryKey {
         let mut debug_struct = f.debug_struct("BigQueryKey");
         debug_struct.field("table_reference", &self.table_reference);
         debug_struct.field("row_number", &self.row_number);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -91927,7 +91572,6 @@ impl std::fmt::Debug for DatastoreKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatastoreKey");
         debug_struct.field("entity_key", &self.entity_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92126,7 +91770,6 @@ impl std::fmt::Debug for Key {
         let mut debug_struct = f.debug_struct("Key");
         debug_struct.field("partition_id", &self.partition_id);
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92410,7 +92053,6 @@ pub mod key {
             let mut debug_struct = f.debug_struct("PathElement");
             debug_struct.field("kind", &self.kind);
             debug_struct.field("id_type", &self.id_type);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -92701,7 +92343,6 @@ impl std::fmt::Debug for RecordKey {
         let mut debug_struct = f.debug_struct("RecordKey");
         debug_struct.field("id_values", &self.id_values);
         debug_struct.field("r#type", &self.r#type);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -92917,7 +92558,6 @@ impl std::fmt::Debug for BigQueryTable {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -93115,7 +92755,6 @@ impl std::fmt::Debug for TableReference {
         debug_struct.field("dataset_id", &self.dataset_id);
         debug_struct.field("table_id", &self.table_id);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -93304,7 +92943,6 @@ impl std::fmt::Debug for BigQueryField {
         let mut debug_struct = f.debug_struct("BigQueryField");
         debug_struct.field("table", &self.table);
         debug_struct.field("field", &self.field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -93461,7 +93099,6 @@ impl std::fmt::Debug for EntityId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EntityId");
         debug_struct.field("field", &self.field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -93610,7 +93247,6 @@ impl std::fmt::Debug for TableOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TableOptions");
         debug_struct.field("identifying_fields", &self.identifying_fields);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/rpc/context/src/model.rs
+++ b/src/generated/rpc/context/src/model.rs
@@ -439,7 +439,6 @@ impl std::fmt::Debug for AttributeContext {
         debug_struct.field("resource", &self.resource);
         debug_struct.field("api", &self.api);
         debug_struct.field("extensions", &self.extensions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -726,7 +725,6 @@ pub mod attribute_context {
             debug_struct.field("labels", &self.labels);
             debug_struct.field("principal", &self.principal);
             debug_struct.field("region_code", &self.region_code);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -954,7 +952,6 @@ pub mod attribute_context {
             debug_struct.field("operation", &self.operation);
             debug_struct.field("protocol", &self.protocol);
             debug_struct.field("version", &self.version);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1259,7 +1256,6 @@ pub mod attribute_context {
             debug_struct.field("presenter", &self.presenter);
             debug_struct.field("claims", &self.claims);
             debug_struct.field("access_levels", &self.access_levels);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1743,7 +1739,6 @@ pub mod attribute_context {
             debug_struct.field("protocol", &self.protocol);
             debug_struct.field("reason", &self.reason);
             debug_struct.field("auth", &self.auth);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2065,7 +2060,6 @@ pub mod attribute_context {
             debug_struct.field("headers", &self.headers);
             debug_struct.field("time", &self.time);
             debug_struct.field("backend_latency", &self.backend_latency);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2589,7 +2583,6 @@ pub mod attribute_context {
             debug_struct.field("delete_time", &self.delete_time);
             debug_struct.field("etag", &self.etag);
             debug_struct.field("location", &self.location);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2912,7 +2905,6 @@ impl std::fmt::Debug for AuditContext {
             &self.scrubbed_response_item_count,
         );
         debug_struct.field("target_resource", &self.target_resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -263,7 +263,6 @@ impl std::fmt::Debug for ErrorInfo {
         debug_struct.field("reason", &self.reason);
         debug_struct.field("domain", &self.domain);
         debug_struct.field("metadata", &self.metadata);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -429,7 +428,6 @@ impl std::fmt::Debug for RetryInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RetryInfo");
         debug_struct.field("retry_delay", &self.retry_delay);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -600,7 +598,6 @@ impl std::fmt::Debug for DebugInfo {
         let mut debug_struct = f.debug_struct("DebugInfo");
         debug_struct.field("stack_entries", &self.stack_entries);
         debug_struct.field("detail", &self.detail);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -759,7 +756,6 @@ impl std::fmt::Debug for QuotaFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("QuotaFailure");
         debug_struct.field("violations", &self.violations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1211,7 +1207,6 @@ pub mod quota_failure {
             debug_struct.field("quota_dimensions", &self.quota_dimensions);
             debug_struct.field("quota_value", &self.quota_value);
             debug_struct.field("future_quota_value", &self.future_quota_value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1365,7 +1360,6 @@ impl std::fmt::Debug for PreconditionFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PreconditionFailure");
         debug_struct.field("violations", &self.violations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1572,7 +1566,6 @@ pub mod precondition_failure {
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("subject", &self.subject);
             debug_struct.field("description", &self.description);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -1724,7 +1717,6 @@ impl std::fmt::Debug for BadRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BadRequest");
         debug_struct.field("field_violations", &self.field_violations);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2005,7 +1997,6 @@ pub mod bad_request {
             debug_struct.field("description", &self.description);
             debug_struct.field("reason", &self.reason);
             debug_struct.field("localized_message", &self.localized_message);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2178,7 +2169,6 @@ impl std::fmt::Debug for RequestInfo {
         let mut debug_struct = f.debug_struct("RequestInfo");
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("serving_data", &self.serving_data);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2408,7 +2398,6 @@ impl std::fmt::Debug for ResourceInfo {
         debug_struct.field("resource_name", &self.resource_name);
         debug_struct.field("owner", &self.owner);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2557,7 +2546,6 @@ impl std::fmt::Debug for Help {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Help");
         debug_struct.field("links", &self.links);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2732,7 +2720,6 @@ pub mod help {
             let mut debug_struct = f.debug_struct("Link");
             debug_struct.field("description", &self.description);
             debug_struct.field("url", &self.url);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2903,7 +2890,6 @@ impl std::fmt::Debug for LocalizedMessage {
         let mut debug_struct = f.debug_struct("LocalizedMessage");
         debug_struct.field("locale", &self.locale);
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3142,7 +3128,6 @@ impl std::fmt::Debug for HttpRequest {
         debug_struct.field("uri", &self.uri);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3399,7 +3384,6 @@ impl std::fmt::Debug for HttpResponse {
         debug_struct.field("reason", &self.reason);
         debug_struct.field("headers", &self.headers);
         debug_struct.field("body", &self.body);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3566,7 +3550,6 @@ impl std::fmt::Debug for HttpHeader {
         let mut debug_struct = f.debug_struct("HttpHeader");
         debug_struct.field("key", &self.key);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3796,7 +3779,6 @@ impl std::fmt::Debug for Status {
         debug_struct.field("code", &self.code);
         debug_struct.field("message", &self.message);
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -570,7 +570,6 @@ impl std::fmt::Debug for RepeatRequest {
         debug_struct.field("p_int32", &self.p_int32);
         debug_struct.field("p_int64", &self.p_int64);
         debug_struct.field("p_double", &self.p_double);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -747,7 +746,6 @@ impl std::fmt::Debug for RepeatResponse {
         let mut debug_struct = f.debug_struct("RepeatResponse");
         debug_struct.field("request", &self.request);
         debug_struct.field("binding_uri", &self.binding_uri);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -897,7 +895,6 @@ impl std::fmt::Debug for ComplianceSuite {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ComplianceSuite");
         debug_struct.field("group", &self.group);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1094,7 +1091,6 @@ impl std::fmt::Debug for ComplianceGroup {
         debug_struct.field("name", &self.name);
         debug_struct.field("rpcs", &self.rpcs);
         debug_struct.field("requests", &self.requests);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2140,7 +2136,6 @@ impl std::fmt::Debug for ComplianceData {
         debug_struct.field("p_bool", &self.p_bool);
         debug_struct.field("p_kingdom", &self.p_kingdom);
         debug_struct.field("p_child", &self.p_child);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2857,7 +2852,6 @@ impl std::fmt::Debug for ComplianceDataChild {
         debug_struct.field("p_bool", &self.p_bool);
         debug_struct.field("p_continent", &self.p_continent);
         debug_struct.field("p_child", &self.p_child);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3066,7 +3060,6 @@ impl std::fmt::Debug for ComplianceDataGrandchild {
         debug_struct.field("f_string", &self.f_string);
         debug_struct.field("f_double", &self.f_double);
         debug_struct.field("f_bool", &self.f_bool);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3208,7 +3201,6 @@ impl std::fmt::Debug for EnumRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnumRequest");
         debug_struct.field("unknown_enum", &self.unknown_enum);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3385,7 +3377,6 @@ impl std::fmt::Debug for EnumResponse {
         let mut debug_struct = f.debug_struct("EnumResponse");
         debug_struct.field("request", &self.request);
         debug_struct.field("continent", &self.continent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3757,7 +3748,6 @@ impl std::fmt::Debug for EchoRequest {
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("other_request_id", &self.other_request_id);
         debug_struct.field("response", &self.response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3994,7 +3984,6 @@ impl std::fmt::Debug for EchoResponse {
         debug_struct.field("severity", &self.severity);
         debug_struct.field("request_id", &self.request_id);
         debug_struct.field("other_request_id", &self.other_request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4171,7 +4160,6 @@ impl std::fmt::Debug for EchoErrorDetailsRequest {
         let mut debug_struct = f.debug_struct("EchoErrorDetailsRequest");
         debug_struct.field("single_detail_text", &self.single_detail_text);
         debug_struct.field("multi_detail_text", &self.multi_detail_text);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4363,7 +4351,6 @@ impl std::fmt::Debug for EchoErrorDetailsResponse {
         let mut debug_struct = f.debug_struct("EchoErrorDetailsResponse");
         debug_struct.field("single_detail", &self.single_detail);
         debug_struct.field("multiple_details", &self.multiple_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4522,7 +4509,6 @@ pub mod echo_error_details_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("SingleDetail");
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4676,7 +4662,6 @@ pub mod echo_error_details_response {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("MultipleDetails");
             debug_struct.field("error", &self.error);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4827,7 +4812,6 @@ impl std::fmt::Debug for ErrorWithSingleDetail {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ErrorWithSingleDetail");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4972,7 +4956,6 @@ impl std::fmt::Debug for ErrorWithMultipleDetails {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ErrorWithMultipleDetails");
         debug_struct.field("details", &self.details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5115,7 +5098,6 @@ impl std::fmt::Debug for PoetryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PoetryError");
         debug_struct.field("poem", &self.poem);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5258,7 +5240,6 @@ impl std::fmt::Debug for FailEchoWithDetailsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FailEchoWithDetailsRequest");
         debug_struct.field("message", &self.message);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5373,7 +5354,6 @@ impl serde::ser::Serialize for FailEchoWithDetailsResponse {
 impl std::fmt::Debug for FailEchoWithDetailsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FailEchoWithDetailsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5588,7 +5568,6 @@ impl std::fmt::Debug for ExpandRequest {
         debug_struct.field("content", &self.content);
         debug_struct.field("error", &self.error);
         debug_struct.field("stream_wait_time", &self.stream_wait_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5800,7 +5779,6 @@ impl std::fmt::Debug for PagedExpandRequest {
         debug_struct.field("content", &self.content);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6016,7 +5994,6 @@ impl std::fmt::Debug for PagedExpandLegacyRequest {
         debug_struct.field("content", &self.content);
         debug_struct.field("max_results", &self.max_results);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6201,7 +6178,6 @@ impl std::fmt::Debug for PagedExpandResponse {
         let mut debug_struct = f.debug_struct("PagedExpandResponse");
         debug_struct.field("responses", &self.responses);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6345,7 +6321,6 @@ impl std::fmt::Debug for PagedExpandResponseList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PagedExpandResponseList");
         debug_struct.field("words", &self.words);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6526,7 +6501,6 @@ impl std::fmt::Debug for PagedExpandLegacyMappedResponse {
         let mut debug_struct = f.debug_struct("PagedExpandLegacyMappedResponse");
         debug_struct.field("alphabetized", &self.alphabetized);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6866,7 +6840,6 @@ impl std::fmt::Debug for WaitRequest {
         let mut debug_struct = f.debug_struct("WaitRequest");
         debug_struct.field("end", &self.end);
         debug_struct.field("response", &self.response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7033,7 +7006,6 @@ impl std::fmt::Debug for WaitResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WaitResponse");
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7187,7 +7159,6 @@ impl std::fmt::Debug for WaitMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("WaitMetadata");
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7459,7 +7430,6 @@ impl std::fmt::Debug for BlockRequest {
         let mut debug_struct = f.debug_struct("BlockRequest");
         debug_struct.field("response_delay", &self.response_delay);
         debug_struct.field("response", &self.response);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7618,7 +7588,6 @@ impl std::fmt::Debug for BlockResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BlockResponse");
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8079,7 +8048,6 @@ impl std::fmt::Debug for User {
         debug_struct.field("height_feet", &self.height_feet);
         debug_struct.field("nickname", &self.nickname);
         debug_struct.field("enable_notifications", &self.enable_notifications);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8233,7 +8201,6 @@ impl std::fmt::Debug for CreateUserRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateUserRequest");
         debug_struct.field("user", &self.user);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8376,7 +8343,6 @@ impl std::fmt::Debug for GetUserRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetUserRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8568,7 +8534,6 @@ impl std::fmt::Debug for UpdateUserRequest {
         let mut debug_struct = f.debug_struct("UpdateUserRequest");
         debug_struct.field("user", &self.user);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8711,7 +8676,6 @@ impl std::fmt::Debug for DeleteUserRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteUserRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8902,7 +8866,6 @@ impl std::fmt::Debug for ListUsersRequest {
         let mut debug_struct = f.debug_struct("ListUsersRequest");
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9091,7 +9054,6 @@ impl std::fmt::Debug for ListUsersResponse {
         let mut debug_struct = f.debug_struct("ListUsersResponse");
         debug_struct.field("users", &self.users);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9358,7 +9320,6 @@ impl std::fmt::Debug for Room {
         debug_struct.field("description", &self.description);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9512,7 +9473,6 @@ impl std::fmt::Debug for CreateRoomRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateRoomRequest");
         debug_struct.field("room", &self.room);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9655,7 +9615,6 @@ impl std::fmt::Debug for GetRoomRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetRoomRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9847,7 +9806,6 @@ impl std::fmt::Debug for UpdateRoomRequest {
         let mut debug_struct = f.debug_struct("UpdateRoomRequest");
         debug_struct.field("room", &self.room);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9990,7 +9948,6 @@ impl std::fmt::Debug for DeleteRoomRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteRoomRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10181,7 +10138,6 @@ impl std::fmt::Debug for ListRoomsRequest {
         let mut debug_struct = f.debug_struct("ListRoomsRequest");
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10370,7 +10326,6 @@ impl std::fmt::Debug for ListRoomsResponse {
         let mut debug_struct = f.debug_struct("ListRoomsResponse");
         debug_struct.field("rooms", &self.rooms);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10844,7 +10799,6 @@ impl std::fmt::Debug for Blurb {
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("content", &self.content);
         debug_struct.field("legacy_id", &self.legacy_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11055,7 +11009,6 @@ impl std::fmt::Debug for CreateBlurbRequest {
         let mut debug_struct = f.debug_struct("CreateBlurbRequest");
         debug_struct.field("parent", &self.parent);
         debug_struct.field("blurb", &self.blurb);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11198,7 +11151,6 @@ impl std::fmt::Debug for GetBlurbRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBlurbRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11390,7 +11342,6 @@ impl std::fmt::Debug for UpdateBlurbRequest {
         let mut debug_struct = f.debug_struct("UpdateBlurbRequest");
         debug_struct.field("blurb", &self.blurb);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11533,7 +11484,6 @@ impl std::fmt::Debug for DeleteBlurbRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBlurbRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11750,7 +11700,6 @@ impl std::fmt::Debug for ListBlurbsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11939,7 +11888,6 @@ impl std::fmt::Debug for ListBlurbsResponse {
         let mut debug_struct = f.debug_struct("ListBlurbsResponse");
         debug_struct.field("blurbs", &self.blurbs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12184,7 +12132,6 @@ impl std::fmt::Debug for SearchBlurbsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12339,7 +12286,6 @@ impl std::fmt::Debug for SearchBlurbsMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SearchBlurbsMetadata");
         debug_struct.field("retry_info", &self.retry_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12514,7 +12460,6 @@ impl std::fmt::Debug for SearchBlurbsResponse {
         let mut debug_struct = f.debug_struct("SearchBlurbsResponse");
         debug_struct.field("blurbs", &self.blurbs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12694,7 +12639,6 @@ impl std::fmt::Debug for StreamBlurbsRequest {
         let mut debug_struct = f.debug_struct("StreamBlurbsRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12878,7 +12822,6 @@ impl std::fmt::Debug for StreamBlurbsResponse {
         let mut debug_struct = f.debug_struct("StreamBlurbsResponse");
         debug_struct.field("blurb", &self.blurb);
         debug_struct.field("action", &self.action);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13168,7 +13111,6 @@ impl std::fmt::Debug for SendBlurbsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SendBlurbsResponse");
         debug_struct.field("names", &self.names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13410,7 +13352,6 @@ impl std::fmt::Debug for ConnectRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConnectRequest");
         debug_struct.field("request", &self.request);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13559,7 +13500,6 @@ pub mod connect_request {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ConnectConfig");
             debug_struct.field("parent", &self.parent);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -13723,7 +13663,6 @@ impl std::fmt::Debug for RestError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("RestError");
         debug_struct.field("error", &self.error);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13970,7 +13909,6 @@ pub mod rest_error {
             debug_struct.field("message", &self.message);
             debug_struct.field("status", &self.status);
             debug_struct.field("details", &self.details);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14144,7 +14082,6 @@ impl std::fmt::Debug for Sequence {
         let mut debug_struct = f.debug_struct("Sequence");
         debug_struct.field("name", &self.name);
         debug_struct.field("responses", &self.responses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14341,7 +14278,6 @@ pub mod sequence {
             let mut debug_struct = f.debug_struct("Response");
             debug_struct.field("status", &self.status);
             debug_struct.field("delay", &self.delay);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14540,7 +14476,6 @@ impl std::fmt::Debug for StreamingSequence {
         debug_struct.field("name", &self.name);
         debug_struct.field("content", &self.content);
         debug_struct.field("responses", &self.responses);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14782,7 +14717,6 @@ pub mod streaming_sequence {
             debug_struct.field("status", &self.status);
             debug_struct.field("delay", &self.delay);
             debug_struct.field("response_index", &self.response_index);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14955,7 +14889,6 @@ impl std::fmt::Debug for StreamingSequenceReport {
         let mut debug_struct = f.debug_struct("StreamingSequenceReport");
         debug_struct.field("name", &self.name);
         debug_struct.field("attempts", &self.attempts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15274,7 +15207,6 @@ pub mod streaming_sequence_report {
             debug_struct.field("response_time", &self.response_time);
             debug_struct.field("attempt_delay", &self.attempt_delay);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15447,7 +15379,6 @@ impl std::fmt::Debug for SequenceReport {
         let mut debug_struct = f.debug_struct("SequenceReport");
         debug_struct.field("name", &self.name);
         debug_struct.field("attempts", &self.attempts);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15766,7 +15697,6 @@ pub mod sequence_report {
             debug_struct.field("response_time", &self.response_time);
             debug_struct.field("attempt_delay", &self.attempt_delay);
             debug_struct.field("status", &self.status);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15918,7 +15848,6 @@ impl std::fmt::Debug for CreateSequenceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateSequenceRequest");
         debug_struct.field("sequence", &self.sequence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16071,7 +16000,6 @@ impl std::fmt::Debug for CreateStreamingSequenceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateStreamingSequenceRequest");
         debug_struct.field("streaming_sequence", &self.streaming_sequence);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16211,7 +16139,6 @@ impl std::fmt::Debug for AttemptSequenceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttemptSequenceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16398,7 +16325,6 @@ impl std::fmt::Debug for AttemptStreamingSequenceRequest {
         let mut debug_struct = f.debug_struct("AttemptStreamingSequenceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("last_fail_index", &self.last_fail_index);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16540,7 +16466,6 @@ impl std::fmt::Debug for AttemptStreamingSequenceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AttemptStreamingSequenceResponse");
         debug_struct.field("content", &self.content);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16680,7 +16605,6 @@ impl std::fmt::Debug for GetSequenceReportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSequenceReportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16820,7 +16744,6 @@ impl std::fmt::Debug for GetStreamingSequenceReportRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetStreamingSequenceReportRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16996,7 +16919,6 @@ impl std::fmt::Debug for Session {
         let mut debug_struct = f.debug_struct("Session");
         debug_struct.field("name", &self.name);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17290,7 +17212,6 @@ impl std::fmt::Debug for CreateSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateSessionRequest");
         debug_struct.field("session", &self.session);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17432,7 +17353,6 @@ impl std::fmt::Debug for GetSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17619,7 +17539,6 @@ impl std::fmt::Debug for ListSessionsRequest {
         let mut debug_struct = f.debug_struct("ListSessionsRequest");
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17805,7 +17724,6 @@ impl std::fmt::Debug for ListSessionsResponse {
         let mut debug_struct = f.debug_struct("ListSessionsResponse");
         debug_struct.field("sessions", &self.sessions);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17947,7 +17865,6 @@ impl std::fmt::Debug for DeleteSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18089,7 +18006,6 @@ impl std::fmt::Debug for ReportSessionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReportSessionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18265,7 +18181,6 @@ impl std::fmt::Debug for ReportSessionResponse {
         let mut debug_struct = f.debug_struct("ReportSessionResponse");
         debug_struct.field("result", &self.result);
         debug_struct.field("test_runs", &self.test_runs);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18639,7 +18554,6 @@ impl std::fmt::Debug for Test {
         debug_struct.field("expectation_level", &self.expectation_level);
         debug_struct.field("description", &self.description);
         debug_struct.field("blueprints", &self.blueprints);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18887,7 +18801,6 @@ pub mod test {
             debug_struct.field("description", &self.description);
             debug_struct.field("request", &self.request);
             debug_struct.field("additional_requests", &self.additional_requests);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19101,7 +19014,6 @@ pub mod test {
                 let mut debug_struct = f.debug_struct("Invocation");
                 debug_struct.field("method", &self.method);
                 debug_struct.field("serialized_request", &self.serialized_request);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -19449,7 +19361,6 @@ impl std::fmt::Debug for Issue {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("severity", &self.severity);
         debug_struct.field("description", &self.description);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19937,7 +19848,6 @@ impl std::fmt::Debug for ListTestsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20123,7 +20033,6 @@ impl std::fmt::Debug for ListTestsResponse {
         let mut debug_struct = f.debug_struct("ListTestsResponse");
         debug_struct.field("tests", &self.tests);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20303,7 +20212,6 @@ impl std::fmt::Debug for TestRun {
         let mut debug_struct = f.debug_struct("TestRun");
         debug_struct.field("test", &self.test);
         debug_struct.field("issue", &self.issue);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20445,7 +20353,6 @@ impl std::fmt::Debug for DeleteTestRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteTestRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20684,7 +20591,6 @@ impl std::fmt::Debug for VerifyTestRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("answer", &self.answer);
         debug_struct.field("answers", &self.answers);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -20836,7 +20742,6 @@ impl std::fmt::Debug for VerifyTestResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("VerifyTestResponse");
         debug_struct.field("issue", &self.issue);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -889,7 +889,6 @@ impl std::fmt::Debug for Backup {
         );
         debug_struct.field("oldest_version_time", &self.oldest_version_time);
         debug_struct.field("instance_partitions", &self.instance_partitions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1285,7 +1284,6 @@ impl std::fmt::Debug for CreateBackupRequest {
         debug_struct.field("backup_id", &self.backup_id);
         debug_struct.field("backup", &self.backup);
         debug_struct.field("encryption_config", &self.encryption_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1547,7 +1545,6 @@ impl std::fmt::Debug for CreateBackupMetadata {
         debug_struct.field("database", &self.database);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("cancel_time", &self.cancel_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1836,7 +1833,6 @@ impl std::fmt::Debug for CopyBackupRequest {
         debug_struct.field("source_backup", &self.source_backup);
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("encryption_config", &self.encryption_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2103,7 +2099,6 @@ impl std::fmt::Debug for CopyBackupMetadata {
         debug_struct.field("source_backup", &self.source_backup);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("cancel_time", &self.cancel_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2304,7 +2299,6 @@ impl std::fmt::Debug for UpdateBackupRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupRequest");
         debug_struct.field("backup", &self.backup);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2451,7 +2445,6 @@ impl std::fmt::Debug for GetBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2598,7 +2591,6 @@ impl std::fmt::Debug for DeleteBackupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2887,7 +2879,6 @@ impl std::fmt::Debug for ListBackupsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3080,7 +3071,6 @@ impl std::fmt::Debug for ListBackupsResponse {
         let mut debug_struct = f.debug_struct("ListBackupsResponse");
         debug_struct.field("backups", &self.backups);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3402,7 +3392,6 @@ impl std::fmt::Debug for ListBackupOperationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3609,7 +3598,6 @@ impl std::fmt::Debug for ListBackupOperationsResponse {
         let mut debug_struct = f.debug_struct("ListBackupOperationsResponse");
         debug_struct.field("operations", &self.operations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3861,7 +3849,6 @@ impl std::fmt::Debug for BackupInfo {
         debug_struct.field("version_time", &self.version_time);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("source_database", &self.source_database);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4087,7 +4074,6 @@ impl std::fmt::Debug for CreateBackupEncryptionConfig {
         debug_struct.field("encryption_type", &self.encryption_type);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_names", &self.kms_key_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4471,7 +4457,6 @@ impl std::fmt::Debug for CopyBackupEncryptionConfig {
         debug_struct.field("encryption_type", &self.encryption_type);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_names", &self.kms_key_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4750,7 +4735,6 @@ impl serde::ser::Serialize for FullBackupSpec {
 impl std::fmt::Debug for FullBackupSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FullBackupSpec");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4869,7 +4853,6 @@ impl serde::ser::Serialize for IncrementalBackupSpec {
 impl std::fmt::Debug for IncrementalBackupSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("IncrementalBackupSpec");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5016,7 +4999,6 @@ impl std::fmt::Debug for BackupInstancePartition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BackupInstancePartition");
         debug_struct.field("instance_partition", &self.instance_partition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5205,7 +5187,6 @@ impl std::fmt::Debug for BackupScheduleSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("BackupScheduleSpec");
         debug_struct.field("schedule_spec", &self.schedule_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5659,7 +5640,6 @@ impl std::fmt::Debug for BackupSchedule {
         debug_struct.field("encryption_config", &self.encryption_config);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("backup_type_spec", &self.backup_type_spec);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5901,7 +5881,6 @@ impl std::fmt::Debug for CrontabSpec {
         debug_struct.field("text", &self.text);
         debug_struct.field("time_zone", &self.time_zone);
         debug_struct.field("creation_window", &self.creation_window);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6115,7 +6094,6 @@ impl std::fmt::Debug for CreateBackupScheduleRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("backup_schedule_id", &self.backup_schedule_id);
         debug_struct.field("backup_schedule", &self.backup_schedule);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6262,7 +6240,6 @@ impl std::fmt::Debug for GetBackupScheduleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetBackupScheduleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6409,7 +6386,6 @@ impl std::fmt::Debug for DeleteBackupScheduleRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteBackupScheduleRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6634,7 +6610,6 @@ impl std::fmt::Debug for ListBackupSchedulesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6831,7 +6806,6 @@ impl std::fmt::Debug for ListBackupSchedulesResponse {
         let mut debug_struct = f.debug_struct("ListBackupSchedulesResponse");
         debug_struct.field("backup_schedules", &self.backup_schedules);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7032,7 +7006,6 @@ impl std::fmt::Debug for UpdateBackupScheduleRequest {
         let mut debug_struct = f.debug_struct("UpdateBackupScheduleRequest");
         debug_struct.field("backup_schedule", &self.backup_schedule);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7271,7 +7244,6 @@ impl std::fmt::Debug for OperationProgress {
         debug_struct.field("progress_percent", &self.progress_percent);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7460,7 +7432,6 @@ impl std::fmt::Debug for EncryptionConfig {
         let mut debug_struct = f.debug_struct("EncryptionConfig");
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_names", &self.kms_key_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7670,7 +7641,6 @@ impl std::fmt::Debug for EncryptionInfo {
         debug_struct.field("encryption_type", &self.encryption_type);
         debug_struct.field("encryption_status", &self.encryption_status);
         debug_struct.field("kms_key_version", &self.kms_key_version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8032,7 +8002,6 @@ impl std::fmt::Debug for RestoreInfo {
         let mut debug_struct = f.debug_struct("RestoreInfo");
         debug_struct.field("source_type", &self.source_type);
         debug_struct.field("source_info", &self.source_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8569,7 +8538,6 @@ impl std::fmt::Debug for Database {
         debug_struct.field("database_dialect", &self.database_dialect);
         debug_struct.field("enable_drop_protection", &self.enable_drop_protection);
         debug_struct.field("reconciling", &self.reconciling);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8945,7 +8913,6 @@ impl std::fmt::Debug for ListDatabasesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9137,7 +9104,6 @@ impl std::fmt::Debug for ListDatabasesResponse {
         let mut debug_struct = f.debug_struct("ListDatabasesResponse");
         debug_struct.field("databases", &self.databases);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9478,7 +9444,6 @@ impl std::fmt::Debug for CreateDatabaseRequest {
         debug_struct.field("encryption_config", &self.encryption_config);
         debug_struct.field("database_dialect", &self.database_dialect);
         debug_struct.field("proto_descriptors", &self.proto_descriptors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9623,7 +9588,6 @@ impl std::fmt::Debug for CreateDatabaseMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateDatabaseMetadata");
         debug_struct.field("database", &self.database);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9769,7 +9733,6 @@ impl std::fmt::Debug for GetDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatabaseRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9965,7 +9928,6 @@ impl std::fmt::Debug for UpdateDatabaseRequest {
         let mut debug_struct = f.debug_struct("UpdateDatabaseRequest");
         debug_struct.field("database", &self.database);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10203,7 +10165,6 @@ impl std::fmt::Debug for UpdateDatabaseMetadata {
         debug_struct.field("request", &self.request);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("cancel_time", &self.cancel_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10530,7 +10491,6 @@ impl std::fmt::Debug for UpdateDatabaseDdlRequest {
         debug_struct.field("operation_id", &self.operation_id);
         debug_struct.field("proto_descriptors", &self.proto_descriptors);
         debug_struct.field("throughput_mode", &self.throughput_mode);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10739,7 +10699,6 @@ impl std::fmt::Debug for DdlStatementActionInfo {
         debug_struct.field("action", &self.action);
         debug_struct.field("entity_type", &self.entity_type);
         debug_struct.field("entity_names", &self.entity_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11046,7 +11005,6 @@ impl std::fmt::Debug for UpdateDatabaseDdlMetadata {
         debug_struct.field("throttled", &self.throttled);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("actions", &self.actions);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11191,7 +11149,6 @@ impl std::fmt::Debug for DropDatabaseRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DropDatabaseRequest");
         debug_struct.field("database", &self.database);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11338,7 +11295,6 @@ impl std::fmt::Debug for GetDatabaseDdlRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetDatabaseDdlRequest");
         debug_struct.field("database", &self.database);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11536,7 +11492,6 @@ impl std::fmt::Debug for GetDatabaseDdlResponse {
         let mut debug_struct = f.debug_struct("GetDatabaseDdlResponse");
         debug_struct.field("statements", &self.statements);
         debug_struct.field("proto_descriptors", &self.proto_descriptors);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11832,7 +11787,6 @@ impl std::fmt::Debug for ListDatabaseOperationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12035,7 +11989,6 @@ impl std::fmt::Debug for ListDatabaseOperationsResponse {
         let mut debug_struct = f.debug_struct("ListDatabaseOperationsResponse");
         debug_struct.field("operations", &self.operations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12324,7 +12277,6 @@ impl std::fmt::Debug for RestoreDatabaseRequest {
         debug_struct.field("database_id", &self.database_id);
         debug_struct.field("encryption_config", &self.encryption_config);
         debug_struct.field("source", &self.source);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12561,7 +12513,6 @@ impl std::fmt::Debug for RestoreDatabaseEncryptionConfig {
         debug_struct.field("encryption_type", &self.encryption_type);
         debug_struct.field("kms_key_name", &self.kms_key_name);
         debug_struct.field("kms_key_names", &self.kms_key_names);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13115,7 +13066,6 @@ impl std::fmt::Debug for RestoreDatabaseMetadata {
             &self.optimize_database_operation_name,
         );
         debug_struct.field("source_info", &self.source_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13315,7 +13265,6 @@ impl std::fmt::Debug for OptimizeRestoredDatabaseMetadata {
         let mut debug_struct = f.debug_struct("OptimizeRestoredDatabaseMetadata");
         debug_struct.field("name", &self.name);
         debug_struct.field("progress", &self.progress);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13459,7 +13408,6 @@ impl std::fmt::Debug for DatabaseRole {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DatabaseRole");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13683,7 +13631,6 @@ impl std::fmt::Debug for ListDatabaseRolesRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13876,7 +13823,6 @@ impl std::fmt::Debug for ListDatabaseRolesResponse {
         let mut debug_struct = f.debug_struct("ListDatabaseRolesResponse");
         debug_struct.field("database_roles", &self.database_roles);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14081,7 +14027,6 @@ impl std::fmt::Debug for AddSplitPointsRequest {
         debug_struct.field("database", &self.database);
         debug_struct.field("split_points", &self.split_points);
         debug_struct.field("initiator", &self.initiator);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14198,7 +14143,6 @@ impl serde::ser::Serialize for AddSplitPointsResponse {
 impl std::fmt::Debug for AddSplitPointsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AddSplitPointsResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14438,7 +14382,6 @@ impl std::fmt::Debug for SplitPoints {
         debug_struct.field("index", &self.index);
         debug_struct.field("keys", &self.keys);
         debug_struct.field("expire_time", &self.expire_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14600,7 +14543,6 @@ pub mod split_points {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Key");
             debug_struct.field("key_parts", &self.key_parts);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -264,7 +264,6 @@ impl std::fmt::Debug for OperationProgress {
         debug_struct.field("progress_percent", &self.progress_percent);
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -406,7 +405,6 @@ impl std::fmt::Debug for ReplicaSelection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ReplicaSelection");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -602,7 +600,6 @@ impl std::fmt::Debug for ReplicaInfo {
         debug_struct.field("location", &self.location);
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("default_leader_location", &self.default_leader_location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1361,7 +1358,6 @@ impl std::fmt::Debug for InstanceConfig {
             "storage_limit_per_processing_unit",
             &self.storage_limit_per_processing_unit,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2253,7 +2249,6 @@ impl std::fmt::Debug for ReplicaComputeCapacity {
         let mut debug_struct = f.debug_struct("ReplicaComputeCapacity");
         debug_struct.field("replica_selection", &self.replica_selection);
         debug_struct.field("compute_capacity", &self.compute_capacity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2522,7 +2517,6 @@ impl std::fmt::Debug for AutoscalingConfig {
             "asymmetric_autoscaling_options",
             &self.asymmetric_autoscaling_options,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2971,7 +2965,6 @@ pub mod autoscaling_config {
             let mut debug_struct = f.debug_struct("AutoscalingLimits");
             debug_struct.field("min_limit", &self.min_limit);
             debug_struct.field("max_limit", &self.max_limit);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3245,7 +3238,6 @@ pub mod autoscaling_config {
                 "storage_utilization_percent",
                 &self.storage_utilization_percent,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3440,7 +3432,6 @@ pub mod autoscaling_config {
             let mut debug_struct = f.debug_struct("AsymmetricAutoscalingOption");
             debug_struct.field("replica_selection", &self.replica_selection);
             debug_struct.field("overrides", &self.overrides);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3666,7 +3657,6 @@ pub mod autoscaling_config {
                     "autoscaling_target_high_priority_cpu_utilization_percent",
                     &self.autoscaling_target_high_priority_cpu_utilization_percent,
                 );
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -4403,7 +4393,6 @@ impl std::fmt::Debug for Instance {
             "default_backup_schedule_type",
             &self.default_backup_schedule_type,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5189,7 +5178,6 @@ impl std::fmt::Debug for ListInstanceConfigsRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5386,7 +5374,6 @@ impl std::fmt::Debug for ListInstanceConfigsResponse {
         let mut debug_struct = f.debug_struct("ListInstanceConfigsResponse");
         debug_struct.field("instance_configs", &self.instance_configs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5532,7 +5519,6 @@ impl std::fmt::Debug for GetInstanceConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstanceConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5779,7 +5765,6 @@ impl std::fmt::Debug for CreateInstanceConfigRequest {
         debug_struct.field("instance_config_id", &self.instance_config_id);
         debug_struct.field("instance_config", &self.instance_config);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6017,7 +6002,6 @@ impl std::fmt::Debug for UpdateInstanceConfigRequest {
         debug_struct.field("instance_config", &self.instance_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6222,7 +6206,6 @@ impl std::fmt::Debug for DeleteInstanceConfigRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("validate_only", &self.validate_only);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6514,7 +6497,6 @@ impl std::fmt::Debug for ListInstanceConfigOperationsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6714,7 +6696,6 @@ impl std::fmt::Debug for ListInstanceConfigOperationsResponse {
         let mut debug_struct = f.debug_struct("ListInstanceConfigOperationsResponse");
         debug_struct.field("operations", &self.operations);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6902,7 +6883,6 @@ impl std::fmt::Debug for GetInstanceRequest {
         let mut debug_struct = f.debug_struct("GetInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("field_mask", &self.field_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7113,7 +7093,6 @@ impl std::fmt::Debug for CreateInstanceRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("instance_id", &self.instance_id);
         debug_struct.field("instance", &self.instance);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7424,7 +7403,6 @@ impl std::fmt::Debug for ListInstancesRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("filter", &self.filter);
         debug_struct.field("instance_deadline", &self.instance_deadline);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7649,7 +7627,6 @@ impl std::fmt::Debug for ListInstancesResponse {
         debug_struct.field("instances", &self.instances);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7853,7 +7830,6 @@ impl std::fmt::Debug for UpdateInstanceRequest {
         let mut debug_struct = f.debug_struct("UpdateInstanceRequest");
         debug_struct.field("instance", &self.instance);
         debug_struct.field("field_mask", &self.field_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7999,7 +7975,6 @@ impl std::fmt::Debug for DeleteInstanceRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteInstanceRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8314,7 +8289,6 @@ impl std::fmt::Debug for CreateInstanceMetadata {
             "expected_fulfillment_period",
             &self.expected_fulfillment_period,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8629,7 +8603,6 @@ impl std::fmt::Debug for UpdateInstanceMetadata {
             "expected_fulfillment_period",
             &self.expected_fulfillment_period,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8860,7 +8833,6 @@ impl std::fmt::Debug for FreeInstanceMetadata {
         debug_struct.field("expire_time", &self.expire_time);
         debug_struct.field("upgrade_time", &self.upgrade_time);
         debug_struct.field("expire_behavior", &self.expire_behavior);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9238,7 +9210,6 @@ impl std::fmt::Debug for CreateInstanceConfigMetadata {
         debug_struct.field("instance_config", &self.instance_config);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("cancel_time", &self.cancel_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9474,7 +9445,6 @@ impl std::fmt::Debug for UpdateInstanceConfigMetadata {
         debug_struct.field("instance_config", &self.instance_config);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("cancel_time", &self.cancel_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10041,7 +10011,6 @@ impl std::fmt::Debug for InstancePartition {
         debug_struct.field("referencing_backups", &self.referencing_backups);
         debug_struct.field("etag", &self.etag);
         debug_struct.field("compute_capacity", &self.compute_capacity);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10484,7 +10453,6 @@ impl std::fmt::Debug for CreateInstancePartitionMetadata {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("cancel_time", &self.cancel_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10702,7 +10670,6 @@ impl std::fmt::Debug for CreateInstancePartitionRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("instance_partition_id", &self.instance_partition_id);
         debug_struct.field("instance_partition", &self.instance_partition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10877,7 +10844,6 @@ impl std::fmt::Debug for DeleteInstancePartitionRequest {
         let mut debug_struct = f.debug_struct("DeleteInstancePartitionRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("etag", &self.etag);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11024,7 +10990,6 @@ impl std::fmt::Debug for GetInstancePartitionRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetInstancePartitionRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11231,7 +11196,6 @@ impl std::fmt::Debug for UpdateInstancePartitionRequest {
         let mut debug_struct = f.debug_struct("UpdateInstancePartitionRequest");
         debug_struct.field("instance_partition", &self.instance_partition);
         debug_struct.field("field_mask", &self.field_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11506,7 +11470,6 @@ impl std::fmt::Debug for UpdateInstancePartitionMetadata {
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("cancel_time", &self.cancel_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11786,7 +11749,6 @@ impl std::fmt::Debug for ListInstancePartitionsRequest {
             "instance_partition_deadline",
             &self.instance_partition_deadline,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12016,7 +11978,6 @@ impl std::fmt::Debug for ListInstancePartitionsResponse {
         debug_struct.field("instance_partitions", &self.instance_partitions);
         debug_struct.field("next_page_token", &self.next_page_token);
         debug_struct.field("unreachable", &self.unreachable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12364,7 +12325,6 @@ impl std::fmt::Debug for ListInstancePartitionOperationsRequest {
             "instance_partition_deadline",
             &self.instance_partition_deadline,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12609,7 +12569,6 @@ impl std::fmt::Debug for ListInstancePartitionOperationsResponse {
             "unreachable_instance_partitions",
             &self.unreachable_instance_partitions,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12782,7 +12741,6 @@ impl std::fmt::Debug for MoveInstanceRequest {
         let mut debug_struct = f.debug_struct("MoveInstanceRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("target_config", &self.target_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12899,7 +12857,6 @@ impl serde::ser::Serialize for MoveInstanceResponse {
 impl std::fmt::Debug for MoveInstanceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MoveInstanceResponse");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13127,7 +13084,6 @@ impl std::fmt::Debug for MoveInstanceMetadata {
         debug_struct.field("target_config", &self.target_config);
         debug_struct.field("progress", &self.progress);
         debug_struct.field("cancel_time", &self.cancel_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -170,7 +170,6 @@ impl std::fmt::Debug for GetGoogleServiceAccountRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetGoogleServiceAccountRequest");
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -324,7 +323,6 @@ impl std::fmt::Debug for CreateTransferJobRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("CreateTransferJobRequest");
         debug_struct.field("transfer_job", &self.transfer_job);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -617,7 +615,6 @@ impl std::fmt::Debug for UpdateTransferJobRequest {
             "update_transfer_job_field_mask",
             &self.update_transfer_job_field_mask,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -787,7 +784,6 @@ impl std::fmt::Debug for GetTransferJobRequest {
         let mut debug_struct = f.debug_struct("GetTransferJobRequest");
         debug_struct.field("job_name", &self.job_name);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -957,7 +953,6 @@ impl std::fmt::Debug for DeleteTransferJobRequest {
         let mut debug_struct = f.debug_struct("DeleteTransferJobRequest");
         debug_struct.field("job_name", &self.job_name);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1200,7 +1195,6 @@ impl std::fmt::Debug for ListTransferJobsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1386,7 +1380,6 @@ impl std::fmt::Debug for ListTransferJobsResponse {
         let mut debug_struct = f.debug_struct("ListTransferJobsResponse");
         debug_struct.field("transfer_jobs", &self.transfer_jobs);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1528,7 +1521,6 @@ impl std::fmt::Debug for PauseTransferOperationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PauseTransferOperationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1670,7 +1662,6 @@ impl std::fmt::Debug for ResumeTransferOperationRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ResumeTransferOperationRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1840,7 +1831,6 @@ impl std::fmt::Debug for RunTransferJobRequest {
         let mut debug_struct = f.debug_struct("RunTransferJobRequest");
         debug_struct.field("job_name", &self.job_name);
         debug_struct.field("project_id", &self.project_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2059,7 +2049,6 @@ impl std::fmt::Debug for CreateAgentPoolRequest {
         debug_struct.field("project_id", &self.project_id);
         debug_struct.field("agent_pool", &self.agent_pool);
         debug_struct.field("agent_pool_id", &self.agent_pool_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2276,7 +2265,6 @@ impl std::fmt::Debug for UpdateAgentPoolRequest {
         let mut debug_struct = f.debug_struct("UpdateAgentPoolRequest");
         debug_struct.field("agent_pool", &self.agent_pool);
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2418,7 +2406,6 @@ impl std::fmt::Debug for GetAgentPoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetAgentPoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2560,7 +2547,6 @@ impl std::fmt::Debug for DeleteAgentPoolRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("DeleteAgentPoolRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2805,7 +2791,6 @@ impl std::fmt::Debug for ListAgentPoolsRequest {
         debug_struct.field("filter", &self.filter);
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2991,7 +2976,6 @@ impl std::fmt::Debug for ListAgentPoolsResponse {
         let mut debug_struct = f.debug_struct("ListAgentPoolsResponse");
         debug_struct.field("agent_pools", &self.agent_pools);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3160,7 +3144,6 @@ impl std::fmt::Debug for GoogleServiceAccount {
         let mut debug_struct = f.debug_struct("GoogleServiceAccount");
         debug_struct.field("account_email", &self.account_email);
         debug_struct.field("subject_id", &self.subject_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3338,7 +3321,6 @@ impl std::fmt::Debug for AwsAccessKey {
         let mut debug_struct = f.debug_struct("AwsAccessKey");
         debug_struct.field("access_key_id", &self.access_key_id);
         debug_struct.field("secret_access_key", &self.secret_access_key);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3489,7 +3471,6 @@ impl std::fmt::Debug for AzureCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("AzureCredentials");
         debug_struct.field("sas_token", &self.sas_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3960,7 +3941,6 @@ impl std::fmt::Debug for ObjectConditions {
         debug_struct.field("exclude_prefixes", &self.exclude_prefixes);
         debug_struct.field("last_modified_since", &self.last_modified_since);
         debug_struct.field("last_modified_before", &self.last_modified_before);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4190,7 +4170,6 @@ impl std::fmt::Debug for GcsData {
             "managed_folder_transfer_enabled",
             &self.managed_folder_transfer_enabled,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4601,7 +4580,6 @@ impl std::fmt::Debug for AwsS3Data {
         debug_struct.field("cloudfront_domain", &self.cloudfront_domain);
         debug_struct.field("credentials_secret", &self.credentials_secret);
         debug_struct.field("private_network", &self.private_network);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4962,7 +4940,6 @@ impl std::fmt::Debug for AzureBlobStorageData {
         debug_struct.field("path", &self.path);
         debug_struct.field("credentials_secret", &self.credentials_secret);
         debug_struct.field("federated_identity_config", &self.federated_identity_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5150,7 +5127,6 @@ pub mod azure_blob_storage_data {
             let mut debug_struct = f.debug_struct("FederatedIdentityConfig");
             debug_struct.field("client_id", &self.client_id);
             debug_struct.field("tenant_id", &self.tenant_id);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -5340,7 +5316,6 @@ impl std::fmt::Debug for HttpData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HttpData");
         debug_struct.field("list_url", &self.list_url);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5483,7 +5458,6 @@ impl std::fmt::Debug for PosixFilesystem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PosixFilesystem");
         debug_struct.field("root_directory", &self.root_directory);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5628,7 +5602,6 @@ impl std::fmt::Debug for HdfsData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("HdfsData");
         debug_struct.field("path", &self.path);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5931,7 +5904,6 @@ impl std::fmt::Debug for AwsS3CompatibleData {
         debug_struct.field("endpoint", &self.endpoint);
         debug_struct.field("region", &self.region);
         debug_struct.field("data_provider", &self.data_provider);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6200,7 +6172,6 @@ impl std::fmt::Debug for S3CompatibleMetadata {
         debug_struct.field("request_model", &self.request_model);
         debug_struct.field("protocol", &self.protocol);
         debug_struct.field("list_api", &self.list_api);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6977,7 +6948,6 @@ impl std::fmt::Debug for AgentPool {
         debug_struct.field("display_name", &self.display_name);
         debug_struct.field("state", &self.state);
         debug_struct.field("bandwidth_limit", &self.bandwidth_limit);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7148,7 +7118,6 @@ pub mod agent_pool {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("BandwidthLimit");
             debug_struct.field("limit_mbps", &self.limit_mbps);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7617,7 +7586,6 @@ impl std::fmt::Debug for TransferOptions {
         );
         debug_struct.field("overwrite_when", &self.overwrite_when);
         debug_struct.field("metadata_options", &self.metadata_options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8701,7 +8669,6 @@ impl std::fmt::Debug for TransferSpec {
             "intermediate_data_location",
             &self.intermediate_data_location,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9098,7 +9065,6 @@ impl std::fmt::Debug for ReplicationSpec {
         debug_struct.field("transfer_options", &self.transfer_options);
         debug_struct.field("data_source", &self.data_source);
         debug_struct.field("data_sink", &self.data_sink);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9521,7 +9487,6 @@ impl std::fmt::Debug for MetadataOptions {
         debug_struct.field("temporary_hold", &self.temporary_hold);
         debug_struct.field("kms_key", &self.kms_key);
         debug_struct.field("time_created", &self.time_created);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10909,7 +10874,6 @@ impl std::fmt::Debug for TransferManifest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("TransferManifest");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11280,7 +11244,6 @@ impl std::fmt::Debug for Schedule {
         debug_struct.field("start_time_of_day", &self.start_time_of_day);
         debug_struct.field("end_time_of_day", &self.end_time_of_day);
         debug_struct.field("repeat_interval", &self.repeat_interval);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11515,7 +11478,6 @@ impl std::fmt::Debug for EventStream {
             "event_stream_expiration_time",
             &self.event_stream_expiration_time,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12181,7 +12143,6 @@ impl std::fmt::Debug for TransferJob {
         debug_struct.field("last_modification_time", &self.last_modification_time);
         debug_struct.field("deletion_time", &self.deletion_time);
         debug_struct.field("latest_operation_name", &self.latest_operation_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12501,7 +12462,6 @@ impl std::fmt::Debug for ErrorLogEntry {
         let mut debug_struct = f.debug_struct("ErrorLogEntry");
         debug_struct.field("url", &self.url);
         debug_struct.field("error_details", &self.error_details);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12721,7 +12681,6 @@ impl std::fmt::Debug for ErrorSummary {
         debug_struct.field("error_code", &self.error_code);
         debug_struct.field("error_count", &self.error_count);
         debug_struct.field("error_log_entries", &self.error_log_entries);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13984,7 +13943,6 @@ impl std::fmt::Debug for TransferCounters {
             "intermediate_objects_failed_cleaned_up",
             &self.intermediate_objects_failed_cleaned_up,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14227,7 +14185,6 @@ impl std::fmt::Debug for NotificationConfig {
         debug_struct.field("pubsub_topic", &self.pubsub_topic);
         debug_struct.field("event_types", &self.event_types);
         debug_struct.field("payload_format", &self.payload_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14761,7 +14718,6 @@ impl std::fmt::Debug for LoggingConfig {
             "enable_onprem_gcs_transfer_logs",
             &self.enable_onprem_gcs_transfer_logs,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -15523,7 +15479,6 @@ impl std::fmt::Debug for TransferOperation {
         debug_struct.field("counters", &self.counters);
         debug_struct.field("error_breakdowns", &self.error_breakdowns);
         debug_struct.field("transfer_job_name", &self.transfer_job_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -458,7 +458,6 @@ impl std::fmt::Debug for Color {
         debug_struct.field("green", &self.green);
         debug_struct.field("blue", &self.blue);
         debug_struct.field("alpha", &self.alpha);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -722,7 +721,6 @@ impl std::fmt::Debug for Date {
         debug_struct.field("year", &self.year);
         debug_struct.field("month", &self.month);
         debug_struct.field("day", &self.day);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1290,7 +1288,6 @@ impl std::fmt::Debug for DateTime {
         debug_struct.field("seconds", &self.seconds);
         debug_struct.field("nanos", &self.nanos);
         debug_struct.field("time_offset", &self.time_offset);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1480,7 +1477,6 @@ impl std::fmt::Debug for TimeZone {
         let mut debug_struct = f.debug_struct("TimeZone");
         debug_struct.field("id", &self.id);
         debug_struct.field("version", &self.version);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1690,7 +1686,6 @@ impl std::fmt::Debug for Decimal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("Decimal");
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1950,7 +1945,6 @@ impl std::fmt::Debug for Expr {
         debug_struct.field("title", &self.title);
         debug_struct.field("description", &self.description);
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2154,7 +2148,6 @@ impl std::fmt::Debug for Fraction {
         let mut debug_struct = f.debug_struct("Fraction");
         debug_struct.field("numerator", &self.numerator);
         debug_struct.field("denominator", &self.denominator);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2356,7 +2349,6 @@ impl std::fmt::Debug for Interval {
         let mut debug_struct = f.debug_struct("Interval");
         debug_struct.field("start_time", &self.start_time);
         debug_struct.field("end_time", &self.end_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2563,7 +2555,6 @@ impl std::fmt::Debug for LatLng {
         let mut debug_struct = f.debug_struct("LatLng");
         debug_struct.field("latitude", &self.latitude);
         debug_struct.field("longitude", &self.longitude);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2734,7 +2725,6 @@ impl std::fmt::Debug for LocalizedText {
         let mut debug_struct = f.debug_struct("LocalizedText");
         debug_struct.field("text", &self.text);
         debug_struct.field("language_code", &self.language_code);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2969,7 +2959,6 @@ impl std::fmt::Debug for Money {
         debug_struct.field("currency_code", &self.currency_code);
         debug_struct.field("units", &self.units);
         debug_struct.field("nanos", &self.nanos);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3268,7 +3257,6 @@ impl std::fmt::Debug for PhoneNumber {
         let mut debug_struct = f.debug_struct("PhoneNumber");
         debug_struct.field("extension", &self.extension);
         debug_struct.field("kind", &self.kind);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3458,7 +3446,6 @@ pub mod phone_number {
             let mut debug_struct = f.debug_struct("ShortCode");
             debug_struct.field("region_code", &self.region_code);
             debug_struct.field("number", &self.number);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3991,7 +3978,6 @@ impl std::fmt::Debug for PostalAddress {
         debug_struct.field("address_lines", &self.address_lines);
         debug_struct.field("recipients", &self.recipients);
         debug_struct.field("organization", &self.organization);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4338,7 +4324,6 @@ impl std::fmt::Debug for Quaternion {
         debug_struct.field("y", &self.y);
         debug_struct.field("z", &self.z);
         debug_struct.field("w", &self.w);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4634,7 +4619,6 @@ impl std::fmt::Debug for TimeOfDay {
         debug_struct.field("minutes", &self.minutes);
         debug_struct.field("seconds", &self.seconds);
         debug_struct.field("nanos", &self.nanos);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/protojson-conformance/src/generated/gapic/model.rs
+++ b/src/protojson-conformance/src/generated/gapic/model.rs
@@ -204,7 +204,6 @@ impl std::fmt::Debug for TestStatus {
         debug_struct.field("name", &self.name);
         debug_struct.field("failure_message", &self.failure_message);
         debug_struct.field("matched_name", &self.matched_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -354,7 +353,6 @@ impl std::fmt::Debug for FailureSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FailureSet");
         debug_struct.field("test", &self.test);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -870,7 +868,6 @@ impl std::fmt::Debug for ConformanceRequest {
         debug_struct.field("jspb_encoding_options", &self.jspb_encoding_options);
         debug_struct.field("print_unknown_fields", &self.print_unknown_fields);
         debug_struct.field("payload", &self.payload);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1495,7 +1492,6 @@ impl std::fmt::Debug for ConformanceResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ConformanceResponse");
         debug_struct.field("result", &self.result);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1724,7 +1720,6 @@ impl std::fmt::Debug for JspbEncodingConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("JspbEncodingConfig");
         debug_struct.field("use_jspb_array_any_format", &self.use_jspb_array_any_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/protojson-conformance/src/generated/test_protos/mod.rs
+++ b/src/protojson-conformance/src/generated/test_protos/mod.rs
@@ -7221,7 +7221,6 @@ impl std::fmt::Debug for TestAllTypesProto3 {
         debug_struct.field("field_name17__", &self.field_name17__);
         debug_struct.field("field_name_18__", &self.field_name_18__);
         debug_struct.field("oneof_field", &self.oneof_field);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7426,7 +7425,6 @@ pub mod test_all_types_proto_3 {
             let mut debug_struct = f.debug_struct("NestedMessage");
             debug_struct.field("a", &self.a);
             debug_struct.field("corecursive", &self.corecursive);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7875,7 +7873,6 @@ impl std::fmt::Debug for ForeignMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ForeignMessage");
         debug_struct.field("c", &self.c);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7988,7 +7985,6 @@ impl serde::ser::Serialize for NullHypothesisProto3 {
 impl std::fmt::Debug for NullHypothesisProto3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("NullHypothesisProto3");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8101,7 +8097,6 @@ impl serde::ser::Serialize for EnumOnlyProto3 {
 impl std::fmt::Debug for EnumOnlyProto3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("EnumOnlyProto3");
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/storage/src/generated/gapic/model.rs
+++ b/src/storage/src/generated/gapic/model.rs
@@ -281,7 +281,6 @@ impl std::fmt::Debug for DeleteBucketRequest {
             "if_metageneration_not_match",
             &self.if_metageneration_not_match,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -593,7 +592,6 @@ impl std::fmt::Debug for GetBucketRequest {
             &self.if_metageneration_not_match,
         );
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -902,7 +900,6 @@ impl std::fmt::Debug for CreateBucketRequest {
             &self.predefined_default_object_acl,
         );
         debug_struct.field("enable_object_retention", &self.enable_object_retention);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1184,7 +1181,6 @@ impl std::fmt::Debug for ListBucketsRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("prefix", &self.prefix);
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1370,7 +1366,6 @@ impl std::fmt::Debug for ListBucketsResponse {
         let mut debug_struct = f.debug_struct("ListBucketsResponse");
         debug_struct.field("buckets", &self.buckets);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1561,7 +1556,6 @@ impl std::fmt::Debug for LockBucketRetentionPolicyRequest {
         let mut debug_struct = f.debug_struct("LockBucketRetentionPolicyRequest");
         debug_struct.field("bucket", &self.bucket);
         debug_struct.field("if_metageneration_match", &self.if_metageneration_match);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1959,7 +1953,6 @@ impl std::fmt::Debug for UpdateBucketRequest {
             &self.predefined_default_object_acl,
         );
         debug_struct.field("update_mask", &self.update_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2424,7 +2417,6 @@ impl std::fmt::Debug for ComposeObjectRequest {
             &self.common_object_request_params,
         );
         debug_struct.field("object_checksums", &self.object_checksums);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2662,7 +2654,6 @@ pub mod compose_object_request {
             debug_struct.field("name", &self.name);
             debug_struct.field("generation", &self.generation);
             debug_struct.field("object_preconditions", &self.object_preconditions);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2856,7 +2847,6 @@ pub mod compose_object_request {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("ObjectPreconditions");
                 debug_struct.field("if_generation_match", &self.if_generation_match);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -3375,7 +3365,6 @@ impl std::fmt::Debug for DeleteObjectRequest {
             "common_object_request_params",
             &self.common_object_request_params,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3958,7 +3947,6 @@ impl std::fmt::Debug for RestoreObjectRequest {
             "common_object_request_params",
             &self.common_object_request_params,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4617,7 +4605,6 @@ impl std::fmt::Debug for ReadObjectRequest {
             &self.common_object_request_params,
         );
         debug_struct.field("read_mask", &self.read_mask);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5238,7 +5225,6 @@ impl std::fmt::Debug for GetObjectRequest {
         );
         debug_struct.field("read_mask", &self.read_mask);
         debug_struct.field("restore_token", &self.restore_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5774,7 +5760,6 @@ impl std::fmt::Debug for WriteObjectSpec {
         );
         debug_struct.field("object_size", &self.object_size);
         debug_struct.field("appendable", &self.appendable);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6332,7 +6317,6 @@ impl std::fmt::Debug for ListObjectsRequest {
         );
         debug_struct.field("match_glob", &self.match_glob);
         debug_struct.field("filter", &self.filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7612,7 +7596,6 @@ impl std::fmt::Debug for RewriteObjectRequest {
             &self.common_object_request_params,
         );
         debug_struct.field("object_checksums", &self.object_checksums);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7910,7 +7893,6 @@ impl std::fmt::Debug for RewriteResponse {
         debug_struct.field("done", &self.done);
         debug_struct.field("rewrite_token", &self.rewrite_token);
         debug_struct.field("resource", &self.resource);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8669,7 +8651,6 @@ impl std::fmt::Debug for MoveObjectRequest {
             "if_metageneration_not_match",
             &self.if_metageneration_not_match,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9237,7 +9218,6 @@ impl std::fmt::Debug for UpdateObjectRequest {
             "override_unlocked_retention",
             &self.override_unlocked_retention,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9489,7 +9469,6 @@ impl std::fmt::Debug for CommonObjectRequestParams {
             "encryption_key_sha256_bytes",
             &self.encryption_key_sha256_bytes,
         );
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10733,7 +10712,6 @@ impl std::fmt::Debug for Bucket {
         debug_struct.field("soft_delete_policy", &self.soft_delete_policy);
         debug_struct.field("object_retention", &self.object_retention);
         debug_struct.field("ip_filter", &self.ip_filter);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10884,7 +10862,6 @@ pub mod bucket {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Billing");
             debug_struct.field("requester_pays", &self.requester_pays);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11146,7 +11123,6 @@ pub mod bucket {
             debug_struct.field("method", &self.method);
             debug_struct.field("response_header", &self.response_header);
             debug_struct.field("max_age_seconds", &self.max_age_seconds);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11487,7 +11463,6 @@ pub mod bucket {
                 "customer_supplied_encryption_enforcement_config",
                 &self.customer_supplied_encryption_enforcement_config,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11700,7 +11675,6 @@ pub mod bucket {
                 let mut debug_struct = f.debug_struct("GoogleManagedEncryptionEnforcementConfig");
                 debug_struct.field("restriction_mode", &self.restriction_mode);
                 debug_struct.field("effective_time", &self.effective_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -11908,7 +11882,6 @@ pub mod bucket {
                 let mut debug_struct = f.debug_struct("CustomerManagedEncryptionEnforcementConfig");
                 debug_struct.field("restriction_mode", &self.restriction_mode);
                 debug_struct.field("effective_time", &self.effective_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12118,7 +12091,6 @@ pub mod bucket {
                     f.debug_struct("CustomerSuppliedEncryptionEnforcementConfig");
                 debug_struct.field("restriction_mode", &self.restriction_mode);
                 debug_struct.field("effective_time", &self.effective_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12326,7 +12298,6 @@ pub mod bucket {
                 &self.uniform_bucket_level_access,
             );
             debug_struct.field("public_access_prevention", &self.public_access_prevention);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12525,7 +12496,6 @@ pub mod bucket {
                 let mut debug_struct = f.debug_struct("UniformBucketLevelAccess");
                 debug_struct.field("enabled", &self.enabled);
                 debug_struct.field("lock_time", &self.lock_time);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -12680,7 +12650,6 @@ pub mod bucket {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Lifecycle");
             debug_struct.field("rule", &self.rule);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12886,7 +12855,6 @@ pub mod bucket {
                 let mut debug_struct = f.debug_struct("Rule");
                 debug_struct.field("action", &self.action);
                 debug_struct.field("condition", &self.condition);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -13086,7 +13054,6 @@ pub mod bucket {
                     let mut debug_struct = f.debug_struct("Action");
                     debug_struct.field("r#type", &self.r#type);
                     debug_struct.field("storage_class", &self.storage_class);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -13827,7 +13794,6 @@ pub mod bucket {
                     debug_struct.field("noncurrent_time_before", &self.noncurrent_time_before);
                     debug_struct.field("matches_prefix", &self.matches_prefix);
                     debug_struct.field("matches_suffix", &self.matches_suffix);
-
                     if !self._unknown_fields.is_empty() {
                         debug_struct.field("_unknown_fields", &self._unknown_fields);
                     }
@@ -14005,7 +13971,6 @@ pub mod bucket {
             let mut debug_struct = f.debug_struct("Logging");
             debug_struct.field("log_bucket", &self.log_bucket);
             debug_struct.field("log_object_prefix", &self.log_object_prefix);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14151,7 +14116,6 @@ pub mod bucket {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("ObjectRetention");
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14376,7 +14340,6 @@ pub mod bucket {
             debug_struct.field("effective_time", &self.effective_time);
             debug_struct.field("is_locked", &self.is_locked);
             debug_struct.field("retention_duration", &self.retention_duration);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14572,7 +14535,6 @@ pub mod bucket {
             let mut debug_struct = f.debug_struct("SoftDeletePolicy");
             debug_struct.field("retention_duration", &self.retention_duration);
             debug_struct.field("effective_time", &self.effective_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14719,7 +14681,6 @@ pub mod bucket {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Versioning");
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -14906,7 +14867,6 @@ pub mod bucket {
             let mut debug_struct = f.debug_struct("Website");
             debug_struct.field("main_page_suffix", &self.main_page_suffix);
             debug_struct.field("not_found_page", &self.not_found_page);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15057,7 +15017,6 @@ pub mod bucket {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CustomPlacementConfig");
             debug_struct.field("data_locations", &self.data_locations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15335,7 +15294,6 @@ pub mod bucket {
                 "terminal_storage_class_update_time",
                 &self.terminal_storage_class_update_time,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15655,7 +15613,6 @@ pub mod bucket {
                 "allow_all_service_agent_access",
                 &self.allow_all_service_agent_access,
             );
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -15820,7 +15777,6 @@ pub mod bucket {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("PublicNetworkSource");
                 debug_struct.field("allowed_ip_cidr_ranges", &self.allowed_ip_cidr_ranges);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16023,7 +15979,6 @@ pub mod bucket {
                 let mut debug_struct = f.debug_struct("VpcNetworkSource");
                 debug_struct.field("network", &self.network);
                 debug_struct.field("allowed_ip_cidr_ranges", &self.allowed_ip_cidr_ranges);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -16169,7 +16124,6 @@ pub mod bucket {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("HierarchicalNamespace");
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -16548,7 +16502,6 @@ impl std::fmt::Debug for BucketAccessControl {
         debug_struct.field("email", &self.email);
         debug_struct.field("domain", &self.domain);
         debug_struct.field("project_team", &self.project_team);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16775,7 +16728,6 @@ impl std::fmt::Debug for ObjectChecksums {
         let mut debug_struct = f.debug_struct("ObjectChecksums");
         debug_struct.field("crc32c", &self.crc32c);
         debug_struct.field("md5_hash", &self.md5_hash);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -16991,7 +16943,6 @@ impl std::fmt::Debug for ObjectCustomContextPayload {
         debug_struct.field("value", &self.value);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17145,7 +17096,6 @@ impl std::fmt::Debug for ObjectContexts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("ObjectContexts");
         debug_struct.field("custom", &self.custom);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -17338,7 +17288,6 @@ impl std::fmt::Debug for CustomerEncryption {
         let mut debug_struct = f.debug_struct("CustomerEncryption");
         debug_struct.field("encryption_algorithm", &self.encryption_algorithm);
         debug_struct.field("key_sha256_bytes", &self.key_sha256_bytes);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18654,7 +18603,6 @@ impl std::fmt::Debug for Object {
         debug_struct.field("soft_delete_time", &self.soft_delete_time);
         debug_struct.field("hard_delete_time", &self.hard_delete_time);
         debug_struct.field("retention", &self.retention);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -18844,7 +18792,6 @@ pub mod object {
             let mut debug_struct = f.debug_struct("Retention");
             debug_struct.field("mode", &self.mode);
             debug_struct.field("retain_until_time", &self.retain_until_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -19373,7 +19320,6 @@ impl std::fmt::Debug for ObjectAccessControl {
         debug_struct.field("email", &self.email);
         debug_struct.field("domain", &self.domain);
         debug_struct.field("project_team", &self.project_team);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19588,7 +19534,6 @@ impl std::fmt::Debug for ListObjectsResponse {
         debug_struct.field("objects", &self.objects);
         debug_struct.field("prefixes", &self.prefixes);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19756,7 +19701,6 @@ impl std::fmt::Debug for ProjectTeam {
         let mut debug_struct = f.debug_struct("ProjectTeam");
         debug_struct.field("project_number", &self.project_number);
         debug_struct.field("team", &self.team);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -19924,7 +19868,6 @@ impl std::fmt::Debug for Owner {
         let mut debug_struct = f.debug_struct("Owner");
         debug_struct.field("entity", &self.entity);
         debug_struct.field("entity_id", &self.entity_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/storage/src/generated/gapic_control/model.rs
+++ b/src/storage/src/generated/gapic_control/model.rs
@@ -151,7 +151,6 @@ impl std::fmt::Debug for PendingRenameInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("PendingRenameInfo");
         debug_struct.field("operation", &self.operation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -456,7 +455,6 @@ impl std::fmt::Debug for Folder {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("pending_rename_info", &self.pending_rename_info);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -758,7 +756,6 @@ impl std::fmt::Debug for GetFolderRequest {
             &self.if_metageneration_not_match,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1024,7 +1021,6 @@ impl std::fmt::Debug for CreateFolderRequest {
         debug_struct.field("folder_id", &self.folder_id);
         debug_struct.field("recursive", &self.recursive);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1326,7 +1322,6 @@ impl std::fmt::Debug for DeleteFolderRequest {
             &self.if_metageneration_not_match,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1686,7 +1681,6 @@ impl std::fmt::Debug for ListFoldersRequest {
         debug_struct.field("lexicographic_start", &self.lexicographic_start);
         debug_struct.field("lexicographic_end", &self.lexicographic_end);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1872,7 +1866,6 @@ impl std::fmt::Debug for ListFoldersResponse {
         let mut debug_struct = f.debug_struct("ListFoldersResponse");
         debug_struct.field("folders", &self.folders);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2204,7 +2197,6 @@ impl std::fmt::Debug for RenameFolderRequest {
             &self.if_metageneration_not_match,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2531,7 +2523,6 @@ impl std::fmt::Debug for CommonLongRunningOperationMetadata {
         debug_struct.field("r#type", &self.r#type);
         debug_struct.field("requested_cancellation", &self.requested_cancellation);
         debug_struct.field("progress_percent", &self.progress_percent);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2745,7 +2736,6 @@ impl std::fmt::Debug for RenameFolderMetadata {
         debug_struct.field("common_metadata", &self.common_metadata);
         debug_struct.field("source_folder_id", &self.source_folder_id);
         debug_struct.field("destination_folder_id", &self.destination_folder_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3020,7 +3010,6 @@ impl std::fmt::Debug for StorageLayout {
         debug_struct.field("location_type", &self.location_type);
         debug_struct.field("custom_placement_config", &self.custom_placement_config);
         debug_struct.field("hierarchical_namespace", &self.hierarchical_namespace);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3176,7 +3165,6 @@ pub mod storage_layout {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("CustomPlacementConfig");
             debug_struct.field("data_locations", &self.data_locations);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3321,7 +3309,6 @@ pub mod storage_layout {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("HierarchicalNamespace");
             debug_struct.field("enabled", &self.enabled);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3518,7 +3505,6 @@ impl std::fmt::Debug for GetStorageLayoutRequest {
         debug_struct.field("name", &self.name);
         debug_struct.field("prefix", &self.prefix);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3782,7 +3768,6 @@ impl std::fmt::Debug for ManagedFolder {
         debug_struct.field("metageneration", &self.metageneration);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4084,7 +4069,6 @@ impl std::fmt::Debug for GetManagedFolderRequest {
             &self.if_metageneration_not_match,
         );
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4323,7 +4307,6 @@ impl std::fmt::Debug for CreateManagedFolderRequest {
         debug_struct.field("managed_folder", &self.managed_folder);
         debug_struct.field("managed_folder_id", &self.managed_folder_id);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4654,7 +4637,6 @@ impl std::fmt::Debug for DeleteManagedFolderRequest {
         );
         debug_struct.field("allow_non_empty", &self.allow_non_empty);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4921,7 +4903,6 @@ impl std::fmt::Debug for ListManagedFoldersRequest {
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("prefix", &self.prefix);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5108,7 +5089,6 @@ impl std::fmt::Debug for ListManagedFoldersResponse {
         let mut debug_struct = f.debug_struct("ListManagedFoldersResponse");
         debug_struct.field("managed_folders", &self.managed_folders);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5414,7 +5394,6 @@ impl std::fmt::Debug for CreateAnywhereCacheMetadata {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("ttl", &self.ttl);
         debug_struct.field("admission_policy", &self.admission_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5720,7 +5699,6 @@ impl std::fmt::Debug for UpdateAnywhereCacheMetadata {
         debug_struct.field("zone", &self.zone);
         debug_struct.field("ttl", &self.ttl);
         debug_struct.field("admission_policy", &self.admission_policy);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6088,7 +6066,6 @@ impl std::fmt::Debug for AnywhereCache {
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
         debug_struct.field("pending_update", &self.pending_update);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6299,7 +6276,6 @@ impl std::fmt::Debug for CreateAnywhereCacheRequest {
         debug_struct.field("parent", &self.parent);
         debug_struct.field("anywhere_cache", &self.anywhere_cache);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6526,7 +6502,6 @@ impl std::fmt::Debug for UpdateAnywhereCacheRequest {
         debug_struct.field("anywhere_cache", &self.anywhere_cache);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6697,7 +6672,6 @@ impl std::fmt::Debug for DisableAnywhereCacheRequest {
         let mut debug_struct = f.debug_struct("DisableAnywhereCacheRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6868,7 +6842,6 @@ impl std::fmt::Debug for PauseAnywhereCacheRequest {
         let mut debug_struct = f.debug_struct("PauseAnywhereCacheRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7039,7 +7012,6 @@ impl std::fmt::Debug for ResumeAnywhereCacheRequest {
         let mut debug_struct = f.debug_struct("ResumeAnywhereCacheRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7209,7 +7181,6 @@ impl std::fmt::Debug for GetAnywhereCacheRequest {
         let mut debug_struct = f.debug_struct("GetAnywhereCacheRequest");
         debug_struct.field("name", &self.name);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7450,7 +7421,6 @@ impl std::fmt::Debug for ListAnywhereCachesRequest {
         debug_struct.field("page_size", &self.page_size);
         debug_struct.field("page_token", &self.page_token);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7637,7 +7607,6 @@ impl std::fmt::Debug for ListAnywhereCachesResponse {
         let mut debug_struct = f.debug_struct("ListAnywhereCachesResponse");
         debug_struct.field("anywhere_caches", &self.anywhere_caches);
         debug_struct.field("next_page_token", &self.next_page_token);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7988,7 +7957,6 @@ impl std::fmt::Debug for IntelligenceConfig {
             &self.effective_intelligence_config,
         );
         debug_struct.field("trial_config", &self.trial_config);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8419,7 +8387,6 @@ pub mod intelligence_config {
             let mut debug_struct = f.debug_struct("Filter");
             debug_struct.field("cloud_storage_locations", &self.cloud_storage_locations);
             debug_struct.field("cloud_storage_buckets", &self.cloud_storage_buckets);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8579,7 +8546,6 @@ pub mod intelligence_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CloudStorageLocations");
                 debug_struct.field("locations", &self.locations);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8740,7 +8706,6 @@ pub mod intelligence_config {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let mut debug_struct = f.debug_struct("CloudStorageBuckets");
                 debug_struct.field("bucket_id_regexes", &self.bucket_id_regexes);
-
                 if !self._unknown_fields.is_empty() {
                     debug_struct.field("_unknown_fields", &self._unknown_fields);
                 }
@@ -8988,7 +8953,6 @@ pub mod intelligence_config {
             let mut debug_struct = f.debug_struct("EffectiveIntelligenceConfig");
             debug_struct.field("effective_edition", &self.effective_edition);
             debug_struct.field("intelligence_config", &self.intelligence_config);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9285,7 +9249,6 @@ pub mod intelligence_config {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("TrialConfig");
             debug_struct.field("expire_time", &self.expire_time);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -9671,7 +9634,6 @@ impl std::fmt::Debug for UpdateOrganizationIntelligenceConfigRequest {
         debug_struct.field("intelligence_config", &self.intelligence_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9899,7 +9861,6 @@ impl std::fmt::Debug for UpdateFolderIntelligenceConfigRequest {
         debug_struct.field("intelligence_config", &self.intelligence_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10127,7 +10088,6 @@ impl std::fmt::Debug for UpdateProjectIntelligenceConfigRequest {
         debug_struct.field("intelligence_config", &self.intelligence_config);
         debug_struct.field("update_mask", &self.update_mask);
         debug_struct.field("request_id", &self.request_id);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10280,7 +10240,6 @@ impl std::fmt::Debug for GetOrganizationIntelligenceConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetOrganizationIntelligenceConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10432,7 +10391,6 @@ impl std::fmt::Debug for GetFolderIntelligenceConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetFolderIntelligenceConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10584,7 +10542,6 @@ impl std::fmt::Debug for GetProjectIntelligenceConfigRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GetProjectIntelligenceConfigRequest");
         debug_struct.field("name", &self.name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -359,7 +359,6 @@ impl std::fmt::Debug for Api {
         debug_struct.field("source_context", &self.source_context);
         debug_struct.field("mixins", &self.mixins);
         debug_struct.field("syntax", &self.syntax);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -666,7 +665,6 @@ impl std::fmt::Debug for Method {
         debug_struct.field("response_streaming", &self.response_streaming);
         debug_struct.field("options", &self.options);
         debug_struct.field("syntax", &self.syntax);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -924,7 +922,6 @@ impl std::fmt::Debug for Mixin {
         let mut debug_struct = f.debug_struct("Mixin");
         debug_struct.field("name", &self.name);
         debug_struct.field("root", &self.root);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1069,7 +1066,6 @@ impl std::fmt::Debug for FileDescriptorSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("FileDescriptorSet");
         debug_struct.field("file", &self.file);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1616,7 +1612,6 @@ impl std::fmt::Debug for FileDescriptorProto {
         debug_struct.field("source_code_info", &self.source_code_info);
         debug_struct.field("syntax", &self.syntax);
         debug_struct.field("edition", &self.edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2024,7 +2019,6 @@ impl std::fmt::Debug for DescriptorProto {
         debug_struct.field("options", &self.options);
         debug_struct.field("reserved_range", &self.reserved_range);
         debug_struct.field("reserved_name", &self.reserved_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2267,7 +2261,6 @@ pub mod descriptor_proto {
             debug_struct.field("start", &self.start);
             debug_struct.field("end", &self.end);
             debug_struct.field("options", &self.options);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2473,7 +2466,6 @@ pub mod descriptor_proto {
             let mut debug_struct = f.debug_struct("ReservedRange");
             debug_struct.field("start", &self.start);
             debug_struct.field("end", &self.end);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2723,7 +2715,6 @@ impl std::fmt::Debug for ExtensionRangeOptions {
         debug_struct.field("declaration", &self.declaration);
         debug_struct.field("features", &self.features);
         debug_struct.field("verification", &self.verification);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2997,7 +2988,6 @@ pub mod extension_range_options {
             debug_struct.field("r#type", &self.r#type);
             debug_struct.field("reserved", &self.reserved);
             debug_struct.field("repeated", &self.repeated);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -3597,7 +3587,6 @@ impl std::fmt::Debug for FieldDescriptorProto {
         debug_struct.field("json_name", &self.json_name);
         debug_struct.field("options", &self.options);
         debug_struct.field("proto3_optional", &self.proto3_optional);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4141,7 +4130,6 @@ impl std::fmt::Debug for OneofDescriptorProto {
         let mut debug_struct = f.debug_struct("OneofDescriptorProto");
         debug_struct.field("name", &self.name);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4413,7 +4401,6 @@ impl std::fmt::Debug for EnumDescriptorProto {
         debug_struct.field("options", &self.options);
         debug_struct.field("reserved_range", &self.reserved_range);
         debug_struct.field("reserved_name", &self.reserved_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4627,7 +4614,6 @@ pub mod enum_descriptor_proto {
             let mut debug_struct = f.debug_struct("EnumReservedRange");
             debug_struct.field("start", &self.start);
             debug_struct.field("end", &self.end);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -4846,7 +4832,6 @@ impl std::fmt::Debug for EnumValueDescriptorProto {
         debug_struct.field("name", &self.name);
         debug_struct.field("number", &self.number);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5053,7 +5038,6 @@ impl std::fmt::Debug for ServiceDescriptorProto {
         debug_struct.field("name", &self.name);
         debug_struct.field("method", &self.method);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5333,7 +5317,6 @@ impl std::fmt::Debug for MethodDescriptorProto {
         debug_struct.field("options", &self.options);
         debug_struct.field("client_streaming", &self.client_streaming);
         debug_struct.field("server_streaming", &self.server_streaming);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6083,7 +6066,6 @@ impl std::fmt::Debug for FileOptions {
         debug_struct.field("ruby_package", &self.ruby_package);
         debug_struct.field("features", &self.features);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6609,7 +6591,6 @@ impl std::fmt::Debug for MessageOptions {
         );
         debug_struct.field("features", &self.features);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7165,7 +7146,6 @@ impl std::fmt::Debug for FieldOptions {
         debug_struct.field("features", &self.features);
         debug_struct.field("feature_support", &self.feature_support);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7337,7 +7317,6 @@ pub mod field_options {
             let mut debug_struct = f.debug_struct("EditionDefault");
             debug_struct.field("edition", &self.edition);
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -7576,7 +7555,6 @@ pub mod field_options {
             debug_struct.field("edition_deprecated", &self.edition_deprecated);
             debug_struct.field("deprecation_warning", &self.deprecation_warning);
             debug_struct.field("edition_removed", &self.edition_removed);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -8328,7 +8306,6 @@ impl std::fmt::Debug for OneofOptions {
         let mut debug_struct = f.debug_struct("OneofOptions");
         debug_struct.field("features", &self.features);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8611,7 +8588,6 @@ impl std::fmt::Debug for EnumOptions {
         );
         debug_struct.field("features", &self.features);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8885,7 +8861,6 @@ impl std::fmt::Debug for EnumValueOptions {
         debug_struct.field("debug_redact", &self.debug_redact);
         debug_struct.field("feature_support", &self.feature_support);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9094,7 +9069,6 @@ impl std::fmt::Debug for ServiceOptions {
         debug_struct.field("features", &self.features);
         debug_struct.field("deprecated", &self.deprecated);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9329,7 +9303,6 @@ impl std::fmt::Debug for MethodOptions {
         debug_struct.field("idempotency_level", &self.idempotency_level);
         debug_struct.field("features", &self.features);
         debug_struct.field("uninterpreted_option", &self.uninterpreted_option);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9848,7 +9821,6 @@ impl std::fmt::Debug for UninterpretedOption {
         debug_struct.field("double_value", &self.double_value);
         debug_struct.field("string_value", &self.string_value);
         debug_struct.field("aggregate_value", &self.aggregate_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10027,7 +9999,6 @@ pub mod uninterpreted_option {
             let mut debug_struct = f.debug_struct("NamePart");
             debug_struct.field("name_part", &self.name_part);
             debug_struct.field("is_extension", &self.is_extension);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -10313,7 +10284,6 @@ impl std::fmt::Debug for FeatureSet {
         debug_struct.field("utf8_validation", &self.utf8_validation);
         debug_struct.field("message_encoding", &self.message_encoding);
         debug_struct.field("json_format", &self.json_format);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11300,7 +11270,6 @@ impl std::fmt::Debug for FeatureSetDefaults {
         debug_struct.field("defaults", &self.defaults);
         debug_struct.field("minimum_edition", &self.minimum_edition);
         debug_struct.field("maximum_edition", &self.maximum_edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -11526,7 +11495,6 @@ pub mod feature_set_defaults {
             debug_struct.field("edition", &self.edition);
             debug_struct.field("overridable_features", &self.overridable_features);
             debug_struct.field("fixed_features", &self.fixed_features);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -11720,7 +11688,6 @@ impl std::fmt::Debug for SourceCodeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceCodeInfo");
         debug_struct.field("location", &self.location);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12117,7 +12084,6 @@ pub mod source_code_info {
             debug_struct.field("leading_comments", &self.leading_comments);
             debug_struct.field("trailing_comments", &self.trailing_comments);
             debug_struct.field("leading_detached_comments", &self.leading_detached_comments);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12270,7 +12236,6 @@ impl std::fmt::Debug for GeneratedCodeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("GeneratedCodeInfo");
         debug_struct.field("annotation", &self.annotation);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -12596,7 +12561,6 @@ pub mod generated_code_info {
             debug_struct.field("begin", &self.begin);
             debug_struct.field("end", &self.end);
             debug_struct.field("semantic", &self.semantic);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -12884,7 +12848,6 @@ impl std::fmt::Debug for SourceContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("SourceContext");
         debug_struct.field("file_name", &self.file_name);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13201,7 +13164,6 @@ impl std::fmt::Debug for Type {
         debug_struct.field("source_context", &self.source_context);
         debug_struct.field("syntax", &self.syntax);
         debug_struct.field("edition", &self.edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -13618,7 +13580,6 @@ impl std::fmt::Debug for Field {
         debug_struct.field("options", &self.options);
         debug_struct.field("json_name", &self.json_name);
         debug_struct.field("default_value", &self.default_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14297,7 +14258,6 @@ impl std::fmt::Debug for Enum {
         debug_struct.field("source_context", &self.source_context);
         debug_struct.field("syntax", &self.syntax);
         debug_struct.field("edition", &self.edition);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14512,7 +14472,6 @@ impl std::fmt::Debug for EnumValue {
         debug_struct.field("name", &self.name);
         debug_struct.field("number", &self.number);
         debug_struct.field("options", &self.options);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -14696,7 +14655,6 @@ impl std::fmt::Debug for Option {
         let mut debug_struct = f.debug_struct("Option");
         debug_struct.field("name", &self.name);
         debug_struct.field("value", &self.value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/wkt/tests/common/src/generated/mod.rs
+++ b/src/wkt/tests/common/src/generated/mod.rs
@@ -261,7 +261,6 @@ impl std::fmt::Debug for MessageWithEnum {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -960,7 +959,6 @@ impl std::fmt::Debug for MessageWithOneOf {
         debug_struct.field("two_strings", &self.two_strings);
         debug_struct.field("one_message", &self.one_message);
         debug_struct.field("mixed", &self.mixed);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -1108,7 +1106,6 @@ pub mod message_with_one_of {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Message");
             debug_struct.field("parent", &self.parent);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2044,7 +2041,6 @@ impl std::fmt::Debug for MessageWithComplexOneOf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug_struct = f.debug_struct("MessageWithComplexOneOf");
         debug_struct.field("complex", &self.complex);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -2195,7 +2191,6 @@ pub mod message_with_complex_one_of {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Inner");
             debug_struct.field("strings", &self.strings);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -2670,7 +2665,6 @@ impl std::fmt::Debug for MessageWithF32 {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3002,7 +2996,6 @@ impl std::fmt::Debug for MessageWithF64 {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3457,7 +3450,6 @@ impl std::fmt::Debug for MessageWithI32 {
         debug_struct.field("map_value", &self.map_value);
         debug_struct.field("map_key", &self.map_key);
         debug_struct.field("map_key_value", &self.map_key_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -3912,7 +3904,6 @@ impl std::fmt::Debug for MessageWithU32 {
         debug_struct.field("map_value", &self.map_value);
         debug_struct.field("map_key", &self.map_key);
         debug_struct.field("map_key_value", &self.map_key_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4367,7 +4358,6 @@ impl std::fmt::Debug for MessageWithI64 {
         debug_struct.field("map_value", &self.map_value);
         debug_struct.field("map_key", &self.map_key);
         debug_struct.field("map_key_value", &self.map_key_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -4822,7 +4812,6 @@ impl std::fmt::Debug for MessageWithU64 {
         debug_struct.field("map_value", &self.map_value);
         debug_struct.field("map_key", &self.map_key);
         debug_struct.field("map_key_value", &self.map_key_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5158,7 +5147,6 @@ impl std::fmt::Debug for MessageWithBytes {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5526,7 +5514,6 @@ impl std::fmt::Debug for MessageWithBool {
         debug_struct.field("map_value", &self.map_value);
         debug_struct.field("map_key", &self.map_key);
         debug_struct.field("map_key_value", &self.map_key_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -5893,7 +5880,6 @@ impl std::fmt::Debug for MessageWithString {
         debug_struct.field("map_value", &self.map_value);
         debug_struct.field("map_key", &self.map_key);
         debug_struct.field("map_key_value", &self.map_key_value);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6157,7 +6143,6 @@ impl std::fmt::Debug for MessageWithRecursion {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -6357,7 +6342,6 @@ pub mod message_with_recursion {
             let mut debug_struct = f.debug_struct("Level0");
             debug_struct.field("level_1", &self.level_1);
             debug_struct.field("side", &self.side);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6512,7 +6496,6 @@ pub mod message_with_recursion {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("Level1");
             debug_struct.field("recurse", &self.recurse);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6655,7 +6638,6 @@ pub mod message_with_recursion {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("NonRecursive");
             debug_struct.field("value", &self.value);
-
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -6910,7 +6892,6 @@ impl std::fmt::Debug for MessageWithValue {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7162,7 +7143,6 @@ impl std::fmt::Debug for MessageWithStruct {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7414,7 +7394,6 @@ impl std::fmt::Debug for MessageWithListValue {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7656,7 +7635,6 @@ impl std::fmt::Debug for MessageWithNullValue {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -7908,7 +7886,6 @@ impl std::fmt::Debug for MessageWithFieldMask {
         debug_struct.field("optional", &self.optional);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8196,7 +8173,6 @@ impl std::fmt::Debug for MessageWithFloatValue {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8487,7 +8463,6 @@ impl std::fmt::Debug for MessageWithDoubleValue {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -8775,7 +8750,6 @@ impl std::fmt::Debug for MessageWithInt32Value {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9066,7 +9040,6 @@ impl std::fmt::Debug for MessageWithUInt32Value {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9354,7 +9327,6 @@ impl std::fmt::Debug for MessageWithInt64Value {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9642,7 +9614,6 @@ impl std::fmt::Debug for MessageWithUInt64Value {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -9935,7 +9906,6 @@ impl std::fmt::Debug for MessageWithBytesValue {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10151,7 +10121,6 @@ impl std::fmt::Debug for MessageWithBoolValue {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }
@@ -10371,7 +10340,6 @@ impl std::fmt::Debug for MessageWithStringValue {
         debug_struct.field("singular", &self.singular);
         debug_struct.field("repeated", &self.repeated);
         debug_struct.field("map", &self.map);
-
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/wkt/tests/message_with_string.rs
+++ b/src/wkt/tests/message_with_string.rs
@@ -229,21 +229,29 @@ mod tests {
         Ok(())
     }
 
-    #[test_case(json!({}))]
-    #[test_case(json!({"unknown0": "hello", "unknown1": "world"}))]
-    fn test_empty_unknown_fields(input: Value) -> Result {
-        let got = serde_json::from_value::<MessageWithString>(input.clone())?;
-        let unknown_fields = serde_json::from_value::<
-            serde_json::Map<std::string::String, serde_json::Value>,
-        >(input)?;
-        if unknown_fields.is_empty() {
-            assert!(!format!("{got:?}").contains("_unknown_fields"));
-            return Ok(());
-        }
-        for (key, value) in unknown_fields.into_iter() {
-            let value_str = serde_json::from_value::<String>(value)?;
-            assert!(format!("{got:?}").contains(&key));
-            assert!(format!("{got:?}").contains(&value_str));
+    #[test]
+    fn test_debug_without_unknown_fields() -> Result {
+        let got = MessageWithString::new()
+            .set_singular("hello")
+            .set_optional("world");
+        let debug_str = format!("{got:?}");
+        assert!(!debug_str.contains("_unknown_fields"));
+        assert!(debug_str.contains("singular: \"hello\""));
+        assert!(debug_str.contains("optional: Some(\"world\")"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_debug_with_unknown_fields() -> Result {
+        let m = serde_json::from_value::<MessageWithString>(
+            json!({"unknown0": "hello", "unknown1": "world"}),
+        )?;
+        let fmt = format!("{m:?}");
+        for detail in ["_unknown_fields", "unknown0", "hello", "unknown1", "world"] {
+            assert!(
+                fmt.contains(detail),
+                "Expected the format string to contain `{detail}`; got: `{fmt}`"
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
Continuation of #1933 and #2744. This PR changes the awkward conditional test with two separate tests to ensure the debug string of a message struct does not include empty `_unknown_fields`, and correctly formats `Option` types.