### PR TITLE
fix(storage): correct resumable uploads threshold

### DIFF
--- a/src/w1r3/src/main.rs
+++ b/src/w1r3/src/main.rs
@@ -159,7 +159,7 @@ async fn runner(
         let (write_op, threshold) = if rand::rng().random_bool(0.5) {
             (Operation::Resumable, 0_usize)
         } else {
-            (Operation::SingleShot, size)
+            (Operation::SingleShot, size + 1)
         };
 
         let builder = SampleBuilder::new(&task, iteration, write_op, size, name.clone());


### PR DESCRIPTION
Resumable uploads are enabled for sizes greater than **or equal** to
the threshold. If we want to guarantee single-shot uploads we need to
make the threshold *larger* than the size.

Motivated by #2824