### PR TITLE
impl(storage): fine grained known checksum tracking

### DIFF
--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -15,7 +15,7 @@
 use super::client::{StorageInner, apply_customer_supplied_encryption_headers};
 use crate::model::Object;
 use crate::retry_policy::ContinueOn308;
-use crate::storage::checksum::{ChecksumEngine, ChecksummedSource, Precomputed};
+use crate::storage::checksum::{ChecksumEngine, ChecksummedSource, Known};
 use crate::storage::client::enc;
 use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use super::{
-    ChecksumEngine, ChecksummedSource, ContinueOn308, Error, IterSource, Object, PerformUpload,
-    Known, Result, ResumableUploadStatus, StreamingSource, X_GOOG_API_CLIENT_HEADER,
+    ChecksumEngine, ChecksummedSource, ContinueOn308, Error, IterSource, Known, Object,
+    PerformUpload, Result, ResumableUploadStatus, StreamingSource, X_GOOG_API_CLIENT_HEADER,
     apply_customer_supplied_encryption_headers,
 };
 use crate::storage::checksum::validate as validate_checksum;

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -14,7 +14,7 @@
 
 use super::{
     ChecksumEngine, ChecksummedSource, ContinueOn308, Error, IterSource, Object, PerformUpload,
-    Precomputed, Result, ResumableUploadStatus, StreamingSource, X_GOOG_API_CLIENT_HEADER,
+    Known, Result, ResumableUploadStatus, StreamingSource, X_GOOG_API_CLIENT_HEADER,
     apply_customer_supplied_encryption_headers,
 };
 use crate::storage::checksum::validate as validate_checksum;
@@ -142,20 +142,15 @@ where
         // Use the computed checksum, if any, and if the spec does not have a
         // checksum already.
         let computed = stream.final_checksum();
-        let has = self
+        let current = self
             .spec
             .resource
             .get_or_insert_default()
             .checksums
             .get_or_insert_default();
-        if has.crc32c.is_none() {
-            has.crc32c = computed.crc32c;
-        }
-        if has.md5_hash.is_empty() {
-            has.md5_hash = computed.md5_hash;
-        }
+        crate::storage::checksum::update(current, computed);
         let upload = PerformUpload {
-            payload: Arc::new(Mutex::new(ChecksummedSource::new(Precomputed, source))),
+            payload: Arc::new(Mutex::new(ChecksummedSource::new(Known, source))),
             inner: self.inner,
             spec: self.spec,
             params: self.params,

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -20,9 +20,7 @@ use super::client::*;
 use super::perform_upload::PerformUpload;
 use super::upload_source::{Seek, StreamingSource};
 use super::*;
-use crate::storage::checksum::{
-    ChecksumEngine, Crc32c, Md5, Known, KnownCrc32c, KnownMd5,
-};
+use crate::storage::checksum::{ChecksumEngine, Crc32c, Known, KnownCrc32c, KnownMd5, Md5};
 
 /// A request builder for object uploads.
 ///


### PR DESCRIPTION
With this change we track whether the CRC32C checksum, the MD5 hash, or
both are set to known values. Once one of them is set to a known value,
the value cannot be changed: the corresponding `with_known_*()` function
is not available. It is also not possible to revert from known values
to computed values. The `compute_*()` functions are not available.

As a side effect: the CRC32C checksum is always present, either known
or computed. It cannot be removed from the upload.

Renamed the (crate private) types from `Precomputed` to `Known*`.
