### PR TITLE
fix(storage): fewer errors abort uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,6 +4357,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "httptest",
+ "hyper",
  "lazy_static",
  "md5",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,6 +293,7 @@ futures            = { default-features = false, version = "0.3" }
 http               = { default-features = false, version = "1", features = ["std"] }
 http-body          = { default-features = false, version = "1" }
 http-body-util     = { default-features = false, version = "0.1" }
+hyper              = { default-features = false, version = "1" }
 lazy_static        = { default-features = false, version = "1" }
 percent-encoding   = { default-features = false, version = "2" }
 pin-project        = { default-features = false, version = "1" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,6 +33,7 @@ crc32c.workspace           = true
 http.workspace             = true
 futures.workspace          = true
 http-body.workspace        = true
+hyper.workspace            = true
 lazy_static.workspace      = true
 md5.workspace              = true
 percent-encoding.workspace = true

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -221,15 +221,6 @@ fn parse_range_end(headers: &reqwest::header::HeaderMap) -> Option<u64> {
     end.parse::<u64>().ok()
 }
 
-fn send_err(error: reqwest::Error) -> Error {
-    match error {
-        e if e.is_body() => Error::ser(e),
-        e if e.is_request() => Error::ser(e),
-        e if e.is_timeout() => Error::timeout(e),
-        e => Error::io(e),
-    }
-}
-
 const RESUME_INCOMPLETE: reqwest::StatusCode = reqwest::StatusCode::PERMANENT_REDIRECT;
 
 #[cfg(test)]

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -95,7 +95,7 @@ where
                 .next_buffer(&mut *self.payload.lock().await)
                 .await?;
             let builder = self.partial_upload_request(upload_url, progress).await?;
-            let response = builder.send().await.map_err(super::send_err)?;
+            let response = builder.send().await.map_err(Self::send_err)?;
             match super::query_resumable_upload_handle_response(response).await {
                 Err(e) => {
                     progress.handle_error();
@@ -174,6 +174,33 @@ where
         self::checksum_validate(&computed, &object.checksums)
             .map_err(|e| Error::ser(UploadError::ChecksumMismatch(e)))?;
         Ok(object)
+    }
+
+    fn as_inner<E>(error: &reqwest::Error) -> Option<&E>
+    where
+        E: std::error::Error + 'static,
+    {
+        use std::error::Error as _;
+        let mut e = error.source()?;
+        // Prevent infinite loops due to cycles in the `source()` errors. This seems
+        // unlikely, and it would require effort to create, but it is easy to
+        // prevent.
+        for _ in 0..32 {
+            if let Some(value) = e.downcast_ref::<E>() {
+                return Some(value);
+            }
+            e = e.source()?;
+        }
+        None
+    }
+
+    pub(crate) fn send_err(error: reqwest::Error) -> Error {
+        if let Some(e) = Self::as_inner::<hyper::Error>(&error) {
+            if e.is_user() {
+                return Error::ser(error);
+            }
+        }
+        Error::io(error)
     }
 }
 

--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -99,7 +99,7 @@ where
             .map_err(Error::ser)?;
         let payload = self.payload_to_body().await?;
         let builder = builder.body(payload);
-        let response = builder.send().await.map_err(super::send_err)?;
+        let response = builder.send().await.map_err(Self::send_err)?;
         let object = self::handle_object_response(response).await?;
         self.validate_response_object(object).await
     }
@@ -126,7 +126,7 @@ where
 
     async fn single_shot_attempt(&self) -> Result<Object> {
         let builder = self.single_shot_builder().await?;
-        let response = builder.send().await.map_err(super::send_err)?;
+        let response = builder.send().await.map_err(Self::send_err)?;
         let object = super::handle_object_response(response).await?;
         self.validate_response_object(object).await
     }


### PR DESCRIPTION
Only errors that come from the user should abort an upload. Other errors
are I/O errors and should allow the upload to continue (subject to the
retry or resume policies).

part of the work for #2811
