### PR TITLE
feat(storage): better retry policy defaults

### DIFF
--- a/src/storage/src/control/client.rs
+++ b/src/storage/src/control/client.rs
@@ -105,14 +105,22 @@ pub type ClientBuilder =
 
 pub(crate) mod client_builder {
     use super::StorageControl;
+    use std::sync::Arc;
+
     pub struct Factory;
     impl gax::client_builder::internal::ClientFactory for Factory {
         type Client = StorageControl;
         type Credentials = gaxi::options::Credentials;
         async fn build(
             self,
-            config: gaxi::options::ClientConfig,
+            mut config: gaxi::options::ClientConfig,
         ) -> gax::client_builder::Result<Self::Client> {
+            if config.retry_policy.is_none() {
+                config.retry_policy = Some(Arc::new(crate::retry_policy::storage_default()));
+            }
+            if config.backoff_policy.is_none() {
+                config.backoff_policy = Some(Arc::new(crate::backoff_policy::default()));
+            }
             Self::Client::new(config).await
         }
     }

--- a/src/storage/src/retry_policy.rs
+++ b/src/storage/src/retry_policy.rs
@@ -50,7 +50,7 @@ use std::time::Duration;
 /// The client will retry all the errors shown as retryable in the service
 /// documentation, and stop retrying after 10 seconds.
 pub(crate) fn storage_default() -> impl RetryPolicy {
-    RetryableErrors.with_time_limit(Duration::from_secs(10))
+    RetryableErrors.with_time_limit(Duration::from_secs(300))
 }
 
 /// Follows the [retry strategy] recommended by the Cloud Storage service guides.


### PR DESCRIPTION
These values are based on the experiment running one billion requests successfully.