### PR TITLE
fix(storage)!: remove ChecksumEngine generic trait from the public API

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -40,7 +40,6 @@ pub use gax::error::Error;
 pub mod backoff_policy;
 pub mod read_resume_policy;
 pub mod retry_policy;
-pub use crate::storage::checksum;
 pub use crate::storage::streaming_source;
 
 mod control;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod checksum;
+pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -17,7 +17,6 @@ use crate::Error;
 use crate::builder::storage::ReadObject;
 use crate::builder::storage::UploadObject;
 use crate::read_resume_policy::ReadResumePolicy;
-use crate::storage::checksum::details::Crc32c;
 use crate::streaming_source::Payload;
 use auth::credentials::CacheableResource;
 use base64::Engine;
@@ -157,12 +156,7 @@ impl Storage {
     /// * `payload` - the object data.
     ///
     /// [Seek]: crate::streaming_source::Seek
-    pub fn upload_object<B, O, T, P>(
-        &self,
-        bucket: B,
-        object: O,
-        payload: T,
-    ) -> UploadObject<P, Crc32c>
+    pub fn upload_object<B, O, T, P>(&self, bucket: B, object: O, payload: T) -> UploadObject<P>
     where
         B: Into<String>,
         O: Into<String>,

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -15,10 +15,8 @@
 use super::client::{StorageInner, apply_customer_supplied_encryption_headers};
 use crate::model::Object;
 use crate::retry_policy::ContinueOn308;
-use crate::storage::checksum::{
-    ChecksumEngine,
-    details::{ChecksummedSource, Known},
-};
+use crate::storage::checksum::details::ChecksumEnum;
+use crate::storage::checksum::details::{ChecksummedSource, Known};
 use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
 use crate::streaming_source::{IterSource, Seek, SizeHint, StreamingSource};
@@ -35,18 +33,18 @@ mod unbuffered;
 /// `send()` or `send_buffered()` to initiate the upload. At that point the
 /// client library creates an instance of this class. Notably, the `payload`
 /// becomes `Arc<Mutex<T>>` because it needs to be reused in the retry loop.
-pub struct PerformUpload<C, S> {
+pub struct PerformUpload<S> {
     // We need `Arc<Mutex<>>` because this is re-used in retryable uploads.
-    payload: Arc<Mutex<ChecksummedSource<C, S>>>,
+    payload: Arc<Mutex<ChecksummedSource<S>>>,
     inner: Arc<StorageInner>,
     spec: crate::model::WriteObjectSpec,
     params: Option<crate::model::CommonObjectRequestParams>,
     options: super::request_options::RequestOptions,
 }
 
-impl<C, S> PerformUpload<C, S> {
+impl<S> PerformUpload<S> {
     pub(crate) fn new(
-        checksum: C,
+        checksum: ChecksumEnum,
         payload: S,
         inner: Arc<StorageInner>,
         spec: crate::model::WriteObjectSpec,

--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -13,16 +13,15 @@
 // limitations under the License.
 
 use super::{
-    ChecksumEngine, ContinueOn308, Error, Object, PerformUpload, Result, ResumableUploadStatus,
-    Seek, SizeHint, StreamingSource, X_GOOG_API_CLIENT_HEADER,
-    apply_customer_supplied_encryption_headers, handle_object_response, v1,
+    ContinueOn308, Error, Object, PerformUpload, Result, ResumableUploadStatus, Seek, SizeHint,
+    StreamingSource, X_GOOG_API_CLIENT_HEADER, apply_customer_supplied_encryption_headers,
+    handle_object_response, v1,
 };
 use futures::stream::unfold;
 use std::sync::Arc;
 
-impl<C, S> PerformUpload<C, S>
+impl<S> PerformUpload<S>
 where
-    C: ChecksumEngine + Send + Sync + 'static,
     S: StreamingSource + Seek + Send + Sync + 'static,
     <S as StreamingSource>::Error: std::error::Error + Send + Sync + 'static,
     <S as Seek>::Error: std::error::Error + Send + Sync + 'static,


### PR DESCRIPTION
Remove the generic parameters for checksums from the public API. This does open the API to misuse a little easier, since we no longer can limit which setters for the checksum are enabled based on the type.

This is still a WIP, needs a bit of cleanup. 

For #2896 
