### PR TITLE
docs(user-guide): improve enum examples

### DIFF
--- a/guide/samples/tests/enums.rs
+++ b/guide/samples/tests/enums.rs
@@ -87,7 +87,7 @@ mod tests {
             }
             State::Enabled => println!("the secret is enabled and can be accessed"),
             State::Disabled => {
-                println!("the secret version it not accessible until it is enabled")
+                println!("the secret version is not accessible until it is enabled")
             }
             State::Destroyed => {
                 println!("the secret is destroyed, the data is no longer accessible")
@@ -111,7 +111,7 @@ mod tests {
             }
             State::Enabled => println!("the secret is enabled and can be accessed"),
             State::Disabled => {
-                println!("the secret version it not accessible until it is enabled")
+                println!("the secret version is not accessible until it is enabled")
             }
             State::Destroyed => {
                 println!("the secret is destroyed, the data is no longer accessible")
@@ -135,6 +135,6 @@ mod tests {
     #[test_case(State::from("UNKNOWN"))]
     fn drive_match_expression(state: State) {
         match_with_warnings(state.clone()).expect("example includes all branches");
-        match_with_wildcard(state).expect("example include all branches");
+        match_with_wildcard(state).expect("example includes all branches");
     }
 }


### PR DESCRIPTION
Avoid `unreachable!()` in code that may be reached, it is bad guidance,
even if it was not the main point of the example. Prefer returning an
error. Document cases where `unreachable!()` may be appropriate.

I also made some cosmetic changes to keep the examples from rendering
with a horizontal scroll bar.

Motivated by https://www.reddit.com/r/rust/comments/1luqn9l/comment/n25a19z
