### PR TITLE
refactor(storage)!: Make `ReadObjectResponse` a trait

### DIFF
--- a/guide/samples/tests/storage/quickstart.rs
+++ b/guide/samples/tests/storage/quickstart.rs
@@ -59,6 +59,7 @@ pub async fn quickstart(project_id: &str, bucket_id: &str) -> anyhow::Result<()>
     // ANCHOR_END: upload
 
     // ANCHOR: download
+    use google_cloud_storage::ReadObjectResponse;
     let mut reader = client.read_object(&bucket.name, "hello.txt").send().await?;
     let mut contents = Vec::new();
     while let Some(chunk) = reader.next().await.transpose()? {

--- a/guide/samples/tests/storage/striped.rs
+++ b/guide/samples/tests/storage/striped.rs
@@ -175,6 +175,7 @@ async fn write_stripe(
     writer.seek(std::io::SeekFrom::Start(offset as u64)).await?;
     // ANCHOR_END: write-stripe-seek
     // ANCHOR: write-stripe-reader
+    use google_cloud_storage::ReadObjectResponse;
     let mut reader = client
         .read_object(&metadata.bucket, &metadata.name)
         // ANCHOR_END: write-stripe-reader

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -19,6 +19,7 @@ use gax::paginator::ItemPaginator as _;
 use gax::retry_policy::RetryPolicyExt;
 use lro::Poller;
 use std::time::Duration;
+use storage::ReadObjectResponse;
 use storage::client::StorageControl;
 use storage::model::Bucket;
 use storage::model::bucket::iam_config::UniformBucketLevelAccess;

--- a/src/storage/examples/src/objects/stream_file_download.rs
+++ b/src/storage/examples/src/objects/stream_file_download.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // [START storage_stream_file_download]
-use google_cloud_storage::client::Storage;
 use google_cloud_storage::ReadObjectResponse;
+use google_cloud_storage::client::Storage;
 
 pub async fn sample(client: &Storage, bucket_id: &str) -> anyhow::Result<()> {
     const NAME: &str = "object-to-download.txt";

--- a/src/storage/examples/src/objects/stream_file_download.rs
+++ b/src/storage/examples/src/objects/stream_file_download.rs
@@ -14,6 +14,7 @@
 
 // [START storage_stream_file_download]
 use google_cloud_storage::client::Storage;
+use google_cloud_storage::ReadObjectResponse;
 
 pub async fn sample(client: &Storage, bucket_id: &str) -> anyhow::Result<()> {
     const NAME: &str = "object-to-download.txt";

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -178,6 +178,7 @@ impl Storage {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let mut resp = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -201,6 +201,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .set_read_offset(100)
@@ -214,6 +215,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .set_read_offset(-100)
@@ -227,6 +229,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .set_read_offset(1000)
@@ -256,6 +259,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .set_read_limit(100)
@@ -269,6 +273,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .set_read_offset(1000)
@@ -293,6 +298,7 @@ where
     /// ```
     /// # use google_cloud_storage::{model_ext::KeyAes256, client::Storage};
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let key: &[u8] = &[97; 32];
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
@@ -313,6 +319,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// use google_cloud_storage::retry_policy::RetryableErrors;
     /// use std::time::Duration;
     /// use gax::retry_policy::RetryPolicyExt;
@@ -339,6 +346,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// use std::time::Duration;
     /// use gax::exponential_backoff::ExponentialBackoff;
     /// let response = client
@@ -368,6 +376,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .with_retry_throttler(adhoc_throttler())
@@ -398,6 +407,7 @@ where
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
     /// let response = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
@@ -742,6 +752,7 @@ pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let object = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()
@@ -763,6 +774,7 @@ pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let mut resp = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -32,7 +32,7 @@ use serde_with::DeserializeAs;
 ///
 /// # Example: accumulate the contents of an object into a vector
 /// ```
-/// use google_cloud_storage::{client::Storage, builder::storage::ReadObject};
+/// use google_cloud_storage::{client::Storage, builder::storage::ReadObject, ReadObjectResponse};
 /// async fn sample(client: &Storage) -> anyhow::Result<()> {
 ///     let builder: ReadObject = client.read_object("projects/_/buckets/my-bucket", "my-object");
 ///     let mut reader = builder.send().await?;
@@ -47,7 +47,7 @@ use serde_with::DeserializeAs;
 ///
 /// # Example: read part of an object
 /// ```
-/// use google_cloud_storage::{client::Storage, builder::storage::ReadObject};
+/// use google_cloud_storage::{client::Storage, builder::storage::ReadObject, ReadObjectResponse};
 /// async fn sample(client: &Storage) -> anyhow::Result<()> {
 ///     const MIB: i64 = 1024 * 1024;
 ///     let mut contents = Vec::new();
@@ -104,6 +104,7 @@ impl ReadObject<Crc32c> {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use google_cloud_storage::ReadObjectResponse;
     /// let builder =  client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .compute_md5();
@@ -124,7 +125,7 @@ impl ReadObject<Crc32c> {
 
 impl<C> ReadObject<C>
 where
-    C: Clone + ChecksumEngine + Send,
+    C: Clone + ChecksumEngine + Send + Sync + 'static,
 {
     fn switch_checksum<F, U>(self, new: F) -> ReadObject<U>
     where
@@ -414,9 +415,9 @@ where
     }
 
     /// Sends the request.
-    pub async fn send(self) -> Result<ReadObjectResponse<C>> {
+    pub async fn send(self) -> Result<impl ReadObjectResponse> {
         let read = self.clone().read().await?;
-        ReadObjectResponse::new(self, read)
+        ReadObjectResponseImpl::new(self, read)
     }
 
     async fn read(self) -> Result<reqwest::Response> {
@@ -553,7 +554,7 @@ fn headers_to_md5_hash(headers: &http::HeaderMap) -> Vec<u8> {
 
 /// A response to a [Storage::read_object] request.
 #[derive(Debug)]
-pub struct ReadObjectResponse<C> {
+struct ReadObjectResponseImpl<C> {
     inner: Option<reqwest::Response>,
     highlights: ObjectHighlights,
     // Fields for tracking the crc checksum checks.
@@ -565,7 +566,7 @@ pub struct ReadObjectResponse<C> {
     resume_count: u32,
 }
 
-impl<C> ReadObjectResponse<C>
+impl<C> ReadObjectResponseImpl<C>
 where
     C: ChecksumEngine + Clone + Send,
 {
@@ -621,61 +622,50 @@ where
     }
 }
 
-impl<C> ReadObjectResponse<C>
+impl<C> ReadObjectResponse for ReadObjectResponseImpl<C>
 where
-    C: ChecksumEngine + Clone + Send,
+    C: ChecksumEngine + Clone + Send + Sync + 'static,
 {
-    /// Get the highlights of the object metadata included in the
-    /// response.
-    ///
-    /// To get full metadata about this object, use [crate::client::StorageControl::get_object].
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_storage::client::Storage;
-    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// let object = client
-    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
-    ///     .send()
-    ///     .await?
-    ///     .object();
-    /// println!("object generation={}", object.generation);
-    /// println!("object metageneration={}", object.metageneration);
-    /// println!("object size={}", object.size);
-    /// println!("object content encoding={}", object.content_encoding);
-    /// # Ok(()) }
-    /// ```
-    pub fn object(&self) -> ObjectHighlights {
+    fn object(&self) -> ObjectHighlights {
         self.highlights.clone()
     }
 
-    /// Stream the next bytes of the object.
-    ///
-    /// When the response has been exhausted, this will return None.
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_storage::client::Storage;
-    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// let mut resp = client
-    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
-    ///     .send()
-    ///     .await?;
-    /// while let Some(next) = resp.next().await {
-    ///     println!("next={:?}", next?);
-    /// }
-    /// # Ok(()) }
-    /// ```
-    pub async fn next(&mut self) -> Option<Result<bytes::Bytes>> {
-        match self.next_attempt().await {
-            None => None,
-            Some(Ok(b)) => Some(Ok(b)),
-            // Recursive async requires pin:
-            //     https://rust-lang.github.io/async-book/07_workarounds/04_recursion.html
-            Some(Err(e)) => Box::pin(self.resume(e)).await,
+    // A type-checking cycle is detected with `async fn` when its return type
+    // depends on an opaque type that is defined within the function body.
+    // Writing out `impl Future` breaks this cycle, allowing the compiler to
+    // resolve the return type and proceed.
+    #[allow(clippy::manual_async_fn)]
+    fn next(&mut self) -> impl Future<Output = Option<Result<bytes::Bytes>>> + Send {
+        async move {
+            match self.next_attempt().await {
+                None => None,
+                Some(Ok(b)) => Some(Ok(b)),
+                // Recursive async requires pin:
+                //     https://rust-lang.github.io/async-book/07_workarounds/04_recursion.html
+                Some(Err(e)) => Box::pin(self.resume(e)).await,
+            }
         }
     }
 
+    #[cfg(feature = "unstable-stream")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
+    fn into_stream(self) -> impl Stream<Item = Result<bytes::Bytes>> + Unpin {
+        use futures::stream::unfold;
+        Box::pin(unfold(Some(self), move |state| async move {
+            if let Some(mut this) = state {
+                if let Some(chunk) = this.next().await {
+                    return Some((chunk, Some(this)));
+                }
+            };
+            None
+        }))
+    }
+}
+
+impl<C> ReadObjectResponseImpl<C>
+where
+    C: ChecksumEngine + Clone + Send + Sync + 'static,
+{
     async fn next_attempt(&mut self) -> Option<Result<bytes::Bytes>> {
         let inner = self.inner.as_mut()?;
         let res = inner.chunk().await.map_err(Error::io);
@@ -734,21 +724,60 @@ where
         };
         self.next().await
     }
+}
+
+mod sealed {
+    pub trait ReadObjectResponse {}
+}
+
+impl<T> sealed::ReadObjectResponse for T where T: ReadObjectResponse {}
+
+pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
+    /// Get the highlights of the object metadata included in the
+    /// response.
+    ///
+    /// To get full metadata about this object, use [crate::client::StorageControl::get_object].
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let object = client
+    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
+    ///     .send()
+    ///     .await?
+    ///     .object();
+    /// println!("object generation={}", object.generation);
+    /// println!("object metageneration={}", object.metageneration);
+    /// println!("object size={}", object.size);
+    /// println!("object content encoding={}", object.content_encoding);
+    /// # Ok(()) }
+    /// ```
+    fn object(&self) -> ObjectHighlights;
+
+    /// Stream the next bytes of the object.
+    ///
+    /// When the response has been exhausted, this will return None.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let mut resp = client
+    ///     .read_object("projects/_/buckets/my-bucket", "my-object")
+    ///     .send()
+    ///     .await?;
+    /// while let Some(next) = resp.next().await {
+    ///     println!("next={:?}", next?);
+    /// }
+    /// # Ok(()) }
+    /// ```
+    fn next(&mut self) -> impl Future<Output = Option<Result<bytes::Bytes>>> + Send;
 
     #[cfg(feature = "unstable-stream")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
     /// Convert the response to a [Stream].
-    pub fn into_stream(self) -> impl Stream<Item = Result<bytes::Bytes>> + Unpin {
-        use futures::stream::unfold;
-        Box::pin(unfold(Some(self), move |state| async move {
-            if let Some(mut this) = state {
-                if let Some(chunk) = this.next().await {
-                    return Some((chunk, Some(this)));
-                }
-            };
-            None
-        }))
-    }
+    fn into_stream(self) -> impl Stream<Item = Result<bytes::Bytes>> + Unpin;
 }
 
 /// Returns the object checksums to validate against.

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -53,6 +53,7 @@ use crate::{
     storage::client::tests::{
         MockBackoffPolicy, MockReadResumePolicy, MockRetryPolicy, MockRetryThrottler, test_builder,
     },
+    storage::read_object::ReadObjectResponse,
 };
 use gax::retry_policy::RetryPolicyExt;
 use gax::retry_result::RetryResult;

--- a/src/w1r3/src/main.rs
+++ b/src/w1r3/src/main.rs
@@ -28,6 +28,7 @@ use clap::Parser;
 use google_cloud_auth::credentials::{Builder as CredentialsBuilder, Credentials};
 use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_gax::retry_policy::RetryPolicyExt;
+use google_cloud_storage::ReadObjectResponse;
 use google_cloud_storage::Result as StorageResult;
 use google_cloud_storage::client::{Storage, StorageControl};
 use google_cloud_storage::model::Object;


### PR DESCRIPTION
Fixes #2901, and helps with #2041 

Conflicts with #2907. @suzmue - I am happy to do this in either order. I had to introduce extra guarantees on the `C: ChecksumEngine` to make this work.... but none of that would be necessary if there was no `C` to begin with.