### PR TITLE
fix(storage)!: remove all_bytes method for storage downloads

### DIFF
--- a/guide/samples/tests/storage/quickstart.rs
+++ b/guide/samples/tests/storage/quickstart.rs
@@ -59,13 +59,15 @@ pub async fn quickstart(project_id: &str, bucket_id: &str) -> anyhow::Result<()>
     // ANCHOR_END: upload
 
     // ANCHOR: download
-    let contents = client
-        .read_object(&bucket.name, "hello.txt")
-        .send()
-        .await?
-        .all_bytes()
-        .await?;
-    println!("object contents successfully downloaded {contents:?}");
+    let mut reader = client.read_object(&bucket.name, "hello.txt").send().await?;
+    let mut contents = Vec::new();
+    while let Some(chunk) = reader.next().await.transpose()? {
+        contents.extend_from_slice(&chunk);
+    }
+    println!(
+        "object contents successfully downloaded {:?}",
+        bytes::Bytes::from_owner(contents)
+    );
     // ANCHOR_END: download
 
     // ANCHOR: cleanup

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -177,13 +177,15 @@ impl Storage {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// let contents = client
+    /// let mut resp = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()
-    ///     .await?
-    ///     .all_bytes()
     ///     .await?;
-    /// println!("object contents={contents:?}");
+    /// let mut contents = Vec::new();
+    /// while let Some(chunk) = resp.next().await.transpose()? {
+    ///   contents.extend_from_slice(&chunk);
+    /// }
+    /// println!("object contents={:?}", bytes::Bytes::from_owner(contents));
     /// # Ok(()) }
     /// ```
     pub fn read_object<B, O>(&self, bucket: B, object: O) -> ReadObject


### PR DESCRIPTION
The `all_bytes` method was added as a convenience function to be used with small object downloads. By providing this method, we were also making it easier for our users to incorrectly use our library. Downloading all of the data into memory is not desirable in many use cases for the storage API.

Since this method is implemented in terms of the `next()` function anyway, this does not actually remove any functionality from the API.