### PR TITLE
cleanup(auth): unit test MDS assumptions

### DIFF
--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -664,7 +664,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn builder_no_mds() -> TestResult {
-        let Err(e) = Builder::builder().build_token_provider().token().await else {
+        let Err(e) = Builder::build().build_token_provider().token().await else {
             // The environment has an MDS, skip the test.
             return Ok(());
         };

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -664,7 +664,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn builder_no_mds() -> TestResult {
-        let Err(e) = Builder::from_adc().build_token_provider().token().await else {
+        let Err(e) = Builder::builder().build_token_provider().token().await else {
             // The environment has an MDS, skip the test.
             return Ok(());
         };

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -622,11 +622,9 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn adc_no_mds() -> TestResult {
-        let token = Builder::from_adc().build_token_provider().token().await;
-        let err = match token {
-            Err(e) => e,
+        let Err(err) = Builder::from_adc().build_token_provider().token().await else {
             // The environment has an MDS, skip the test.
-            Ok(_) => return Ok(()),
+            return Ok(());
         };
 
         let original_err = find_source_error::<CredentialsError>(&err).unwrap();
@@ -666,11 +664,9 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn builder_no_mds() -> TestResult {
-        let token = Builder::default().build_token_provider().token().await;
-        let e = match token {
-            Err(e) => e,
+        let Err(e) = Builder::from_adc().build_token_provider().token().await else {
             // The environment has an MDS, skip the test.
-            Ok(_) => return Ok(()),
+            return Ok(());
         };
 
         let original_err = find_source_error::<CredentialsError>(&e).unwrap();

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -664,7 +664,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn builder_no_mds() -> TestResult {
-        let Err(e) = Builder::build().build_token_provider().token().await else {
+        let Err(e) = Builder::default().build_token_provider().token().await else {
             // The environment has an MDS, skip the test.
             return Ok(());
         };


### PR DESCRIPTION
Fixes #2292 

The tests assumed there was no MDS present. They fail on a fresh GCE VM.

We fix this case by short circuiting the test if we get a valid token.

Then there is the Googler-only case of running on your Cloudtop, where the default SA doesn't work with the default scopes. In this case, fetching a token returns a `404` which is not transient.

We address this by making less assertions about the error contents.