### PR TITLE
feat(gax): Add retry_loop_with_on_retry method.

### DIFF
--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -758,14 +758,13 @@ mod tests {
 
         let inner = async move |d| call.call(d);
         let backoff = async move |d| sleep.sleep(d).await;
-        let response = retry_loop_with_callback(
+        let response = retry_loop(
             inner,
             backoff,
             true,
             to_retry_throttler(throttler),
             to_retry_policy(retry_policy),
             to_backoff_policy(backoff_policy),
-            |_, _, _| (),
         )
         .await;
         let err = response.expect_err("retry loop should terminate");
@@ -879,14 +878,13 @@ mod tests {
 
         let inner = async move |d| call.call(d);
         let backoff = async move |d| sleep.sleep(d).await;
-        let response = retry_loop_with_callback(
+        let response = retry_loop(
             inner,
             backoff,
             true,
             to_retry_throttler(throttler),
             to_retry_policy(retry_policy),
             to_backoff_policy(backoff_policy),
-            |_, _, _| (),
         )
         .await;
         let err = response.expect_err("retry loop should terminate");

--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -59,7 +59,7 @@ where
     F: AsyncFnMut(Option<Duration>) -> Result<Response> + Send,
     S: AsyncFn(Duration) -> () + Send,
 {
-    retry_loop_with_callback(
+    retry_loop_with_on_retry(
         inner,
         sleep,
         idempotent,
@@ -82,7 +82,7 @@ where
 ///
 /// The `on_retry` callback is called before sleeping, with the attempt count,
 /// the error, and the delay.
-pub async fn retry_loop_with_callback<F, S, OnRetry, Response>(
+pub async fn retry_loop_with_on_retry<F, S, OnRetry, Response>(
     mut inner: F,
     sleep: S,
     idempotent: bool,
@@ -1017,7 +1017,7 @@ mod tests {
                 log.push((attempt, error.status().cloned().unwrap(), delay));
             }
         };
-        let response = retry_loop_with_callback(
+        let response = retry_loop_with_on_retry(
             inner,
             backoff,
             true,
@@ -1135,7 +1135,7 @@ mod tests {
             }
         };
 
-        let response = retry_loop_with_callback(
+        let response = retry_loop_with_on_retry(
             inner,
             backoff,
             true, // idempotency

--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -42,7 +42,7 @@ impl RetryLoopAttempt {
 /// Information about a retry attempt provided to the `on_retry` callback.
 ///
 /// An `on_retry` callback can be passed to
-/// [`retry_loop_with_on_retry`][super::retry_loop_with_on_retry]. It is invoked
+/// [`retry_loop_with_on_retry`]. It is invoked
 /// when a retryable error occurs and the retry policy decides to continue. This
 /// struct contains details about the attempt that just failed, and the upcoming
 /// retry attempt.


### PR DESCRIPTION
The fundamental problem with the original retry_loop is that it completely encapsulates the retry logic, only returning the final outcome. This hides intermediate failures, preventing the end user to see why the current attempt failed and after how long next retry will happen. So adding another method to support this use case.