### PR TITLE
impl(storage): compare final checksums on upload

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -792,23 +792,127 @@ pub async fn checksums(
 
     type ObjectResult = storage::Result<storage::model::Object>;
 
-    let uploads: Vec::<(&str, std::pin::Pin<Box<dyn Future<Output = ObjectResult>>>)> = vec![
-        ("verify/default", Box::pin(client.upload_object(bucket_name, "verify/default",  VEXING).with_if_generation_match(0).send())),
-        ("verify/disabled", Box::pin(client.upload_object(bucket_name, "verify/disabled", VEXING).with_if_generation_match(0).disable_computed_checksums().send())),
-        ("verify/crc32c", Box::pin(client.upload_object(bucket_name, "verify/crc32c",   VEXING).with_if_generation_match(0).disable_computed_checksums().compute_crc32c().send())),
-        ("verify/md5", Box::pin(client.upload_object(bucket_name, "verify/md5",      VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().send())),
-        ("verify/both", Box::pin(client.upload_object(bucket_name, "verify/both",     VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().send())),
-        ("computed/default", Box::pin(client.upload_object(bucket_name, "computed/default",  VEXING).with_if_generation_match(0).precompute_checksums().await?.send())),
-        ("computed/disabled", Box::pin(client.upload_object(bucket_name, "computed/disabled", VEXING).with_if_generation_match(0).disable_computed_checksums().precompute_checksums().await?.send())),
-        ("computed/crc32c", Box::pin(client.upload_object(bucket_name, "computed/crc32c",   VEXING).with_if_generation_match(0).disable_computed_checksums().compute_crc32c().precompute_checksums().await?.send())),
-        ("computed/md5", Box::pin(client.upload_object(bucket_name, "computed/md5",      VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().precompute_checksums().await?.send())),
-        ("computed/both", Box::pin(client.upload_object(bucket_name, "computed/both",     VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().precompute_checksums().await?.send())),
+    let uploads: Vec<(&str, std::pin::Pin<Box<dyn Future<Output = ObjectResult>>>)> = vec![
+        (
+            "verify/default",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "verify/default", VEXING)
+                    .with_if_generation_match(0)
+                    .send(),
+            ),
+        ),
+        (
+            "verify/disabled",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "verify/disabled", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .send(),
+            ),
+        ),
+        (
+            "verify/crc32c",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "verify/crc32c", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .compute_crc32c()
+                    .send(),
+            ),
+        ),
+        (
+            "verify/md5",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "verify/md5", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .compute_md5()
+                    .send(),
+            ),
+        ),
+        (
+            "verify/both",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "verify/both", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .compute_md5()
+                    .send(),
+            ),
+        ),
+        (
+            "computed/default",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "computed/default", VEXING)
+                    .with_if_generation_match(0)
+                    .precompute_checksums()
+                    .await?
+                    .send(),
+            ),
+        ),
+        (
+            "computed/disabled",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "computed/disabled", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .precompute_checksums()
+                    .await?
+                    .send(),
+            ),
+        ),
+        (
+            "computed/crc32c",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "computed/crc32c", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .compute_crc32c()
+                    .precompute_checksums()
+                    .await?
+                    .send(),
+            ),
+        ),
+        (
+            "computed/md5",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "computed/md5", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .compute_md5()
+                    .precompute_checksums()
+                    .await?
+                    .send(),
+            ),
+        ),
+        (
+            "computed/both",
+            Box::pin(
+                client
+                    .upload_object(bucket_name, "computed/both", VEXING)
+                    .with_if_generation_match(0)
+                    .disable_computed_checksums()
+                    .compute_md5()
+                    .precompute_checksums()
+                    .await?
+                    .send(),
+            ),
+        ),
     ];
 
     for (name, upload) in uploads.into_iter() {
         tracing::info!("waiting for {name}");
         match upload.await {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(e) => {
                 println!("error running in {name}: {e:?}");
                 return Err(e.into());

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -791,7 +791,7 @@ pub async fn checksums(
     const VEXING: &str = "how vexingly quick daft zebras jump";
 
     type ObjectResult = storage::Result<storage::model::Object>;
-    type Boxed = std::pin::Pin<Box<dyn Future<Output = ObjectResult>>>;
+    type Boxed = futures::future::BoxFuture<'static, ObjectResult>;
     let uploads: Vec<(&str, Boxed)> = vec![
         (
             "verify/default",
@@ -841,6 +841,7 @@ pub async fn checksums(
                     .upload_object(bucket_name, "verify/both", VEXING)
                     .with_if_generation_match(0)
                     .disable_computed_checksums()
+                    .compute_crc32c()
                     .compute_md5()
                     .send(),
             ),
@@ -901,6 +902,7 @@ pub async fn checksums(
                     .upload_object(bucket_name, "computed/both", VEXING)
                     .with_if_generation_match(0)
                     .disable_computed_checksums()
+                    .compute_crc32c()
                     .compute_md5()
                     .precompute_checksums()
                     .await?

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -791,8 +791,8 @@ pub async fn checksums(
     const VEXING: &str = "how vexingly quick daft zebras jump";
 
     type ObjectResult = storage::Result<storage::model::Object>;
-
-    let uploads: Vec<(&str, std::pin::Pin<Box<dyn Future<Output = ObjectResult>>>)> = vec![
+    type Boxed = std::pin::Pin<Box<dyn Future<Output = ObjectResult>>>;
+    let uploads: Vec<(&str, Boxed)> = vec![
         (
             "verify/default",
             Box::pin(

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -767,6 +767,58 @@ async fn abort_upload_buffered(client: storage::client::Storage, bucket_name: &s
     Ok(())
 }
 
+pub async fn checksums(
+    builder: storage::builder::storage::ClientBuilder,
+    bucket_name: &str,
+) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    tracing::info!("checksums test, using bucket {bucket_name}");
+
+    let client = builder.build().await?;
+    const VEXING: &str = "how vexingly quick daft zebras jump";
+
+    type ObjectResult = storage::Result<storage::model::Object>;
+
+    let uploads: Vec::<(&str, std::pin::Pin<Box<dyn Future<Output = ObjectResult>>>)> = vec![
+        ("verify/default", Box::pin(client.upload_object(bucket_name, "verify/default",  VEXING).with_if_generation_match(0).send())),
+        ("verify/disabled", Box::pin(client.upload_object(bucket_name, "verify/disabled", VEXING).with_if_generation_match(0).disable_computed_checksums().send())),
+        ("verify/crc32c", Box::pin(client.upload_object(bucket_name, "verify/crc32c",   VEXING).with_if_generation_match(0).disable_computed_checksums().compute_crc32c().send())),
+        ("verify/md5", Box::pin(client.upload_object(bucket_name, "verify/md5",      VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().send())),
+        ("verify/both", Box::pin(client.upload_object(bucket_name, "verify/both",     VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().send())),
+        ("computed/default", Box::pin(client.upload_object(bucket_name, "computed/default",  VEXING).with_if_generation_match(0).precompute_checksums().await?.send())),
+        ("computed/disabled", Box::pin(client.upload_object(bucket_name, "computed/disabled", VEXING).with_if_generation_match(0).disable_computed_checksums().precompute_checksums().await?.send())),
+        ("computed/crc32c", Box::pin(client.upload_object(bucket_name, "computed/crc32c",   VEXING).with_if_generation_match(0).disable_computed_checksums().compute_crc32c().precompute_checksums().await?.send())),
+        ("computed/md5", Box::pin(client.upload_object(bucket_name, "computed/md5",      VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().precompute_checksums().await?.send())),
+        ("computed/both", Box::pin(client.upload_object(bucket_name, "computed/both",     VEXING).with_if_generation_match(0).disable_computed_checksums().compute_md5().precompute_checksums().await?.send())),
+    ];
+
+    for (name, upload) in uploads.into_iter() {
+        tracing::info!("waiting for {name}");
+        match upload.await {
+            Ok(_) => {},
+            Err(e) => {
+                println!("error running in {name}: {e:?}");
+                return Err(e.into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn create_test_bucket() -> Result<(StorageControl, Bucket)> {
     let project_id = crate::project_id()?;
     let client = StorageControl::builder()

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -197,6 +197,19 @@ mod driver {
         result
     }
 
+    #[test_case(Storage::builder(); "default")]
+    #[tokio::test]
+    async fn run_storage_checksums(
+        builder: storage::builder::storage::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        let (control, bucket) = integration_tests::storage::create_test_bucket().await?;
+        let result = integration_tests::storage::checksums(builder, &bucket.name)
+            .await
+            .map_err(integration_tests::report_error);
+        let _ = integration_tests::storage::cleanup_bucket(control, bucket.name).await;
+        result
+    }
+
     #[test_case(Storage::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects_with_key(

--- a/src/storage/src/storage/perform_upload/tests.rs
+++ b/src/storage/src/storage/perform_upload/tests.rs
@@ -24,6 +24,8 @@ use test_case::test_case;
 
 type Result = anyhow::Result<()>;
 
+mod checksums;
+
 fn response_body() -> Value {
     json!({
         "name": "test-object",

--- a/src/storage/src/storage/perform_upload/tests/checksums.rs
+++ b/src/storage/src/storage/perform_upload/tests/checksums.rs
@@ -329,7 +329,7 @@ fn bad_checksums_body() -> Value {
     // The magic strings can be regenerated using:
     //     rm empty.txt
     //     touch empty.txt
-    //     gcloud hash vexing.txt
+    //     gcloud hash empty.txt
     json!({
         "bucket": "/projects/_/buckets/test-bucket",
         "name": "test-object",

--- a/src/storage/src/storage/perform_upload/tests/checksums.rs
+++ b/src/storage/src/storage/perform_upload/tests/checksums.rs
@@ -56,8 +56,8 @@ mod buffered_single_shot {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send()
             .await
             .expect_err("expected a checksum error");
@@ -70,8 +70,8 @@ mod buffered_single_shot {
         let server = prepare_server(good_checksums_body());
         let object = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send()
             .await?;
         assert_eq!(object.name, "test-object");
@@ -114,8 +114,8 @@ mod buffered_resumable {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send()
             .await
             .expect_err("expected a checksum error");
@@ -128,8 +128,8 @@ mod buffered_resumable {
         let server = prepare_server(good_checksums_body());
         let object = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send()
             .await?;
         assert_eq!(object.name, "test-object");
@@ -172,8 +172,8 @@ mod unbuffered_single_shot {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send_unbuffered()
             .await
             .expect_err("expected a checksum error");
@@ -186,8 +186,8 @@ mod unbuffered_single_shot {
         let server = prepare_server(good_checksums_body());
         let object = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send_unbuffered()
             .await?;
         assert_eq!(object.name, "test-object");
@@ -230,8 +230,8 @@ mod unbuffered_resumable {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send_unbuffered()
             .await
             .expect_err("expected a checksum error");
@@ -244,8 +244,8 @@ mod unbuffered_resumable {
         let server = prepare_server(good_checksums_body());
         let object = start_upload(&server)
             .await?
-            .with_crc32c(vexing_crc32c())
-            .with_md5_hash(vexing_md5())
+            .with_known_crc32c(vexing_crc32c())
+            .with_known_md5_hash(vexing_md5())
             .send_unbuffered()
             .await?;
         assert_eq!(object.name, "test-object");

--- a/src/storage/src/storage/perform_upload/tests/checksums.rs
+++ b/src/storage/src/storage/perform_upload/tests/checksums.rs
@@ -1,0 +1,353 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verify the client library correctly detects mismatched checksums on uploads.
+
+use super::*;
+use crate::storage::upload_source::BytesSource;
+use httptest::{Expectation, Server, matchers::*, responders::*};
+use serde_json::{Value, json};
+
+const VEXING: &str = "how vexingly quick daft zebras jump";
+
+mod buffered_single_shot {
+    use super::*;
+
+    fn prepare_server(body: Value) -> Server {
+        super::single_shot_server(body)
+    }
+    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+        super::start_single_shot(server).await
+    }
+
+    #[tokio::test]
+    async fn computed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .send()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn computed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server).await?.send().await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send()
+            .await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+}
+
+mod buffered_resumable {
+    use super::*;
+
+    fn prepare_server(body: Value) -> Server {
+        super::resumable_server(body)
+    }
+    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+        super::start_resumable(server).await
+    }
+
+    #[tokio::test]
+    async fn computed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .send()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn computed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server).await?.send().await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send()
+            .await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+}
+
+mod unbuffered_single_shot {
+    use super::*;
+
+    fn prepare_server(body: Value) -> Server {
+        super::single_shot_server(body)
+    }
+    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+        super::start_single_shot(server).await
+    }
+
+    #[tokio::test]
+    async fn computed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .send()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn computed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server).await?.send().await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send_unbuffered()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send_unbuffered()
+            .await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+}
+
+mod unbuffered_resumable {
+    use super::*;
+
+    fn prepare_server(body: Value) -> Server {
+        super::resumable_server(body)
+    }
+    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+        super::start_resumable(server).await
+    }
+
+    #[tokio::test]
+    async fn computed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .send()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn computed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server).await?.send_unbuffered().await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_mismatch() -> Result {
+        let server = prepare_server(bad_checksums_body());
+        let err = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send_unbuffered()
+            .await
+            .expect_err("expected a checksum error");
+        assert!(err.is_serialization(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn precomputed_match() -> Result {
+        let server = prepare_server(good_checksums_body());
+        let object = start_upload(&server)
+            .await?
+            .with_crc32c(vexing_crc32c())
+            .with_md5_hash(vexing_md5())
+            .send_unbuffered()
+            .await?;
+        assert_eq!(object.name, "test-object");
+        Ok(())
+    }
+}
+
+async fn start_resumable(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .build()
+        .await?;
+    Ok(client
+        .upload_object("projects/_/buckets/test-bucket", "test-object", VEXING)
+        .with_resumable_upload_threshold(0_usize))
+}
+
+async fn start_single_shot(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+    let client = test_builder()
+        .with_endpoint(format!("http://{}", server.addr()))
+        .build()
+        .await?;
+    Ok(client
+        .upload_object("projects/_/buckets/test-bucket", "test-object", VEXING)
+        .with_resumable_upload_threshold(1024 * 1024_usize))
+}
+
+fn single_shot_server(body: Value) -> Server {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("POST", "/upload/storage/v1/b/test-bucket/o"),
+            request::query(url_decoded(contains(("name", "test-object")))),
+            request::query(url_decoded(contains(("uploadType", "multipart")))),
+        ])
+        .respond_with(status_code(200).body(body.to_string())),
+    );
+    server
+}
+
+fn resumable_server(body: Value) -> Server {
+    let server = Server::run();
+    let session = server.url("/upload/session/test-only-001");
+    let path = session.path().to_string();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("POST", "/upload/storage/v1/b/test-bucket/o"),
+            request::query(url_decoded(contains(("name", "test-object")))),
+            request::query(url_decoded(contains(("uploadType", "resumable")))),
+        ])
+        .respond_with(status_code(200).append_header("location", session.to_string())),
+    );
+    let len = VEXING.len();
+    assert_ne!(len, 0);
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("PUT", path.clone()),
+            request::headers(contains((
+                "content-range",
+                format!("bytes 0-{}/{len}", len - 1)
+            )))
+        ])
+        .respond_with(
+            status_code(200)
+                .append_header("content-type", "application/json")
+                .body(body.to_string()),
+        ),
+    );
+    server
+}
+
+fn vexing_crc32c() -> u32 {
+    crc32c::crc32c(VEXING.as_bytes())
+}
+
+fn vexing_md5() -> bytes::Bytes {
+    bytes::Bytes::from_owner(md5::compute(VEXING.as_bytes()).0)
+}
+
+fn bad_checksums_body() -> Value {
+    // The magic strings can be regenerated using:
+    //     rm empty.txt
+    //     touch empty.txt
+    //     gcloud hash vexing.txt
+    json!({
+        "bucket": "/projects/_/buckets/test-bucket",
+        "name": "test-object",
+        "crc32c": "AAAAAA==",
+        "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "size": 0,
+    })
+}
+
+fn good_checksums_body() -> Value {
+    // The magic strings can be regenerated using:
+    //     echo -n 'how vexingly quick daft zebras jump' > vexing.txt
+    //     gcloud hash vexing.txt
+    json!({
+        "bucket": "/projects/_/buckets/test-bucket",
+        "name": "test-object",
+        "crc32c": "9esWHQ==",
+        "md5Hash": "XsWNN3ATlnzCdna3JNYDJw==",
+        "size": 35,
+    })
+}

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -1035,6 +1035,7 @@ where
             offset += n.len() as u64;
         }
         let ck = self.checksum.finalize();
+        self.payload.seek(0_u64).await.map_err(Error::ser)?;
         let _ = self.mut_resource().checksums.insert(ck);
         Ok(self.switch_checksum(|_| Precomputed))
     }

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -765,8 +765,9 @@ impl<T, C> UploadObject<T, C> {
             .expect("resource field initialized in `new()`")
     }
 
-    pub(crate) fn build(self) -> PerformUpload<InsertPayload<T>> {
+    pub(crate) fn build(self) -> PerformUpload<C, InsertPayload<T>> {
         PerformUpload::new(
+            self.checksum,
             self.payload,
             self.inner,
             self.spec,
@@ -966,6 +967,7 @@ impl<T> UploadObject<T> {
 
 impl<T, C> UploadObject<T, C>
 where
+    C: ChecksumEngine + Send + Sync + 'static,
     T: StreamingSource + Seek + Send + Sync + 'static,
     <T as StreamingSource>::Error: std::error::Error + Send + Sync + 'static,
     <T as Seek>::Error: std::error::Error + Send + Sync + 'static,
@@ -1040,6 +1042,7 @@ where
 
 impl<T, C> UploadObject<T, C>
 where
+    C: ChecksumEngine + Send + Sync + 'static,
     T: StreamingSource + Send + Sync + 'static,
     T::Error: std::error::Error + Send + Sync + 'static,
 {


### PR DESCRIPTION
Compare the computed (or pre-computed) checksums against the values
received from the service. Returning an error if the values do not
match.

Part of the work for #2050
