### PR TITLE
fix(storage): percent-encode name once on uploads

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -948,6 +948,16 @@ pub async fn object_names(
 
     assert_eq!(got, want);
 
+    for name in names {
+        control
+            .delete_object()
+            .set_bucket(bucket_name)
+            .set_object(name)
+            .with_idempotency(true)
+            .send()
+            .await?;
+    }
+
     Ok(())
 }
 

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -859,6 +859,98 @@ pub async fn checksums(
     Ok(())
 }
 
+pub async fn object_names(
+    builder: storage::builder::storage::ClientBuilder,
+    control: storage::client::StorageControl,
+    bucket_name: &str,
+) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    tracing::info!("object names test, using bucket {bucket_name}");
+
+    let client = builder.build().await?;
+
+    let names = ["a/1", "a/2", "b/c/d/e", "b/c/d/e#1", "b/c/d/f", "b/c/d/g"];
+
+    for name in names {
+        let upload = client
+            .upload_object(bucket_name, name, "")
+            .with_if_generation_match(0)
+            .send_unbuffered()
+            .await?;
+        assert_eq!(upload.bucket, bucket_name);
+        assert_eq!(upload.name, name);
+        assert_eq!(upload.size, 0_i64);
+
+        let reader = client
+            .read_object(&upload.bucket, &upload.name)
+            .with_generation(upload.generation)
+            .send()
+            .await?;
+        let highlights = reader.object();
+        assert_eq!(highlights.storage_class, "STANDARD");
+        assert_eq!(highlights.generation, upload.generation);
+        assert_eq!(highlights.metageneration, upload.metageneration);
+        assert_eq!(highlights.etag, upload.etag);
+        assert_eq!(highlights.size, upload.size);
+
+        let get = control
+            .get_object()
+            .set_bucket(&upload.bucket)
+            .set_object(&upload.name)
+            .set_generation(upload.generation)
+            .send()
+            .await?;
+        // Not all fields match (the service returns different values with
+        // equivalent semantics).
+        assert_eq!(get.bucket, upload.bucket);
+        assert_eq!(get.name, upload.name);
+        assert_eq!(get.etag, upload.etag);
+        assert_eq!(get.generation, upload.generation);
+        assert_eq!(get.metageneration, upload.metageneration);
+        assert_eq!(get.storage_class, upload.storage_class);
+        assert_eq!(get.size, upload.size);
+        assert_eq!(get.create_time, upload.create_time);
+        assert_eq!(get.checksums, upload.checksums);
+    }
+
+    use gax::paginator::ItemPaginator;
+    let mut list = control
+        .list_objects()
+        .set_parent(bucket_name)
+        .set_prefix("b/c")
+        .by_item();
+    let mut from_list = Vec::new();
+    while let Some(o) = list.next().await.transpose()? {
+        from_list.push(o.name);
+    }
+    use std::collections::BTreeSet;
+    let got = from_list
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let want = names
+        .iter()
+        .filter_map(|n| n.strip_prefix("b/c").map(|_| *n))
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(got, want);
+
+    Ok(())
+}
+
 pub async fn create_test_bucket() -> Result<(StorageControl, Bucket)> {
     let project_id = crate::project_id()?;
     let client = StorageControl::builder()

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -210,6 +210,20 @@ mod driver {
         result
     }
 
+    #[test_case(Storage::builder(); "default")]
+    #[tokio::test]
+    async fn run_storage_object_names(
+        builder: storage::builder::storage::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        let (control, bucket) = integration_tests::storage::create_test_bucket().await?;
+        let result =
+            integration_tests::storage::object_names(builder, control.clone(), &bucket.name)
+                .await
+                .map_err(integration_tests::report_error);
+        // let _ = integration_tests::storage::cleanup_bucket(control, bucket.name).await;
+        result
+    }
+
     #[test_case(Storage::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects_with_key(

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -220,7 +220,7 @@ mod driver {
             integration_tests::storage::object_names(builder, control.clone(), &bucket.name)
                 .await
                 .map_err(integration_tests::report_error);
-        // let _ = integration_tests::storage::cleanup_bucket(control, bucket.name).await;
+        let _ = integration_tests::storage::cleanup_bucket(control, bucket.name).await;
         result
     }
 

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -16,7 +16,6 @@ use super::client::{StorageInner, apply_customer_supplied_encryption_headers};
 use crate::model::Object;
 use crate::retry_policy::ContinueOn308;
 use crate::storage::checksum::{ChecksumEngine, ChecksummedSource, Known};
-use crate::storage::client::enc;
 use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
 use crate::upload_source::{IterSource, Seek, StreamingSource};
@@ -92,7 +91,7 @@ impl<C, S> PerformUpload<C, S> {
                 format!("{}/upload/storage/v1/b/{bucket_id}/o", &self.inner.endpoint),
             )
             .query(&[("uploadType", "resumable")])
-            .query(&[("name", enc(object))])
+            .query(&[("name", object)])
             .header("content-type", "application/json")
             .header(
                 "x-goog-api-client",

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -272,22 +272,21 @@ mod tests {
         Ok(())
     }
 
-    #[test_case("projects/p", "projects%2Fp")]
-    #[test_case("kebab-case", "kebab-case")]
-    #[test_case("dot.name", "dot.name")]
-    #[test_case("under_score", "under_score")]
-    #[test_case("tilde~123", "tilde~123")]
-    #[test_case("exclamation!point!", "exclamation%21point%21")]
-    #[test_case("spaces   spaces", "spaces%20%20%20spaces")]
-    #[test_case("preserve%percent%21", "preserve%percent%21")]
-    #[test_case(
-        "testall !#$&'()*+,/:;=?@[]",
-        "testall%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
-    )]
+    #[test_case("projects/p")]
+    #[test_case("kebab-case")]
+    #[test_case("dot.name")]
+    #[test_case("under_score")]
+    #[test_case("tilde~123")]
+    #[test_case("exclamation!point!")]
+    #[test_case("spaces   spaces")]
+    #[test_case("preserve%percent%21")]
+    #[test_case("testall !#$&'()*+,/:;=?@[]")]
+    #[test_case(concat!("Benjamín pidió una bebida de kiwi y fresa. ",
+            "Noé, sin vergüenza, la más exquisita champaña del menú"))]
     #[tokio::test]
-    async fn test_percent_encoding_object_name(name: &str, want: &str) -> Result {
+    async fn test_percent_encoding_object_name(want: &str) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = UploadObject::new(inner, "projects/_/buckets/bucket", name, "hello")
+        let request = UploadObject::new(inner, "projects/_/buckets/bucket", want, "hello")
             .build()
             .start_resumable_upload_request()
             .await?

--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -15,7 +15,7 @@
 use super::{
     ChecksumEngine, ContinueOn308, Error, Object, PerformUpload, Result, ResumableUploadStatus,
     Seek, StreamingSource, X_GOOG_API_CLIENT_HEADER, apply_customer_supplied_encryption_headers,
-    enc, handle_object_response, v1,
+    handle_object_response, v1,
 };
 use futures::stream::unfold;
 use std::sync::Arc;
@@ -152,7 +152,7 @@ where
                 format!("{}/upload/storage/v1/b/{bucket_id}/o", &self.inner.endpoint),
             )
             .query(&[("uploadType", "multipart")])
-            .query(&[("name", enc(object))])
+            .query(&[("name", object)])
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&X_GOOG_API_CLIENT_HEADER),


### PR DESCRIPTION
During uploads we were percent encoding the name of the objects twice.
Once manually, and another time because `.query()` automatically percent
encode things.

Consequently the names of the uploaded objects were all wrong (they were
the percent encoded names), and using the objects in `get_object()` or
`read_object()` or `list_objects()` became extremely difficult.

