### PR TITLE
impl(storage): make `ChecksumEngine` public

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -40,6 +40,7 @@ pub use gax::error::Error;
 pub mod backoff_policy;
 pub mod download_resume_policy;
 pub mod retry_policy;
+pub use crate::storage::checksum;
 pub use crate::storage::upload_source;
 
 mod control;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod checksum;
+pub mod checksum;
 pub(crate) mod client;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage/checksum.rs
+++ b/src/storage/src/storage/checksum.rs
@@ -12,6 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Define types to compute and compare Cloud Storage object checksums.
+//!
+//! The [ChecksumEngine] trait is sealed, and cannot be used to create new
+//! implementations. However, it may be useful when working with
+//! [UploadObject][crate::builder::storage::UploadObject].
+//!
+//! # Example
+//! ```
+//! use google_cloud_storage::builder::storage::UploadObject;
+//! use google_cloud_storage::model::Object;
+//! use google_cloud_storage::{upload_source::StreamingSource, checksum::ChecksumEngine};
+//!
+//! async fn example<S, C>(builder: UploadObject<S, C>) -> anyhow::Result<Object>
+//! where
+//!     S: StreamingSource + Send + Sync + 'static,
+//!     C: ChecksumEngine + Send + Sync + 'static
+//! {
+//!     // Finish configuring `builder` and complete the upload
+//!     let object = builder
+//!         .with_if_generation_match(0)
+//!         .with_resumable_upload_threshold(0_usize)
+//!         .send()
+//!         .await?;
+//!     Ok(object)
+//! }
+//! ```
+
 use crate::model::ObjectChecksums;
 use crate::storage::ChecksumMismatch;
 


### PR DESCRIPTION
Applications need this to use the `UploadObject` builder in generic
code.

Fixes #2826
