### PR TITLE
fix(storage): missing header when resuming uploads

### DIFF
--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -115,6 +115,7 @@ impl<C, S> PerformUpload<C, S> {
             .request(reqwest::Method::PUT, upload_url)
             .header("content-type", "application/octet-stream")
             .header("Content-Range", "bytes */*")
+            .header("content-length", 0)
             .header(
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&X_GOOG_API_CLIENT_HEADER),

--- a/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
@@ -163,7 +163,8 @@ async fn empty_success() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -223,7 +224,8 @@ async fn resumable_empty_unknown() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -301,7 +303,8 @@ async fn empty_csek() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -465,7 +468,8 @@ async fn put_permanent_error() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -511,7 +515,8 @@ async fn put_too_many_transients() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(2)
         .respond_with(status_code(308)),
@@ -588,7 +593,8 @@ async fn put_partial_and_recover() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .respond_with(status_code(308).append_header("range", format!("bytes=0-{}", QUANTUM - 1))),
     );
@@ -642,7 +648,8 @@ async fn put_error_and_finalized() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(cycle![status_code(200).body(response_body().to_string()),]),

--- a/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
@@ -129,7 +129,8 @@ async fn resumable_empty_success() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -189,7 +190,8 @@ async fn resumable_empty_unknown() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -267,7 +269,8 @@ async fn resumable_empty_csek() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -473,7 +476,8 @@ async fn resumable_query_permanent_error() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(2)
         .respond_with(cycle![
@@ -521,7 +525,8 @@ async fn resumable_query_too_many_transients() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(2)
         .respond_with(status_code(429).body("try-again")),
@@ -572,7 +577,8 @@ async fn resumable_put_permanent_error() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", path.clone()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(status_code(308)),
@@ -618,7 +624,8 @@ async fn resumable_put_too_many_transients() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(2)
         .respond_with(status_code(308)),
@@ -678,7 +685,8 @@ async fn resumable_put_partial_and_recover_unknown_size() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(2)
         .respond_with(cycle![
@@ -750,7 +758,8 @@ async fn resumable_put_partial_and_recover_known_size() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(2)
         .respond_with(cycle![
@@ -804,7 +813,8 @@ async fn resumable_put_error_and_finalized() -> Result {
     server.expect(
         Expectation::matching(all_of![
             request::method_path("PUT", session.path().to_string()),
-            request::headers(contains(("content-range", "bytes */*")))
+            request::headers(contains(("content-range", "bytes */*"))),
+            request::headers(contains(("content-length", "0"))),
         ])
         .times(1)
         .respond_with(cycle![status_code(200).body(response_body().to_string()),]),


### PR DESCRIPTION
The `content-length` header was missing query querying the upload
status.

Part of the work for #2909