### PR TITLE
impl(sidekick): new routing info grouping

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -244,6 +244,76 @@ type Method struct {
 	Codec any
 }
 
+// The routing info is stored as a map from the key to a list of the variants.
+// e.g.:
+//
+// ```
+//
+//	{
+//	  a: [va1, va2, va3],
+//	  b: [vb1, vb2]
+//	  c: [vc1]
+//	}
+//
+// ```
+//
+// We reorganize each kv pair into a list of pairs. e.g.:
+//
+// ```
+// [
+//
+//	[(a, va1), (a, va2), (a, va3)],
+//	[(b, vb1), (b, vb2)],
+//	[(c, vc1)],
+//
+// ]
+// ```
+//
+// Then we take a Cartesian product of that list to find all the combinations.
+// e.g.:
+//
+// ```
+// [
+//
+//	[(a, va1), (b, vb1), (c, vc1)],
+//	[(a, va1), (b, vb2), (c, vc1)],
+//	[(a, va2), (b, vb1), (c, vc1)],
+//	[(a, va2), (b, vb2), (c, vc1)],
+//	[(a, va3), (b, vb1), (c, vc1)],
+//	[(a, va3), (b, vb2), (c, vc1)],
+//
+// ]
+// ```
+func (m *Method) RoutingCombos() []*RoutingInfoCombo {
+	combos := []*RoutingInfoCombo{
+		{},
+	}
+	for _, info := range m.Routing {
+		next := []*RoutingInfoCombo{}
+		for _, c := range combos {
+			for _, v := range info.Variants {
+				next = append(next, &RoutingInfoCombo{
+					Items: append(c.Items, &RoutingInfoComboItem{
+						Name:    info.Name,
+						Variant: v,
+					}),
+				})
+			}
+		}
+		combos = next
+	}
+	return combos
+}
+
+type RoutingInfoCombo struct {
+	Items []*RoutingInfoComboItem
+}
+
+type RoutingInfoComboItem struct {
+	Name    string
+	Variant *RoutingInfoVariant
+}
+
 func (m *Method) HasRouting() bool {
 	return len(m.Routing) != 0
 }

--- a/generator/internal/api/model_test.go
+++ b/generator/internal/api/model_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func Test_RoutingCombos(t *testing.T) {
+	va1 := &RoutingInfoVariant{
+		FieldPath: []string{"va1"},
+	}
+	va2 := &RoutingInfoVariant{
+		FieldPath: []string{"va2"},
+	}
+	va3 := &RoutingInfoVariant{
+		FieldPath: []string{"va3"},
+	}
+	a := &RoutingInfo{
+		Name:     "a",
+		Variants: []*RoutingInfoVariant{va1, va2, va3},
+	}
+
+	vb1 := &RoutingInfoVariant{
+		FieldPath: []string{"vb1"},
+	}
+	vb2 := &RoutingInfoVariant{
+		FieldPath: []string{"vb2"},
+	}
+	b := &RoutingInfo{
+		Name:     "b",
+		Variants: []*RoutingInfoVariant{vb1, vb2},
+	}
+
+	vc1 := &RoutingInfoVariant{
+		FieldPath: []string{"vc1"},
+	}
+	c := &RoutingInfo{
+		Name:     "c",
+		Variants: []*RoutingInfoVariant{vc1},
+	}
+
+	method := Method{
+		Routing: []*RoutingInfo{a, b, c},
+	}
+
+	got := method.RoutingCombos()
+
+	make_combo := func(va *RoutingInfoVariant, vb *RoutingInfoVariant, vc *RoutingInfoVariant) *RoutingInfoCombo {
+		return &RoutingInfoCombo{
+			Items: []*RoutingInfoComboItem{
+				{
+					Name:    "a",
+					Variant: va,
+				},
+				{
+					Name:    "b",
+					Variant: vb,
+				},
+				{
+					Name:    "c",
+					Variant: vc,
+				},
+			},
+		}
+	}
+	want := []*RoutingInfoCombo{
+		make_combo(va1, vb1, vc1),
+		make_combo(va1, vb2, vc1),
+		make_combo(va2, vb1, vc1),
+		make_combo(va2, vb2, vc1),
+		make_combo(va3, vb1, vc1),
+		make_combo(va3, vb2, vc1),
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Incorrect routing combos (-want, +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Related to #2401 

I will use this in storage control to determine whether failures to extract the routing parameters belong in the same path (as in `precondition1 && precondition2`) or in separate paths (as in `precondition1 || precondition2`).

If you are curious, this is the full change: https://github.com/googleapis/google-cloud-rust/commit/023e970e029693911dc7538476eb0f4b53dbd899