### PR TITLE
feat(storage)!: return object on checksum mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "0.25.0-preview5"
+version = "0.25.0-preview6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,7 +385,7 @@ google-cloud-language-v2      = { version = "0.4.4", path = "src/generated/cloud
 google-cloud-speech-v2        = { version = "0.4.4", path = "src/generated/cloud/speech/v2" }
 google-cloud-secretmanager-v1 = { version = "0.4.4", path = "src/generated/cloud/secretmanager/v1" }
 google-cloud-aiplatform-v1    = { version = "0.4.4", default-features = false, path = "src/generated/cloud/aiplatform/v1" }
-google-cloud-storage          = { version = "0.25.0-preview4", path = "src/storage" }
+google-cloud-storage          = { version = "0.25.0-preview6", path = "src/storage" }
 
 # Local test package
 integration-tests = { path = "src/integration-tests" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-storage"
-version     = "0.25.0-preview5"
+version     = "0.25.0-preview6"
 description = "Google Cloud Client Libraries for Rust - Storage"
 # Inherit other attributes from the workspace.
 edition.workspace      = true

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -17,7 +17,7 @@
 //! The storage client defines additional error types. These are often returned
 //! as the `source()` of an [Error][crate::Error].
 
-use crate::model::ObjectChecksums;
+use crate::model::{Object, ObjectChecksums};
 
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -210,8 +210,11 @@ pub enum UploadError {
     /// hosting the service.
     ///
     /// If possible, resend the data from a different machine.
-    #[error("checksum mismatch {0}")]
-    ChecksumMismatch(ChecksumMismatch),
+    #[error("checksum mismatch {mismatch} when uploading {} to {}", object.name, object.bucket)]
+    ChecksumMismatch {
+        mismatch: ChecksumMismatch,
+        object: Box<Object>,
+    },
 }
 
 #[cfg(test)]

--- a/src/storage/src/storage/perform_upload/tests/checksums.rs
+++ b/src/storage/src/storage/perform_upload/tests/checksums.rs
@@ -15,9 +15,11 @@
 //! Verify the client library correctly detects mismatched checksums on uploads.
 
 use super::*;
+use crate::error::UploadError;
 use crate::storage::upload_source::BytesSource;
 use httptest::{Expectation, Server, matchers::*, responders::*};
 use serde_json::{Value, json};
+use std::error::Error as StdError;
 
 const VEXING: &str = "how vexingly quick daft zebras jump";
 
@@ -40,6 +42,11 @@ mod buffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -62,6 +69,11 @@ mod buffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -98,6 +110,11 @@ mod buffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -120,6 +137,11 @@ mod buffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -156,6 +178,11 @@ mod unbuffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -178,6 +205,11 @@ mod unbuffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -214,6 +246,11 @@ mod unbuffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -236,6 +273,11 @@ mod unbuffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
+        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        assert!(
+            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            "{err:?}"
+        );
         Ok(())
     }
 
@@ -337,6 +379,11 @@ fn bad_checksums_body() -> Value {
         "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg==",
         "size": 0,
     })
+}
+
+fn bad_checksums_object() -> Object {
+    let v1 = serde_json::from_value::<v1::Object>(bad_checksums_body()).unwrap();
+    Object::from(v1)
 }
 
 fn good_checksums_body() -> Value {


### PR DESCRIPTION
When uploading an object we return an error if the resulting object
checksums do not match the computed or expected checksums. We should
include the object metadata in the error, as the object was created.

Fixes #2855
