### PR TITLE
refactor(storage)!: rename `send()` for uploads

### DIFF
--- a/guide/samples/tests/storage/queue.rs
+++ b/guide/samples/tests/storage/queue.rs
@@ -44,7 +44,7 @@ pub async fn queue(bucket_name: &str, object_name: &str) -> anyhow::Result<()> {
     // ANCHOR: create-upload
     let upload = client
         .upload_object(bucket_name, object_name, QueueSource(receiver))
-        .send();
+        .send_buffered();
     // ANCHOR_END: create-upload
     // ANCHOR: create-task
     let task = tokio::spawn(upload);

--- a/guide/samples/tests/storage/quickstart.rs
+++ b/guide/samples/tests/storage/quickstart.rs
@@ -53,7 +53,7 @@ pub async fn quickstart(project_id: &str, bucket_id: &str) -> anyhow::Result<()>
     // ANCHOR: upload
     let object = client
         .upload_object(&bucket.name, "hello.txt", "Hello World!")
-        .send()
+        .send_buffered()
         .await?;
     println!("object successfully uploaded {object:?}");
     // ANCHOR_END: upload

--- a/guide/samples/tests/storage/terminate_uploads.rs
+++ b/guide/samples/tests/storage/terminate_uploads.rs
@@ -71,7 +71,7 @@ pub async fn attempt_upload(bucket_name: &str) -> anyhow::Result<()> {
     // ANCHOR: attempt-upload-upload
     let upload = client
         .upload_object(bucket_name, "expect-error", MySource::default())
-        .send()
+        .send_buffered()
         .await;
     // ANCHOR_END: attempt-upload-upload
     // ANCHOR: attempt-upload-inspect-err

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -365,7 +365,7 @@ pub async fn upload_buffered(builder: storage::builder::storage::ClientBuilder) 
     let insert = client
         .upload_object(&bucket.name, "empty.txt", "")
         .with_if_generation_match(0)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 0_i64);
@@ -375,7 +375,7 @@ pub async fn upload_buffered(builder: storage::builder::storage::ClientBuilder) 
     let insert = client
         .upload_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 128 * 1024_i64);
@@ -385,7 +385,7 @@ pub async fn upload_buffered(builder: storage::builder::storage::ClientBuilder) 
     let insert = client
         .upload_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 512 * 1024_i64);
@@ -422,7 +422,7 @@ pub async fn upload_buffered_resumable_known_size(
         .upload_object(&bucket.name, "empty.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 0_i64);
@@ -433,7 +433,7 @@ pub async fn upload_buffered_resumable_known_size(
         .upload_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 128 * 1024_i64);
@@ -444,7 +444,7 @@ pub async fn upload_buffered_resumable_known_size(
         .upload_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 512 * 1024_i64);
@@ -481,7 +481,7 @@ pub async fn upload_buffered_resumable_unknown_size(
         .upload_object(&bucket.name, "empty.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 0_i64);
@@ -492,7 +492,7 @@ pub async fn upload_buffered_resumable_unknown_size(
         .upload_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 128 * 1024_i64);
@@ -503,7 +503,7 @@ pub async fn upload_buffered_resumable_unknown_size(
         .upload_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 512 * 1024_i64);
@@ -514,7 +514,7 @@ pub async fn upload_buffered_resumable_unknown_size(
         .upload_object(&bucket.name, "500K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
-        .send()
+        .send_buffered()
         .await?;
     tracing::info!("success with insert={insert:?}");
     assert_eq!(insert.size, 500 * 1024_i64);
@@ -757,7 +757,7 @@ async fn abort_upload_buffered(client: storage::client::Storage, bucket_name: &s
     for (number, AbortUploadTestCase { name, upload }) in test_cases.into_iter().enumerate() {
         tracing::info!("[{number}] {name}");
         let err = upload
-            .send()
+            .send_buffered()
             .await
             .expect_err(&format!("[{number}] {name} - expected error"));
         tracing::info!("[{number}] {name} - got error {err:?}");
@@ -807,7 +807,7 @@ pub async fn checksums(
                 client
                     .upload_object(bucket_name, "verify/default", VEXING)
                     .with_if_generation_match(0)
-                    .send(),
+                    .send_buffered(),
             ),
         ),
         (
@@ -817,7 +817,7 @@ pub async fn checksums(
                     .upload_object(bucket_name, "verify/md5", VEXING)
                     .with_if_generation_match(0)
                     .compute_md5()
-                    .send(),
+                    .send_buffered(),
             ),
         ),
         (
@@ -828,7 +828,7 @@ pub async fn checksums(
                     .with_if_generation_match(0)
                     .precompute_checksums()
                     .await?
-                    .send(),
+                    .send_buffered(),
             ),
         ),
         (
@@ -840,7 +840,7 @@ pub async fn checksums(
                     .compute_md5()
                     .precompute_checksums()
                     .await?
-                    .send(),
+                    .send_buffered(),
             ),
         ),
     ];

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -36,7 +36,7 @@ use crate::{Error, Result};
 /// let upload = client
 ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
 ///     .with_if_generation_not_match(0);
-/// match upload.send().await {
+/// match upload.send_buffered().await {
 ///     Ok(object) => println!("Successfully uploaded the object"),
 ///     Err(error) if error.is_serialization() => {
 ///         println!("Some problem {error:?} sending the data to the service");

--- a/src/storage/src/storage/checksum.rs
+++ b/src/storage/src/storage/checksum.rs
@@ -33,7 +33,7 @@
 //!     let object = builder
 //!         .with_if_generation_match(0)
 //!         .with_resumable_upload_threshold(0_usize)
-//!         .send()
+//!         .send_buffered()
 //!         .await?;
 //!     Ok(object)
 //! }

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -133,7 +133,7 @@ impl Storage {
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -172,12 +172,7 @@ impl Storage {
         UploadObject::new(self.inner.clone(), bucket, object, payload)
     }
 
-    /// A simple download into a buffer.
-    ///
-    /// # Parameters
-    /// * `bucket` - the bucket name containing the object. In
-    ///   `projects/_/buckets/{bucket_id}` format.
-    /// * `object` - the object name.
+    /// Downloads the contents of an object.
     ///
     /// # Example
     /// ```
@@ -194,6 +189,11 @@ impl Storage {
     /// println!("object contents={:?}", bytes::Bytes::from_owner(contents));
     /// # Ok(()) }
     /// ```
+    ///
+    /// # Parameters
+    /// * `bucket` - the bucket name containing the object. In
+    ///   `projects/_/buckets/{bucket_id}` format.
+    /// * `object` - the object name.
     pub fn read_object<B, O>(&self, bucket: B, object: O) -> ReadObject
     where
         B: Into<String>,
@@ -446,7 +446,7 @@ impl ClientBuilder {
     ///     .await?;
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -486,7 +486,7 @@ impl ClientBuilder {
     ///     .await?;
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -233,7 +233,7 @@ mod tests {
             .await?;
         let response = client
             .upload_object("projects/_/buckets/test-bucket", "test-object", "")
-            .send()
+            .send_buffered()
             .await?;
         assert_eq!(response.name, "test-object");
         assert_eq!(response.bucket, "projects/_/buckets/test-bucket");
@@ -267,7 +267,7 @@ mod tests {
             .returning(|| Ok((1024_u64, Some(1024_u64))));
         let err = client
             .upload_object("projects/_/buckets/test-bucket", "test-object", source)
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a serialization error");
         assert!(err.is_serialization(), "{err:?}");

--- a/src/storage/src/storage/perform_upload/tests/checksums.rs
+++ b/src/storage/src/storage/perform_upload/tests/checksums.rs
@@ -36,7 +36,7 @@ mod buffered_single_shot {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
@@ -46,7 +46,7 @@ mod buffered_single_shot {
     #[tokio::test]
     async fn computed_match() -> Result {
         let server = prepare_server(good_checksums_body());
-        let object = start_upload(&server).await?.send().await?;
+        let object = start_upload(&server).await?.send_buffered().await?;
         assert_eq!(object.name, "test-object");
         Ok(())
     }
@@ -58,7 +58,7 @@ mod buffered_single_shot {
             .await?
             .with_known_crc32c(vexing_crc32c())
             .with_known_md5_hash(vexing_md5())
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
@@ -72,7 +72,7 @@ mod buffered_single_shot {
             .await?
             .with_known_crc32c(vexing_crc32c())
             .with_known_md5_hash(vexing_md5())
-            .send()
+            .send_buffered()
             .await?;
         assert_eq!(object.name, "test-object");
         Ok(())
@@ -94,7 +94,7 @@ mod buffered_resumable {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
@@ -104,7 +104,7 @@ mod buffered_resumable {
     #[tokio::test]
     async fn computed_match() -> Result {
         let server = prepare_server(good_checksums_body());
-        let object = start_upload(&server).await?.send().await?;
+        let object = start_upload(&server).await?.send_buffered().await?;
         assert_eq!(object.name, "test-object");
         Ok(())
     }
@@ -116,7 +116,7 @@ mod buffered_resumable {
             .await?
             .with_known_crc32c(vexing_crc32c())
             .with_known_md5_hash(vexing_md5())
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
@@ -130,7 +130,7 @@ mod buffered_resumable {
             .await?
             .with_known_crc32c(vexing_crc32c())
             .with_known_md5_hash(vexing_md5())
-            .send()
+            .send_buffered()
             .await?;
         assert_eq!(object.name, "test-object");
         Ok(())
@@ -152,7 +152,7 @@ mod unbuffered_single_shot {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
@@ -162,7 +162,7 @@ mod unbuffered_single_shot {
     #[tokio::test]
     async fn computed_match() -> Result {
         let server = prepare_server(good_checksums_body());
-        let object = start_upload(&server).await?.send().await?;
+        let object = start_upload(&server).await?.send_buffered().await?;
         assert_eq!(object.name, "test-object");
         Ok(())
     }
@@ -210,7 +210,7 @@ mod unbuffered_resumable {
         let server = prepare_server(bad_checksums_body());
         let err = start_upload(&server)
             .await?
-            .send()
+            .send_buffered()
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -68,7 +68,7 @@ use crate::storage::checksum::{
 /// async fn sample(client: &Storage) -> anyhow::Result<()> {
 ///     let response = client
 ///         .upload_object("projects/_/buckets/my-bucket", "my-object", DataSource)
-///         .send()
+///         .send_buffered()
 ///         .await?;
 ///     println!("response details={response:?}");
 ///     Ok(())
@@ -97,7 +97,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_if_generation_match(0)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -124,7 +124,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_if_generation_not_match(0)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -152,7 +152,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_if_metageneration_match(1234)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -181,7 +181,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_if_metageneration_not_match(1234)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -206,7 +206,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_acl([ObjectAccessControl::new().set_entity("allAuthenticatedUsers").set_role("READER")])
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -231,7 +231,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_cache_control("public; max-age=7200")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -257,7 +257,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_content_disposition("inline")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -285,7 +285,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", bytes::Bytes::from_owner(e.finish()?))
     ///     .with_content_encoding("gzip")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -311,7 +311,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_content_language("en")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -336,7 +336,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_content_type("text/plain")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -361,7 +361,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_custom_time(time)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -386,7 +386,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_event_based_hold(true)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -411,7 +411,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_metadata([("test-only", "true"), ("environment", "qa")])
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -441,7 +441,7 @@ impl<T, C> UploadObject<T, C> {
     ///         Retention::new()
     ///             .set_mode(retention::Mode::Locked)
     ///             .set_retain_until_time(wkt::Timestamp::try_from("2035-01-01T00:00:00Z")?))
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -465,7 +465,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_storage_class("ARCHIVE")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -493,7 +493,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_temporary_hold(true)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -521,7 +521,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_kms_key("projects/test-project/locations/us-central1/keyRings/test-ring/cryptoKeys/test-key")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -545,7 +545,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_predefined_acl("private")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -572,7 +572,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_key(KeyAes256::new(key)?)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -609,7 +609,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_idempotency(true)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -637,7 +637,7 @@ impl<T, C> UploadObject<T, C> {
     ///         .with_attempt_limit(5)
     ///         .with_time_limit(Duration::from_secs(10)),
     ///     )
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -658,7 +658,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_backoff_policy(ExponentialBackoff::default())
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -685,7 +685,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_retry_throttler(adhoc_throttler())
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// fn adhoc_throttler() -> gax::retry_throttler::SharedRetryThrottler {
@@ -710,7 +710,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_resumable_upload_threshold(0_usize) // Forces a resumable upload.
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -747,7 +747,7 @@ impl<T, C> UploadObject<T, C> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_resumable_upload_buffer_size(32 * 1024 * 1024_usize)
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -833,7 +833,7 @@ impl<T> UploadObject<T, Crc32c> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_known_crc32c(crc32c(b"hello world"))
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -867,7 +867,7 @@ impl<T> UploadObject<T, Crc32c> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .with_known_md5_hash(bytes::Bytes::from_owner(hash.0))
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -904,7 +904,7 @@ impl<T> UploadObject<T, Crc32c> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", payload)
     ///     .compute_md5()
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
@@ -1088,12 +1088,12 @@ where
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let response = client
     ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .send()
+    ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
     /// ```
-    pub async fn send(self) -> crate::Result<Object> {
+    pub async fn send_buffered(self) -> crate::Result<Object> {
         self.build().send().await
     }
 }
@@ -1195,7 +1195,7 @@ mod tests {
 
         let upload = client
             .upload_object("projects/_/buckets/test-bucket", "test-object", "")
-            .send();
+            .send_buffered();
         need_send(&upload);
         need_static(&upload);
 


### PR DESCRIPTION
Uploads can be buffered or not, they have very different performance.
This is an important enough distinction that we should not offer an
ambiguous `send()` method that defaults to buffered uploads.

Fixes #2835
