### PR TITLE
cleanup(storage): accurate binding error edge cases

### DIFF
--- a/generator/internal/rust/templates/grpc-client/routinginfo.mustache
+++ b/generator/internal/rust/templates/grpc-client/routinginfo.mustache
@@ -36,10 +36,12 @@ if x_goog_request_params.is_empty() {
     use gaxi::routing_parameter::Segment;
     use gaxi::path_parameter::PathMismatchBuilder;
     let mut paths = Vec::new();
-    {{#Routing}}
-    {{#Variants}}
+    {{#RoutingCombos}}
     {
-        let builder = PathMismatchBuilder::default().maybe_add(
+        let builder = PathMismatchBuilder::default();
+        {{#Items}}
+        {{#Variant}}
+        let builder = builder.maybe_add(
             Some(&req){{#Codec.FieldAccessors}}{{{.}}}{{/Codec.FieldAccessors}},
             &[
                 {{#Codec.PrefixSegments}}{{{.}}}, {{/Codec.PrefixSegments}}
@@ -48,10 +50,11 @@ if x_goog_request_params.is_empty() {
             ],
             "{{FieldName}}",
             "{{{TemplateAsString}}}");
+        {{/Variant}}
+        {{/Items}}
         paths.push(builder.build());
     }
-    {{/Variants}}
-    {{/Routing}}
+    {{/RoutingCombos}}
     return Err(gax::error::Error::binding(BindingError { paths }))
 }
 {{/Codec.RoutingRequired}}

--- a/src/storage/src/generated/gapic/transport.rs
+++ b/src/storage/src/generated/gapic/transport.rs
@@ -92,7 +92,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "name",
@@ -152,7 +153,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "name",
@@ -223,7 +225,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req)
                         .and_then(|m| m.bucket.as_ref())
                         .map(|m| &m.project)
@@ -232,10 +235,7 @@ impl super::stub::StorageControl for StorageControl {
                     "bucket.project",
                     "**",
                 );
-                paths.push(builder.build());
-            }
-            {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -295,7 +295,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -357,7 +358,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "bucket",
@@ -430,7 +432,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -442,10 +445,7 @@ impl super::stub::StorageControl for StorageControl {
                     "resource",
                     "projects/*/buckets/*/**",
                 );
-                paths.push(builder.build());
-            }
-            {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "resource",
@@ -518,7 +518,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -530,10 +531,7 @@ impl super::stub::StorageControl for StorageControl {
                     "resource",
                     "projects/*/buckets/*/**",
                 );
-                paths.push(builder.build());
-            }
-            {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "resource",
@@ -623,7 +621,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -636,10 +635,7 @@ impl super::stub::StorageControl for StorageControl {
                     "resource",
                     "projects/*/buckets/*/managedFolders/**",
                 );
-                paths.push(builder.build());
-            }
-            {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -652,10 +648,7 @@ impl super::stub::StorageControl for StorageControl {
                     "resource",
                     "projects/*/buckets/*/objects/**",
                 );
-                paths.push(builder.build());
-            }
-            {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "resource",
@@ -718,7 +711,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req)
                         .and_then(|m| m.bucket.as_ref())
                         .map(|m| &m.name)
@@ -784,7 +778,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req)
                         .and_then(|m| m.destination.as_ref())
                         .map(|m| &m.bucket)
@@ -847,7 +842,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "bucket",
@@ -907,7 +903,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "bucket",
@@ -967,7 +964,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "bucket",
@@ -1030,7 +1028,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req)
                         .and_then(|m| m.object.as_ref())
                         .map(|m| &m.bucket)
@@ -1093,7 +1092,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -1165,7 +1165,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req)
                         .map(|m| &m.destination_bucket)
                         .map(|s| s.as_str()),
@@ -1173,10 +1174,7 @@ impl super::stub::StorageControl for StorageControl {
                     "destination_bucket",
                     "**",
                 );
-                paths.push(builder.build());
-            }
-            {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.source_bucket).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "source_bucket",
@@ -1236,7 +1234,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.bucket).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "bucket",

--- a/src/storage/src/generated/gapic_control/transport.rs
+++ b/src/storage/src/generated/gapic_control/transport.rs
@@ -94,7 +94,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -161,7 +162,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -234,7 +236,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -302,7 +305,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -369,7 +373,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -442,7 +447,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -510,7 +516,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -577,7 +584,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -650,7 +658,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -718,7 +727,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -780,7 +790,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",
@@ -850,7 +861,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req)
                         .and_then(|m| m.anywhere_cache.as_ref())
                         .map(|m| &m.name)
@@ -926,7 +938,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -999,7 +1012,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -1072,7 +1086,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -1145,7 +1160,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
                     &[
                         Segment::Literal("projects/"),
@@ -1213,7 +1229,8 @@ impl super::stub::StorageControl for StorageControl {
             use gaxi::routing_parameter::Segment;
             let mut paths = Vec::new();
             {
-                let builder = PathMismatchBuilder::default().maybe_add(
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
                     &[Segment::MultiWildcard],
                     "parent",


### PR DESCRIPTION
Related to #2401 

Assume that all routing keys are required in storage/storage control.

Any extra variants for the same routing key should appear in `BindingError` as a different possible path (an OR requirement).

Variants for separate routing keys should appear in `BindingError` as the same path (an AND requirement).