### PR TITLE
feat(storage): add more fields to ObjectHighlights

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -128,6 +128,9 @@ pub async fn objects(builder: storage::builder::storage::ClientBuilder) -> Resul
     let insert = client
         .upload_object(&bucket.name, "quick.text", CONTENTS)
         .with_metadata([("verify-metadata-works", "yes")])
+        .with_content_type("text/plain")
+        .with_content_language("en")
+        .with_storage_class("STANDARD")
         .send_unbuffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
@@ -155,6 +158,11 @@ pub async fn objects(builder: storage::builder::storage::ClientBuilder) -> Resul
         object.checksums.unwrap().crc32c,
         Some(crc32c::crc32c(CONTENTS.as_bytes()))
     );
+    assert_eq!(object.storage_class, "STANDARD");
+    assert_eq!(object.content_language, "en");
+    assert_eq!(object.content_type, "text/plain");
+    assert!(!object.content_disposition.is_empty());
+    assert!(!object.etag.is_empty());
 
     let mut contents = Vec::new();
     while let Some(b) = response.next().await.transpose()? {

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -678,6 +678,7 @@ impl ReadObjectResponse {
 
 /// ObjectHighlights contains select metadata from a [crate::model::Object].
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub struct ObjectHighlights {
     /// The content generation of this object. Used for object versioning.
     pub generation: i64,
@@ -689,11 +690,11 @@ pub struct ObjectHighlights {
     pub metageneration: i64,
 
     /// Content-Length of the object data in bytes, matching
-    /// [<https://tools.ietf.org/html/rfc7230#section-3.3.2>][RFC 7230 §3.3.2].
+    /// [RFC 7230 §3.3.2][<https://tools.ietf.org/html/rfc7230#section-3.3.2>]
     pub size: i64,
 
     /// Content-Encoding of the object data, matching
-    /// [<https://tools.ietf.org/html/rfc7231#section-3.1.2.2>][RFC 7231 §3.1.2.2]
+    /// [RFC 7231 §3.1.2.2][<https://tools.ietf.org/html/rfc7231#section-3.1.2.2>]
     pub content_encoding: String,
 
     /// Hashes for the data part of this object. The checksums of the complete
@@ -706,17 +707,17 @@ pub struct ObjectHighlights {
     pub storage_class: String,
 
     /// Content-Language of the object data, matching
-    /// [<https://tools.ietf.org/html/rfc7231#section-3.1.3.2>][RFC 7231 §3.1.3.2].
+    /// [RFC 7231 §3.1.3.2][<https://tools.ietf.org/html/rfc7231#section-3.1.3.2>].
     pub content_language: String,
 
     /// Content-Type of the object data, matching
-    /// [<https://tools.ietf.org/html/rfc7231#section-3.1.1.5>][RFC 7231 §3.1.1.5].
+    /// [RFC 7231 §3.1.1.5][<https://tools.ietf.org/html/rfc7231#section-3.1.1.5>].
     /// If an object is stored without a Content-Type, it is served as
     /// `application/octet-stream`.
     pub content_type: String,
 
     /// Content-Disposition of the object data, matching
-    /// [<https://tools.ietf.org/html/rfc6266>][RFC 6266].
+    /// [RFC 6266][<https://tools.ietf.org/html/rfc6266>].
     pub content_disposition: String,
 
     /// The etag of the object.

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -528,6 +528,31 @@ impl ReadObjectResponse {
                     .set_or_clear_crc32c(headers_to_crc32c(headers))
                     .set_md5_hash(headers_to_md5_hash(headers))
             }),
+            storage_class: headers
+                .get("x-goog-storage-class")
+                .and_then(|sc| sc.to_str().ok())
+                .map(|sc| sc.to_string())
+                .unwrap_or_default(),
+            content_type: headers
+                .get("content-type")
+                .and_then(|sc| sc.to_str().ok())
+                .map(|sc| sc.to_string())
+                .unwrap_or_default(),
+            content_language: headers
+                .get("content-language")
+                .and_then(|sc| sc.to_str().ok())
+                .map(|sc| sc.to_string())
+                .unwrap_or_default(),
+            content_disposition: headers
+                .get("content-disposition")
+                .and_then(|sc| sc.to_str().ok())
+                .map(|sc| sc.to_string())
+                .unwrap_or_default(),
+            etag: headers
+                .get("etag")
+                .and_then(|sc| sc.to_str().ok())
+                .map(|sc| sc.to_string())
+                .unwrap_or_default(),
         };
 
         Ok(Self {
@@ -697,6 +722,26 @@ pub struct ObjectHighlights {
     /// the client should compute one of these checksums over the downloaded
     /// object and compare it against the value provided here.
     pub checksums: std::option::Option<crate::model::ObjectChecksums>,
+
+    /// Storage class of the object.
+    pub storage_class: String,
+
+    /// Content-Language of the object data, matching
+    /// [<https://tools.ietf.org/html/rfc7231#section-3.1.3.2>][RFC 7231 §3.1.3.2].
+    pub content_language: std::string::String,
+
+    /// Content-Type of the object data, matching
+    /// [<https://tools.ietf.org/html/rfc7231#section-3.1.1.5>][RFC 7231 §3.1.1.5].
+    /// If an object is stored without a Content-Type, it is served as
+    /// `application/octet-stream`.
+    pub content_type: std::string::String,
+
+    /// Content-Disposition of the object data, matching
+    /// [<https://tools.ietf.org/html/rfc6266>][RFC 6266].
+    pub content_disposition: std::string::String,
+
+    /// The etag of the object.
+    pub etag: std::string::String,
 }
 
 /// Represents an error that can occur when reading response data.
@@ -928,7 +973,12 @@ mod tests {
                     .append_header("x-goog-generation", 500)
                     .append_header("x-goog-metageneration", "1")
                     .append_header("x-goog-stored-content-length", 30)
-                    .append_header("x-goog-stored-content-encoding", "identity"),
+                    .append_header("x-goog-stored-content-encoding", "identity")
+                    .append_header("x-goog-storage-class", "STANDARD")
+                    .append_header("content-language", "en")
+                    .append_header("content-type", "text/plain")
+                    .append_header("content-disposition", "inline")
+                    .append_header("etag", "etagval"),
             ),
         );
 


### PR DESCRIPTION
Add remaining fields for data that is returned as headers for object downloads.

Fixes #2626 