### PR TITLE
cleanup(storage)!: rename `upload_object()`

### DIFF
--- a/guide/samples/tests/storage/queue.rs
+++ b/guide/samples/tests/storage/queue.rs
@@ -41,11 +41,11 @@ pub async fn queue(bucket_name: &str, object_name: &str) -> anyhow::Result<()> {
     // ANCHOR: create-queue
     let (sender, receiver) = mpsc::channel::<bytes::Bytes>(32);
     // ANCHOR_END: create-queue
-    // ANCHOR: create-upload
+    // ANCHOR: create-writer
     let upload = client
-        .upload_object(bucket_name, object_name, QueueSource(receiver))
+        .write_object(bucket_name, object_name, QueueSource(receiver))
         .send_buffered();
-    // ANCHOR_END: create-upload
+    // ANCHOR_END: create-writer
     // ANCHOR: create-task
     let task = tokio::spawn(upload);
     // ANCHOR_END: create-task

--- a/guide/samples/tests/storage/quickstart.rs
+++ b/guide/samples/tests/storage/quickstart.rs
@@ -52,7 +52,7 @@ pub async fn quickstart(project_id: &str, bucket_id: &str) -> anyhow::Result<()>
 
     // ANCHOR: upload
     let object = client
-        .upload_object(&bucket.name, "hello.txt", "Hello World!")
+        .write_object(&bucket.name, "hello.txt", "Hello World!")
         .send_buffered()
         .await?;
     println!("object successfully uploaded {object:?}");

--- a/guide/samples/tests/storage/rewrite_object.rs
+++ b/guide/samples/tests/storage/rewrite_object.rs
@@ -102,7 +102,7 @@ async fn upload(bucket_name: &str) -> anyhow::Result<Object> {
     // We need the size to exceed 1MiB to exercise the rewrite token logic.
     let payload = bytes::Bytes::from(vec![65_u8; 3 * 1024 * 1024]);
     let object = storage
-        .upload_object(bucket_name, "rewrite-object-source", payload)
+        .write_object(bucket_name, "rewrite-object-source", payload)
         .send_unbuffered()
         .await?;
     Ok(object)

--- a/guide/samples/tests/storage/striped.rs
+++ b/guide/samples/tests/storage/striped.rs
@@ -25,10 +25,10 @@ async fn seed(client: Storage, control: StorageControl, bucket_name: &str) -> an
     use google_cloud_storage::model::compose_object_request::SourceObject;
     // ANCHOR_END: seed-use
 
-    // ANCHOR: upload-1MiB
+    // ANCHOR: create-1MiB
     let buffer = String::from_iter(('a'..='z').cycle().take(1024 * 1024));
     let seed = client
-        .upload_object(bucket_name, "1MiB.txt", bytes::Bytes::from_owner(buffer))
+        .write_object(bucket_name, "1MiB.txt", bytes::Bytes::from_owner(buffer))
         .send_unbuffered()
         .await?;
     println!(
@@ -36,7 +36,7 @@ async fn seed(client: Storage, control: StorageControl, bucket_name: &str) -> an
         seed.name,
         seed.size / 1024
     );
-    // ANCHOR_END: upload-1MiB
+    // ANCHOR_END: create-1MiB
 
     // ANCHOR: compose-32
     let seed_32 = control

--- a/guide/samples/tests/storage/terminate_uploads.rs
+++ b/guide/samples/tests/storage/terminate_uploads.rs
@@ -70,7 +70,7 @@ pub async fn attempt_upload(bucket_name: &str) -> anyhow::Result<()> {
     // ANCHOR_END: attempt-upload-client
     // ANCHOR: attempt-upload-upload
     let upload = client
-        .upload_object(bucket_name, "expect-error", MySource::default())
+        .write_object(bucket_name, "expect-error", MySource::default())
         .send_buffered()
         .await;
     // ANCHOR_END: attempt-upload-upload

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -22,7 +22,7 @@ limitations under the License.
 - [How to initialize a client](initialize_a_client.md)
 - [Generate text using the Vertex AI Gemini API](generate_text_using_the_vertex_ai_gemini_api.md)
 - [Using Google Cloud Storage](storage.md)
-  - [Push data on object uploads](storage/queue.md)
+  - [Push data on object writes](storage/queue.md)
   - [Rewriting objects](storage/rewrite_object.md)
   - [Speed up large object downloads](storage/striped_downloads.md)
   - [Use errors to terminate uploads](storage/terminate_uploads.md)

--- a/guide/src/storage/queue.md
+++ b/guide/src/storage/queue.md
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Push data on object uploads
+# Push data on object writes
 
-The client API to upload [Cloud Storage] objects pulls the upload data from a
-type provided by the application. Some applications generate the upload data in
-a thread and would rather "push" the object payload to the service.
+The client API to write [Cloud Storage] objects pulls the payload from a type
+provided by the application. Some applications generate the payload in a thread
+and would rather "push" the object payload to the service.
 
-This guide will show you how to upload an object to [Cloud Storage] using a push
-data source.
+This guide shows you how to write an object to [Cloud Storage] using a push data
+source.
 
 ## Prerequisites
 
@@ -34,11 +34,11 @@ The guide assumes you have an existing [Google Cloud project] with
 cargo add google-cloud-storage
 ```
 
-## Convert a queue to an upload source
+## Convert a queue to a `StreamingSource`
 
 The key idea is to use a queue to separate the task pushing new data from the
-task pulling the upload data. This tutorial uses a Tokio [mpsc queue], but you
-can use any queue that integrates with Tokio's async runtime.
+task pulling the payload. This tutorial uses a Tokio [mpsc queue], but you can
+use any queue that integrates with Tokio's async runtime.
 
 First wrap the receiver in our own type:
 
@@ -61,7 +61,7 @@ bucket and object name as parameters:
 {{#rustdoc_include ../../samples/tests/storage/queue.rs:end-sample-function}}
 ```
 
-As usual you initialize a client for the upload:
+Initialize a client:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/queue.rs:client}}
@@ -73,20 +73,20 @@ Create a queue, obtaining the receiver and sender:
 {{#rustdoc_include ../../samples/tests/storage/queue.rs:create-queue}}
 ```
 
-Use the client to upload the data received from this queue. Note that we do not
-`await` the future created in the `upload_object()` method.
+Use the client to write an object with the data received from this queue. Note
+that we do not `await` the future created in the `write_object()` method.
 
 ```rust,ignore,noplayground
-{{#rustdoc_include ../../samples/tests/storage/queue.rs:create-upload}}
+{{#rustdoc_include ../../samples/tests/storage/queue.rs:create-writer}}
 ```
 
-Create a task to process the queue and upload the data in the background:
+Create a task to process the queue and write the data in the background:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/queue.rs:create-task}}
 ```
 
-In the main task, send some data to upload:
+In the main task, send some data to write:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/queue.rs:send-data}}

--- a/guide/src/storage/striped_downloads.md
+++ b/guide/src/storage/striped_downloads.md
@@ -58,15 +58,15 @@ As usual, the function starts with some use declarations to simplify the code:
 {{#rustdoc_include ../../samples/tests/storage/striped.rs:seed-use}}
 ```
 
-Using the storage client, you upload a 1MiB object:
+Using the storage client, you create a 1MiB object:
 
 ```rust,ignore,noplayground
-{{#rustdoc_include ../../samples/tests/storage/striped.rs:upload-1MiB}}
+{{#rustdoc_include ../../samples/tests/storage/striped.rs:create-1MiB}}
 ```
 
 Then you use the storage control client to concatenate 32 copies of this object
-into a larger object. This operation does not require downloading or uploading
-any object data, it is performed by the service:
+into a larger object. This operation does not require transferring any object
+data to the client, it is performed by the service:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/striped.rs:compose-32}}

--- a/guide/src/storage/terminate_uploads.md
+++ b/guide/src/storage/terminate_uploads.md
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Use errors to terminate uploads
+# Use errors to terminate object writes
 
 In this guide you will learn how to use errors and custom data sources to
-terminate an upload before it is finalized. This is useful when applications
-want to upload data but may want to stop the client library from finalizing the
-upload if there is some error condition.
+terminate an object write before it is finalized. This is useful when
+applications want to stop the client library from finalizing the object creation
+if there is some error condition.
 
 ## Prerequisites
 
@@ -37,18 +37,18 @@ cargo add google-cloud-storage
 
 ## Overview
 
-The client library uploads data from any type implementing the `StreamingSource`
-trait. The client library pulls data from implementations of the trait. The
-library terminates the upload on the first error.
+The client library creates objects from any type implementing the
+`StreamingSource` trait. The client library pulls data from implementations of
+the trait. The library terminates the object write on the first error.
 
 In this guide you will build a custom implementation of `StreamingSource` that
-returns some data and then stops on an error. You will verify that an upload
-using this custom data source returns an error.
+returns some data and then stops on an error. You will verify that an object
+write using this custom data source returns an error.
 
 ## Create a custom error type
 
-To terminate an upload without finalizing it, your [StreamingSource] must return
-an error. In this example you will create a simple error type, in your
+To terminate an object write without finalizing it, your [StreamingSource] must
+return an error. In this example you will create a simple error type, in your
 application code you can use any existing error type:
 
 ```rust,ignore,noplayground
@@ -70,8 +70,8 @@ As you may recall, that requires implementing [Display] too:
 
 ## Create a custom `StreamingSource`
 
-Create a type that generates the data to upload. In this example you will use
-synthetic data using a counter:
+Create a type that generates the data for your object. In this example you will
+use synthetic data using a counter:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/terminate_uploads.rs:my-source}}
@@ -98,21 +98,21 @@ And implement the main function in this trait. Note how this function will
 {{#rustdoc_include ../../samples/tests/storage/terminate_uploads.rs:my-source-impl-next}}
 ```
 
-## Perform an upload
+## Create the object
 
-As usual, you will need a client to interact with [Cloud Storage]:
+You will need a client to interact with [Cloud Storage]:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/terminate_uploads.rs:attempt-upload-client}}
 ```
 
-Use the custom type to perform an upload:
+Use the custom type to create the object:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/terminate_uploads.rs:attempt-upload-upload}}
 ```
 
-As expected, this upload fails. You can inspect the error details:
+As expected, this object write fails. You can inspect the error details:
 
 ```rust,ignore,noplayground
 {{#rustdoc_include ../../samples/tests/storage/terminate_uploads.rs:attempt-upload-inspect-error}}
@@ -120,7 +120,7 @@ As expected, this upload fails. You can inspect the error details:
 
 ## Next Steps
 
-- [Push data on object uploads](queue.md)
+- [Push data on object writes](queue.md)
 
 ## Full Program
 

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -131,7 +131,7 @@ pub async fn objects(builder: storage::builder::storage::ClientBuilder) -> Resul
     tracing::info!("testing insert_object()");
     const CONTENTS: &str = "the quick brown fox jumps over the lazy dog";
     let insert = client
-        .upload_object(&bucket.name, "quick.text", CONTENTS)
+        .write_object(&bucket.name, "quick.text", CONTENTS)
         .with_metadata([("verify-metadata-works", "yes")])
         .with_content_type("text/plain")
         .with_content_language("en")
@@ -219,7 +219,7 @@ pub async fn objects_customer_supplied_encryption(
     const CONTENTS: &str = "the quick brown fox jumps over the lazy dog";
     let key = vec![b'a'; 32];
     let insert = client
-        .upload_object(&bucket.name, "quick.text", CONTENTS)
+        .write_object(&bucket.name, "quick.text", CONTENTS)
         .with_key(KeyAes256::new(&key)?)
         .send_unbuffered()
         .await?;
@@ -284,7 +284,7 @@ pub async fn objects_large_file(builder: storage::builder::storage::ClientBuilde
 
     tracing::info!("testing insert_object()");
     let insert = client
-        .upload_object(
+        .write_object(
             &bucket.name,
             "quick.text",
             bytes::Bytes::from_owner(contents.clone()),
@@ -368,7 +368,7 @@ pub async fn upload_buffered(builder: storage::builder::storage::ClientBuilder) 
 
     tracing::info!("testing upload_object_buffered() [1]");
     let insert = client
-        .upload_object(&bucket.name, "empty.txt", "")
+        .write_object(&bucket.name, "empty.txt", "")
         .with_if_generation_match(0)
         .send_buffered()
         .await?;
@@ -378,7 +378,7 @@ pub async fn upload_buffered(builder: storage::builder::storage::ClientBuilder) 
     let payload = bytes::Bytes::from_owner(Vec::from_iter((0..128 * 1024).map(|_| 0_u8)));
     tracing::info!("testing upload_object_buffered() [2]");
     let insert = client
-        .upload_object(&bucket.name, "128K.txt", payload)
+        .write_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .send_buffered()
         .await?;
@@ -388,7 +388,7 @@ pub async fn upload_buffered(builder: storage::builder::storage::ClientBuilder) 
     let payload = bytes::Bytes::from_owner(Vec::from_iter((0..512 * 1024).map(|_| 0_u8)));
     tracing::info!("testing upload_object_buffered() [3]");
     let insert = client
-        .upload_object(&bucket.name, "512K.txt", payload)
+        .write_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .send_buffered()
         .await?;
@@ -424,7 +424,7 @@ pub async fn upload_buffered_resumable_known_size(
     tracing::info!("testing send_unbuffered() [1]");
     let payload = TestDataSource::new(0_u64);
     let insert = client
-        .upload_object(&bucket.name, "empty.txt", payload)
+        .write_object(&bucket.name, "empty.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -435,7 +435,7 @@ pub async fn upload_buffered_resumable_known_size(
     let payload = TestDataSource::new(128 * 1024_u64);
     tracing::info!("testing upload_object_buffered() [2]");
     let insert = client
-        .upload_object(&bucket.name, "128K.txt", payload)
+        .write_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -446,7 +446,7 @@ pub async fn upload_buffered_resumable_known_size(
     let payload = TestDataSource::new(512 * 1024_u64);
     tracing::info!("testing upload_object_buffered() [3]");
     let insert = client
-        .upload_object(&bucket.name, "512K.txt", payload)
+        .write_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -483,7 +483,7 @@ pub async fn upload_buffered_resumable_unknown_size(
     tracing::info!("testing send_unbuffered() [1]");
     let payload = TestDataSource::new(0_u64).without_size_hint();
     let insert = client
-        .upload_object(&bucket.name, "empty.txt", payload)
+        .write_object(&bucket.name, "empty.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -494,7 +494,7 @@ pub async fn upload_buffered_resumable_unknown_size(
     let payload = TestDataSource::new(128 * 1024_u64).without_size_hint();
     tracing::info!("testing upload_object_buffered() [2]");
     let insert = client
-        .upload_object(&bucket.name, "128K.txt", payload)
+        .write_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -505,7 +505,7 @@ pub async fn upload_buffered_resumable_unknown_size(
     let payload = TestDataSource::new(512 * 1024_u64).without_size_hint();
     tracing::info!("testing upload_object_buffered() [3]");
     let insert = client
-        .upload_object(&bucket.name, "512K.txt", payload)
+        .write_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -516,7 +516,7 @@ pub async fn upload_buffered_resumable_unknown_size(
     let payload = TestDataSource::new(500 * 1024_u64).without_size_hint();
     tracing::info!("testing upload_object_buffered() [4]");
     let insert = client
-        .upload_object(&bucket.name, "500K.txt", payload)
+        .write_object(&bucket.name, "500K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -553,7 +553,7 @@ pub async fn upload_unbuffered_resumable_known_size(
     tracing::info!("testing send_unbuffered() [1]");
     let payload = TestDataSource::new(0_u64);
     let insert = client
-        .upload_object(&bucket.name, "empty.txt", payload)
+        .write_object(&bucket.name, "empty.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -564,7 +564,7 @@ pub async fn upload_unbuffered_resumable_known_size(
     let payload = TestDataSource::new(128 * 1024_u64);
     tracing::info!("testing upload_object_buffered() [2]");
     let insert = client
-        .upload_object(&bucket.name, "128K.txt", payload)
+        .write_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -575,7 +575,7 @@ pub async fn upload_unbuffered_resumable_known_size(
     let payload = TestDataSource::new(512 * 1024_u64);
     tracing::info!("testing upload_object_buffered() [3]");
     let insert = client
-        .upload_object(&bucket.name, "512K.txt", payload)
+        .write_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -612,7 +612,7 @@ pub async fn upload_unbuffered_resumable_unknown_size(
     tracing::info!("testing send_unbuffered() [1]");
     let payload = TestDataSource::new(0_u64).without_size_hint();
     let insert = client
-        .upload_object(&bucket.name, "empty.txt", payload)
+        .write_object(&bucket.name, "empty.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -623,7 +623,7 @@ pub async fn upload_unbuffered_resumable_unknown_size(
     let payload = TestDataSource::new(128 * 1024_u64).without_size_hint();
     tracing::info!("testing upload_object_buffered() [2]");
     let insert = client
-        .upload_object(&bucket.name, "128K.txt", payload)
+        .write_object(&bucket.name, "128K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -634,7 +634,7 @@ pub async fn upload_unbuffered_resumable_unknown_size(
     let payload = TestDataSource::new(512 * 1024_u64).without_size_hint();
     tracing::info!("testing upload_object_buffered() [3]");
     let insert = client
-        .upload_object(&bucket.name, "512K.txt", payload)
+        .write_object(&bucket.name, "512K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -645,7 +645,7 @@ pub async fn upload_unbuffered_resumable_unknown_size(
     let payload = TestDataSource::new(500 * 1024_u64).without_size_hint();
     tracing::info!("testing upload_object_buffered() [4]");
     let insert = client
-        .upload_object(&bucket.name, "500K.txt", payload)
+        .write_object(&bucket.name, "500K.txt", payload)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -691,7 +691,7 @@ pub async fn abort_upload(
 
 struct AbortUploadTestCase {
     name: String,
-    upload: storage::builder::storage::UploadObject<TestDataSource>,
+    upload: storage::builder::storage::WriteObject<TestDataSource>,
 }
 
 fn abort_upload_test_cases(
@@ -720,7 +720,7 @@ fn abort_upload_test_cases(
         for t in thresholds {
             let name = format!("{prefix}-{}-{}.txt", s.0, t.0);
             let upload = client
-                .upload_object(bucket_name, &name, s.1.clone())
+                .write_object(bucket_name, &name, s.1.clone())
                 .with_if_generation_match(0)
                 .with_resumable_upload_threshold(t.1);
             uploads.push(AbortUploadTestCase { name, upload });
@@ -810,7 +810,7 @@ pub async fn checksums(
             "verify/default",
             Box::pin(
                 client
-                    .upload_object(bucket_name, "verify/default", VEXING)
+                    .write_object(bucket_name, "verify/default", VEXING)
                     .with_if_generation_match(0)
                     .send_buffered(),
             ),
@@ -819,7 +819,7 @@ pub async fn checksums(
             "verify/md5",
             Box::pin(
                 client
-                    .upload_object(bucket_name, "verify/md5", VEXING)
+                    .write_object(bucket_name, "verify/md5", VEXING)
                     .with_if_generation_match(0)
                     .compute_md5()
                     .send_buffered(),
@@ -829,7 +829,7 @@ pub async fn checksums(
             "computed/default",
             Box::pin(
                 client
-                    .upload_object(bucket_name, "computed/default", VEXING)
+                    .write_object(bucket_name, "computed/default", VEXING)
                     .with_if_generation_match(0)
                     .precompute_checksums()
                     .await?
@@ -840,7 +840,7 @@ pub async fn checksums(
             "computed/md5",
             Box::pin(
                 client
-                    .upload_object(bucket_name, "computed/md5", VEXING)
+                    .write_object(bucket_name, "computed/md5", VEXING)
                     .with_if_generation_match(0)
                     .compute_md5()
                     .precompute_checksums()
@@ -891,7 +891,7 @@ pub async fn object_names(
 
     for name in names {
         let upload = client
-            .upload_object(bucket_name, name, "")
+            .write_object(bucket_name, name, "")
             .with_if_generation_match(0)
             .send_unbuffered()
             .await?;

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -169,7 +169,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     create_bucket_hierarchical_namespace::sample(&control, &project_id, &id).await?;
 
     tracing::info!("create test objects for the examples");
-    let uploads = [
+    let writers = [
         "object-to-download.txt",
         "prefixes/are-not-always/folders-001",
         "prefixes/are-not-always/folders-002",
@@ -180,7 +180,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
         "deleted-object-name",
     ]
     .map(|name| make_object(&client, &id, name));
-    let _ = futures::future::join_all(uploads)
+    let _ = futures::future::join_all(writers)
         .await
         .into_iter()
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -216,7 +216,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
 async fn make_object(client: &Storage, bucket_id: &str, name: &str) -> anyhow::Result<Object> {
     const VEXING: &str = "how vexingly quick daft zebras jump\n";
     let object = client
-        .upload_object(format!("projects/_/buckets/{bucket_id}"), name, VEXING)
+        .write_object(format!("projects/_/buckets/{bucket_id}"), name, VEXING)
         .with_if_generation_match(0)
         .send_buffered()
         .await?;

--- a/src/storage/examples/src/objects/stream_file_upload.rs
+++ b/src/storage/examples/src/objects/stream_file_upload.rs
@@ -20,7 +20,7 @@ pub async fn sample(client: &Storage, bucket_id: &str) -> anyhow::Result<()> {
     const NAME: &str = "object-to-upload.txt";
     let payload = Payload(100);
     let object = client
-        .upload_object(format!("projects/_/buckets/{bucket_id}"), NAME, payload)
+        .write_object(format!("projects/_/buckets/{bucket_id}"), NAME, payload)
         .with_if_generation_match(0)
         .send_buffered()
         .await?;

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -148,17 +148,17 @@ pub enum ReadError {
 ///
 /// # Example
 /// ```
-/// # use google_cloud_storage::{client::Storage, error::UploadError};
+/// # use google_cloud_storage::{client::Storage, error::WriteError};
 /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
 /// use std::error::Error as _;
-/// let upload = client
-///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+/// let writer = client
+///     .write_object("projects/_/buckets/my-bucket", "my-object", "hello world")
 ///     .with_if_generation_not_match(0);
-/// match upload.send_buffered().await {
-///     Ok(object) => println!("Successfully uploaded the object"),
+/// match writer.send_buffered().await {
+///     Ok(object) => println!("Successfully created the object {object:?}"),
 ///     Err(error) if error.is_serialization() => {
 ///         println!("Some problem {error:?} sending the data to the service");
-///         if let Some(m) = error.source().and_then(|e| e.downcast_ref::<UploadError>()) {
+///         if let Some(m) = error.source().and_then(|e| e.downcast_ref::<WriteError>()) {
 ///             println!("{m}");
 ///         }
 ///     },
@@ -169,7 +169,7 @@ pub enum ReadError {
 ///
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
-pub enum UploadError {
+pub enum WriteError {
     /// The service has "uncommitted" previously persisted bytes.
     ///
     /// # Troubleshoot

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -57,7 +57,7 @@ pub mod builder {
         //! Request builders for [Storage][crate::client::Storage].
         pub use crate::storage::client::ClientBuilder;
         pub use crate::storage::read_object::ReadObject;
-        pub use crate::storage::upload_object::UploadObject;
+        pub use crate::storage::write_object::WriteObject;
     }
     pub mod storage_control {
         //! Request builders for [StorageControl][crate::client::StorageControl].

--- a/src/storage/src/model/request_helpers.rs
+++ b/src/storage/src/model/request_helpers.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Types used in the request builders ([ReadObject] and/or [UploadObject])
+//! Types used in the request builders ([ReadObject] and/or [WriteObject])
 //! to improve type safety or ergonomics.
 //!
 //! [ReadObject]: crate::builder::storage::ReadObject
-//! [UploadObject]: crate::builder::storage::UploadObject
+//! [WriteObject]: crate::builder::storage::WriteObject
 
 use crate::error::KeyAes256Error;
 use sha2::{Digest, Sha256};

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,8 +18,8 @@ pub(crate) mod perform_upload;
 pub(crate) mod read_object;
 pub(crate) mod request_options;
 pub mod streaming_source;
-pub(crate) mod upload_object;
 pub(crate) mod v1;
+pub(crate) mod write_object;
 
 use crate::model::Object;
 use crate::streaming_source::Payload;

--- a/src/storage/src/storage/checksum.rs
+++ b/src/storage/src/storage/checksum.rs
@@ -16,20 +16,20 @@
 //!
 //! The [ChecksumEngine] trait is sealed, and cannot be used to create new
 //! implementations. However, it may be useful when working with
-//! [UploadObject][crate::builder::storage::UploadObject].
+//! [WriteObject][crate::builder::storage::WriteObject].
 //!
 //! # Example
 //! ```
-//! use google_cloud_storage::builder::storage::UploadObject;
+//! use google_cloud_storage::builder::storage::WriteObject;
 //! use google_cloud_storage::model::Object;
 //! use google_cloud_storage::{streaming_source::StreamingSource, checksum::ChecksumEngine};
 //!
-//! async fn example<S, C>(builder: UploadObject<S, C>) -> anyhow::Result<Object>
+//! async fn example<S, C>(builder: WriteObject<S, C>) -> anyhow::Result<Object>
 //! where
 //!     S: StreamingSource + Send + Sync + 'static,
 //!     C: ChecksumEngine + Send + Sync + 'static
 //! {
-//!     // Finish configuring `builder` and complete the upload
+//!     // Finish configuring `builder` and complete the upload.
 //!     let object = builder
 //!         .with_if_generation_match(0)
 //!         .with_resumable_upload_threshold(0_usize)

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -15,7 +15,7 @@
 use super::request_options::RequestOptions;
 use crate::Error;
 use crate::builder::storage::ReadObject;
-use crate::builder::storage::UploadObject;
+use crate::builder::storage::WriteObject;
 use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::checksum::details::Crc32c;
 use crate::streaming_source::Payload;
@@ -113,12 +113,13 @@ impl Storage {
         ClientBuilder::new()
     }
 
-    /// Upload an object using a local buffer.
+    /// Write an object using a local buffer.
     ///
     /// If the data source does **not** implement [Seek] the client library must
-    /// buffer uploaded data until this data is persisted in the service. This
-    /// requires more memory in the client, and when the buffer grows too large,
-    /// may require stalling the upload until the service can persist the data.
+    /// buffer data sent to the service until the service confirms it has
+    /// persisted the data. This requires more memory in the client, and when
+    /// the buffer grows too large, may require stalling the writer until the
+    /// service can persist the data.
     ///
     /// Use this function for data sources representing computations where
     /// it is expensive or impossible to restart said computation. This function
@@ -131,7 +132,7 @@ impl Storage {
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let response = client
-    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .write_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
@@ -143,7 +144,7 @@ impl Storage {
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let response = client
-    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .write_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .send_unbuffered()
     ///     .await?;
     /// println!("response details={response:?}");
@@ -157,18 +158,18 @@ impl Storage {
     /// * `payload` - the object data.
     ///
     /// [Seek]: crate::streaming_source::Seek
-    pub fn upload_object<B, O, T, P>(
+    pub fn write_object<B, O, T, P>(
         &self,
         bucket: B,
         object: O,
         payload: T,
-    ) -> UploadObject<P, Crc32c>
+    ) -> WriteObject<P, Crc32c>
     where
         B: Into<String>,
         O: Into<String>,
         T: Into<Payload<P>>,
     {
-        UploadObject::new(self.inner.clone(), bucket, object, payload)
+        WriteObject::new(self.inner.clone(), bucket, object, payload)
     }
 
     /// Reads the contents of an object.
@@ -444,21 +445,21 @@ impl ClientBuilder {
     ///     .build()
     ///     .await?;
     /// let response = client
-    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .write_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
     /// # Ok(()) }
     /// ```
     ///
-    /// The client library can perform uploads using [single-shot] or
-    /// [resumable] uploads. For small objects, single-shot uploads offer better
+    /// The client library can write objects using [single-shot] or [resumable]
+    /// uploads. For small objects, single-shot uploads offer better
     /// performance, as they require a single HTTP transfer. For larger objects,
     /// the additional request latency is not significant, and resumable uploads
     /// offer better recovery on errors.
     ///
     /// The library automatically selects resumable uploads when the payload is
-    /// equal to or larger than this option. For smaller uploads the client
+    /// equal to or larger than this option. For smaller writes the client
     /// library uses single-shot uploads.
     ///
     /// The exact threshold depends on where the application is deployed and
@@ -484,7 +485,7 @@ impl ClientBuilder {
     ///     .build()
     ///     .await?;
     /// let response = client
-    ///     .upload_object("projects/_/buckets/my-bucket", "my-object", "hello world")
+    ///     .write_object("projects/_/buckets/my-bucket", "my-object", "hello world")
     ///     .send_buffered()
     ///     .await?;
     /// println!("response details={response:?}");
@@ -493,13 +494,13 @@ impl ClientBuilder {
     ///
     /// When performing [resumable uploads] from sources without [Seek] the
     /// client library needs to buffer data in memory until it is persisted by
-    /// the service. Otherwise the data would be lost if the upload fails.
-    /// Applications may want to tune this buffer size:
+    /// the service. Otherwise the data would be lost if the upload is
+    /// interrupted. Applications may want to tune this buffer size:
     ///
-    /// - Use smaller buffer sizes to support more concurrent uploads in the
+    /// - Use smaller buffer sizes to support more concurrent writes in the
     ///   same application.
     /// - Use larger buffer sizes for better throughput. Sending many small
-    ///   buffers stalls the upload until the client receives a successful
+    ///   buffers stalls the writer until the client receives a successful
     ///   response from the service.
     ///
     /// Keep in mind that there are diminishing returns on using larger buffers.

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -29,9 +29,9 @@ use tokio::sync::Mutex;
 mod buffered;
 mod unbuffered;
 
-/// Represents an upload constructed via `UploadObject<T>`.
+/// Represents an upload constructed via `WriteObject<T>`.
 ///
-/// Once the application has fully configured an `UploadObject<T>` it calls
+/// Once the application has fully configured an `WriteObject<T>` it calls
 /// `send()` or `send_buffered()` to initiate the upload. At that point the
 /// client library creates an instance of this class. Notably, the `payload`
 /// becomes `Arc<Mutex<T>>` because it needs to be reused in the retry loop.

--- a/src/storage/src/storage/perform_upload/buffered/progress.rs
+++ b/src/storage/src/storage/perform_upload/buffered/progress.rs
@@ -16,7 +16,7 @@ use super::RESUMABLE_UPLOAD_QUANTUM;
 use super::{SizeHint, StreamingSource};
 use crate::Error;
 use crate::Result;
-use crate::error::UploadError;
+use crate::error::WriteError;
 use futures::stream::unfold;
 use std::collections::VecDeque;
 
@@ -185,12 +185,12 @@ impl InProgressUpload {
 
     pub fn handle_partial(&mut self, persisted_size: u64) -> Result<()> {
         let consumed = match (self.offset, self.buffer_size as u64, persisted_size) {
-            (o, _, p) if p < o => Err(UploadError::UnexpectedRewind {
+            (o, _, p) if p < o => Err(WriteError::UnexpectedRewind {
                 offset: o,
                 persisted: p,
             }),
             (o, n, p) if p <= o + n => Ok((p - o) as usize),
-            (o, n, p) => Err(UploadError::TooMuchProgress {
+            (o, n, p) => Err(WriteError::TooMuchProgress {
                 sent: o + n,
                 persisted: p,
             }),
@@ -597,10 +597,10 @@ mod tests {
         assert!(err.is_serialization(), "{err:?}");
         let source = err
             .source()
-            .and_then(|e| e.downcast_ref::<UploadError>())
+            .and_then(|e| e.downcast_ref::<WriteError>())
             .expect("source should be a ProgressError");
         assert!(
-            matches!(source, UploadError::TooMuchProgress { sent, persisted } if *sent == 2 * LEN as u64 && *persisted == 4 * LEN as u64 ),
+            matches!(source, WriteError::TooMuchProgress { sent, persisted } if *sent == 2 * LEN as u64 && *persisted == 4 * LEN as u64 ),
             "{source:?}"
         );
         Ok(())
@@ -623,10 +623,10 @@ mod tests {
         assert!(err.is_serialization(), "{err:?}");
         let source = err
             .source()
-            .and_then(|e| e.downcast_ref::<UploadError>())
+            .and_then(|e| e.downcast_ref::<WriteError>())
             .expect("source should be a ProgressError");
         assert!(
-            matches!(source, UploadError::UnexpectedRewind { offset, persisted } if *offset == 2 * LEN as u64 && *persisted == LEN as u64 ),
+            matches!(source, WriteError::UnexpectedRewind { offset, persisted } if *offset == 2 * LEN as u64 && *persisted == LEN as u64 ),
             "{source:?}"
         );
         Ok(())

--- a/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
@@ -175,7 +175,7 @@ async fn empty_success() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_buffered()
         .await?;
@@ -235,7 +235,7 @@ async fn resumable_empty_unknown() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object(
+        .write_object(
             "projects/_/buckets/test-bucket",
             "test-object",
             UnknownSize::new(BytesSource::new(bytes::Bytes::from_static(b""))),
@@ -313,7 +313,7 @@ async fn empty_csek() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .with_key(KeyAes256::new(&key)?)
         .send_buffered()
@@ -362,7 +362,7 @@ async fn source_next_error() -> Result {
         .once()
         .returning(|| Ok(SizeHint::with_exact(1024)));
     let err = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", source)
+        .write_object("projects/_/buckets/test-bucket", "test-object", source)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_buffered()
@@ -396,7 +396,7 @@ async fn start_permanent_error() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_buffered()
         .await
@@ -426,7 +426,7 @@ async fn start_too_many_transients() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_buffered()
@@ -477,7 +477,7 @@ async fn put_permanent_error() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_buffered()
         .await
@@ -523,7 +523,7 @@ async fn put_too_many_transients() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_buffered()
@@ -602,7 +602,7 @@ async fn put_partial_and_recover() -> Result {
         .build()
         .await?;
     let upload = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", payload)
+        .write_object("projects/_/buckets/test-bucket", "test-object", payload)
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .with_resumable_upload_buffer_size(TARGET);
@@ -655,7 +655,7 @@ async fn put_error_and_finalized() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", payload)
+        .write_object("projects/_/buckets/test-bucket", "test-object", payload)
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_buffered()
@@ -717,7 +717,7 @@ async fn start_resumable_upload_request_retry_options() -> Result {
         .build()
         .await?;
     let err = client
-        .upload_object("projects/_/buckets/bucket", "object", "hello")
+        .write_object("projects/_/buckets/bucket", "object", "hello")
         .with_retry_policy(retry.with_attempt_limit(3))
         .with_backoff_policy(backoff)
         .with_retry_throttler(throttler)
@@ -781,7 +781,7 @@ async fn start_resumable_upload_client_retry_options() -> Result {
         .build()
         .await?;
     let err = client
-        .upload_object("projects/_/buckets/bucket", "object", "hello")
+        .write_object("projects/_/buckets/bucket", "object", "hello")
         .send_buffered()
         .await
         .expect_err("request should fail after 3 retry attempts");

--- a/src/storage/src/storage/perform_upload/tests.rs
+++ b/src/storage/src/storage/perform_upload/tests.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use super::*;
+use crate::builder::storage::WriteObject;
 use crate::model::request_helpers::{KeyAes256, tests::create_key_helper};
 use crate::storage::client::tests::{test_builder, test_inner_client};
-use crate::storage::upload_object::UploadObject;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use test_case::test_case;
@@ -37,7 +37,7 @@ fn response_body() -> Value {
 #[tokio::test]
 async fn start_resumable_upload() -> Result {
     let inner = test_inner_client(test_builder());
-    let mut request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+    let mut request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
         .build()
         .start_resumable_upload_request()
         .await?
@@ -61,7 +61,7 @@ async fn start_resumable_upload_headers() -> Result {
     let (key, key_base64, _, key_sha256_base64) = create_key_helper();
 
     let inner = test_inner_client(test_builder());
-    let request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+    let request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
         .with_key(KeyAes256::new(&key)?)
         .build()
         .start_resumable_upload_request()
@@ -92,7 +92,7 @@ async fn start_resumable_upload_headers() -> Result {
 #[tokio::test]
 async fn start_resumable_upload_bad_bucket() -> Result {
     let inner = test_inner_client(test_builder());
-    UploadObject::new(inner, "malformed", "object", "hello")
+    WriteObject::new(inner, "malformed", "object", "hello")
         .build()
         .start_resumable_upload_request()
         .await
@@ -104,7 +104,7 @@ async fn start_resumable_upload_bad_bucket() -> Result {
 async fn start_resumable_upload_metadata_in_request() -> Result {
     use crate::model::ObjectAccessControl;
     let inner = test_inner_client(test_builder());
-    let mut request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "")
+    let mut request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "")
         .with_if_generation_match(10)
         .with_if_generation_not_match(20)
         .with_if_metageneration_match(30)
@@ -187,7 +187,7 @@ async fn start_resumable_upload_credentials() -> Result {
     let inner = test_inner_client(
         test_builder().with_credentials(auth::credentials::testing::error_credentials(false)),
     );
-    let _ = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+    let _ = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
         .build()
         .start_resumable_upload_request()
         .await

--- a/src/storage/src/storage/perform_upload/tests/checksums.rs
+++ b/src/storage/src/storage/perform_upload/tests/checksums.rs
@@ -15,7 +15,7 @@
 //! Verify the client library correctly detects mismatched checksums on uploads.
 
 use super::*;
-use crate::error::UploadError;
+use crate::error::WriteError;
 use crate::storage::streaming_source::BytesSource;
 use httptest::{Expectation, Server, matchers::*, responders::*};
 use serde_json::{Value, json};
@@ -29,7 +29,7 @@ mod buffered_single_shot {
     fn prepare_server(body: Value) -> Server {
         super::single_shot_server(body)
     }
-    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+    async fn start_upload(server: &Server) -> anyhow::Result<WriteObject<BytesSource>> {
         super::start_single_shot(server).await
     }
 
@@ -42,9 +42,9 @@ mod buffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -69,9 +69,9 @@ mod buffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -97,7 +97,7 @@ mod buffered_resumable {
     fn prepare_server(body: Value) -> Server {
         super::resumable_server(body)
     }
-    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+    async fn start_upload(server: &Server) -> anyhow::Result<WriteObject<BytesSource>> {
         super::start_resumable(server).await
     }
 
@@ -110,9 +110,9 @@ mod buffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -137,9 +137,9 @@ mod buffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -165,7 +165,7 @@ mod unbuffered_single_shot {
     fn prepare_server(body: Value) -> Server {
         super::single_shot_server(body)
     }
-    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+    async fn start_upload(server: &Server) -> anyhow::Result<WriteObject<BytesSource>> {
         super::start_single_shot(server).await
     }
 
@@ -178,9 +178,9 @@ mod unbuffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -205,9 +205,9 @@ mod unbuffered_single_shot {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -233,7 +233,7 @@ mod unbuffered_resumable {
     fn prepare_server(body: Value) -> Server {
         super::resumable_server(body)
     }
-    async fn start_upload(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+    async fn start_upload(server: &Server) -> anyhow::Result<WriteObject<BytesSource>> {
         super::start_resumable(server).await
     }
 
@@ -246,9 +246,9 @@ mod unbuffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -273,9 +273,9 @@ mod unbuffered_resumable {
             .await
             .expect_err("expected a checksum error");
         assert!(err.is_serialization(), "{err:?}");
-        let source = err.source().and_then(|e| e.downcast_ref::<UploadError>());
+        let source = err.source().and_then(|e| e.downcast_ref::<WriteError>());
         assert!(
-            matches!(source, Some(UploadError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
+            matches!(source, Some(WriteError::ChecksumMismatch { object, .. }) if object.as_ref() == &bad_checksums_object()),
             "{err:?}"
         );
         Ok(())
@@ -295,23 +295,23 @@ mod unbuffered_resumable {
     }
 }
 
-async fn start_resumable(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+async fn start_resumable(server: &Server) -> anyhow::Result<WriteObject<BytesSource>> {
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
         .build()
         .await?;
     Ok(client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", VEXING)
+        .write_object("projects/_/buckets/test-bucket", "test-object", VEXING)
         .with_resumable_upload_threshold(0_usize))
 }
 
-async fn start_single_shot(server: &Server) -> anyhow::Result<UploadObject<BytesSource>> {
+async fn start_single_shot(server: &Server) -> anyhow::Result<WriteObject<BytesSource>> {
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
         .build()
         .await?;
     Ok(client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", VEXING)
+        .write_object("projects/_/buckets/test-bucket", "test-object", VEXING)
         .with_resumable_upload_threshold(1024 * 1024_usize))
 }
 

--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -205,12 +205,12 @@ mod resumable_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder::storage::WriteObject;
     use crate::model::request_helpers::{KeyAes256, tests::create_key_helper};
     use crate::storage::client::{
         Storage,
         tests::{test_builder, test_inner_client},
     };
-    use crate::storage::upload_object::UploadObject;
     use crate::streaming_source::IterSource;
     use gax::retry_policy::RetryPolicyExt;
     use http_body_util::BodyExt;
@@ -243,7 +243,7 @@ mod tests {
             .build()
             .await?;
         let response = client
-            .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+            .write_object("projects/_/buckets/test-bucket", "test-object", "")
             .send_unbuffered()
             .await?;
         assert_eq!(response.name, "test-object");
@@ -274,7 +274,7 @@ mod tests {
             .build()
             .await?;
         let err = client
-            .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+            .write_object("projects/_/buckets/test-bucket", "test-object", "")
             .send_unbuffered()
             .await
             .expect_err("expected a not found error");
@@ -301,7 +301,7 @@ mod tests {
             .build()
             .await?;
         let err = client
-            .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+            .write_object("projects/_/buckets/test-bucket", "test-object", "")
             .send_unbuffered()
             .await
             .expect_err("expected a deserialization error");
@@ -332,7 +332,7 @@ mod tests {
             .once()
             .returning(|| Ok(SizeHint::with_exact(1024)));
         let err = client
-            .upload_object("projects/_/buckets/test-bucket", "test-object", source)
+            .write_object("projects/_/buckets/test-bucket", "test-object", source)
             .send_unbuffered()
             .await
             .expect_err("expected a serialization error");
@@ -372,7 +372,7 @@ mod tests {
             .once()
             .returning(|| Ok(SizeHint::with_exact(1024_u64)));
         let err = client
-            .upload_object("projects/_/buckets/test-bucket", "test-object", source)
+            .write_object("projects/_/buckets/test-bucket", "test-object", source)
             .send_unbuffered()
             .await
             .expect_err("expected a serialization error");
@@ -429,7 +429,7 @@ mod tests {
     async fn upload_object_bytes() -> Result {
         const PAYLOAD: &str = "hello";
         let inner = test_inner_client(test_builder());
-        let request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", PAYLOAD)
+        let request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", PAYLOAD)
             .build()
             .single_shot_builder(SizeHint::with_exact(PAYLOAD.len() as u64))
             .await?
@@ -448,7 +448,7 @@ mod tests {
     #[tokio::test]
     async fn upload_object_metadata() -> Result {
         let inner = test_inner_client(test_builder());
-        let request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+        let request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .with_metadata([("k0", "v0"), ("k1", "v1")])
             .build()
             .single_shot_builder(SizeHint::new())
@@ -476,7 +476,7 @@ mod tests {
             .map(|x| bytes::Bytes::from_static(x.as_bytes())),
         );
         let inner = test_inner_client(test_builder());
-        let request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", stream)
+        let request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", stream)
             .build()
             .single_shot_builder(SizeHint::new())
             .await?
@@ -497,7 +497,7 @@ mod tests {
         let inner = test_inner_client(
             test_builder().with_credentials(auth::credentials::testing::error_credentials(false)),
         );
-        let _ = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+        let _ = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .build()
             .single_shot_builder(SizeHint::new())
             .await
@@ -509,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn upload_object_bad_bucket() -> Result {
         let inner = test_inner_client(test_builder());
-        UploadObject::new(inner, "malformed", "object", "hello")
+        WriteObject::new(inner, "malformed", "object", "hello")
             .build()
             .single_shot_builder(SizeHint::new())
             .await
@@ -523,7 +523,7 @@ mod tests {
         let (key, key_base64, _, key_sha256_base64) = create_key_helper();
 
         let inner = test_inner_client(test_builder());
-        let request = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+        let request = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .with_key(KeyAes256::new(&key)?)
             .build()
             .single_shot_builder(SizeHint::new())
@@ -569,7 +569,7 @@ mod tests {
 
         let inner =
             test_inner_client(test_builder().with_endpoint(format!("http://{}", server.addr())));
-        let err = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+        let err = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .send_unbuffered()
             .await
             .expect_err("expected error as request is not idempotent");
@@ -596,7 +596,7 @@ mod tests {
 
         let inner =
             test_inner_client(test_builder().with_endpoint(format!("http://{}", server.addr())));
-        let got = UploadObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
+        let got = WriteObject::new(inner, "projects/_/buckets/bucket", "object", "hello")
             .with_idempotency(true)
             .send_unbuffered()
             .await?;
@@ -624,7 +624,7 @@ mod tests {
 
         let inner =
             test_inner_client(test_builder().with_endpoint(format!("http://{}", server.addr())));
-        let got = UploadObject::new(
+        let got = WriteObject::new(
             inner,
             "projects/_/buckets/test-bucket",
             "test-object",
@@ -657,7 +657,7 @@ mod tests {
 
         let inner =
             test_inner_client(test_builder().with_endpoint(format!("http://{}", server.addr())));
-        let err = UploadObject::new(
+        let err = WriteObject::new(
             inner,
             "projects/_/buckets/test-bucket",
             "test-object",
@@ -690,7 +690,7 @@ mod tests {
 
         let inner =
             test_inner_client(test_builder().with_endpoint(format!("http://{}", server.addr())));
-        let err = UploadObject::new(
+        let err = WriteObject::new(
             inner,
             "projects/_/buckets/test-bucket",
             "test-object",

--- a/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
@@ -141,7 +141,7 @@ async fn resumable_empty_success() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_unbuffered()
         .await?;
@@ -201,7 +201,7 @@ async fn resumable_empty_unknown() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object(
+        .write_object(
             "projects/_/buckets/test-bucket",
             "test-object",
             UnknownSize::new(BytesSource::new(bytes::Bytes::from_static(b""))),
@@ -279,7 +279,7 @@ async fn resumable_empty_csek() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .with_key(KeyAes256::new(&key)?)
         .send_unbuffered()
@@ -329,7 +329,7 @@ async fn source_seek_error() -> Result {
         .once()
         .returning(|| Ok(SizeHint::with_exact(1024)));
     let err = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", source)
+        .write_object("projects/_/buckets/test-bucket", "test-object", source)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -374,7 +374,7 @@ async fn source_next_error() -> Result {
         .expect_size_hint()
         .returning(|| Ok(SizeHint::with_exact(1024)));
     let err = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", source)
+        .write_object("projects/_/buckets/test-bucket", "test-object", source)
         .with_if_generation_match(0)
         .with_resumable_upload_threshold(0_usize)
         .send_unbuffered()
@@ -408,7 +408,7 @@ async fn resumable_start_permanent_error() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_unbuffered()
         .await
@@ -438,7 +438,7 @@ async fn resumable_start_too_many_transients() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_unbuffered()
@@ -488,7 +488,7 @@ async fn resumable_query_permanent_error() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_unbuffered()
         .await
@@ -533,7 +533,7 @@ async fn resumable_query_too_many_transients() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_unbuffered()
@@ -584,7 +584,7 @@ async fn resumable_put_permanent_error() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_if_generation_match(0_i64)
         .send_unbuffered()
         .await
@@ -630,7 +630,7 @@ async fn resumable_put_too_many_transients() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", "")
+        .write_object("projects/_/buckets/test-bucket", "test-object", "")
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_unbuffered()
@@ -694,7 +694,7 @@ async fn resumable_put_partial_and_recover_unknown_size() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object(
+        .write_object(
             "projects/_/buckets/test-bucket",
             "test-object",
             UnknownSize::new(BytesSource::new(payload)),
@@ -766,7 +766,7 @@ async fn resumable_put_partial_and_recover_known_size() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", payload)
+        .write_object("projects/_/buckets/test-bucket", "test-object", payload)
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_unbuffered()
@@ -817,7 +817,7 @@ async fn resumable_put_error_and_finalized() -> Result {
         .build()
         .await?;
     let response = client
-        .upload_object("projects/_/buckets/test-bucket", "test-object", payload)
+        .write_object("projects/_/buckets/test-bucket", "test-object", payload)
         .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
         .with_if_generation_match(0_i64)
         .send_unbuffered()

--- a/src/w1r3/src/main.rs
+++ b/src/w1r3/src/main.rs
@@ -96,7 +96,7 @@ async fn runner(
 
         let write_start = Instant::now();
         let upload = client
-            .upload_object(
+            .write_object(
                 format!("projects/_/buckets/{}", &args.bucket_name),
                 &name,
                 buffer.slice(0..size),


### PR DESCRIPTION
Rename the function, related types, and change the documentation to prefer
saying "write object" vs. "upload". When referring to things like "resumable
uploads" I left the name unchanged, that is the name of the protocol.

Fixes #2892
