### PR TITLE
feat(storage): return bytes::Buf from all_bytes function

### DIFF
--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -88,7 +88,9 @@ async fn start_retry_normal() -> Result {
         .read_object("projects/_/buckets/test-bucket", "test-object")
         .send()
         .await?;
-    let got = reader.all_bytes().await?;
+    let mut buf = reader.all_bytes().await?;
+    use bytes::Buf;
+    let got = buf.copy_to_bytes(buf.remaining());
     assert_eq!(got, "hello world");
 
     Ok(())


### PR DESCRIPTION
This avoids copying the Bytes out of the buffer.

WIP: want to add unit tests for AllBytesBuf.