### PR TITLE
fix: workload identity federation service account impersonation

### DIFF
--- a/src/auth/src/credentials/external_account_sources/file_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/file_sourced.rs
@@ -34,7 +34,12 @@ pub(crate) struct FileSourcedCredentials {
 impl FileSourcedCredentials {
     pub(crate) fn new(file: String, format_source: Option<CredentialSourceFormat>) -> Self {
         let (format, subject_token_field_name) = format_source
-            .map(|f| (f.format_type, f.subject_token_field_name))
+            .map(|f| {
+                (
+                    f.format_type,
+                    f.subject_token_field_name.unwrap_or_default(),
+                )
+            })
             .unwrap_or(("text".to_string(), String::new()));
         Self {
             file,

--- a/src/auth/src/credentials/external_account_sources/url_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/url_sourced.rs
@@ -42,7 +42,12 @@ impl UrlSourcedCredentials {
         format_source: Option<CredentialSourceFormat>,
     ) -> Self {
         let (format, subject_token_field_name) = format_source
-            .map(|f| (f.format_type, f.subject_token_field_name))
+            .map(|f| {
+                (
+                    f.format_type,
+                    f.subject_token_field_name.unwrap_or_default(),
+                )
+            })
             .unwrap_or(("text".to_string(), String::new()));
         Self {
             url,


### PR DESCRIPTION
Howdy folks, I came across https://github.com/googleapis/google-cloud-rust/issues/1342 and wanted to test, but wasn't able to get service account impersonation working; attempted patching it here. We've tested this works for us.

This pull request improves how external account credentials are parsed and handled, particularly for Kubernetes Workload Identity Federation (WIF) scenarios. The main focus is on making the `subject_token_field_name` optional, setting sensible defaults, and enhancing test coverage for Kubernetes identity configurations.

**Parsing and struct improvements:**

* Made the `subject_token_field_name` field in `CredentialSourceFormat` optional (`Option<String>`) to allow for configurations where it may be omitted.
* Updated construction logic in both `FileSourcedCredentials` and `UrlSourcedCredentials` to use an empty string as the default value for `subject_token_field_name` when not provided. [[1]](diffhunk://#diff-aeb4d0e86f16c6fe270b6e0a4d99a576b4bbb5dda53d80614694e936612d191dL37-R37) [[2]](diffhunk://#diff-1c1521b5f83d83d8f96a2609e7c133c887ed4c6cee713cb08b41ddb4bd6c3293L45-R45)

**Enum and test enhancements:**

* Reordered variants in the `CredentialSourceFile` enum to ensure correct deserialization for untagged enums, prioritizing the `Executable` variant.
* Added new tests for Kubernetes WIF direct identity and impersonation config parsing, verifying correct defaulting and field extraction for file-sourced credentials.