### PR TITLE
refactor(storage)!: `ReadObjectResponse` uses pimpl

### DIFF
--- a/guide/samples/tests/storage/quickstart.rs
+++ b/guide/samples/tests/storage/quickstart.rs
@@ -59,7 +59,6 @@ pub async fn quickstart(project_id: &str, bucket_id: &str) -> anyhow::Result<()>
     // ANCHOR_END: upload
 
     // ANCHOR: download
-    use google_cloud_storage::read_object::ReadObjectResponse;
     let mut reader = client.read_object(&bucket.name, "hello.txt").send().await?;
     let mut contents = Vec::new();
     while let Some(chunk) = reader.next().await.transpose()? {

--- a/guide/samples/tests/storage/striped.rs
+++ b/guide/samples/tests/storage/striped.rs
@@ -177,7 +177,6 @@ async fn write_stripe(
     writer.seek(std::io::SeekFrom::Start(offset)).await?;
     // ANCHOR_END: write-stripe-seek
     // ANCHOR: write-stripe-reader
-    use google_cloud_storage::read_object::ReadObjectResponse;
     let mut reader = client
         .read_object(&metadata.bucket, &metadata.name)
         // ANCHOR_END: write-stripe-reader

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -24,7 +24,6 @@ use storage::model::Bucket;
 use storage::model::bucket::iam_config::UniformBucketLevelAccess;
 use storage::model::bucket::{HierarchicalNamespace, IamConfig};
 use storage::model_ext::KeyAes256;
-use storage::read_object::ReadObjectResponse;
 use storage::streaming_source::{Seek, SizeHint, StreamingSource};
 use storage_samples::cleanup_bucket;
 

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -24,6 +24,7 @@ use storage::model::Bucket;
 use storage::model::bucket::iam_config::UniformBucketLevelAccess;
 use storage::model::bucket::{HierarchicalNamespace, IamConfig};
 use storage::model_ext::KeyAes256;
+use storage::read_object::ReadObjectResponse;
 use storage::streaming_source::{Seek, SizeHint, StreamingSource};
 use storage_samples::cleanup_bucket;
 
@@ -855,10 +856,7 @@ pub async fn ranged_reads(
     Ok(())
 }
 
-async fn read_all<R>(mut response: R) -> Result<Vec<u8>>
-where
-    R: ReadObjectResponse,
-{
+async fn read_all(mut response: ReadObjectResponse) -> Result<Vec<u8>> {
     let mut contents = Vec::new();
     while let Some(b) = response.next().await.transpose()? {
         contents.extend_from_slice(&b);

--- a/src/storage/examples/src/objects/download_byte_range.rs
+++ b/src/storage/examples/src/objects/download_byte_range.rs
@@ -15,7 +15,6 @@
 // [START storage_download_byte_range]
 use google_cloud_storage::client::Storage;
 use google_cloud_storage::model_ext::ReadRange;
-use google_cloud_storage::read_object::ReadObjectResponse;
 
 pub async fn sample(
     client: &Storage,

--- a/src/storage/examples/src/objects/download_encrypted_file.rs
+++ b/src/storage/examples/src/objects/download_encrypted_file.rs
@@ -15,7 +15,6 @@
 // [START storage_download_encrypted_file]
 use google_cloud_storage::client::Storage;
 use google_cloud_storage::model_ext::KeyAes256;
-use google_cloud_storage::read_object::ReadObjectResponse;
 
 pub async fn sample(
     client: &Storage,

--- a/src/storage/examples/src/objects/stream_file_download.rs
+++ b/src/storage/examples/src/objects/stream_file_download.rs
@@ -14,7 +14,6 @@
 
 // [START storage_stream_file_download]
 use google_cloud_storage::client::Storage;
-use google_cloud_storage::read_object::ReadObjectResponse;
 
 pub async fn sample(client: &Storage, bucket_id: &str) -> anyhow::Result<()> {
     const NAME: &str = "object-to-download.txt";

--- a/src/storage/src/read_object.rs
+++ b/src/storage/src/read_object.rs
@@ -25,13 +25,13 @@ use futures::Stream;
 /// also provides an accessor to retrieve the object's metadata.
 #[derive(Debug)]
 pub struct ReadObjectResponse {
-    inner: Box<dyn dynamic::ReadObjectResponse>,
+    inner: Box<dyn dynamic::ReadObjectResponse + Send>,
 }
 
 impl ReadObjectResponse {
     pub(crate) fn new<T>(inner: Box<T>) -> Self
     where
-        T: dynamic::ReadObjectResponse + 'static,
+        T: dynamic::ReadObjectResponse + Send + 'static,
     {
         Self { inner }
     }

--- a/src/storage/src/read_object.rs
+++ b/src/storage/src/read_object.rs
@@ -19,14 +19,23 @@ use crate::model_ext::ObjectHighlights;
 #[cfg(feature = "unstable-stream")]
 use futures::Stream;
 
-mod sealed {
-    pub trait ReadObjectResponse {}
+/// The result of a `ReadObject` request.
+///
+/// Objects can be large, and must be returned as a stream of bytes. This struct
+/// also provides an accessor to retrieve the object's metadata.
+#[derive(Debug)]
+pub struct ReadObjectResponse {
+    inner: Box<dyn dynamic::ReadObjectResponse>,
 }
 
-impl<T> sealed::ReadObjectResponse for T where T: ReadObjectResponse {}
+impl ReadObjectResponse {
+    pub(crate) fn new<T>(inner: Box<T>) -> Self
+    where
+        T: dynamic::ReadObjectResponse + 'static,
+    {
+        Self { inner }
+    }
 
-/// A trait representing the interface to read an object
-pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// Get the highlights of the object metadata included in the
     /// response.
     ///
@@ -36,7 +45,6 @@ pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// use google_cloud_storage::read_object::ReadObjectResponse;
     /// let object = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()
@@ -48,7 +56,9 @@ pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// println!("object content encoding={}", object.content_encoding);
     /// # Ok(()) }
     /// ```
-    fn object(&self) -> ObjectHighlights;
+    pub fn object(&self) -> ObjectHighlights {
+        self.inner.object()
+    }
 
     /// Stream the next bytes of the object.
     ///
@@ -58,7 +68,6 @@ pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// use google_cloud_storage::read_object::ReadObjectResponse;
     /// let mut resp = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()
@@ -68,10 +77,34 @@ pub trait ReadObjectResponse: sealed::ReadObjectResponse + std::fmt::Debug {
     /// }
     /// # Ok(()) }
     /// ```
-    fn next(&mut self) -> impl Future<Output = Option<Result<bytes::Bytes>>> + Send;
+    pub async fn next(&mut self) -> Option<Result<bytes::Bytes>> {
+        self.inner.next().await
+    }
 
     #[cfg(feature = "unstable-stream")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
     /// Convert the response to a [Stream].
-    fn into_stream(self) -> impl Stream<Item = Result<bytes::Bytes>> + Unpin;
+    pub fn into_stream(self) -> impl Stream<Item = Result<bytes::Bytes>> + Unpin {
+        use futures::stream::unfold;
+        Box::pin(unfold(Some(self), move |state| async move {
+            if let Some(mut this) = state {
+                if let Some(chunk) = this.next().await {
+                    return Some((chunk, Some(this)));
+                }
+            };
+            None
+        }))
+    }
+}
+
+pub(crate) mod dynamic {
+    use crate::Result;
+    use crate::model_ext::ObjectHighlights;
+
+    /// A trait representing the interface to read an object
+    #[async_trait::async_trait]
+    pub trait ReadObjectResponse: std::fmt::Debug {
+        fn object(&self) -> ObjectHighlights;
+        async fn next(&mut self) -> Option<Result<bytes::Bytes>>;
+    }
 }

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -172,7 +172,6 @@ impl Storage {
     /// ```
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// use google_cloud_storage::read_object::ReadObjectResponse;
     /// let mut resp = client
     ///     .read_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -50,7 +50,6 @@
 
 use crate::model_ext::ReadRange;
 use crate::{
-    read_object::ReadObjectResponse,
     read_resume_policy::{ReadResumePolicyExt, Recommended},
     storage::client::tests::{
         MockBackoffPolicy, MockReadResumePolicy, MockRetryPolicy, MockRetryThrottler, test_builder,

--- a/src/w1r3/src/main.rs
+++ b/src/w1r3/src/main.rs
@@ -35,7 +35,6 @@ use google_cloud_gax::retry_policy::{RetryPolicy, RetryPolicyExt};
 use google_cloud_storage::Result as StorageResult;
 use google_cloud_storage::client::{Storage, StorageControl};
 use google_cloud_storage::model::Object;
-use google_cloud_storage::read_object::ReadObjectResponse;
 use google_cloud_storage::retry_policy::RetryableErrors;
 use humantime::parse_duration;
 use instrumented_future::Instrumented;


### PR DESCRIPTION
Part of the work for #2041, reverts #2931 

Restore `ReadObjectResponse` to be a concrete object.

Implement it using a pimpl pattern. This will let us inject a fake implementation when we need to mock it as a return type.