### PR TITLE
cleanup(storage)!: change `size_hint()` return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,6 +4354,7 @@ dependencies = [
  "google-cloud-type",
  "google-cloud-wkt",
  "http",
+ "http-body",
  "http-body-util",
  "httptest",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,7 @@ chrono             = { default-features = false, version = "0.4" }
 crc32c             = { default-features = false, version = "0.6" }
 futures            = { default-features = false, version = "0.3" }
 http               = { default-features = false, version = "1", features = ["std"] }
+http-body          = { default-features = false, version = "1" }
 http-body-util     = { default-features = false, version = "0.1" }
 lazy_static        = { default-features = false, version = "1" }
 percent-encoding   = { default-features = false, version = "2" }

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -23,12 +23,13 @@ use storage::client::StorageControl;
 use storage::model::Bucket;
 use storage::model::bucket::iam_config::UniformBucketLevelAccess;
 use storage::model::bucket::{HierarchicalNamespace, IamConfig};
+use storage::upload_source::{Seek, SizeHint, StreamingSource};
 
 /// An upload data source used in tests.
 #[derive(Clone, Debug)]
 struct TestDataSource {
     size: u64,
-    hint: (u64, Option<u64>),
+    hint: SizeHint,
     offset: u64,
     abort: u64,
 }
@@ -39,14 +40,16 @@ impl TestDataSource {
     fn new(size: u64) -> Self {
         Self {
             size,
-            hint: (size, Some(size)),
+            hint: SizeHint::with_exact(size),
             offset: 0,
             abort: u64::MAX,
         }
     }
 
     fn without_size_hint(mut self) -> Self {
-        self.hint = (0, None);
+        let mut hint = SizeHint::new();
+        hint.set_lower(self.hint.lower());
+        self.hint = hint;
         self
     }
 
@@ -56,7 +59,7 @@ impl TestDataSource {
     }
 }
 
-impl storage::upload_source::StreamingSource for TestDataSource {
+impl StreamingSource for TestDataSource {
     type Error = std::io::Error;
     async fn next(&mut self) -> Option<std::result::Result<bytes::Bytes, Self::Error>> {
         match self.offset {
@@ -84,12 +87,12 @@ impl storage::upload_source::StreamingSource for TestDataSource {
             }
         }
     }
-    async fn size_hint(&self) -> std::result::Result<(u64, Option<u64>), Self::Error> {
-        Ok(self.hint)
+    async fn size_hint(&self) -> std::result::Result<SizeHint, Self::Error> {
+        Ok(self.hint.clone())
     }
 }
 
-impl storage::upload_source::Seek for TestDataSource {
+impl Seek for TestDataSource {
     type Error = std::io::Error;
     async fn seek(&mut self, offset: u64) -> std::result::Result<(), Self::Error> {
         if offset % Self::LINE_SIZE != 0 {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -32,6 +32,7 @@ bytes.workspace            = true
 crc32c.workspace           = true
 http.workspace             = true
 futures.workspace          = true
+http-body.workspace        = true
 lazy_static.workspace      = true
 md5.workspace              = true
 percent-encoding.workspace = true

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -21,7 +21,7 @@ use crate::storage::checksum::{
 };
 use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
-use crate::upload_source::{IterSource, Seek, StreamingSource};
+use crate::upload_source::{IterSource, Seek, SizeHint, StreamingSource};
 use crate::{Error, Result};
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -14,8 +14,8 @@
 
 use super::{
     ChecksumEngine, ChecksummedSource, ContinueOn308, Error, IterSource, Known, Object,
-    PerformUpload, Result, ResumableUploadStatus, StreamingSource, X_GOOG_API_CLIENT_HEADER,
-    apply_customer_supplied_encryption_headers,
+    PerformUpload, Result, ResumableUploadStatus, SizeHint, StreamingSource,
+    X_GOOG_API_CLIENT_HEADER, apply_customer_supplied_encryption_headers,
 };
 use crate::storage::UploadError;
 use crate::storage::checksum::details::{update as checksum_update, validate as checksum_validate};
@@ -40,14 +40,14 @@ where
             .await
             .map_err(Error::ser)?;
         let threshold = self.options.resumable_upload_threshold as u64;
-        if hint.1.is_none_or(|max| max >= threshold) {
+        if hint.upper().is_none_or(|max| max >= threshold) {
             self.send_buffered_resumable(hint).await
         } else {
             self.send_buffered_single_shot().await
         }
     }
 
-    async fn send_buffered_resumable(self, hint: (u64, Option<u64>)) -> Result<Object> {
+    async fn send_buffered_resumable(self, hint: SizeHint) -> Result<Object> {
         let mut progress = InProgressUpload::new(self.options.resumable_upload_buffer_size, hint);
         let mut url = None;
         let throttler = self.options.retry_throttler.clone();
@@ -264,7 +264,7 @@ mod tests {
         source
             .expect_size_hint()
             .once()
-            .returning(|| Ok((1024_u64, Some(1024_u64))));
+            .returning(|| Ok(SizeHint::with_exact(1024)));
         let err = client
             .upload_object("projects/_/buckets/test-bucket", "test-object", source)
             .send_buffered()

--- a/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
@@ -80,7 +80,7 @@ use crate::storage::client::{
     KeyAes256, Storage,
     tests::{create_key_helper, test_builder},
 };
-use crate::upload_source::{BytesSource, tests::UnknownSize};
+use crate::upload_source::{BytesSource, SizeHint, tests::UnknownSize};
 use gax::retry_policy::RetryPolicyExt;
 use httptest::{Expectation, Server, matchers::*, responders::*};
 use serde_json::{Value, json};
@@ -329,7 +329,7 @@ async fn source_seek_error() -> Result {
     source
         .expect_size_hint()
         .once()
-        .returning(|| Ok((1024_u64, Some(1024_u64))));
+        .returning(|| Ok(SizeHint::with_exact(1024)));
     let err = client
         .upload_object("projects/_/buckets/test-bucket", "test-object", source)
         .with_if_generation_match(0)
@@ -375,7 +375,7 @@ async fn source_next_error() -> Result {
     source
         .expect_size_hint()
         .once()
-        .returning(|| Ok((1024_u64, Some(1024_u64))));
+        .returning(|| Ok(SizeHint::with_exact(1024)));
     let err = client
         .upload_object("projects/_/buckets/test-bucket", "test-object", source)
         .with_if_generation_match(0)


### PR DESCRIPTION
Use `http_body::SizeHint`, which has better documentation. The previous
type `(u64, Option<u64>)` is often used to hint the number of messages
in a stream, and what we need is the number of bytes.

Fixes #2848
