### PR TITLE
fix(w1r3): scale channel with task count

### DIFF
--- a/src/w1r3/src/main.rs
+++ b/src/w1r3/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
             .collect::<Vec<_>>(),
     );
     tracing::info!("random data ready");
-    let (tx, mut rx) = tokio::sync::mpsc::channel(128);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1024 * args.task_count);
     let test_start = Instant::now();
     let tasks = (0..args.task_count)
         .map(|task| {


### PR DESCRIPTION
The more tasks, the more writers to the channel, the more space we need
to avoid blocking the writers.

Part of the work for #2824
