### PR TITLE
cleanup(storage)!: rename `RecommendedPolicy`

### DIFF
--- a/guide/samples/tests/storage/rewrite_object.rs
+++ b/guide/samples/tests/storage/rewrite_object.rs
@@ -17,7 +17,7 @@ use gcs::Result;
 use gcs::builder::storage_control::RewriteObject;
 use gcs::client::StorageControl;
 use gcs::model::Object;
-use gcs::retry_policy::RecommendedPolicy;
+use gcs::retry_policy::RetryableErrors;
 use google_cloud_gax::retry_policy::RetryPolicyExt as _;
 use google_cloud_storage as gcs;
 
@@ -26,7 +26,7 @@ pub async fn rewrite_object(bucket_name: &str) -> anyhow::Result<()> {
 
     // ANCHOR: client
     let control = StorageControl::builder()
-        .with_retry_policy(RecommendedPolicy.with_attempt_limit(5))
+        .with_retry_policy(RetryableErrors.with_attempt_limit(5))
         .build()
         .await?;
     // ANCHOR_END: client

--- a/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
@@ -430,7 +430,7 @@ async fn start_too_many_transients() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", "")
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_buffered()
         .await
@@ -529,7 +529,7 @@ async fn put_too_many_transients() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", "")
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_buffered()
         .await
@@ -609,7 +609,7 @@ async fn put_partial_and_recover() -> Result {
         .await?;
     let upload = client
         .write_object("projects/_/buckets/test-bucket", "test-object", payload)
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .with_resumable_upload_buffer_size(TARGET);
     let response = upload.send_buffered().await;
@@ -663,7 +663,7 @@ async fn put_error_and_finalized() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", payload)
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_buffered()
         .await?;

--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -697,7 +697,7 @@ mod tests {
             "hello",
         )
         .set_if_generation_match(0)
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .send_unbuffered()
         .await
         .expect_err("expected permanent error");

--- a/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
@@ -442,7 +442,7 @@ async fn resumable_start_too_many_transients() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", "")
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_unbuffered()
         .await
@@ -539,7 +539,7 @@ async fn resumable_query_too_many_transients() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", "")
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_unbuffered()
         .await
@@ -638,7 +638,7 @@ async fn resumable_put_too_many_transients() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", "")
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_unbuffered()
         .await
@@ -707,7 +707,7 @@ async fn resumable_put_partial_and_recover_unknown_size() -> Result {
             "test-object",
             UnknownSize::new(BytesSource::new(payload)),
         )
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_unbuffered()
         .await?;
@@ -776,7 +776,7 @@ async fn resumable_put_partial_and_recover_known_size() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", payload)
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_unbuffered()
         .await?;
@@ -828,7 +828,7 @@ async fn resumable_put_error_and_finalized() -> Result {
         .await?;
     let response = client
         .write_object("projects/_/buckets/test-bucket", "test-object", payload)
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .set_if_generation_match(0_i64)
         .send_unbuffered()
         .await?;

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -311,14 +311,15 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// use google_cloud_storage::retry_policy::RecommendedPolicy;
+    /// use google_cloud_storage::retry_policy::RetryableErrors;
     /// use std::time::Duration;
     /// use gax::retry_policy::RetryPolicyExt;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
-    ///     .with_retry_policy(RecommendedPolicy
-    ///         .with_attempt_limit(5)
-    ///         .with_time_limit(Duration::from_secs(10)),
+    ///     .with_retry_policy(
+    ///         RetryableErrors
+    ///             .with_attempt_limit(5)
+    ///             .with_time_limit(Duration::from_secs(10)),
     ///     )
     ///     .send()
     ///     .await?;

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -143,7 +143,7 @@ async fn start_too_many_transients() -> Result {
         .await?;
     let err = client
         .read_object("projects/_/buckets/test-bucket", "test-object")
-        .with_retry_policy(crate::retry_policy::RecommendedPolicy.with_attempt_limit(3))
+        .with_retry_policy(crate::retry_policy::RetryableErrors.with_attempt_limit(3))
         .send()
         .await
         .expect_err("test generates permanent error");

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -39,7 +39,7 @@ const RESUMABLE_UPLOAD_TARGET_CHUNK: usize = 8 * MIB;
 
 impl RequestOptions {
     pub(crate) fn new() -> Self {
-        let retry_policy = Arc::new(crate::retry_policy::default());
+        let retry_policy = Arc::new(crate::retry_policy::storage_default());
         let backoff_policy = Arc::new(crate::backoff_policy::default());
         let retry_throttler = Arc::new(Mutex::new(AdaptiveThrottler::default()));
         let read_resume_policy = Arc::new(Recommended);

--- a/src/storage/src/storage/write_object.rs
+++ b/src/storage/src/storage/write_object.rs
@@ -603,7 +603,6 @@ impl<T, C> WriteObject<T, C> {
     /// # Example
     /// ```
     /// # use google_cloud_storage::client::Storage;
-    /// # use google_cloud_storage::retry_policy::RecommendedPolicy;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use std::time::Duration;
     /// use gax::retry_policy::RetryPolicyExt;
@@ -628,15 +627,16 @@ impl<T, C> WriteObject<T, C> {
     /// # Example
     /// ```
     /// # use google_cloud_storage::client::Storage;
-    /// # use google_cloud_storage::retry_policy::RecommendedPolicy;
+    /// # use google_cloud_storage::retry_policy::RetryableErrors;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use std::time::Duration;
     /// use gax::retry_policy::RetryPolicyExt;
     /// let response = client
     ///     .write_object("projects/_/buckets/my-bucket", "my-object", "hello world")
-    ///     .with_retry_policy(RecommendedPolicy
-    ///         .with_attempt_limit(5)
-    ///         .with_time_limit(Duration::from_secs(10)),
+    ///     .with_retry_policy(
+    ///         RetryableErrors
+    ///             .with_attempt_limit(5)
+    ///             .with_time_limit(Duration::from_secs(90)),
     ///     )
     ///     .send_buffered()
     ///     .await?;


### PR DESCRIPTION
The name implied that no decorators were needed to use the policy, but
they are. One needs to set limits on the number of retry attempts.

Fixes #2893
