### PR TITLE
docs(user-guide): improve list operations guide

### DIFF
--- a/guide/samples/src/pagination.rs
+++ b/guide/samples/src/pagination.rs
@@ -17,7 +17,9 @@
 use google_cloud_gax as gax;
 
 pub async fn paginator_iterate_pages(project_id: &str) -> crate::Result<()> {
+    // ANCHOR: paginator-use
     use google_cloud_gax::paginator::Paginator as _;
+    // ANCHOR_END: paginator-use
     use google_cloud_gax::retry_policy::AlwaysRetry;
     use google_cloud_gax::retry_policy::RetryPolicyExt;
     use google_cloud_secretmanager_v1 as secret_manager;
@@ -87,9 +89,9 @@ pub async fn paginator_stream_pages(project_id: &str) -> crate::Result<()> {
 }
 
 pub async fn paginator_iterate_items(project_id: &str) -> crate::Result<()> {
-    // ANCHOR: paginator-use
+    // ANCHOR: item-paginator-use
     use google_cloud_gax::paginator::ItemPaginator as _;
-    // ANCHOR_END: paginator-use
+    // ANCHOR_END: item-paginator-use
     use google_cloud_gax::retry_policy::AlwaysRetry;
     use google_cloud_gax::retry_policy::RetryPolicyExt;
     use google_cloud_secretmanager_v1 as secret_manager;
@@ -119,8 +121,10 @@ pub async fn paginator_iterate_items(project_id: &str) -> crate::Result<()> {
 }
 
 pub async fn paginator_stream_items(project_id: &str) -> crate::Result<()> {
+    // ANCHOR: paginator-stream-items-use
     use futures::stream::StreamExt;
     use google_cloud_gax::paginator::ItemPaginator as _;
+    // ANCHOR_END: paginator-stream-items-use
     use google_cloud_gax::retry_policy::AlwaysRetry;
     use google_cloud_gax::retry_policy::RetryPolicyExt;
     use google_cloud_secretmanager_v1 as secret_manager;

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -31,7 +31,7 @@ limitations under the License.
 - [Error handling](error_handling.md)
 - [Examine error details](examine_error_details.md)
 - [Handling binding errors](binding_errors.md)
-- [Working with List operations](pagination.md)
+- [Working with list operations](pagination.md)
 - [Working with long-running operations](working_with_long_running_operations.md)
 - [Configuring polling policies](configuring_polling_policies.md)
 - [How to write tests using a client](mock_a_client.md)

--- a/guide/src/pagination.md
+++ b/guide/src/pagination.md
@@ -131,8 +131,8 @@ token to resume paginating from a specific page.
 
 The standard [Google API List] method follows the pagination guideline defined
 by [AIP-158]. Each call to a `List` method for a resource returns a page of
-resource items (e.g. secrets) along with a next-page token that can be passed
-to the `List` method to retrieve the next page.
+resource items (e.g. secrets) along with a next-page token that can be passed to
+the `List` method to retrieve the next page.
 
 The Google Cloud Client Libraries for Rust provide an adapter to convert the
 list RPCs as defined by [AIP-4233] into a streams that can be iterated over in

--- a/guide/src/pagination.md
+++ b/guide/src/pagination.md
@@ -14,61 +14,69 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Working with List operations
+# Working with list operations
 
 Some services return potentially large lists of items, such as rows or resource
 descriptions. To keep CPU and memory usage under control, services return these
 resources in `pages`: smaller subsets of the items with a continuation token to
 request the next subset.
 
-Iterating over items in this way can be tedious. The client libraries provide
-adapters to convert the pages into asynchronous iterators. This guide will show
-you how to work with these adapters.
+Iterating over items by page can be tedious. The client libraries provide
+adapters to convert the pages into asynchronous iterators. This guide shows you
+how to work with these adapters.
 
 ## Prerequisites
 
-The guide uses the [Secret Manager] service. That makes the examples more
-concrete and therefore easier to follow. With that said, the same ideas work for
-any other service.
+This guide uses the [Secret Manager] service to demonstrate list operations, but
+the concepts apply to other services as well.
 
-You may want to follow the service [quickstart]. This guide will walk you
-through the steps necessary to enable the service, ensure you have logged in,
-and that your account has the necessary permissions.
+You may want to follow the service [quickstart], which shows you how to enable
+the service and ensure that you've logged in and that your account has the
+necessary permissions.
+
+For complete setup instructions for the Rust libraries, see
+[Setting up your development environment].
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
-file. We use:
+Add the Secret Manager library to your `Cargo.toml` file:
 
 ```shell
 cargo add google-cloud-secretmanager-v1
 ```
 
-## Iterating List methods
+## Iterating list methods
 
 To help iterate the items in a list method, the APIs return an implementation of
-the `Paginator` trait. We need to introduce it in scope via a `use` declaration:
+the `ItemPaginator` trait. Introduce it into scope via a `use` declaration:
 
 ```rust,ignore
-{{#include ../samples/src/pagination.rs:paginator-use}}
+{{#include ../samples/src/pagination.rs:item-paginator-use}}
 ```
 
-To iterate the items, we use the provided Paginator `items` function.
+To iterate the items, use the `by_item` function.
 
 ```rust,ignore
 {{#include ../samples/src/pagination.rs:paginator-iterate-items}}
 ```
 
-In rare cases, pages contain extra information outside of the items that you may
-need access to. Or you may need to checkpoint your progress across processes. In
-these cases, you can do so by iterating over the full pages instead of the
-individual items.
+In rare cases, pages might contain extra information that you need access to. Or
+you may need to checkpoint your progress across processes. In these cases, you
+can iterate over full pages instead of individual items.
+
+First introduce `Paginator` into scope via a `use` declaration:
+
+```rust,ignore
+{{#include ../samples/src/pagination.rs:paginator-use}}
+```
+
+Then iterate over the pages using `by_page`:
 
 ```rust,ignore
 {{#include ../samples/src/pagination.rs:paginator-iterate-pages}}
 ```
 
-### Working with futures::Stream
+### Working with `futures::Stream`
 
 You may want to use these APIs in the larger Rust ecosystem of asynchronous
 streams, such as `tokio::Stream`. This is readily done, but you must first
@@ -83,30 +91,36 @@ unstable, because they are! You should only use them if you are prepared to deal
 with any breaks that result from incompatible changes to the
 [`futures::Stream`][future-stub] trait.
 
-The examples will also use the `futures::stream::StreamExt` trait, so we must
-add the crate that defines it.
+The following examples also use the `futures::stream::StreamExt` trait, which
+you enable by adding the `futures` crate.
 
 ```shell
 cargo add futures
 ```
 
-We use the `into_stream` function to convert the Paginator into a
+Add the requred `use` declarations:
+
+```rust,ignore
+{{#include ../samples/src/pagination.rs:paginator-stream-items-use}}
+```
+
+Then use the `into_stream` function to convert `ItemPaginator` into a
 `futures::Stream` of items.
 
 ```rust,ignore
 {{#include ../samples/src/pagination.rs:paginator-stream-items}}
 ```
 
-Similarly, we can use the `into_stream` function to convert the Paginator into
+Similarly, you can use the `into_stream` function to convert `Paginator` into a
 `futures::Stream` of pages.
 
 ```rust,ignore
 {{#include ../samples/src/pagination.rs:paginator-stream-pages}}
 ```
 
-## Resuming List methods by setting next page token
+## Resuming list methods by setting next page token
 
-In some cases such as an interrupted List operation, we can set the next page
+In some cases, such as an interrupted list operation, you can set the next page
 token to resume paginating from a specific page.
 
 ```rust,ignore
@@ -115,17 +129,28 @@ token to resume paginating from a specific page.
 
 ## Additional paginator technical details
 
-The standard Google API List method follows the pagination guideline defined by
-[AIP-158]. Each call to a List method for a resource returns a "page" of
-resource items (e.g. Secrets) along with a "next-page token" that can be passed
-to the List method to retrieve the next page.
+The standard [Google API List] method follows the pagination guideline defined
+by [AIP-158]. Each call to a `List` method for a resource returns a page of
+resource items (e.g. secrets) along with a next-page token that can be passed
+to the `List` method to retrieve the next page.
 
 The Google Cloud Client Libraries for Rust provide an adapter to convert the
 list RPCs as defined by [AIP-4233] into a streams that can be iterated over in
 an async fashion.
 
+## What's next
+
+Learn more about working with the Cloud Client Libraries for Rust:
+
+- [Working with long-running operations]
+- [Configuring polling policies]
+
 [aip-158]: https://google.aip.dev/158
 [aip-4233]: https://google.aip.dev/client-libraries/4233
+[configuring polling policies]: configuring_polling_policies.md
 [future-stub]: https://docs.rs/futures/latest/futures/stream/
+[google api list]: https://google.aip.dev/132
 [quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
 [secret manager]: https://cloud.google.com/secret-manager
+[setting up your development environment]: setting_up_your_development_environment.md
+[working with long-running operations]: working_with_long_running_operations.md

--- a/guide/src/pagination.md
+++ b/guide/src/pagination.md
@@ -98,7 +98,7 @@ you enable by adding the `futures` crate.
 cargo add futures
 ```
 
-Add the requred `use` declarations:
+Add the required `use` declarations:
 
 ```rust,ignore
 {{#include ../samples/src/pagination.rs:paginator-stream-items-use}}


### PR DESCRIPTION
* Updated "Prerequisites" to match other updated guides that use Secret Manager.
* Updated first example (iterating over items) to mention `ItemPaginator` and `by_item`. It looks like an older version of the guide showed `Paginator` and `items`, and the code got updated but not the text.
* Updated second example (iterating over pages) to show how to bring `Paginator` into scope and to mention `by_page`.
* Documented `use` statement for streaming example.
* Made various nitty style updates, including user "list" instead of "List", unless we're talking about the API operation.
* Add two "What's next" links.