### PR TITLE
test(wkt): natural names for `intXX` fields

### DIFF
--- a/src/wkt/tests/common/src/generated/mod.rs
+++ b/src/wkt/tests/common/src/generated/mod.rs
@@ -1322,12 +1322,12 @@ impl MessageWithComplexOneOf {
     }
 
     /// The value of [complex][crate::generated::MessageWithComplexOneOf::complex]
-    /// if it holds a `Int`, `None` if the field is not set or
+    /// if it holds a `Int32`, `None` if the field is not set or
     /// holds a different branch.
-    pub fn int(&self) -> std::option::Option<&i32> {
+    pub fn int32(&self) -> std::option::Option<&i32> {
         #[allow(unreachable_patterns)]
         self.complex.as_ref().and_then(|v| match v {
-            crate::generated::message_with_complex_one_of::Complex::Int(v) => {
+            crate::generated::message_with_complex_one_of::Complex::Int32(v) => {
                 std::option::Option::Some(v)
             }
             _ => std::option::Option::None,
@@ -1335,24 +1335,24 @@ impl MessageWithComplexOneOf {
     }
 
     /// Sets the value of [complex][crate::generated::MessageWithComplexOneOf::complex]
-    /// to hold a `Int`.
+    /// to hold a `Int32`.
     ///
     /// Note that all the setters affecting `complex` are
     /// mutually exclusive.
-    pub fn set_int<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+    pub fn set_int32<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.complex = std::option::Option::Some(
-            crate::generated::message_with_complex_one_of::Complex::Int(v.into()),
+            crate::generated::message_with_complex_one_of::Complex::Int32(v.into()),
         );
         self
     }
 
     /// The value of [complex][crate::generated::MessageWithComplexOneOf::complex]
-    /// if it holds a `Long`, `None` if the field is not set or
+    /// if it holds a `Int64`, `None` if the field is not set or
     /// holds a different branch.
-    pub fn long(&self) -> std::option::Option<&i64> {
+    pub fn int64(&self) -> std::option::Option<&i64> {
         #[allow(unreachable_patterns)]
         self.complex.as_ref().and_then(|v| match v {
-            crate::generated::message_with_complex_one_of::Complex::Long(v) => {
+            crate::generated::message_with_complex_one_of::Complex::Int64(v) => {
                 std::option::Option::Some(v)
             }
             _ => std::option::Option::None,
@@ -1360,13 +1360,13 @@ impl MessageWithComplexOneOf {
     }
 
     /// Sets the value of [complex][crate::generated::MessageWithComplexOneOf::complex]
-    /// to hold a `Long`.
+    /// to hold a `Int64`.
     ///
     /// Note that all the setters affecting `complex` are
     /// mutually exclusive.
-    pub fn set_long<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+    pub fn set_int64<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.complex = std::option::Option::Some(
-            crate::generated::message_with_complex_one_of::Complex::Long(v.into()),
+            crate::generated::message_with_complex_one_of::Complex::Int64(v.into()),
         );
         self
     }
@@ -1540,8 +1540,8 @@ impl<'de> serde::de::Deserialize<'de> for MessageWithComplexOneOf {
             __string_value,
             __float_value,
             __double_value,
-            __int,
-            __long,
+            __int32,
+            __int64,
             __enum,
             __inner,
             __duration,
@@ -1578,8 +1578,8 @@ impl<'de> serde::de::Deserialize<'de> for MessageWithComplexOneOf {
                             "float_value" => Ok(__FieldTag::__float_value),
                             "doubleValue" => Ok(__FieldTag::__double_value),
                             "double_value" => Ok(__FieldTag::__double_value),
-                            "int" => Ok(__FieldTag::__int),
-                            "long" => Ok(__FieldTag::__long),
+                            "int32" => Ok(__FieldTag::__int32),
+                            "int64" => Ok(__FieldTag::__int64),
                             "enum" => Ok(__FieldTag::__enum),
                             "inner" => Ok(__FieldTag::__inner),
                             "duration" => Ok(__FieldTag::__duration),
@@ -1749,10 +1749,10 @@ impl<'de> serde::de::Deserialize<'de> for MessageWithComplexOneOf {
                                 ),
                             );
                         }
-                        __FieldTag::__int => {
-                            if !fields.insert(__FieldTag::__int) {
+                        __FieldTag::__int32 => {
+                            if !fields.insert(__FieldTag::__int32) {
                                 return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for int",
+                                    "multiple values for int32",
                                 ));
                             }
                             struct __With(std::option::Option<i32>);
@@ -1768,19 +1768,19 @@ impl<'de> serde::de::Deserialize<'de> for MessageWithComplexOneOf {
                             }
                             if result.complex.is_some() {
                                 return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for `complex`, a oneof with full ID .google.rust.sdk.test.MessageWithComplexOneOf.int, latest field was int",
+                                    "multiple values for `complex`, a oneof with full ID .google.rust.sdk.test.MessageWithComplexOneOf.int32, latest field was int32",
                                 ));
                             }
                             result.complex = std::option::Option::Some(
-                                crate::generated::message_with_complex_one_of::Complex::Int(
+                                crate::generated::message_with_complex_one_of::Complex::Int32(
                                     map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
                         }
-                        __FieldTag::__long => {
-                            if !fields.insert(__FieldTag::__long) {
+                        __FieldTag::__int64 => {
+                            if !fields.insert(__FieldTag::__int64) {
                                 return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for long",
+                                    "multiple values for int64",
                                 ));
                             }
                             struct __With(std::option::Option<i64>);
@@ -1796,11 +1796,11 @@ impl<'de> serde::de::Deserialize<'de> for MessageWithComplexOneOf {
                             }
                             if result.complex.is_some() {
                                 return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for `complex`, a oneof with full ID .google.rust.sdk.test.MessageWithComplexOneOf.long, latest field was long",
+                                    "multiple values for `complex`, a oneof with full ID .google.rust.sdk.test.MessageWithComplexOneOf.int64, latest field was int64",
                                 ));
                             }
                             result.complex = std::option::Option::Some(
-                                crate::generated::message_with_complex_one_of::Complex::Long(
+                                crate::generated::message_with_complex_one_of::Complex::Int64(
                                     map.next_value::<__With>()?.0.unwrap_or_default(),
                                 ),
                             );
@@ -1980,7 +1980,7 @@ impl serde::ser::Serialize for MessageWithComplexOneOf {
             }
             state.serialize_entry("doubleValue", &__With(value))?;
         }
-        if let Some(value) = self.int() {
+        if let Some(value) = self.int32() {
             struct __With<'a>(&'a i32);
             impl<'a> serde::ser::Serialize for __With<'a> {
                 fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -1990,9 +1990,9 @@ impl serde::ser::Serialize for MessageWithComplexOneOf {
                     serde_with::As::<wkt::internal::I32>::serialize(self.0, serializer)
                 }
             }
-            state.serialize_entry("int", &__With(value))?;
+            state.serialize_entry("int32", &__With(value))?;
         }
-        if let Some(value) = self.long() {
+        if let Some(value) = self.int64() {
             struct __With<'a>(&'a i64);
             impl<'a> serde::ser::Serialize for __With<'a> {
                 fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -2002,7 +2002,7 @@ impl serde::ser::Serialize for MessageWithComplexOneOf {
                     serde_with::As::<wkt::internal::I64>::serialize(self.0, serializer)
                 }
             }
-            state.serialize_entry("long", &__With(value))?;
+            state.serialize_entry("int64", &__With(value))?;
         }
         if let Some(value) = self.r#enum() {
             state.serialize_entry("enum", value)?;
@@ -2329,10 +2329,8 @@ pub mod message_with_complex_one_of {
         StringValue(std::string::String),
         FloatValue(f32),
         DoubleValue(f64),
-        /// TODO(#2382) - the natural name does not work.
-        Int(i32),
-        /// TODO(#2382) - the natural name does not work.
-        Long(i64),
+        Int32(i32),
+        Int64(i64),
         Enum(crate::generated::message_with_complex_one_of::TestEnum),
         Inner(std::boxed::Box<crate::generated::message_with_complex_one_of::Inner>),
         Duration(std::boxed::Box<wkt::Duration>),

--- a/src/wkt/tests/complex_oneofs.rs
+++ b/src/wkt/tests/complex_oneofs.rs
@@ -42,14 +42,14 @@ mod tests {
     #[test_case(MessageWithComplexOneOf::new().set_double_value(1.5), json!({"doubleValue": 1.5}))]
     #[test_case(MessageWithComplexOneOf::new().set_double_value(2.5), json!({"doubleValue": 2.5}))]
     #[test_case(MessageWithComplexOneOf::new().set_double_value(3.0), json!({"doubleValue": 3.0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(0), json!({"int": 0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(1), json!({"int": 1}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(2), json!({"int": 2}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(3), json!({"int": 3}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(0), json!({"long": "0"}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(1), json!({"long": "1"}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(2), json!({"long": "2"}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(3), json!({"long": "3"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(0), json!({"int32": 0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(1), json!({"int32": 1}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(2), json!({"int32": 2}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(3), json!({"int32": 3}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(0), json!({"int64": "0"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(1), json!({"int64": "1"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(2), json!({"int64": "2"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(3), json!({"int64": "3"}))]
     #[test_case(MessageWithComplexOneOf::new().set_enum(TestEnum::default()), json!({"enum": 0}))]
     #[test_case(MessageWithComplexOneOf::new().set_inner(Inner::default().set_strings(["a", "b"])), json!({"inner": {"strings": ["a", "b"]}}))]
     #[test_case(MessageWithComplexOneOf::new().set_duration(Duration::clamp(-1, -750_000_000)), json!({"duration": "-1.75s"}))]
@@ -76,14 +76,14 @@ mod tests {
     #[test_case(MessageWithComplexOneOf::new().set_double_value(1.5), json!({"doubleValue": "1.5"}))]
     #[test_case(MessageWithComplexOneOf::new().set_double_value(2.5), json!({"doubleValue": 2.5}))]
     #[test_case(MessageWithComplexOneOf::new().set_double_value(3.0), json!({"doubleValue": 3}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(0), json!({"int": 0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(1), json!({"int": "1"}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(2), json!({"int": 2.0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_int(3), json!({"int": 3e0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(0), json!({"long": 0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(1), json!({"long": "1"}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(2), json!({"long": 2.0}))]
-    #[test_case(MessageWithComplexOneOf::new().set_long(3), json!({"long": 3e0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(0), json!({"int32": 0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(1), json!({"int32": "1"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(2), json!({"int32": 2.0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int32(3), json!({"int32": 3e0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(0), json!({"int64": 0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(1), json!({"int64": "1"}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(2), json!({"int64": 2.0}))]
+    #[test_case(MessageWithComplexOneOf::new().set_int64(3), json!({"int64": 3e0}))]
     #[test_case(MessageWithComplexOneOf::new().set_enum(TestEnum::default()), json!({"enum": 0}))]
     #[test_case(MessageWithComplexOneOf::new().set_inner(Inner::default().set_strings(["a", "b"])), json!({"inner": {"strings": ["a", "b"]}}))]
     #[test_case(MessageWithComplexOneOf::new().set_duration(Duration::clamp(-1, -750_000_000)), json!({"duration": "-1.75s"}))]
@@ -107,8 +107,8 @@ mod tests {
     #[test_case(r#"{"string_value": null}"#, MessageWithComplexOneOf::new().set_string_value(""))]
     #[test_case(r#"{"float_value":  null}"#, MessageWithComplexOneOf::new().set_float_value(0_f32))]
     #[test_case(r#"{"double_value": null}"#, MessageWithComplexOneOf::new().set_double_value(0_f64))]
-    #[test_case(r#"{"int":          null}"#, MessageWithComplexOneOf::new().set_int(0))]
-    #[test_case(r#"{"long":         null}"#, MessageWithComplexOneOf::new().set_long(0_i64))]
+    #[test_case(r#"{"int32":        null}"#, MessageWithComplexOneOf::new().set_int32(0))]
+    #[test_case(r#"{"int64":        null}"#, MessageWithComplexOneOf::new().set_int64(0_i64))]
     #[test_case(r#"{"enum":         null}"#, MessageWithComplexOneOf::new().set_enum(TestEnum::default()))]
     #[test_case(r#"{"inner":        null}"#, MessageWithComplexOneOf::new().set_inner(Inner::default()))]
     #[test_case(r#"{"duration":     null}"#, MessageWithComplexOneOf::new().set_duration(Duration::default()))]
@@ -131,10 +131,10 @@ mod tests {
     #[test_case(r#"{"floatValue":     0,         "floatValue":     0}"#)]
     #[test_case(r#"{"null":           null,      "doubleValue":    0}"#)]
     #[test_case(r#"{"doubleValue":    0,         "doubleValue":    0}"#)]
-    #[test_case(r#"{"null":           null,      "int":            0}"#)]
-    #[test_case(r#"{"int":            0,         "int":            0}"#)]
-    #[test_case(r#"{"null":           null,      "long":           0}"#)]
-    #[test_case(r#"{"long":           0,         "long":           0}"#)]
+    #[test_case(r#"{"null":           null,      "int32":          0}"#)]
+    #[test_case(r#"{"int32":          0,         "int32":          0}"#)]
+    #[test_case(r#"{"null":           null,      "int64":          0}"#)]
+    #[test_case(r#"{"int64":          0,         "int64":          0}"#)]
     #[test_case(r#"{"null":           null,      "enum":           "BLACK"}"#)]
     #[test_case(r#"{"enum":           "BLACK",   "enum":           "BLACK"}"#)]
     #[test_case(r#"{"null":           null,      "inner":          {}}"#)]
@@ -226,25 +226,25 @@ mod tests {
         Ok(())
     }
 
-    #[test_case(json!({"int": 0}), 0)]
-    #[test_case(json!({"int": "0"}), 0; "0 as str")]
-    #[test_case(json!({"int": 1}), 1)]
-    #[test_case(json!({"int": "1"}), 1; "1 as str")]
+    #[test_case(json!({"int32": 0}), 0)]
+    #[test_case(json!({"int32": "0"}), 0; "0 as str")]
+    #[test_case(json!({"int32": 1}), 1)]
+    #[test_case(json!({"int32": "1"}), 1; "1 as str")]
     fn test_int(input: Value, want: i32) -> Result {
         let got = serde_json::from_value::<MessageWithComplexOneOf>(input)?;
-        assert_eq!(got.int(), Some(&want), "{got:?}");
+        assert_eq!(got.int32(), Some(&want), "{got:?}");
         let roundtrip = serde_json::from_value(serde_json::to_value(&got)?)?;
         assert_eq!(got, roundtrip);
         Ok(())
     }
 
-    #[test_case(json!({"long": 0}), 0)]
-    #[test_case(json!({"long": "0"}), 0; "0 as str")]
-    #[test_case(json!({"long": 1}), 1)]
-    #[test_case(json!({"long": "1"}), 1; "1 as str")]
+    #[test_case(json!({"int64": 0}), 0)]
+    #[test_case(json!({"int64": "0"}), 0; "0 as str")]
+    #[test_case(json!({"int64": 1}), 1)]
+    #[test_case(json!({"int64": "1"}), 1; "1 as str")]
     fn test_long(input: Value, want: i64) -> Result {
         let got = serde_json::from_value::<MessageWithComplexOneOf>(input)?;
-        assert_eq!(got.long(), Some(&want), "{got:?}");
+        assert_eq!(got.int64(), Some(&want), "{got:?}");
         let roundtrip = serde_json::from_value(serde_json::to_value(&got)?)?;
         assert_eq!(got, roundtrip);
         Ok(())

--- a/src/wkt/tests/protos/oneofs.proto
+++ b/src/wkt/tests/protos/oneofs.proto
@@ -51,10 +51,8 @@ message MessageWithComplexOneOf {
         string string_value = 4;
         float float_value = 5;
         double double_value = 6;
-        // TODO(#2382) - the natural name does not work.
-        int32 int = 7;
-        // TODO(#2382) - the natural name does not work.
-        int64 long = 8;
+        int32 int32 = 7;
+        int64 int64 = 8;
         TestEnum enum = 9;
         Inner inner = 10;
         google.protobuf.Duration duration = 11;


### PR DESCRIPTION
The tests used `int` instead of `int32` and `long` instead of `int64` to
workaround problems in name serialization for oneof fields. I fixed
the serialization problems, but neglected to update the tests.

See #2383 for more history.