### PR TITLE
refactor(storage): Checksum as an option

### DIFF
--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -15,7 +15,7 @@
 use super::client::{StorageInner, apply_customer_supplied_encryption_headers};
 use crate::model::Object;
 use crate::retry_policy::ContinueOn308;
-use crate::storage::checksum::details::{Checksum, ChecksummedSource};
+use crate::storage::checksum::details::ChecksummedSource;
 use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
 use crate::streaming_source::{IterSource, Seek, SizeHint, StreamingSource};
@@ -43,13 +43,13 @@ pub struct PerformUpload<S> {
 
 impl<S> PerformUpload<S> {
     pub(crate) fn new(
-        checksum: Checksum,
         payload: S,
         inner: Arc<StorageInner>,
         spec: crate::model::WriteObjectSpec,
         params: Option<crate::model::CommonObjectRequestParams>,
         options: super::request_options::RequestOptions,
     ) -> Self {
+        let checksum = options.checksum.clone();
         Self {
             payload: Arc::new(Mutex::new(ChecksummedSource::new(checksum, payload))),
             inner,

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::read_resume_policy::{ReadResumePolicy, Recommended};
+use crate::storage::checksum::details::{Checksum, Crc32c};
 use gax::{
     backoff_policy::BackoffPolicy,
     retry_policy::RetryPolicy,
@@ -22,13 +23,14 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub(crate) struct RequestOptions {
-    pub retry_policy: Arc<dyn RetryPolicy>,
-    pub backoff_policy: Arc<dyn BackoffPolicy>,
-    pub retry_throttler: SharedRetryThrottler,
-    pub read_resume_policy: Arc<dyn ReadResumePolicy>,
-    pub resumable_upload_threshold: usize,
-    pub resumable_upload_buffer_size: usize,
-    pub idempotency: Option<bool>,
+    pub(crate) retry_policy: Arc<dyn RetryPolicy>,
+    pub(crate) backoff_policy: Arc<dyn BackoffPolicy>,
+    pub(crate) retry_throttler: SharedRetryThrottler,
+    pub(crate) read_resume_policy: Arc<dyn ReadResumePolicy>,
+    pub(crate) resumable_upload_threshold: usize,
+    pub(crate) resumable_upload_buffer_size: usize,
+    pub(crate) idempotency: Option<bool>,
+    pub(crate) checksum: Checksum,
 }
 
 const MIB: usize = 1024 * 1024_usize;
@@ -51,6 +53,10 @@ impl RequestOptions {
             resumable_upload_threshold: RESUMABLE_UPLOAD_THRESHOLD,
             resumable_upload_buffer_size: RESUMABLE_UPLOAD_TARGET_CHUNK,
             idempotency: None,
+            checksum: Checksum {
+                crc32c: Some(Crc32c::default()),
+                md5_hash: None,
+            },
         }
     }
 }


### PR DESCRIPTION
Part of the work for #2041 

Fold `Checksum` into `RequestOptions`. This means we do not need to include `Checksum` as a parameter in the stub signatures.

The `RequestOptions` could/should hold an enum representing the checksum config that only gets turned into an engine when the engine is actually needed. We can do that later.

Also while we are here, make all the fields of `RequestOptions` crate-private. This gives us leeway to change the types if we make `RequestOptions` public.