### PR TITLE
impl(generator/rust): plumb routing-required option

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -187,6 +187,7 @@ type methodAnnotation struct {
 	ReturnType          string
 	HasVeneer           bool
 	Attributes          []string
+	RoutingRequired     bool
 }
 
 type pathInfoAnnotation struct {
@@ -687,6 +688,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		SystemParameters:    c.systemParameters,
 		ReturnType:          returnType,
 		HasVeneer:           c.hasVeneer,
+		RoutingRequired:     c.routingRequired,
 	}
 	if annotation.Name == "clone" {
 		// Some methods look too similar to standard Rust traits. Clippy makes

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -138,6 +138,12 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 			codec.hasVeneer = value
 		case key == "internal-types":
 			codec.internalTypes = strings.Split(definition, ",")
+		case key == "routing-required":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `routing-required` value %q to boolean: %w", definition, err)
+			}
+			codec.routingRequired = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -248,6 +254,9 @@ type codec struct {
 	//
 	// Only supports messages.
 	internalTypes []string
+	// If true, fail requests locally that do not yield a gRPC routing
+	// header.
+	routingRequired bool
 }
 
 type systemParameter struct {


### PR DESCRIPTION
Part of the work for #2401 

Introduce a new codec option and plumb it where we will need it. (on a method annotation)