### PR TITLE
docs: error handling full code + cleanups

### DIFF
--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -108,6 +108,12 @@ cargo build --package user-guide-samples
 and verify they run using the instructions in the
 [Integration Tests](#integration-tests) section.
 
+To format the example code in the user guide, run the following command:
+
+```bash
+cargo fmt -p user-guide-samples
+```
+
 ### Using `mdbook serve`
 
 If you are working on the user guide you may find this handy:

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -66,11 +66,8 @@ when the container already exists.
 
 ## Handling the error
 
-Here's the code for updating a secret version:
-
-```rust,ignore
-{{#include ../samples/src/error_handling.rs:update-secret}}
-```
+This section walks you through a function to update a secret. For the full code
+sample, see [`update_secret`](#update_secret).
 
 First make an attempt to create a new secret version:
 
@@ -127,7 +124,11 @@ ______________________________________________________________________
 
 ## Code samples
 
-For the complete sample, see [error_handling.rs].
+### `update_secret`
+
+```rust,ignore
+{{#include ../samples/src/error_handling.rs:update-secret}}
+```
 
 ### `update_attempt`
 
@@ -142,7 +143,6 @@ For the complete sample, see [error_handling.rs].
 ```
 
 [configuring retry policies]: /configuring_retry_policies.md
-[error_handling.rs]: https://github.com/pcoet/google-cloud-rust/blob/main/guide/samples/src/error_handling.rs
 [examine error details]: examine_error_details.md
 [handling binding errors]: binding_errors.md
 [quickstart]: https://cloud.google.com/secret-manager/docs/quickstart

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -32,9 +32,9 @@ such errors.
 The guide uses the [Secret Manager] service to demonstrate error handling, but
 the concepts apply to other services as well.
 
-You may want to follow the service [quickstart]. This guide shows you how to
-enable the service and ensure that you've logged in and that your account has
-the necessary permissions.
+You may want to follow the service [quickstart], which shows you how to enable
+the service and ensure that you've logged in and that your account has the
+necessary permissions.
 
 For complete setup instructions for the Rust libraries, see
 [Setting up your development environment].

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -110,7 +110,7 @@ returns on failure:
 ```
 
 Assuming [`create_secret`](#create_secret-complete-code) is successful, you can
-try to update the secret version again, this time just returning an error if
+try to add the secret version again, this time just returning an error if
 anything fails:
 
 ```rust,ignore

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -17,30 +17,31 @@ limitations under the License.
 # Error handling
 
 Sometimes applications need to branch based on the type and details of the error
-returned by the client library. This guide will show you how to write code to
-handle such errors.
+returned by the client library. This guide shows you how to write code to handle
+such errors.
 
-> **Retryable errors:** one of the most common reasons to handle errors in
+> **Retryable errors:** One of the most common reasons to handle errors in
 > distributed systems is to retry requests that fail due to transient errors.
-> The Google Cloud client libraries for Rust implement a policy-based retry
+> The Google Cloud Client Libraries for Rust implement a policy-based retry
 > loop. You only need to configure the policies to enable the retry loop, and
 > the libraries implement common retry policies. Consult the
 > [Configuring Retry Policies] section before implementing your own retry loop.
 
 ## Prerequisites
 
-The guide uses the [Secret Manager] service, that makes the examples more
-concrete and therefore easier to follow. With that said, the same ideas work for
-any other service.
+The guide uses the [Secret Manager] service to demonstrate error handling, but
+the concepts apply to other services as well.
 
-You may want to follow the service [quickstart]. This guide will walk you
-through the steps necessary to enable the service, ensure you have logged in,
-and that your account has the necessary permissions.
+You may want to follow the service [quickstart]. This guide shows you how to
+enable the service and ensure that you've logged in and that your account has
+the necessary permissions.
+
+For complete setup instructions for the Rust libraries, see
+[Setting up your development environment].
 
 ### Dependencies
 
-As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
-file. We use:
+Add the Secret Manager library to your `Cargo.toml` file:
 
 ```shell
 cargo add google-cloud-secretmanager-v1
@@ -54,9 +55,9 @@ cargo add crc32c
 
 ## Motivation
 
-In this guide we will create a new *secret version*. Secret versions are
-contained in *secrets*. One must create the secret before creating secret
-versions. A common pattern in cloud services is to use a resource as-if the
+In this guide you'll create a new [secret version]. Secret versions are
+contained in [secrets]. You must create the secret before adding secret
+versions. A common pattern in cloud services is to use a resource as if the
 container for it existed, and only create the container if there is an error. If
 the container exists most of the time, such an approach is more efficient than
 checking if the container exists before making the request. Checking if the
@@ -65,13 +66,20 @@ when the container already exists.
 
 ## Handling the error
 
+Here's the code for updating a secret version:
+
+```rust,ignore
+{{#include ../samples/src/error_handling.rs:update-secret}}
+```
+
 First make an attempt to create a new secret version:
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-secret-initial-attempt}}
 ```
 
-If this succeeds, we can just print the successful result and return:
+If [`update_attempt`](#update_attempt-complete-code) succeeds, you can just
+print the successful result and return:
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-secret-success}}
@@ -81,7 +89,7 @@ The request may have failed for many reasons: because the connection dropped
 before the request was fully sent, or the connection dropped before the response
 was received, or because it was impossible to create the authentication tokens.
 
-The retry policies can deal with most of these errors, here we are interested
+The retry policies can deal with most of these errors. Here we are interested
 only in errors returned by the service:
 
 ```rust,ignore
@@ -94,28 +102,50 @@ and then only in errors that correspond to a missing secret:
 {{#include ../samples/src/error_handling.rs:update-secret-not-found}}
 ```
 
-If this is a "not found" error, we try to create the secret. This will simply
-return on failures:
+If this is a "not found" error, you can try to create the secret. This simply
+returns on failure:
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-secret-create}}
 ```
 
-Assuming the creation of the secret is successful, we can try to create the
-secret version again, this time just returning an error if anything fails:
+Assuming [`create_secret`](#create_secret-complete-code) is successful, you can
+try to update the secret version again, this time just returning an error if
+anything fails:
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-secret-try-again}}
 ```
 
+## What's next
+
+Learn more about error handling:
+
+- [Examine error details]
+- [Handling binding errors]
+
 ______________________________________________________________________
 
-## Error handling: complete code
+## `update_attempt`: complete code
 
 ```rust,ignore
-{{#include ../samples/src/error_handling.rs:update-secret}}
+{{#include ../samples/src/error_handling.rs:update-attempt}}
 ```
 
+## `create_secret`: complete code
+
+```rust,ignore
+{{#include ../samples/src/error_handling.rs:create-secret}}
+```
+
+For the complete sample, see [error_handling.rs]. 
+
 [configuring retry policies]: /configuring_retry_policies.md
+[error_handling.rs]: https://github.com/pcoet/google-cloud-rust/blob/main/guide/samples/src/error_handling.rs
+[examine error details]: examine_error_details.md
+[handling binding errors]: binding_errors.md
 [quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
+[secrets]: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
 [secret manager]: https://cloud.google.com/secret-manager
+[secret version]: https://cloud.google.com/secret-manager/docs/add-secret-version
+[setting up your development environment]: setting_up_your_development_environment.md

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -78,7 +78,7 @@ First make an attempt to create a new secret version:
 {{#include ../samples/src/error_handling.rs:update-secret-initial-attempt}}
 ```
 
-If [`update_attempt`](#update_attempt-complete-code) succeeds, you can just
+If [`update_attempt`](#update_attempt) succeeds, you can just
 print the successful result and return:
 
 ```rust,ignore
@@ -109,7 +109,7 @@ returns on failure:
 {{#include ../samples/src/error_handling.rs:update-secret-create}}
 ```
 
-Assuming [`create_secret`](#create_secret-complete-code) is successful, you can
+Assuming [`create_secret`](#create_secret) is successful, you can
 try to add the secret version again, this time just returning an error if
 anything fails:
 
@@ -126,19 +126,21 @@ Learn more about error handling:
 
 ______________________________________________________________________
 
-## `update_attempt`: complete code
+## Code samples
+
+For the complete sample, see [error_handling.rs].
+
+### `update_attempt`
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-attempt}}
 ```
 
-## `create_secret`: complete code
+### `create_secret`
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:create-secret}}
 ```
-
-For the complete sample, see [error_handling.rs]. 
 
 [configuring retry policies]: /configuring_retry_policies.md
 [error_handling.rs]: https://github.com/pcoet/google-cloud-rust/blob/main/guide/samples/src/error_handling.rs

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -78,8 +78,8 @@ First make an attempt to create a new secret version:
 {{#include ../samples/src/error_handling.rs:update-secret-initial-attempt}}
 ```
 
-If [`update_attempt`](#update_attempt) succeeds, you can just
-print the successful result and return:
+If [`update_attempt`](#update_attempt) succeeds, you can just print the
+successful result and return:
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-secret-success}}
@@ -109,9 +109,8 @@ returns on failure:
 {{#include ../samples/src/error_handling.rs:update-secret-create}}
 ```
 
-Assuming [`create_secret`](#create_secret) is successful, you can
-try to add the secret version again, this time just returning an error if
-anything fails:
+Assuming [`create_secret`](#create_secret) is successful, you can try to add the
+secret version again, this time just returning an error if anything fails:
 
 ```rust,ignore
 {{#include ../samples/src/error_handling.rs:update-secret-try-again}}
@@ -147,7 +146,7 @@ For the complete sample, see [error_handling.rs].
 [examine error details]: examine_error_details.md
 [handling binding errors]: binding_errors.md
 [quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
-[secrets]: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
 [secret manager]: https://cloud.google.com/secret-manager
 [secret version]: https://cloud.google.com/secret-manager/docs/add-secret-version
+[secrets]: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
 [setting up your development environment]: setting_up_your_development_environment.md


### PR DESCRIPTION
* Added instructions for formatting code examples to the contributor guide.
* Made a few nitty style fixes, including:
  * Prefer present to future tense.
  * Prefer "you" to "we".
* Added several links to the Secret Manager docs.
* Added cross links to several other guides.
* Added complete `update_secret` function to the start of "Handling the error." (It feels a little easier to follow the explanation if you can see the entire function first.)
* Added a "What's next" section.
* Added complete code for the helper functions, and linked to them.
* Made verbs match operations (*create* a secret vs. *add* a secret version).