### PR TITLE
refactor(storage): `UploadObject` is a builder

### DIFF
--- a/src/storage/src/storage/upload_object/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/upload_object/buffered/resumable_tests.rs
@@ -720,6 +720,7 @@ async fn start_resumable_upload_request_retry_options() -> Result {
         .with_retry_policy(retry.with_attempt_limit(3))
         .with_backoff_policy(backoff)
         .with_retry_throttler(throttler)
+        .build()
         .send_buffered_resumable((0, None))
         .await
         .expect_err("request should fail after 3 retry attempts");


### PR DESCRIPTION
Make this type into a builder object, with the actual upload methods
moved to `PerformUpload`. This will be useful when we introduce a
`Checksum` field into the builder. It may also help me move the code
into smaller files.

Part of the work for #2050
