### PR TITLE
chore: bump all versions

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -41,7 +41,7 @@ conformance-sha256          = '008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2
 [codec]
 # The default version for all crates. This can be overridden in the crate's
 # `.sidekick.toml` file.
-version = "0.4.3"
+version = "0.4.4"
 # The default release level for all crates.
 release-level = "preview"
 # Disable a number of warnings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "google-cloud-accessapproval-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-advisorynotifications-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-aiplatform-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-alloydb-connectors-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-alloydb-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-cloudquotas-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicecontrol-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicecontrol-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicemanagement-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-serviceusage-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apigateway-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apigeeconnect-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apihub-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apikeys-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-appengine-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apphub-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-calendar"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-docs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-drive"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-gmail"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-sheets"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-slides"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-artifactregistry-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-asset-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-assuredworkloads-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-backupdr-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-baremetalsolution-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1362,7 +1362,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-beyondcorp-appconnections-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-appconnectors-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-appgateways-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-clientconnectorservices-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-clientgateways-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1476,7 +1476,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-bigquery-analyticshub-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-connection-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-datapolicies-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-datapolicies-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-datatransfer-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-migration-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-reservation-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1636,7 +1636,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-bigtable-admin-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-billing-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-binaryauthorization-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-build-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-build-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-certificatemanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-chronicle-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-cloudcontrolspartner-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-clouddms-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-commerce-consumer-procurement-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-common"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-confidentialcomputing-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-config-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-configdelivery-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-connectors-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-contactcenterinsights-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-container-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-containeranalysis-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datacatalog-lineage-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datacatalog-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataform-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datafusion-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataplex-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataproc-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2135,7 +2135,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-datastore-admin-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datastream-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-deploy-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-developerconnect-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-devicestreaming-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-cx-v3"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-discoveryengine-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-documentai-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-domains-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-edgecontainer-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-edgenetwork-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-essentialcontacts-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-eventarc-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-filestore-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-financialservices-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-firestore-admin-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-functions-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkebackup-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkeconnect-gateway-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-configmanagement-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-multiclusteringress-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkemulticloud-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-grafeas-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gsuiteaddons-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-admin-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-credentials-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v3"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iap-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-identity-accesscontextmanager-type"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-identity-accesscontextmanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-ids-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-kms-inventory-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-kms-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-language-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-licensemanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-location"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-logging-type"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-logging-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-longrunning"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lro"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lustre-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedidentities-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedkafka-schemaregistry-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedkafka-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-memcache-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-memorystore-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-metastore-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-migrationcenter-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-modelarmor-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-dashboard-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-metricsscope-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-v3"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-netapp-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkconnectivity-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkmanagement-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networksecurity-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkservices-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-notebooks-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-optimization-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oracledatabase-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orchestration-airflow-service-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orgpolicy-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orgpolicy-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-osconfig-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oslogin-common"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oslogin-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-parallelstore-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-parametermanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policysimulator-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policytroubleshooter-iam-v3"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policytroubleshooter-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privacy-dlp-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privilegedaccessmanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-profiler-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3811,7 +3811,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-rapidmigrationassessment-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-recaptchaenterprise-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-recommender-logging-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-recommender-v1",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-recommender-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-redis-cluster-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-redis-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-resourcemanager-v3"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-retail-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc-context"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-run-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-scheduler-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-secretmanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securesourcemanager-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-security-privateca-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-security-publicca-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securitycenter-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securityposture-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-servicedirectory-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-servicehealth-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-shell-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-showcase-v1beta1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4251,7 +4251,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-spanner-admin-database-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-spanner-admin-instance-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-speech-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-sql-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storagebatchoperations-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storageinsights-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storagetransfer-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-support-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-talent-v4"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-tasks-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-telcoautomation-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-texttospeech-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-timeseriesinsights-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-tpu-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-trace-v2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-translation-v3"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-type"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-livestream-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-stitcher-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-transcoder-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-videointelligence-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vision-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vmmigration-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vmwareengine-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vpcaccess-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-webrisk-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-websecurityscanner-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workflows-executions-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workflows-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workstations-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6319,7 +6319,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secretmanager-openapi-v1"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,48 +342,48 @@ tokio-stream   = { default-features = false, version = "0.1" }
 tokio-test     = { default-features = false, version = "0.4" }
 
 # Local packages used as dependencies
-auth                          = { version = "0.22.2", path = "src/auth", package = "google-cloud-auth" }
-gax                           = { version = "0.23.2", path = "src/gax", package = "google-cloud-gax" }
-google-cloud-gax              = { version = "0.23.2", path = "src/gax", package = "google-cloud-gax" }
-gaxi                          = { version = "0.4.1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
-iam_v1                        = { version = "0.4.3", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
-location                      = { version = "0.4.3", path = "src/generated/cloud/location", package = "google-cloud-location" }
-longrunning                   = { version = "0.25.3", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
-google-cloud-longrunning      = { version = "0.25.3", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
-lro                           = { version = "0.3.3", path = "src/lro", package = "google-cloud-lro" }
-google-cloud-lro              = { version = "0.3.3", path = "src/lro", package = "google-cloud-lro" }
-wkt                           = { version = "0.5.3", path = "src/wkt", package = "google-cloud-wkt" }
-google-cloud-wkt              = { version = "0.5.3", path = "src/wkt", package = "google-cloud-wkt" }
-api                           = { version = "0.4.3", path = "src/generated/api/types", package = "google-cloud-api" }
-cloud_common                  = { version = "0.4.3", path = "src/generated/cloud/common", package = "google-cloud-common" }
-gtype                         = { version = "0.4.3", path = "src/generated/type", package = "google-cloud-type" }
-grafeas                       = { version = "0.4.3", path = "src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
-logging_type                  = { version = "0.4.3", path = "src/generated/logging/type", package = "google-cloud-logging-type" }
-rpc                           = { version = "0.4.3", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
-google-cloud-rpc              = { version = "0.4.3", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
-rpc_context                   = { version = "0.4.3", path = "src/generated/rpc/context", package = "google-cloud-rpc-context" }
-apps_script_type              = { version = "0.4.3", path = "src/generated/apps/script/gtype", package = "google-cloud-apps-script-type" }
-accesscontextmanager_v1       = { version = "0.4.3", path = "src/generated/identity/accesscontextmanager/v1", package = "google-cloud-identity-accesscontextmanager-v1" }
-orgpolicy_v1                  = { version = "0.4.3", path = "src/generated/cloud/orgpolicy/v1", package = "google-cloud-orgpolicy-v1" }
-orgpolicy_v2                  = { version = "0.4.3", path = "src/generated/cloud/orgpolicy/v2", package = "google-cloud-orgpolicy-v2" }
-osconfig_v1                   = { version = "0.4.3", path = "src/generated/cloud/osconfig/v1", package = "google-cloud-osconfig-v1" }
-gkehub_configmanagement_v1    = { version = "0.4.3", path = "src/generated/cloud/gkehub/configmanagement/v1", package = "google-cloud-gkehub-configmanagement-v1" }
-gkehub_multiclusteringress_v1 = { version = "0.4.3", path = "src/generated/cloud/gkehub/multiclusteringress/v1", package = "google-cloud-gkehub-multiclusteringress-v1" }
-apps_script_calendar          = { version = "0.4.3", path = "src/generated/apps/script/calendar", package = "google-cloud-apps-script-type-calendar" }
-apps_script_docs              = { version = "0.4.3", path = "src/generated/apps/script/docs", package = "google-cloud-apps-script-type-docs" }
-apps_script_drive             = { version = "0.4.3", path = "src/generated/apps/script/drive", package = "google-cloud-apps-script-type-drive" }
-apps_script_gmail             = { version = "0.4.3", path = "src/generated/apps/script/gmail", package = "google-cloud-apps-script-type-gmail" }
-apps_script_sheets            = { version = "0.4.3", path = "src/generated/apps/script/sheets", package = "google-cloud-apps-script-type-sheets" }
-apps_script_slides            = { version = "0.4.3", path = "src/generated/apps/script/slides", package = "google-cloud-apps-script-type-slides" }
-kms                           = { version = "0.4.3", path = "src/generated/cloud/kms/v1", package = "google-cloud-kms-v1" }
-oslogin_common                = { version = "0.4.3", path = "src/generated/oslogin/common", package = "google-cloud-oslogin-common" }
-iam_v2                        = { version = "0.4.3", path = "src/generated/iam/v2", package = "google-cloud-iam-v2" }
-recommender                   = { version = "0.4.3", path = "src/generated/cloud/recommender/v1", package = "google-cloud-recommender-v1" }
-accesscontextmanager_type     = { version = "0.4.3", path = "src/generated/identity/accesscontextmanager/type", package = "google-cloud-identity-accesscontextmanager-type" }
-google-cloud-language-v2      = { version = "0.4.3", path = "src/generated/cloud/language/v2" }
-google-cloud-speech-v2        = { version = "0.4.3", path = "src/generated/cloud/speech/v2" }
-google-cloud-secretmanager-v1 = { version = "0.4.3", path = "src/generated/cloud/secretmanager/v1" }
-google-cloud-aiplatform-v1    = { version = "0.4.3", default-features = false, path = "src/generated/cloud/aiplatform/v1" }
+auth                          = { version = "0.22.3", path = "src/auth", package = "google-cloud-auth" }
+gax                           = { version = "0.23.3", path = "src/gax", package = "google-cloud-gax" }
+google-cloud-gax              = { version = "0.23.3", path = "src/gax", package = "google-cloud-gax" }
+gaxi                          = { version = "0.5.0", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+iam_v1                        = { version = "0.4.4", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
+location                      = { version = "0.4.4", path = "src/generated/cloud/location", package = "google-cloud-location" }
+longrunning                   = { version = "0.25.4", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+google-cloud-longrunning      = { version = "0.25.4", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+lro                           = { version = "0.3.4", path = "src/lro", package = "google-cloud-lro" }
+google-cloud-lro              = { version = "0.3.4", path = "src/lro", package = "google-cloud-lro" }
+wkt                           = { version = "0.5.4", path = "src/wkt", package = "google-cloud-wkt" }
+google-cloud-wkt              = { version = "0.5.4", path = "src/wkt", package = "google-cloud-wkt" }
+api                           = { version = "0.4.4", path = "src/generated/api/types", package = "google-cloud-api" }
+cloud_common                  = { version = "0.4.4", path = "src/generated/cloud/common", package = "google-cloud-common" }
+gtype                         = { version = "0.4.4", path = "src/generated/type", package = "google-cloud-type" }
+grafeas                       = { version = "0.4.4", path = "src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
+logging_type                  = { version = "0.4.4", path = "src/generated/logging/type", package = "google-cloud-logging-type" }
+rpc                           = { version = "0.4.4", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
+google-cloud-rpc              = { version = "0.4.4", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
+rpc_context                   = { version = "0.4.4", path = "src/generated/rpc/context", package = "google-cloud-rpc-context" }
+apps_script_type              = { version = "0.4.4", path = "src/generated/apps/script/gtype", package = "google-cloud-apps-script-type" }
+accesscontextmanager_v1       = { version = "0.4.4", path = "src/generated/identity/accesscontextmanager/v1", package = "google-cloud-identity-accesscontextmanager-v1" }
+orgpolicy_v1                  = { version = "0.4.4", path = "src/generated/cloud/orgpolicy/v1", package = "google-cloud-orgpolicy-v1" }
+orgpolicy_v2                  = { version = "0.4.4", path = "src/generated/cloud/orgpolicy/v2", package = "google-cloud-orgpolicy-v2" }
+osconfig_v1                   = { version = "0.4.4", path = "src/generated/cloud/osconfig/v1", package = "google-cloud-osconfig-v1" }
+gkehub_configmanagement_v1    = { version = "0.4.4", path = "src/generated/cloud/gkehub/configmanagement/v1", package = "google-cloud-gkehub-configmanagement-v1" }
+gkehub_multiclusteringress_v1 = { version = "0.4.4", path = "src/generated/cloud/gkehub/multiclusteringress/v1", package = "google-cloud-gkehub-multiclusteringress-v1" }
+apps_script_calendar          = { version = "0.4.4", path = "src/generated/apps/script/calendar", package = "google-cloud-apps-script-type-calendar" }
+apps_script_docs              = { version = "0.4.4", path = "src/generated/apps/script/docs", package = "google-cloud-apps-script-type-docs" }
+apps_script_drive             = { version = "0.4.4", path = "src/generated/apps/script/drive", package = "google-cloud-apps-script-type-drive" }
+apps_script_gmail             = { version = "0.4.4", path = "src/generated/apps/script/gmail", package = "google-cloud-apps-script-type-gmail" }
+apps_script_sheets            = { version = "0.4.4", path = "src/generated/apps/script/sheets", package = "google-cloud-apps-script-type-sheets" }
+apps_script_slides            = { version = "0.4.4", path = "src/generated/apps/script/slides", package = "google-cloud-apps-script-type-slides" }
+kms                           = { version = "0.4.4", path = "src/generated/cloud/kms/v1", package = "google-cloud-kms-v1" }
+oslogin_common                = { version = "0.4.4", path = "src/generated/oslogin/common", package = "google-cloud-oslogin-common" }
+iam_v2                        = { version = "0.4.4", path = "src/generated/iam/v2", package = "google-cloud-iam-v2" }
+recommender                   = { version = "0.4.4", path = "src/generated/cloud/recommender/v1", package = "google-cloud-recommender-v1" }
+accesscontextmanager_type     = { version = "0.4.4", path = "src/generated/identity/accesscontextmanager/type", package = "google-cloud-identity-accesscontextmanager-type" }
+google-cloud-language-v2      = { version = "0.4.4", path = "src/generated/cloud/language/v2" }
+google-cloud-speech-v2        = { version = "0.4.4", path = "src/generated/cloud/speech/v2" }
+google-cloud-secretmanager-v1 = { version = "0.4.4", path = "src/generated/cloud/secretmanager/v1" }
+google-cloud-aiplatform-v1    = { version = "0.4.4", default-features = false, path = "src/generated/cloud/aiplatform/v1" }
 google-cloud-storage          = { version = "0.25.0-preview4", path = "src/storage" }
 
 # Local test package

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-auth"
-version     = "0.22.2"
+version     = "0.22.3"
 description = "Google Cloud Client Libraries for Rust - Authentication"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.4.1"
+version     = "0.5.0"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apikeys-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - API Keys API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/cloudquotas/v1/Cargo.toml
+++ b/src/generated/api/cloudquotas/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-cloudquotas-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Quotas API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicecontrol/v1/Cargo.toml
+++ b/src/generated/api/servicecontrol/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicecontrol-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Control API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicecontrol-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Control API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicemanagement-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-serviceusage-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Usage API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/types/Cargo.toml
+++ b/src/generated/api/types/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Config API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-appengine-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - App Engine Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/calendar/Cargo.toml
+++ b/src/generated/apps/script/calendar/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-calendar"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/docs/Cargo.toml
+++ b/src/generated/apps/script/docs/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-docs"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/drive/Cargo.toml
+++ b/src/generated/apps/script/drive/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-drive"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/gmail/Cargo.toml
+++ b/src/generated/apps/script/gmail/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-gmail"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/gtype/Cargo.toml
+++ b/src/generated/apps/script/gtype/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/sheets/Cargo.toml
+++ b/src/generated/apps/script/sheets/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-sheets"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/slides/Cargo.toml
+++ b/src/generated/apps/script/slides/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-slides"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigtable-admin-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Bigtable Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/accessapproval/v1/Cargo.toml
+++ b/src/generated/cloud/accessapproval/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-accessapproval-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Access Approval API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/advisorynotifications/v1/Cargo.toml
+++ b/src/generated/cloud/advisorynotifications/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-advisorynotifications-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Advisory Notifications API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-aiplatform-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-alloydb-connectors-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - AlloyDB connectors"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-alloydb-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - AlloyDB API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apigateway-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - API Gateway API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apigeeconnect/v1/Cargo.toml
+++ b/src/generated/cloud/apigeeconnect/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apigeeconnect-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Apigee Connect API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apihub-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - API hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apphub-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - App Hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-asset-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Asset API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-assuredworkloads-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Assured Workloads API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-backupdr-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Backup and DR Service API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-baremetalsolution-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Bare Metal Solution API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appconnections-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appconnectors-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appgateways-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-clientconnectorservices-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-clientgateways-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-analyticshub-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Analytics Hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/connection/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/connection/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-connection-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Connection API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-datapolicies-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Data Policy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/datapolicies/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-datapolicies-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Data Policy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-datatransfer-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Data Transfer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/migration/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/migration/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-migration-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-reservation-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Reservation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - BigQuery API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/billing/v1/Cargo.toml
+++ b/src/generated/cloud/billing/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-billing-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Billing API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/binaryauthorization/v1/Cargo.toml
+++ b/src/generated/cloud/binaryauthorization/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-binaryauthorization-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Binary Authorization API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-certificatemanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Certificate Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/chronicle/v1/Cargo.toml
+++ b/src/generated/cloud/chronicle/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-chronicle-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Chronicle API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-cloudcontrolspartner-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Controls Partner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-clouddms-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Database Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-commerce-consumer-procurement-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Commerce Consumer Procurement API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/common/Cargo.toml
+++ b/src/generated/cloud/common/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-common"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Common Operation Metadata type"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-confidentialcomputing-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Confidential Computing API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-config-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Infrastructure Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/configdelivery/v1/Cargo.toml
+++ b/src/generated/cloud/configdelivery/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-configdelivery-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Config Delivery API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-connectors-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Connectors API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-contactcenterinsights-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Contact Center AI Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datacatalog-lineage-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Data Lineage API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datacatalog-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Data Catalog API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataform/v1/Cargo.toml
+++ b/src/generated/cloud/dataform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataform-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Dataform API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datafusion-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Data Fusion API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataplex/v1/Cargo.toml
+++ b/src/generated/cloud/dataplex/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataplex-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataplex API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataproc-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataproc API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datastream-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Datastream API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-deploy-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Deploy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-developerconnect-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Developer Connect API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/devicestreaming/v1/Cargo.toml
+++ b/src/generated/cloud/devicestreaming/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-devicestreaming-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Device Streaming API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-cx-v3"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-discoveryengine-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Discovery Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-documentai-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Document AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-domains-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Domains API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-edgecontainer-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Distributed Cloud Edge Container API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-edgenetwork-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Distributed Cloud Edge Network API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/essentialcontacts/v1/Cargo.toml
+++ b/src/generated/cloud/essentialcontacts/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-essentialcontacts-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Essential Contacts API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-eventarc-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Eventarc API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-filestore-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Filestore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-financialservices-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Financial Services API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-functions-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Functions API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkebackup-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Backup for GKE API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkeconnect-gateway-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Connect Gateway API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-configmanagement-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-multiclusteringress-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkemulticloud-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - GKE Multi-Cloud API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gsuiteaddons-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Workspace add-ons API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/iap/v1/Cargo.toml
+++ b/src/generated/cloud/iap/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iap-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Identity-Aware Proxy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-ids-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud IDS API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/kms/inventory/v1/Cargo.toml
+++ b/src/generated/cloud/kms/inventory/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-kms-inventory-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - KMS Inventory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-kms-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Key Management Service (KMS) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/language/v2/Cargo.toml
+++ b/src/generated/cloud/language/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-language-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Natural Language API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/licensemanager/v1/Cargo.toml
+++ b/src/generated/cloud/licensemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-licensemanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - License Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-location"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Metadata API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/lustre/v1/Cargo.toml
+++ b/src/generated/cloud/lustre/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-lustre-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Managed Lustre API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedidentities-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Microsoft Active Directory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/Cargo.toml
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedkafka-schemaregistry-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Apache Kafka API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedkafka/v1/Cargo.toml
+++ b/src/generated/cloud/managedkafka/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedkafka-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Apache Kafka API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-memcache-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Memorystore for Memcached API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-memorystore-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Memorystore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-metastore-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Dataproc Metastore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-migrationcenter-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Migration Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/modelarmor/v1/Cargo.toml
+++ b/src/generated/cloud/modelarmor/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-modelarmor-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Model Armor API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-netapp-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - NetApp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkconnectivity-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Network Connectivity API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkmanagement-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Network Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networksecurity-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Network Security API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkservices-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Network Services API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-notebooks-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Notebooks API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-optimization-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Optimization API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oracledatabase-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Oracle Database@Google Cloud API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orchestration-airflow-service-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Composer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orgpolicy/v1/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orgpolicy-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Organization Policy Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orgpolicy/v2/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orgpolicy-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Organization Policy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-osconfig-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - OS Config API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/oslogin/v1/Cargo.toml
+++ b/src/generated/cloud/oslogin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oslogin-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud OS Login API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-parallelstore-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Parallelstore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/parametermanager/v1/Cargo.toml
+++ b/src/generated/cloud/parametermanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-parametermanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Parameter Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policysimulator-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Policy Simulator API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policytroubleshooter-iam-v3"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Policy Troubleshooter API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policytroubleshooter-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Policy Troubleshooter API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privilegedaccessmanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Privileged Access Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rapidmigrationassessment-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Rapid Migration Assessment API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-recaptchaenterprise-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - reCAPTCHA Enterprise API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/recommender/logging/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/logging/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-recommender-logging-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Recommender API Logging"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/recommender/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-recommender-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Recommender API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-redis-cluster-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Memorystore for Redis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-redis-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Memorystore for Redis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-resourcemanager-v3"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Resource Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-retail-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI Search for commerce API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-run-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Run Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/scheduler/v1/Cargo.toml
+++ b/src/generated/cloud/scheduler/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-scheduler-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Scheduler API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-secretmanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Secret Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securesourcemanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Secure Source Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-security-privateca-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Certificate Authority API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/security/publicca/v1/Cargo.toml
+++ b/src/generated/cloud/security/publicca/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-security-publicca-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Public Certificate Authority API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securitycenter-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Security Command Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securityposture-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Security Posture API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/servicedirectory/v1/Cargo.toml
+++ b/src/generated/cloud/servicedirectory/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-servicedirectory-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Directory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/servicehealth/v1/Cargo.toml
+++ b/src/generated/cloud/servicehealth/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-servicehealth-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Service Health API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-shell-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Shell API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-speech-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Speech-to-Text API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-sql-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud SQL Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
+++ b/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storagebatchoperations-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Storage Batch Operations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storageinsights-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Storage Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/support/v2/Cargo.toml
+++ b/src/generated/cloud/support/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-support-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Support API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-talent-v4"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Talent Solution API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/tasks/v2/Cargo.toml
+++ b/src/generated/cloud/tasks/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-tasks-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Tasks API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-telcoautomation-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Telco Automation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-texttospeech-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Text-to-Speech API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-timeseriesinsights-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Timeseries Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-tpu-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud TPU API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-translation-v3"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Translation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-livestream-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Live Stream API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-stitcher-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Video Stitcher API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/transcoder/v1/Cargo.toml
+++ b/src/generated/cloud/video/transcoder/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-transcoder-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Transcoder API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-videointelligence-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Video Intelligence API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vision-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Vision API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vmmigration-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - VM Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vmwareengine-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - VMware Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vpcaccess-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Serverless VPC Access API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-webrisk-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Web Risk API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/websecurityscanner/v1/Cargo.toml
+++ b/src/generated/cloud/websecurityscanner/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-websecurityscanner-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Web Security Scanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workflows/executions/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/executions/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workflows-executions-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Workflow Executions API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workflows-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Workflows API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workstations-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Workstations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/container/v1/Cargo.toml
+++ b/src/generated/container/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-container-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Kubernetes Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datastore-admin-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Datastore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-artifactregistry-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Artifact Registry API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-build-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Build API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-build-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Build API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudprofiler/v2/Cargo.toml
+++ b/src/generated/devtools/cloudprofiler/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-profiler-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Profiler API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-trace-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Stackdriver Trace API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/containeranalysis/v1/Cargo.toml
+++ b/src/generated/devtools/containeranalysis/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-containeranalysis-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Container Analysis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-firestore-admin-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Firestore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/grafeas/v1/Cargo.toml
+++ b/src/generated/grafeas/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-grafeas-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Container Analysis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/admin/v1/Cargo.toml
+++ b/src/generated/iam/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-admin-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/credentials/v1/Cargo.toml
+++ b/src/generated/iam/credentials/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-credentials-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - IAM Service Account Credentials API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - IAM Meta API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v3"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/identity/accesscontextmanager/type/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-identity-accesscontextmanager-type"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Access Context Manager Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-identity-accesscontextmanager-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Access Context Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/logging/type/Cargo.toml
+++ b/src/generated/logging/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-logging-type"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Logging types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-logging-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Logging API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -36,6 +36,6 @@ operations.
 [codec]
 # We inherited an existing crate for `google-cloud-longrunning`. We need to use
 # version numbers higher than the existing releases until we hit 1.0.
-version               = "0.25.3"
+version               = "0.25.4"
 copyright-year        = '2024'
 'package:longrunning' = 'ignore=true'

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-longrunning"
-version                = "0.25.3"
+version                = "0.25.4"
 description            = "Google Cloud Client Libraries for Rust - Long Running Operations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/dashboard/v1/Cargo.toml
+++ b/src/generated/monitoring/dashboard/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-dashboard-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-metricsscope-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/v3/Cargo.toml
+++ b/src/generated/monitoring/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-v3"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "secretmanager-openapi-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Secret Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/oslogin/common/Cargo.toml
+++ b/src/generated/oslogin/common/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oslogin-common"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud OS Login Common Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privacy-dlp-v2"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Sensitive Data Protection (DLP)"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/rpc/context/Cargo.toml
+++ b/src/generated/rpc/context/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rpc-context"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - RPC Audit and Logging Attributes"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/rpc/types/Cargo.toml
+++ b/src/generated/rpc/types/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rpc"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Google RPC Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/showcase/Cargo.toml
+++ b/src/generated/showcase/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-showcase-v1beta1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Client Libraries Showcase API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-spanner-admin-database-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Spanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-spanner-admin-instance-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Cloud Spanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storagetransfer-v1"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Storage Transfer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-type"
-version                = "0.4.3"
+version                = "0.4.4"
 description            = "Google Cloud Client Libraries for Rust - Common Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "Google Cloud Client Libraries for Rust - LRO Helpers"
 name        = "google-cloud-lro"
-version     = "0.3.3"
+version     = "0.3.4"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "Google Cloud Client Libraries for Rust - Well Known Types"
 name        = "google-cloud-wkt"
-version     = "0.5.3"
+version     = "0.5.4"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true


### PR DESCRIPTION
`gax-internal` had a breaking change to handle empty bodies. Needs a
bump and that propagates to (nearly) all generated clients: the need at
least a minor bump. They also have different code because of the empty
body thing.

`wkt` had a documentation change. Still a change and that needs to be
propagated to `gax`, and `auth`.