### PR TITLE
cleanup(user-guide): prefer `cargo add`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -653,17 +652,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,18 +338,23 @@ tokio-test     = { default-features = false, version = "0.4" }
 # Local packages used as dependencies
 auth                          = { version = "0.22.2", path = "src/auth", package = "google-cloud-auth" }
 gax                           = { version = "0.23.2", path = "src/gax", package = "google-cloud-gax" }
+google-cloud-gax              = { version = "0.23.2", path = "src/gax", package = "google-cloud-gax" }
 gaxi                          = { version = "0.4.1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.4.3", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 location                      = { version = "0.4.3", path = "src/generated/cloud/location", package = "google-cloud-location" }
 longrunning                   = { version = "0.25.3", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+google-cloud-longrunning      = { version = "0.25.3", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
 lro                           = { version = "0.3.3", path = "src/lro", package = "google-cloud-lro" }
+google-cloud-lro              = { version = "0.3.3", path = "src/lro", package = "google-cloud-lro" }
 wkt                           = { version = "0.5.3", path = "src/wkt", package = "google-cloud-wkt" }
+google-cloud-wkt              = { version = "0.5.3", path = "src/wkt", package = "google-cloud-wkt" }
 api                           = { version = "0.4.3", path = "src/generated/api/types", package = "google-cloud-api" }
 cloud_common                  = { version = "0.4.3", path = "src/generated/cloud/common", package = "google-cloud-common" }
 gtype                         = { version = "0.4.3", path = "src/generated/type", package = "google-cloud-type" }
 grafeas                       = { version = "0.4.3", path = "src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
 logging_type                  = { version = "0.4.3", path = "src/generated/logging/type", package = "google-cloud-logging-type" }
 rpc                           = { version = "0.4.3", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
+google-cloud-rpc              = { version = "0.4.3", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
 rpc_context                   = { version = "0.4.3", path = "src/generated/rpc/context", package = "google-cloud-rpc-context" }
 apps_script_type              = { version = "0.4.3", path = "src/generated/apps/script/gtype", package = "google-cloud-apps-script-type" }
 accesscontextmanager_v1       = { version = "0.4.3", path = "src/generated/identity/accesscontextmanager/v1", package = "google-cloud-identity-accesscontextmanager-v1" }
@@ -369,6 +374,11 @@ oslogin_common                = { version = "0.4.3", path = "src/generated/oslog
 iam_v2                        = { version = "0.4.3", path = "src/generated/iam/v2", package = "google-cloud-iam-v2" }
 recommender                   = { version = "0.4.3", path = "src/generated/cloud/recommender/v1", package = "google-cloud-recommender-v1" }
 accesscontextmanager_type     = { version = "0.4.3", path = "src/generated/identity/accesscontextmanager/type", package = "google-cloud-identity-accesscontextmanager-type" }
+google-cloud-language-v2      = { version = "0.4.3", path = "src/generated/cloud/language/v2" }
+google-cloud-speech-v2        = { version = "0.4.3", path = "src/generated/cloud/speech/v2" }
+google-cloud-secretmanager-v1 = { version = "0.4.3", path = "src/generated/cloud/secretmanager/v1" }
+google-cloud-aiplatform-v1    = { version = "0.4.3", default-features = false, path = "src/generated/cloud/aiplatform/v1" }
+google-cloud-storage          = { version = "0.25.0-preview4", path = "src/storage" }
 
 # Local test package
 integration-tests = { path = "src/integration-tests" }

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -28,92 +28,30 @@ categories.workspace = true
 name = "getting_started"
 
 [dependencies]
-# ANCHOR: longrunning
-google-cloud-longrunning = { version = "0.25.2", path = "../../src/generated/longrunning" }
-# ANCHOR_END: longrunning
-# ANCHOR: language
-google-cloud-language-v2 = { version = "0.4.3", path = "../../src/generated/cloud/language/v2" }
-# ANCHOR_END: language
-google-cloud-rpc = { version = "0.4.3", path = "../../src/generated/rpc/types" }
-google-cloud-wkt = { version = "0.5.3", path = "../../src/wkt" }
-anyhow.workspace = true
+anyhow.workspace                        = true
+crc32c.workspace                        = true
+futures.workspace                       = true
+google-cloud-aiplatform-v1              = { workspace = true, default-features = false, features = ["prediction-service"] }
+google-cloud-gax                        = { workspace = true, features = ["unstable-stream"] }
+google-cloud-language-v2.workspace      = true
+google-cloud-longrunning.workspace      = true
+google-cloud-lro                        = { workspace = true, features = ["unstable-stream"] }
+google-cloud-rpc.workspace              = true
+google-cloud-secretmanager-v1.workspace = true
+google-cloud-speech-v2.workspace        = true
+google-cloud-storage.workspace          = true
+google-cloud-wkt.workspace              = true
+serde_json.workspace                    = true
+tokio                                   = { workspace = true, features = ["full", "macros"] }
 
-# ANCHOR: speech
-[dependencies.google-cloud-speech-v2]
-version = "0.4.3"
-# ANCHOR_END: speech
-path = "../../src/generated/cloud/speech/v2"
-
-# ANCHOR: storage
-[dependencies.google-cloud-storage]
-version = "0.25.0-preview4"
-# ANCHOR_END: storage
-path = "../../src/storage"
-
-# ANCHOR: serde_json
-[dependencies.serde_json]
-workspace = true
-# ANCHOR_END: serde_json
-
-# ANCHOR: secretmanager
-[dependencies.google-cloud-secretmanager-v1]
-version = "0.4.3"
-# ANCHOR_END: secretmanager
-path = "../../src/generated/cloud/secretmanager/v1"
-
-# ANCHOR: aiplatform
-[dependencies.google-cloud-aiplatform-v1]
-version          = "0.4.3"
-default-features = false
-features         = ["prediction-service"]
-# ANCHOR_END: aiplatform
-path = "../../src/generated/cloud/aiplatform/v1"
-
-# ANCHOR: crc32c
-[dependencies.crc32c]
-version = "0.6"
-# ANCHOR_END: crc32c
-
-# ANCHOR: futures
-[dependencies.futures]
-version = "0.3"
-# ANCHOR_END: futures
-
-# ANCHOR: lro-with-streams
-# ANCHOR: lro
-[dependencies.google-cloud-lro]
-version = "0.3.2"
-# ANCHOR_END: lro
-features = ["unstable-stream"]
-# ANCHOR_END: lro-with-streams
-path = "../../src/lro"
-
-# ANCHOR: gax-with-streams
-# ANCHOR: gax
-[dependencies.google-cloud-gax]
-version = "0.23.2"
-# ANCHOR_END: gax
-features = ["unstable-stream"]
-# ANCHOR_END: gax-with-streams
-path = "../../src/gax"
-
-# ANCHOR: mockall
 [dev-dependencies]
-mockall = "0.13"
-# ANCHOR_END: mockall
-anyhow.workspace    = true
-bytes.workspace     = true
-rand.workspace      = true
-tempfile.workspace  = true
-test-case.workspace = true
-# Local
+anyhow.workspace            = true
+bytes.workspace             = true
 integration-tests.workspace = true
-
-# ANCHOR: tokio
-[dependencies.tokio]
-version  = "1"
-features = ["full", "macros"]
-# ANCHOR_END: tokio
+mockall.workspace           = true
+rand.workspace              = true
+tempfile.workspace          = true
+test-case.workspace         = true
 
 [features]
 run-integration-tests = []

--- a/guide/src/configuring_polling_policies.md
+++ b/guide/src/configuring_polling_policies.md
@@ -55,10 +55,8 @@ diagnose.
 As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
 file. We use:
 
-```toml
-{{#include ../samples/Cargo.toml:speech}}
-
-{{#include ../samples/Cargo.toml:lro}}
+```shell
+cargo add google-cloud-speech-v2 google-cloud-lro
 ```
 
 ## Configuring the polling frequency for all requests in a client

--- a/guide/src/configuring_retry_policies.md
+++ b/guide/src/configuring_retry_policies.md
@@ -39,8 +39,8 @@ and that your account has the necessary permissions.
 
 As usual with Rust, you must declare dependencies in your `Cargo.toml` file:
 
-```toml
-{{#include ../samples/Cargo.toml:secretmanager}}
+```shell
+cargo add google-cloud-secretmanager-v1
 ```
 
 ## Configuring the default retry policy

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -42,14 +42,14 @@ and that your account has the necessary permissions.
 As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
 file. We use:
 
-```toml
-{{#include ../samples/Cargo.toml:secretmanager}}
+```shell
+cargo add google-cloud-secretmanager-v1
 ```
 
 In addition, this guide uses `crc32c` to calculate the checksum:
 
-```toml
-{{#include ../samples/Cargo.toml:crc32c}}
+```shell
+cargo add crc32c
 ```
 
 ## Motivation

--- a/guide/src/examine_error_details.md
+++ b/guide/src/examine_error_details.md
@@ -40,9 +40,8 @@ and that your account has the necessary permissions.
 As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
 file:
 
-```toml
-[dependencies]
-{{#include ../samples/Cargo.toml:language}}
+```shell
+cargo add google-cloud-language-v2
 ```
 
 ## Examining error details

--- a/guide/src/generate_text_using_the_vertex_ai_gemini_api.md
+++ b/guide/src/generate_text_using_the_vertex_ai_gemini_api.md
@@ -30,8 +30,8 @@ The Vertex AI client library includes many features. Compiling all of them is
 relatively slow. To speed up compilation, you can just enable the features you
 need:
 
-```toml
-{{#include ../samples/Cargo.toml:aiplatform}}
+```shell
+cargo add google-cloud-aiplatform-v1 --no-default-features --features prediction-service
 ```
 
 ## Send a prompt to the Vertex AI Gemini API

--- a/guide/src/initialize_a_client.md
+++ b/guide/src/initialize_a_client.md
@@ -41,8 +41,8 @@ log in to configure the [Application Default Credentials] used in this guide.
 
 As usual with Rust, you must declare the dependency in your `Cargo.toml` file:
 
-```toml
-{{#include ../samples/Cargo.toml:secretmanager}}
+```shell
+cargo add google-cloud-secretmanager-v1
 ```
 
 To initialize a client, you first call `Client::builder()` to obtain an

--- a/guide/src/mock_a_client.md
+++ b/guide/src/mock_a_client.md
@@ -29,8 +29,8 @@ This guide shows how.
 There are several [mocking frameworks] in Rust. This guide uses [`mockall`],
 which seems to be the most popular.
 
-```toml
-{{#include ../samples/Cargo.toml:mockall}}
+```shell
+cargo add --dev mockall
 ```
 
 This guide will use a [`Speech`][speech-client] client. Note that the same ideas
@@ -39,10 +39,8 @@ in this guide apply to all of the clients, not just the `Speech` client.
 We declare the dependency in our `Cargo.toml`. Yours will be similar, but
 without the custom `path`.
 
-```toml
-{{#include ../samples/Cargo.toml:speech}}
-
-{{#include ../samples/Cargo.toml:lro}}
+```shell
+cargo add google-cloud-speech-v2 google-cloud-lro
 ```
 
 ## Mocking a client

--- a/guide/src/pagination.md
+++ b/guide/src/pagination.md
@@ -40,8 +40,8 @@ and that your account has the necessary permissions.
 As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
 file. We use:
 
-```toml
-{{#include ../samples/Cargo.toml:secretmanager}}
+```shell
+cargo add google-cloud-secretmanager-v1
 ```
 
 ## Iterating List methods
@@ -74,8 +74,8 @@ You may want to use these APIs in the larger Rust ecosystem of asynchronous
 streams, such as `tokio::Stream`. This is readily done, but you must first
 enable the `unstable-streams` feature in the `google_cloud_gax` crate:
 
-```toml
-{{#include ../samples/Cargo.toml:gax-with-streams}}
+```shell
+cargo add google-cloud-gax --features unstable-stream
 ```
 
 The name of this feature is intended to convey that we consider these APIs
@@ -86,8 +86,8 @@ with any breaks that result from incompatible changes to the
 The examples will also use the `futures::stream::StreamExt` trait, so we must
 add the crate that defines it.
 
-```toml
-{{#include ../samples/Cargo.toml:futures}}
+```shell
+cargo add futures
 ```
 
 We use the `into_stream` function to convert the Paginator into a

--- a/guide/src/storage.md
+++ b/guide/src/storage.md
@@ -37,7 +37,7 @@ The guide assumes you have an existing [Google Cloud project] with
 ### Add the client library as a dependency
 
 ```toml
-{{#include ../samples/Cargo.toml:storage}}
+cargo add google-cloud-storage
 ```
 
 ### Create a storage bucket

--- a/guide/src/storage/queue.md
+++ b/guide/src/storage/queue.md
@@ -30,8 +30,8 @@ The guide assumes you have an existing [Google Cloud project] with
 
 ## Add the client library as a dependency
 
-```toml
-{{#include ../../samples/Cargo.toml:storage}}
+```shell
+cargo add google-cloud-storage
 ```
 
 ## Convert a queue to an upload source

--- a/guide/src/storage/rewrite_object.md
+++ b/guide/src/storage/rewrite_object.md
@@ -31,8 +31,8 @@ The guide assumes you have an existing [Google Cloud project] with
 
 ## Add the client library as a dependency
 
-```toml
-{{#include ../../samples/Cargo.toml:storage}}
+```shell
+cargo add google-cloud-storage
 ```
 
 ## Rewriting an object

--- a/guide/src/storage/striped_downloads.md
+++ b/guide/src/storage/striped_downloads.md
@@ -32,8 +32,8 @@ library. If not, read the [quickstart guide].
 
 ## Add the client library as a dependency
 
-```toml
-{{#include ../../samples/Cargo.toml:storage}}
+```shell
+cargo add google-cloud-storage
 ```
 
 ## Create source data

--- a/guide/src/storage/terminate_uploads.md
+++ b/guide/src/storage/terminate_uploads.md
@@ -31,8 +31,8 @@ library. If not, you may want to read the [quickstart guide] first.
 
 ## Add the client library as a dependency
 
-```toml
-{{#include ../../samples/Cargo.toml:storage}}
+```shell
+cargo add google-cloud-storage
 ```
 
 ## Overview

--- a/guide/src/working_with_enums.md
+++ b/guide/src/working_with_enums.md
@@ -41,9 +41,8 @@ enumeration in any other client library.
 As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
 file. We use:
 
-```toml
-{{#include ../samples/Cargo.toml:secretmanager}}
-{{#include ../samples/Cargo.toml:serde_json}}
+```shell
+cargo add google-cloud-secretmanager-v1 serde_json
 ```
 
 ## Handling known values

--- a/guide/src/working_with_long_running_operations.md
+++ b/guide/src/working_with_long_running_operations.md
@@ -42,16 +42,14 @@ diagnose.
 As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
 file. We use:
 
-```toml
-{{#include ../samples/Cargo.toml:speech}}
-
-{{#include ../samples/Cargo.toml:lro}}
+```shell
+cargo add google-cloud-speech-v1 google-cloud-lro
 ```
 
 And:
 
 ```toml
-{{#include ../samples/Cargo.toml:tokio}}
+cargo add tokio --features full,macro
 ```
 
 ## Starting a long-running operation


### PR DESCRIPTION
This is much easier to maintain, and anybody following the guide would
get the latest (non-preview) version by default.  However, this is not
as robust, as the `cargo add` command is not tested. OTOH, the version
numbers in the published doc may be out of date too, so neither approach
is perfect.
