### PR TITLE
docs(storage): examples for anywhere cache

### DIFF
--- a/src/storage/examples/src/control/create_anywhere_cache.rs
+++ b/src/storage/examples/src/control/create_anywhere_cache.rs
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_control_create_anywhere_cache]
+use google_cloud_lro::Poller;
+use google_cloud_storage::client::StorageControl;
+use google_cloud_storage::model::AnywhereCache;
+
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    cache_id: &str,
+    zone: &str,
+) -> anyhow::Result<()> {
+    let anywhere_cache = AnywhereCache::new()
+        .set_zone(zone.to_string())
+        .set_admission_policy("ADMIT_ALL".to_string());
+    let operation = client
+        .create_anywhere_cache()
+        .set_parent(format!("projects/_/buckets/{}", bucket_id))
+        .set_anywhere_cache_id(cache_id)
+        .set_anywhere_cache(anywhere_cache)
+        .poller()
+        .until_done()
+        .await?;
+    println!("Created anywhere cache: {:?}", operation);
+    Ok(())
+}
+// [END storage_control_create_anywhere_cache]

--- a/src/storage/examples/src/control/create_anywhere_cache.rs
+++ b/src/storage/examples/src/control/create_anywhere_cache.rs
@@ -17,24 +17,17 @@ use google_cloud_lro::Poller;
 use google_cloud_storage::client::StorageControl;
 use google_cloud_storage::model::AnywhereCache;
 
-pub async fn sample(
-    client: &StorageControl,
-    bucket_id: &str,
-    cache_id: &str,
-    zone: &str,
-) -> anyhow::Result<()> {
-    let anywhere_cache = AnywhereCache::new()
-        .set_zone(zone.to_string())
-        .set_admission_policy("ADMIT_ALL".to_string());
-    let operation = client
+pub async fn sample(client: &StorageControl, bucket_id: &str, zone: &str) -> anyhow::Result<()> {
+    let cache = client
         .create_anywhere_cache()
-        .set_parent(format!("projects/_/buckets/{}", bucket_id))
-        .set_anywhere_cache_id(cache_id)
-        .set_anywhere_cache(anywhere_cache)
+        .set_parent(format!("projects/_/buckets/{bucket_id}"))
+        .set_anywhere_cache(AnywhereCache::new().set_zone(zone).set_name(format!(
+            "projects/_/buckets/{bucket_id}/anywhereCaches/{zone}"
+        )))
         .poller()
         .until_done()
         .await?;
-    println!("Created anywhere cache: {:?}", operation);
+    println!("Created anywhere cache: {cache:?}");
     Ok(())
 }
 // [END storage_control_create_anywhere_cache]

--- a/src/storage/examples/src/control/disable_anywhere_cache.rs
+++ b/src/storage/examples/src/control/disable_anywhere_cache.rs
@@ -12,20 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create_anywhere_cache;
-pub mod create_folder;
-pub mod delete_folder;
-pub mod disable_anywhere_cache;
-pub mod get_anywhere_cache;
-pub mod get_folder;
-pub mod list_anywhere_caches;
-pub mod list_folders;
-pub mod managed_folder_create;
-pub mod managed_folder_delete;
-pub mod managed_folder_get;
-pub mod managed_folder_list;
-pub mod pause_anywhere_cache;
-pub mod quickstart;
-pub mod rename_folder;
-pub mod resume_anywhere_cache;
-pub mod update_anywhere_cache;
+// [START storage_control_disable_anywhere_cache]
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    cache_id: &str,
+) -> anyhow::Result<()> {
+    let cache = client
+        .disable_anywhere_cache()
+        .set_name(format!(
+            "projects/_/buckets/{}/anywhereCaches/{}",
+            bucket_id, cache_id
+        ))
+        .send()
+        .await?;
+    println!("Disabled anywhere cache: {:?}", cache);
+    Ok(())
+}
+// [END storage_control_disable_anywhere_cache]

--- a/src/storage/examples/src/control/get_anywhere_cache.rs
+++ b/src/storage/examples/src/control/get_anywhere_cache.rs
@@ -12,20 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create_anywhere_cache;
-pub mod create_folder;
-pub mod delete_folder;
-pub mod disable_anywhere_cache;
-pub mod get_anywhere_cache;
-pub mod get_folder;
-pub mod list_anywhere_caches;
-pub mod list_folders;
-pub mod managed_folder_create;
-pub mod managed_folder_delete;
-pub mod managed_folder_get;
-pub mod managed_folder_list;
-pub mod pause_anywhere_cache;
-pub mod quickstart;
-pub mod rename_folder;
-pub mod resume_anywhere_cache;
-pub mod update_anywhere_cache;
+// [START storage_control_get_anywhere_cache]
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    cache_id: &str,
+) -> anyhow::Result<()> {
+    let cache = client
+        .get_anywhere_cache()
+        .set_name(format!(
+            "projects/_/buckets/{}/anywhereCaches/{}",
+            bucket_id, cache_id
+        ))
+        .send()
+        .await?;
+    println!("Got anywhere cache: {:?}", cache);
+    Ok(())
+}
+// [END storage_control_get_anywhere_cache]

--- a/src/storage/examples/src/control/get_anywhere_cache.rs
+++ b/src/storage/examples/src/control/get_anywhere_cache.rs
@@ -23,8 +23,7 @@ pub async fn sample(
     let cache = client
         .get_anywhere_cache()
         .set_name(format!(
-            "projects/_/buckets/{}/anywhereCaches/{}",
-            bucket_id, cache_id
+            "projects/_/buckets/{bucket_id}/anywhereCaches/{cache_id}"
         ))
         .send()
         .await?;

--- a/src/storage/examples/src/control/list_anywhere_caches.rs
+++ b/src/storage/examples/src/control/list_anywhere_caches.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START storage_control_list_anywhere_caches]
-
 use google_cloud_gax::paginator::ItemPaginator;
 use google_cloud_storage::client::StorageControl;
 

--- a/src/storage/examples/src/control/list_anywhere_caches.rs
+++ b/src/storage/examples/src/control/list_anywhere_caches.rs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create_anywhere_cache;
-pub mod create_folder;
-pub mod delete_folder;
-pub mod disable_anywhere_cache;
-pub mod get_anywhere_cache;
-pub mod get_folder;
-pub mod list_anywhere_caches;
-pub mod list_folders;
-pub mod managed_folder_create;
-pub mod managed_folder_delete;
-pub mod managed_folder_get;
-pub mod managed_folder_list;
-pub mod pause_anywhere_cache;
-pub mod quickstart;
-pub mod rename_folder;
-pub mod resume_anywhere_cache;
-pub mod update_anywhere_cache;
+// [START storage_control_list_anywhere_caches]
+
+use google_cloud_gax::paginator::ItemPaginator;
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(client: &StorageControl, bucket_id: &str) -> anyhow::Result<()> {
+    let mut stream = client
+        .list_anywhere_caches()
+        .set_parent(format!("projects/_/buckets/{}", bucket_id))
+        .by_item();
+    while let Some(cache) = stream.next().await {
+        println!("Found cache: {:?}", cache?);
+    }
+    Ok(())
+}
+// [END storage_control_list_anywhere_caches]

--- a/src/storage/examples/src/control/pause_anywhere_cache.rs
+++ b/src/storage/examples/src/control/pause_anywhere_cache.rs
@@ -12,20 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create_anywhere_cache;
-pub mod create_folder;
-pub mod delete_folder;
-pub mod disable_anywhere_cache;
-pub mod get_anywhere_cache;
-pub mod get_folder;
-pub mod list_anywhere_caches;
-pub mod list_folders;
-pub mod managed_folder_create;
-pub mod managed_folder_delete;
-pub mod managed_folder_get;
-pub mod managed_folder_list;
-pub mod pause_anywhere_cache;
-pub mod quickstart;
-pub mod rename_folder;
-pub mod resume_anywhere_cache;
-pub mod update_anywhere_cache;
+// [START storage_control_pause_anywhere_cache]
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    cache_id: &str,
+) -> anyhow::Result<()> {
+    let cache = client
+        .pause_anywhere_cache()
+        .set_name(format!(
+            "projects/_/buckets/{}/anywhereCaches/{}",
+            bucket_id, cache_id
+        ))
+        .send()
+        .await?;
+    println!("Paused anywhere cache: {:?}", cache);
+    Ok(())
+}
+// [END storage_control_pause_anywhere_cache]

--- a/src/storage/examples/src/control/pause_anywhere_cache.rs
+++ b/src/storage/examples/src/control/pause_anywhere_cache.rs
@@ -23,8 +23,7 @@ pub async fn sample(
     let cache = client
         .pause_anywhere_cache()
         .set_name(format!(
-            "projects/_/buckets/{}/anywhereCaches/{}",
-            bucket_id, cache_id
+            "projects/_/buckets/{bucket_id}/anywhereCaches/{cache_id}"
         ))
         .send()
         .await?;

--- a/src/storage/examples/src/control/resume_anywhere_cache.rs
+++ b/src/storage/examples/src/control/resume_anywhere_cache.rs
@@ -12,20 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create_anywhere_cache;
-pub mod create_folder;
-pub mod delete_folder;
-pub mod disable_anywhere_cache;
-pub mod get_anywhere_cache;
-pub mod get_folder;
-pub mod list_anywhere_caches;
-pub mod list_folders;
-pub mod managed_folder_create;
-pub mod managed_folder_delete;
-pub mod managed_folder_get;
-pub mod managed_folder_list;
-pub mod pause_anywhere_cache;
-pub mod quickstart;
-pub mod rename_folder;
-pub mod resume_anywhere_cache;
-pub mod update_anywhere_cache;
+// [START storage_control_resume_anywhere_cache]
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    cache_id: &str,
+) -> anyhow::Result<()> {
+    let cache = client
+        .resume_anywhere_cache()
+        .set_name(format!(
+            "projects/_/buckets/{}/anywhereCaches/{}",
+            bucket_id, cache_id
+        ))
+        .send()
+        .await?;
+    println!("Resumed anywhere cache: {:?}", cache);
+    Ok(())
+}
+// [END storage_control_resume_anywhere_cache]

--- a/src/storage/examples/src/control/update_anywhere_cache.rs
+++ b/src/storage/examples/src/control/update_anywhere_cache.rs
@@ -28,7 +28,7 @@ pub async fn sample(
             "projects/_/buckets/{}/anywhereCaches/{}",
             bucket_id, cache_id
         ))
-        .set_admission_policy("ADMIT_ALL".to_string());
+        .set_admission_policy("ADMIT_ON_SECOND_MISS".to_string());
     let operation = client
         .update_anywhere_cache()
         .set_anywhere_cache(anywhere_cache)

--- a/src/storage/examples/src/control/update_anywhere_cache.rs
+++ b/src/storage/examples/src/control/update_anywhere_cache.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_control_update_anywhere_cache]
+use google_cloud_lro::Poller;
+use google_cloud_storage::client::StorageControl;
+use google_cloud_storage::model::AnywhereCache;
+use google_cloud_wkt::FieldMask;
+
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    cache_id: &str,
+) -> anyhow::Result<()> {
+    let anywhere_cache = AnywhereCache::new()
+        .set_name(format!(
+            "projects/_/buckets/{}/anywhereCaches/{}",
+            bucket_id, cache_id
+        ))
+        .set_admission_policy("ADMIT_ALL".to_string());
+    let operation = client
+        .update_anywhere_cache()
+        .set_anywhere_cache(anywhere_cache)
+        .set_update_mask(FieldMask::default().set_paths(["admission_policy"]))
+        .poller()
+        .until_done()
+        .await?;
+    println!("Updated anywhere cache: {:?}", operation);
+    Ok(())
+}
+// [END storage_control_update_anywhere_cache]

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -30,6 +30,64 @@ use std::time::Duration;
 
 pub const BUCKET_ID_LENGTH: usize = 63;
 
+pub async fn run_anywhere_cache_examples(buckets: &mut Vec<String>) -> anyhow::Result<()> {
+    use google_cloud_storage::model::{
+        Bucket,
+        bucket::iam_config::UniformBucketLevelAccess,
+        bucket::{HierarchicalNamespace, IamConfig},
+    };
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    let client = control_client().await?;
+    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+
+    let id = random_bucket_id();
+    buckets.push(id.clone());
+    let zone = "us-central1-f";
+    tracing::info!("Create bucket for anywhere cache examples");
+    let _bucket = client
+        .create_bucket()
+        .set_parent("projects/_")
+        .set_bucket_id(&id)
+        .set_bucket(
+            Bucket::new()
+                .set_project(format!("projects/{project_id}"))
+                .set_location("us-central1")
+                .set_hierarchical_namespace(HierarchicalNamespace::new().set_enabled(true))
+                .set_iam_config(IamConfig::new().set_uniform_bucket_level_access(
+                    UniformBucketLevelAccess::new().set_enabled(true),
+                )),
+        )
+        .send()
+        .await?;
+
+    tracing::info!("running control_create_anywhere_cache");
+    control::create_anywhere_cache::sample(&client, &id, zone).await?;
+    tracing::info!("running control_get_anywhere_cache");
+    control::get_anywhere_cache::sample(&client, &id, zone).await?;
+    tracing::info!("running control_list_anywhere_caches");
+    control::list_anywhere_caches::sample(&client, &id).await?;
+    tracing::info!("running control_pause_anywhere_caches");
+    control::pause_anywhere_cache::sample(&client, &id, zone).await?;
+    tracing::info!("running control_resume_anywhere_caches");
+    control::resume_anywhere_cache::sample(&client, &id, zone).await?;
+    tracing::info!("running control_update_anywhere_caches");
+    control::update_anywhere_cache::sample(&client, &id, zone).await?;
+    tracing::info!("running control_disable_anywhere_caches");
+    control::disable_anywhere_cache::sample(&client, &id, zone).await?;
+
+    Ok(())
+}
+
 pub async fn run_bucket_examples(buckets: &mut Vec<String>) -> anyhow::Result<()> {
     let _guard = {
         use tracing_subscriber::fmt::format::FmtSpan;
@@ -42,33 +100,7 @@ pub async fn run_bucket_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
         tracing::subscriber::set_default(subscriber)
     };
 
-    // Avoid creating more than one bucket every 2 seconds:
-    //     https://cloud.google.com/storage/quotas
-    const BUCKET_CREATION_DELAY: Duration = Duration::from_secs(2);
-    // Avoid mutating a bucket more than once per second:
-    //     https://cloud.google.com/storage/quotas
-    const BUCKET_MUTATION_DELAY: Duration = Duration::from_secs(1);
-
-    // Use a longer than normal initial backoff, to better handle rate limit
-    // errors.
-    let backoff = ExponentialBackoffBuilder::new()
-        .with_initial_delay(std::cmp::max(BUCKET_CREATION_DELAY, BUCKET_MUTATION_DELAY))
-        .with_maximum_delay(Duration::from_secs(60))
-        .build()?;
-
-    let client = StorageControl::builder()
-        .with_backoff_policy(backoff)
-        .with_retry_policy(
-            // Retry all errors, the examples are tested with on newly created
-            // buckets, using a static configuration. Most likely the errors are
-            // network problems and can be safely retried. Or at least, we will
-            // get fewer flakes from retrying failures vs. not.
-            RetryableErrors
-                .with_time_limit(Duration::from_secs(900))
-                .always_idempotent(),
-        )
-        .build()
-        .await?;
+    let client = control_client().await?;
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
     let service_account = std::env::var("GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT")?;
 
@@ -208,7 +240,7 @@ pub async fn run_managed_folder_examples(buckets: &mut Vec<String>) -> anyhow::R
         tracing::subscriber::set_default(subscriber)
     };
 
-    let client = StorageControl::builder().build().await?;
+    let client = control_client().await?;
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
 
     let id = random_bucket_id();
@@ -262,7 +294,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
         tracing::subscriber::set_default(subscriber)
     };
 
-    let control = StorageControl::builder().build().await?;
+    let control = control_client().await?;
     let client = Storage::builder().build().await?;
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
 
@@ -320,6 +352,37 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     control::delete_folder::sample(&control, &id).await?;
 
     Ok(())
+}
+
+async fn control_client() -> anyhow::Result<StorageControl> {
+    // Avoid creating more than one bucket every 2 seconds:
+    //     https://cloud.google.com/storage/quotas
+    const BUCKET_CREATION_DELAY: Duration = Duration::from_secs(2);
+    // Avoid mutating a bucket more than once per second:
+    //     https://cloud.google.com/storage/quotas
+    const BUCKET_MUTATION_DELAY: Duration = Duration::from_secs(1);
+
+    // Use a longer than normal initial backoff, to better handle rate limit
+    // errors.
+    let backoff = ExponentialBackoffBuilder::new()
+        .with_initial_delay(std::cmp::max(BUCKET_CREATION_DELAY, BUCKET_MUTATION_DELAY))
+        .with_maximum_delay(Duration::from_secs(60))
+        .build()?;
+
+    let control = StorageControl::builder()
+        .with_backoff_policy(backoff)
+        .with_retry_policy(
+            // Retry all errors, the examples are tested with on newly created
+            // buckets, using a static configuration. Most likely the errors are
+            // network problems and can be safely retried. Or at least, we will
+            // get fewer flakes from retrying failures vs. not.
+            RetryableErrors
+                .with_time_limit(Duration::from_secs(900))
+                .always_idempotent(),
+        )
+        .build()
+        .await?;
+    Ok(control)
 }
 
 async fn make_object(client: &Storage, bucket_id: &str, name: &str) -> anyhow::Result<Object> {

--- a/src/storage/examples/tests/integration.rs
+++ b/src/storage/examples/tests/integration.rs
@@ -17,6 +17,20 @@ mod tests {
     use google_cloud_storage::client::StorageControl;
     use storage_samples::*;
 
+    #[cfg(feature = "skipped-integration-tests")]
+    #[tokio::test]
+    async fn anywhere_cache_examples() -> anyhow::Result<()> {
+        let client = StorageControl::builder().build().await?;
+
+        let mut buckets = Vec::new();
+        let result = run_anywhere_cache_examples(&mut buckets).await;
+        // Ignore cleanup errors.
+        for id in buckets.into_iter() {
+            let _ = cleanup_bucket(client.clone(), format!("projects/_/buckets/{id}")).await;
+        }
+        result
+    }
+
     #[tokio::test]
     async fn bucket_examples() -> anyhow::Result<()> {
         let client = StorageControl::builder().build().await?;


### PR DESCRIPTION
These examples are disabled by default, they are too slow for CI. But we can
run them manually if something breaks.

Fixes #3035, fixes #3036, fixes #3037, fixes #3038, fixes #3039, fixes #3040, and fixes #3041
