### PR TITLE
feat(storage): expose `ReadObject` types

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -72,8 +72,8 @@ pub use storage::ChecksumMismatch;
 pub use storage::ReadError;
 pub use storage::UploadError;
 
-pub use storage::read_object::ReadObjectResponse;
 pub use storage::read_object::ObjectHighlights;
+pub use storage::read_object::ReadObjectResponse;
 
 #[allow(dead_code)]
 pub(crate) mod generated;

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -699,12 +699,14 @@ pub struct ObjectHighlights {
     /// generation of a particular object.
     pub metageneration: i64,
 
-    /// Content-Length of the object data in bytes, matching
-    /// [RFC 7230 §3.3.2][<https://tools.ietf.org/html/rfc7230#section-3.3.2>]
+    /// Content-Length of the object data in bytes, matching [RFC 7230 §3.3.2].
+    ///
+    /// [rfc 7230 §3.3.2]: https://tools.ietf.org/html/rfc7230#section-3.3.2
     pub size: i64,
 
-    /// Content-Encoding of the object data, matching
-    /// [RFC 7231 §3.1.2.2][<https://tools.ietf.org/html/rfc7231#section-3.1.2.2>]
+    /// Content-Encoding of the object data, matching [RFC 7231 §3.1.2.2].
+    ///
+    /// [rfc 7231 §3.1.2.2]: https://tools.ietf.org/html/rfc7231#section-3.1.2.2
     pub content_encoding: String,
 
     /// Hashes for the data part of this object. The checksums of the complete
@@ -716,18 +718,21 @@ pub struct ObjectHighlights {
     /// Storage class of the object.
     pub storage_class: String,
 
-    /// Content-Language of the object data, matching
-    /// [RFC 7231 §3.1.3.2][<https://tools.ietf.org/html/rfc7231#section-3.1.3.2>].
+    /// Content-Language of the object data, matching [RFC 7231 §3.1.3.2].
+    ///
+    /// [rfc 7231 §3.1.3.2]: https://tools.ietf.org/html/rfc7231#section-3.1.3.2
     pub content_language: String,
 
-    /// Content-Type of the object data, matching
-    /// [RFC 7231 §3.1.1.5][<https://tools.ietf.org/html/rfc7231#section-3.1.1.5>].
-    /// If an object is stored without a Content-Type, it is served as
+    /// Content-Type of the object data, matching [RFC 7231 §3.1.1.5]. If an
+    /// object is stored without a Content-Type, it is served as
     /// `application/octet-stream`.
+    ///
+    /// [rfc 7231 §3.1.1.5]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
     pub content_type: String,
 
-    /// Content-Disposition of the object data, matching
-    /// [RFC 6266][<https://tools.ietf.org/html/rfc6266>].
+    /// Content-Disposition of the object data, matching [RFC 6266].
+    ///
+    /// [rfc 6266]: https://tools.ietf.org/html/rfc6266
     pub content_disposition: String,
 
     /// The etag of the object.


### PR DESCRIPTION
We need to expose these types so they can show up in our docs, and so customers can name them.

https://docs.rs/google-cloud-storage/0.25.0-preview4/google_cloud_storage/builder/storage/struct.ReadObject.html#method.send

---

`cargo +1.91` errors on angle bracket links with `#` in them and also links without angle brackets. Eventually we may have to deal with this for the generated code.