### PR TITLE
impl(storage): `read_object()` retries at start

### DIFF
--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -284,7 +284,7 @@ impl ReadObject {
     ///
     /// Most of the time you want to use the same throttler for all the requests
     /// in a client, and even the same throttler for many clients. Rarely it
-    /// maybe be necessary to use an ad-hoc throttler for some subset of the
+    /// may be necessary to use an custom throttler for some subset of the
     /// requests.
     ///
     /// # Example
@@ -603,7 +603,7 @@ mod tests {
 
     // Verify `read_object()` meets normal Send, Sync, requirements.
     #[tokio::test]
-    async fn test_upload_is_send_and_static() -> Result {
+    async fn test_read_is_send_and_static() -> Result {
         let client = Storage::builder()
             .with_credentials(auth::credentials::testing::test_credentials())
             .build()

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -37,6 +37,7 @@ use futures::Stream;
 pub struct ReadObject {
     inner: std::sync::Arc<StorageInner>,
     request: crate::model::ReadObjectRequest,
+    options: super::request_options::RequestOptions,
 }
 
 impl ReadObject {
@@ -45,11 +46,13 @@ impl ReadObject {
         B: Into<String>,
         O: Into<String>,
     {
+        let options = inner.options.clone();
         ReadObject {
             inner,
             request: crate::model::ReadObjectRequest::new()
                 .set_bucket(bucket)
                 .set_object(object),
+            options,
         }
     }
 
@@ -228,18 +231,102 @@ impl ReadObject {
         self
     }
 
+    /// The retry policy used for this request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # use google_cloud_storage::retry_policy::RecommendedPolicy;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use std::time::Duration;
+    /// use gax::retry_policy::RetryPolicyExt;
+    /// let response = client
+    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
+    ///     .with_retry_policy(RecommendedPolicy
+    ///         .with_attempt_limit(5)
+    ///         .with_time_limit(Duration::from_secs(10)),
+    ///     )
+    ///     .send()
+    ///     .await?;
+    /// println!("response details={response:?}");
+    /// # Ok(()) }
+    /// ```
+    pub fn with_retry_policy<V: Into<gax::retry_policy::RetryPolicyArg>>(mut self, v: V) -> Self {
+        self.options.retry_policy = v.into().into();
+        self
+    }
+
+    /// The backoff policy used for this request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use std::time::Duration;
+    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// let response = client
+    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
+    ///     .with_backoff_policy(ExponentialBackoff::default())
+    ///     .send()
+    ///     .await?;
+    /// println!("response details={response:?}");
+    /// # Ok(()) }
+    /// ```
+    pub fn with_backoff_policy<V: Into<gax::backoff_policy::BackoffPolicyArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.backoff_policy = v.into().into();
+        self
+    }
+
+    /// The retry throttler used for this request.
+    ///
+    /// Most of the time you want to use the same throttler for all the requests
+    /// in a client, and even the same throttler for many clients. Rarely it
+    /// maybe be necessary to use an ad-hoc throttler for some subset of the
+    /// requests.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
+    ///     .with_retry_throttler(adhoc_throttler())
+    ///     .send()
+    ///     .await?;
+    /// println!("response details={response:?}");
+    /// fn adhoc_throttler() -> gax::retry_throttler::SharedRetryThrottler {
+    ///     # panic!();
+    /// }
+    /// # Ok(()) }
+    /// ```
+    pub fn with_retry_throttler<V: Into<gax::retry_throttler::RetryThrottlerArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.retry_throttler = v.into().into();
+        self
+    }
+
     /// Sends the request.
     pub async fn send(self) -> Result<ReadObjectResponse> {
         let full_content_requested = self.request.read_offset == 0 && self.request.read_limit == 0;
+        let throttler = self.options.retry_throttler.clone();
+        let retry = self.options.retry_policy.clone();
+        let backoff = self.options.backoff_policy.clone();
 
-        let builder = self.http_request_builder().await?;
+        let response = gax::retry_loop_internal::retry_loop(
+            async move |_| self.download_attempt().await,
+            async |duration| tokio::time::sleep(duration).await,
+            true,
+            throttler,
+            retry,
+            backoff,
+        )
+        .await?;
 
-        tracing::info!("builder={builder:?}");
-
-        let response = builder.send().await.map_err(Error::io)?;
-        if !response.status().is_success() {
-            return gaxi::http::to_http_error(response).await;
-        }
         let response_crc32c = crc32c_from_response(
             full_content_requested,
             response.status(),
@@ -252,9 +339,18 @@ impl ReadObject {
         })
     }
 
-    async fn http_request_builder(self) -> Result<reqwest::RequestBuilder> {
+    async fn download_attempt(&self) -> Result<reqwest::Response> {
+        let builder = self.http_request_builder().await?;
+        let response = builder.send().await.map_err(Error::io)?;
+        if !response.status().is_success() {
+            return gaxi::http::to_http_error(response).await;
+        }
+        Ok(response)
+    }
+
+    async fn http_request_builder(&self) -> Result<reqwest::RequestBuilder> {
         // Collect the required bucket and object parameters.
-        let bucket: String = self.request.bucket;
+        let bucket = &self.request.bucket;
         let bucket_id = bucket
             .as_str()
             .strip_prefix("projects/_/buckets/")
@@ -263,7 +359,7 @@ impl ReadObject {
                     "malformed bucket name, it must start with `projects/_/buckets/`: {bucket}"
                 ))
             })?;
-        let object: String = self.request.object;
+        let object = &self.request.object;
 
         // Build the request.
         let builder = self
@@ -274,7 +370,7 @@ impl ReadObject {
                 format!(
                     "{}/storage/v1/b/{bucket_id}/o/{}",
                     &self.inner.endpoint,
-                    enc(&object)
+                    enc(object)
                 ),
             )
             .query(&[("alt", "media")])
@@ -490,6 +586,9 @@ fn check_crc32c_match(crc32c: u32, response: Option<u32>) -> Result<()> {
 }
 
 #[cfg(test)]
+mod resume_tests;
+
+#[cfg(test)]
 mod tests {
     use super::client::tests::{create_key_helper, test_builder, test_inner_client};
     use super::*;
@@ -502,6 +601,31 @@ mod tests {
 
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
+    // Verify `read_object()` meets normal Send, Sync, requirements.
+    #[tokio::test]
+    async fn test_upload_is_send_and_static() -> Result {
+        let client = Storage::builder()
+            .with_credentials(auth::credentials::testing::test_credentials())
+            .build()
+            .await?;
+
+        fn need_send<T: Send>(_val: &T) {}
+        fn need_sync<T: Sync>(_val: &T) {}
+        fn need_static<T: 'static>(_val: &T) {}
+
+        let read = client.read_object("projects/_/buckets/test-bucket", "test-object");
+        need_send(&read);
+        need_sync(&read);
+        need_static(&read);
+
+        let read = client
+            .read_object("projects/_/buckets/test-bucket", "test-object")
+            .send();
+        need_send(&read);
+        need_static(&read);
+
+        Ok(())
+    }
     #[tokio::test]
     async fn read_object_normal() -> Result {
         let server = Server::run();

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -1,0 +1,238 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verify read_object() retries downloads.
+//!
+//! Downloads requests may be rejected by the service. Even after they start
+//! successfully, they may be interrupted. The client library should
+//! automatically retry downloads that fail to start, and automatically resume
+//! downloads that are interrupted.
+//!
+//! This module contains tests to verify the library performs these functions.
+//!
+//! TODO(#2048) - also test "resume", that is, continuing a download after an
+//!   interrupted stream.
+
+use crate::storage::client::tests::{
+    MockBackoffPolicy, MockRetryPolicy, MockRetryThrottler, test_builder,
+};
+use gax::retry_policy::RetryPolicyExt;
+use gax::retry_result::RetryResult;
+use httptest::{Expectation, Server, matchers::*, responders::*};
+use std::time::Duration;
+
+type Result = anyhow::Result<()>;
+
+#[tokio::test]
+async fn start_retry_normal() -> Result {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/storage/v1/b/test-bucket/o/test-object"),
+            request::query(url_decoded(contains(("alt", "media")))),
+        ])
+        .times(2)
+        .respond_with(cycle![
+            status_code(429).body("try-again"),
+            status_code(200).body("hello world"),
+        ]),
+    );
+
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .with_credentials(auth::credentials::testing::test_credentials())
+        .build()
+        .await?;
+    let reader = client
+        .read_object("projects/_/buckets/test-bucket", "test-object")
+        .send()
+        .await?;
+    let got = reader.all_bytes().await?;
+    assert_eq!(got, "hello world");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn start_permanent_error() -> Result {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/storage/v1/b/test-bucket/o/test-object"),
+            request::query(url_decoded(contains(("alt", "media")))),
+        ])
+        .times(2)
+        .respond_with(cycle![
+            status_code(429).body("try-again"),
+            status_code(401).body("uh-oh"),
+        ]),
+    );
+
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .with_credentials(auth::credentials::testing::test_credentials())
+        .build()
+        .await?;
+    let err = client
+        .read_object("projects/_/buckets/test-bucket", "test-object")
+        .send()
+        .await
+        .expect_err("test generates permanent error");
+    assert_eq!(err.http_status_code(), Some(401), "{err:?}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn start_too_many_transients() -> Result {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/storage/v1/b/test-bucket/o/test-object"),
+            request::query(url_decoded(contains(("alt", "media")))),
+        ])
+        .times(3)
+        .respond_with(cycle![status_code(429).body("try-again"),]),
+    );
+
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .with_credentials(auth::credentials::testing::test_credentials())
+        .build()
+        .await?;
+    let err = client
+        .read_object("projects/_/buckets/test-bucket", "test-object")
+        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .send()
+        .await
+        .expect_err("test generates permanent error");
+    assert_eq!(err.http_status_code(), Some(429), "{err:?}");
+    Ok(())
+}
+
+// Verify the retry options are used and that exhausted policies result in
+// errors.
+#[tokio::test]
+async fn request_retry_options() -> Result {
+    let server = Server::run();
+    let matching = || {
+        Expectation::matching(all_of![
+            request::method_path("GET", "/storage/v1/b/bucket/o/object"),
+            request::query(url_decoded(contains(("alt", "media")))),
+        ])
+    };
+    server.expect(
+        matching()
+            .times(3)
+            .respond_with(status_code(503).body("try-again")),
+    );
+
+    let mut retry = MockRetryPolicy::new();
+    retry
+        .expect_on_error()
+        .times(1..)
+        .returning(|_, _, _, e| RetryResult::Continue(e));
+
+    let mut backoff = MockBackoffPolicy::new();
+    backoff
+        .expect_on_failure()
+        .times(1..)
+        .return_const(Duration::from_micros(1));
+
+    let mut throttler = MockRetryThrottler::new();
+    throttler
+        .expect_throttle_retry_attempt()
+        .times(1..)
+        .return_const(false);
+    throttler
+        .expect_on_retry_failure()
+        .times(1..)
+        .return_const(());
+    throttler.expect_on_success().never().return_const(());
+
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .with_resumable_upload_threshold(0_usize)
+        .build()
+        .await?;
+    let err = client
+        .read_object("projects/_/buckets/bucket", "object")
+        .with_retry_policy(retry.with_attempt_limit(3))
+        .with_backoff_policy(backoff)
+        .with_retry_throttler(throttler)
+        .send()
+        .await
+        .expect_err("request should fail after 3 retry attempts");
+    assert_eq!(err.http_status_code(), Some(503), "{err:?}");
+
+    Ok(())
+}
+
+// Verify the client retry options are used and that exhausted policies
+// result in errors.
+#[tokio::test]
+async fn start_resumable_upload_client_retry_options() -> Result {
+    use gax::retry_policy::RetryPolicyExt;
+    let server = Server::run();
+    let matching = || {
+        Expectation::matching(all_of![
+            request::method_path("GET", "/storage/v1/b/bucket/o/object"),
+            request::query(url_decoded(contains(("alt", "media")))),
+        ])
+    };
+    server.expect(
+        matching()
+            .times(3)
+            .respond_with(status_code(503).body("try-again")),
+    );
+
+    let mut retry = MockRetryPolicy::new();
+    retry
+        .expect_on_error()
+        .times(1..)
+        .returning(|_, _, _, e| RetryResult::Continue(e));
+
+    let mut backoff = MockBackoffPolicy::new();
+    backoff
+        .expect_on_failure()
+        .times(1..)
+        .return_const(Duration::from_micros(1));
+
+    let mut throttler = MockRetryThrottler::new();
+    throttler
+        .expect_throttle_retry_attempt()
+        .times(1..)
+        .return_const(false);
+    throttler
+        .expect_on_retry_failure()
+        .times(1..)
+        .return_const(());
+    throttler.expect_on_success().never().return_const(());
+
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .with_retry_policy(retry.with_attempt_limit(3))
+        .with_backoff_policy(backoff)
+        .with_retry_throttler(throttler)
+        .with_resumable_upload_threshold(0_usize)
+        .build()
+        .await?;
+    let err = client
+        .read_object("projects/_/buckets/bucket", "object")
+        .send()
+        .await
+        .expect_err("request should fail after 3 retry attempts");
+    assert_eq!(err.http_status_code(), Some(503), "{err:?}");
+
+    Ok(())
+}

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -181,7 +181,7 @@ async fn request_retry_options() -> Result {
 // Verify the client retry options are used and that exhausted policies
 // result in errors.
 #[tokio::test]
-async fn start_resumable_upload_client_retry_options() -> Result {
+async fn client_retry_options() -> Result {
     use gax::retry_policy::RetryPolicyExt;
     let server = Server::run();
     let matching = || {

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -14,7 +14,7 @@
 
 //! Verify read_object() retries downloads.
 //!
-//! Downloads requests may be rejected by the service. Even after they start
+//! Download requests may be rejected by the service. Even after they start
 //! successfully, they may be interrupted. The client library should
 //! automatically retry downloads that fail to start, and automatically resume
 //! downloads that are interrupted.
@@ -224,7 +224,6 @@ async fn client_retry_options() -> Result {
         .with_retry_policy(retry.with_attempt_limit(3))
         .with_backoff_policy(backoff)
         .with_retry_throttler(throttler)
-        .with_resumable_upload_threshold(0_usize)
         .build()
         .await?;
     let err = client

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -608,7 +608,7 @@ impl<T> UploadObject<T> {
     ///
     /// Most of the time you want to use the same throttler for all the requests
     /// in a client, and even the same throttler for many clients. Rarely it
-    /// maybe be necessary to use an ad-hoc throttler for some subset of the
+    /// may be necessary to use an custom throttler for some subset of the
     /// requests.
     ///
     /// # Example


### PR DESCRIPTION
Weave the retry options into the `read_object()` builder, so we can at least
retry the initial request. Resuming interrupted downloads will come in a future PR.

Part of the work for #2048