### PR TITLE
cleanup(storate): drop `Insert` from `InsertPayload`

### DIFF
--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -23,7 +23,7 @@ pub mod upload_source;
 pub(crate) mod v1;
 
 use crate::model::Object;
-use crate::upload_source::InsertPayload;
+use crate::upload_source::Payload;
 use crate::{Error, Result};
 
 /// An unrecoverable problem in the upload protocol.

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -18,7 +18,7 @@ use crate::builder::storage::ReadObject;
 use crate::builder::storage::UploadObject;
 use crate::download_resume_policy::DownloadResumePolicy;
 use crate::storage::checksum::Crc32c;
-use crate::upload_source::InsertPayload;
+use crate::upload_source::Payload;
 use auth::credentials::CacheableResource;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -167,7 +167,7 @@ impl Storage {
     where
         B: Into<String>,
         O: Into<String>,
-        T: Into<InsertPayload<P>>,
+        T: Into<Payload<P>>,
     {
         UploadObject::new(self.inner.clone(), bucket, object, payload)
     }

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -77,7 +77,7 @@ pub struct UploadObject<T, C = Crc32c> {
     inner: std::sync::Arc<StorageInner>,
     spec: crate::model::WriteObjectSpec,
     params: Option<crate::model::CommonObjectRequestParams>,
-    payload: InsertPayload<T>,
+    payload: Payload<T>,
     options: super::request_options::RequestOptions,
     checksum: C,
 }
@@ -819,7 +819,7 @@ impl<T, C> UploadObject<T, C> {
             .expect("resource field initialized in `new()`")
     }
 
-    pub(crate) fn build(self) -> PerformUpload<C, InsertPayload<T>> {
+    pub(crate) fn build(self) -> PerformUpload<C, Payload<T>> {
         PerformUpload::new(
             self.checksum,
             self.payload,
@@ -1002,7 +1002,7 @@ impl<T> UploadObject<T> {
     where
         B: Into<String>,
         O: Into<String>,
-        P: Into<InsertPayload<T>>,
+        P: Into<Payload<T>>,
     {
         let options = inner.options.clone();
         let resource = crate::model::Object::new()


### PR DESCRIPTION
The original name was (partly) justified because the method was
`insert_object()`. The method is now `upload_object()`, and `upload` is
already part of the module name.

Part of the work for #2641
