### PR TITLE
cleanup(storage)!: rename `download_resume_policy`

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -110,7 +110,7 @@ pub enum ReadError {
     ShortRead(u64),
 
     /// The read received more bytes than expected.
-    #[error("too many bytes received: expected {expected}, stopped download at {got}")]
+    #[error("too many bytes received: expected {expected}, stopped read at {got}")]
     LongRead { got: u64, expected: u64 },
 
     /// Only 200 and 206 status codes are expected in successful responses.

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -38,7 +38,7 @@ pub use gax::Result;
 pub use gax::error::Error;
 
 pub mod backoff_policy;
-pub mod download_resume_policy;
+pub mod read_resume_policy;
 pub mod retry_policy;
 pub use crate::storage::checksum;
 pub use crate::storage::upload_source;

--- a/src/storage/src/storage/checksum.rs
+++ b/src/storage/src/storage/checksum.rs
@@ -45,7 +45,7 @@ use crate::model::ObjectChecksums;
 /// Computes a checksum or hash for [Cloud Storage] transfers.
 ///
 /// We want to minimize code complexity in our implementation of data integrity
-/// checks for uploads and downloads. This trait defines a composable interface
+/// checks for writes and reads. This trait defines a composable interface
 /// to support:
 /// - No checksums (`Null`): the client library does not compute any checksums,
 ///   and therefore does not validate checksums either.

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -16,8 +16,8 @@ use super::request_options::RequestOptions;
 use crate::Error;
 use crate::builder::storage::ReadObject;
 use crate::builder::storage::UploadObject;
-use crate::download_resume_policy::DownloadResumePolicy;
 use crate::error::KeyAes256Error;
+use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::checksum::details::Crc32c;
 use crate::upload_source::Payload;
 use auth::credentials::CacheableResource;
@@ -173,7 +173,7 @@ impl Storage {
         UploadObject::new(self.inner.clone(), bucket, object, payload)
     }
 
-    /// Downloads the contents of an object.
+    /// Reads the contents of an object.
     ///
     /// # Example
     /// ```
@@ -513,29 +513,29 @@ impl ClientBuilder {
         self
     }
 
-    /// Configure the resume policy for downloads.
+    /// Configure the resume policy for object reads.
     ///
-    /// The Cloud Storage client library can automatically resume a download
+    /// The Cloud Storage client library can automatically resume a read request
     /// that is interrupted by a transient error. Applications may want to
-    /// limit the number of download attempts, or may wish to expand the type
+    /// limit the number of read attempts, or may wish to expand the type
     /// of errors treated as retryable.
     ///
     /// # Example
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// use google_cloud_storage::download_resume_policy::{AlwaysResume, DownloadResumePolicyExt};
+    /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
     /// let client = Storage::builder()
-    ///     .with_download_resume_policy(AlwaysResume.with_attempt_limit(3))
+    ///     .with_read_resume_policy(AlwaysResume.with_attempt_limit(3))
     ///     .build()
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn with_download_resume_policy<V>(mut self, v: V) -> Self
+    pub fn with_read_resume_policy<V>(mut self, v: V) -> Self
     where
-        V: DownloadResumePolicy + 'static,
+        V: ReadResumePolicy + 'static,
     {
-        self.default_options.download_resume_policy = Arc::new(v);
+        self.default_options.read_resume_policy = Arc::new(v);
         self
     }
 }
@@ -781,10 +781,10 @@ pub(crate) mod tests {
 
     mockall::mock! {
         #[derive(Debug)]
-        pub DownloadResumePolicy {}
+        pub ReadResumePolicy {}
 
-        impl crate::download_resume_policy::DownloadResumePolicy for DownloadResumePolicy {
-            fn on_error(&self, query: &crate::download_resume_policy::ResumeQuery, error: gax::error::Error) -> crate::download_resume_policy::ResumeResult;
+        impl crate::read_resume_policy::ReadResumePolicy for ReadResumePolicy {
+            fn on_error(&self, query: &crate::read_resume_policy::ResumeQuery, error: gax::error::Error) -> crate::read_resume_policy::ResumeResult;
         }
     }
 }

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -14,9 +14,9 @@
 
 use super::client::*;
 use super::*;
-use crate::download_resume_policy::DownloadResumePolicy;
 use crate::error::{RangeError, ReadError};
 use crate::model::ObjectChecksums;
+use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::checksum::{
     ChecksumEngine,
     details::{Crc32c, Md5, validate},
@@ -96,7 +96,7 @@ impl ReadObject<Crc32c> {
     /// 2. All of the content is returned (status != PartialContent).
     /// 3. The server sent a checksum header.
     /// 4. The http stack did not uncompress the file.
-    /// 5. The server did not uncompress data on download.
+    /// 5. The server did not uncompress data on read.
     ///
     /// # Example
     /// ```
@@ -383,46 +383,46 @@ where
         self
     }
 
-    /// Configure the resume policy for downloads.
+    /// Configure the resume policy for read requests.
     ///
-    /// The Cloud Storage client library can automatically resume a download
-    /// that is interrupted by a transient error. Applications may want to
-    /// limit the number of download attempts, or may wish to expand the type
-    /// of errors treated as retryable.
+    /// The Cloud Storage client library can automatically resume a read that is
+    /// interrupted by a transient error. Applications may want to limit the
+    /// number of read attempts, or may wish to expand the type of errors
+    /// treated as retryable.
     ///
     /// # Example
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// use google_cloud_storage::download_resume_policy::{AlwaysResume, DownloadResumePolicyExt};
+    /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
-    ///     .with_download_resume_policy(AlwaysResume.with_attempt_limit(3))
+    ///     .with_read_resume_policy(AlwaysResume.with_attempt_limit(3))
     ///     .send()
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn with_download_resume_policy<V>(mut self, v: V) -> Self
+    pub fn with_read_resume_policy<V>(mut self, v: V) -> Self
     where
-        V: DownloadResumePolicy + 'static,
+        V: ReadResumePolicy + 'static,
     {
-        self.options.download_resume_policy = std::sync::Arc::new(v);
+        self.options.read_resume_policy = std::sync::Arc::new(v);
         self
     }
 
     /// Sends the request.
     pub async fn send(self) -> Result<ReadObjectResponse<C>> {
-        let download = self.clone().download().await?;
-        ReadObjectResponse::new(self, download)
+        let read = self.clone().read().await?;
+        ReadObjectResponse::new(self, read)
     }
 
-    async fn download(self) -> Result<reqwest::Response> {
+    async fn read(self) -> Result<reqwest::Response> {
         let throttler = self.options.retry_throttler.clone();
         let retry = self.options.retry_policy.clone();
         let backoff = self.options.backoff_policy.clone();
 
         gax::retry_loop_internal::retry_loop(
-            async move |_| self.download_attempt().await,
+            async move |_| self.read_attempt().await,
             async |duration| tokio::time::sleep(duration).await,
             true,
             throttler,
@@ -432,7 +432,7 @@ where
         .await
     }
 
-    async fn download_attempt(&self) -> Result<reqwest::Response> {
+    async fn read_attempt(&self) -> Result<reqwest::Response> {
         let builder = self.http_request_builder().await?;
         let response = builder.send().await.map_err(Error::io)?;
         if !response.status().is_success() {
@@ -555,7 +555,7 @@ pub struct ReadObjectResponse<C> {
     highlights: ObjectHighlights,
     // Fields for tracking the crc checksum checks.
     response_checksums: ObjectChecksums,
-    // Fields for resuming download.
+    // Fields for resuming a read request.
     range: ReadRange,
     generation: i64,
     builder: ReadObject<C>,
@@ -609,7 +609,7 @@ where
             highlights,
             // Fields for computing checksums.
             response_checksums,
-            // Fields for resuming download.
+            // Fields for resuming a read request.
             range,
             generation,
             builder,
@@ -709,16 +709,16 @@ where
     }
 
     async fn resume(&mut self, error: Error) -> Option<Result<bytes::Bytes>> {
-        use crate::download_resume_policy::{ResumeQuery, ResumeResult};
+        use crate::read_resume_policy::{ResumeQuery, ResumeResult};
 
-        // The existing download is no longer valid.
+        // The existing read is no longer valid.
         self.inner = None;
         self.resume_count += 1;
         let query = ResumeQuery::new(self.resume_count);
         match self
             .builder
             .options
-            .download_resume_policy
+            .read_resume_policy
             .on_error(&query, error)
         {
             ResumeResult::Continue(_) => {}
@@ -728,7 +728,7 @@ where
         self.builder.request.read_offset = self.range.start as i64;
         self.builder.request.read_limit = self.range.limit as i64;
         self.builder.request.generation = self.generation;
-        self.inner = match self.builder.clone().download().await {
+        self.inner = match self.builder.clone().read().await {
             Ok(r) => Some(r),
             Err(e) => return Some(Err(e)),
         };
@@ -775,9 +775,9 @@ pub struct ObjectHighlights {
     pub content_encoding: String,
 
     /// Hashes for the data part of this object. The checksums of the complete
-    /// object regardless of data range. If the object is downloaded in full,
-    /// the client should compute one of these checksums over the downloaded
-    /// object and compare it against the value provided here.
+    /// object regardless of data range. If the object is read in full, the
+    /// client should compute one of these checksums over the read object and
+    /// compare it against the value provided here.
     pub checksums: std::option::Option<crate::model::ObjectChecksums>,
 
     /// Storage class of the object.
@@ -814,7 +814,7 @@ pub struct ObjectHighlights {
 /// 2. We got all the content (status != PartialContent).
 /// 3. The server sent a CRC header.
 /// 4. The http stack did not uncompress the file.
-/// 5. We were not served compressed data that was uncompressed on download.
+/// 5. We were not served compressed data that was uncompressed on read.
 ///
 /// For 4, we turn off automatic decompression in reqwest::Client when we
 /// create it,
@@ -1068,7 +1068,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_object_next_then_consume_response() -> Result {
-        // Create a large enough file that will require multiple chunks to download.
+        // Create a large enough file that will require multiple chunks to read.
         const BLOCK_SIZE: usize = 500;
         let mut contents = Vec::new();
         for i in 0..50 {

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::download_resume_policy::{DownloadResumePolicy, Recommended};
+use crate::read_resume_policy::{ReadResumePolicy, Recommended};
 use gax::{
     backoff_policy::BackoffPolicy,
     retry_policy::RetryPolicy,
@@ -25,7 +25,7 @@ pub(crate) struct RequestOptions {
     pub retry_policy: Arc<dyn RetryPolicy>,
     pub backoff_policy: Arc<dyn BackoffPolicy>,
     pub retry_throttler: SharedRetryThrottler,
-    pub download_resume_policy: Arc<dyn DownloadResumePolicy>,
+    pub read_resume_policy: Arc<dyn ReadResumePolicy>,
     pub resumable_upload_threshold: usize,
     pub resumable_upload_buffer_size: usize,
     pub idempotency: Option<bool>,
@@ -42,12 +42,12 @@ impl RequestOptions {
         let retry_policy = Arc::new(crate::retry_policy::default());
         let backoff_policy = Arc::new(crate::backoff_policy::default());
         let retry_throttler = Arc::new(Mutex::new(AdaptiveThrottler::default()));
-        let download_resume_policy = Arc::new(Recommended);
+        let read_resume_policy = Arc::new(Recommended);
         Self {
             retry_policy,
             backoff_policy,
             retry_throttler,
-            download_resume_policy,
+            read_resume_policy,
             resumable_upload_threshold: RESUMABLE_UPLOAD_THRESHOLD,
             resumable_upload_buffer_size: RESUMABLE_UPLOAD_TARGET_CHUNK,
             idempotency: None,

--- a/src/storage/src/storage/upload_object.rs
+++ b/src/storage/src/storage/upload_object.rs
@@ -171,8 +171,8 @@ impl<T, C> UploadObject<T, C> {
     ///
     /// With this precondition the request fails if the current object metadata
     /// generation matches the provided value. This is rarely useful in uploads,
-    /// it is more commonly used on downloads to prevent downloads if the value
-    /// is already cached.
+    /// it is more commonly used on reads to prevent a large response if the
+    /// data is already cached.
     ///
     /// # Example
     /// ```
@@ -272,7 +272,7 @@ impl<T, C> UploadObject<T, C> {
     /// Sets the [content encoding] for the object data.
     ///
     /// This can be used to upload compressed data and enable [transcoding] of
-    /// the data during downloads.
+    /// the data during reads.
     ///
     /// # Example
     /// ```
@@ -840,8 +840,8 @@ impl<T> UploadObject<T, Crc32c> {
     /// ```
     ///
     /// In some applications, the payload's CRC32C checksum is already known.
-    /// For example, the application may be downloading the data from another
-    /// blob storage system.
+    /// For example, the application may be reading the data from another blob
+    /// storage system.
     ///
     /// In such cases, it is safer to pass the known CRC32C of the payload to
     /// [Cloud Storage], and more efficient to skip the computation in the
@@ -874,7 +874,7 @@ impl<T> UploadObject<T, Crc32c> {
     /// ```
     ///
     /// In some applications, the payload's MD5 hash is already known. For
-    /// example, the application may be downloading the data from another blob
+    /// example, the application may be reading the data from another blob
     /// storage system.
     ///
     /// In such cases, it is safer to pass the known MD5 of the payload to

--- a/src/storage/src/storage/upload_source.rs
+++ b/src/storage/src/storage/upload_source.rs
@@ -132,7 +132,7 @@ pub trait StreamingSource {
 /// Provides bytes for an upload from sources that support seek.
 ///
 /// Implementations of this trait provide data for Google Cloud Storage uploads.
-/// The data may be received asynchronously, such as downloads from Google Cloud
+/// The data may be received asynchronously, such as reads from Google Cloud
 /// Storage, other remote storage systems, or the result of repeatable
 /// computations.
 pub trait Seek {


### PR DESCRIPTION
And the related types, updated all the documentation and comments to use
`read` instead of `download`.

Fixes #2888