### PR TITLE
impl(storage): introduce stub interface

### DIFF
--- a/src/gax-internal/src/unimplemented.rs
+++ b/src/gax-internal/src/unimplemented.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub const UNIMPLEMENTED: &str = concat!(
+    "to prevent breaking changes as services gain new RPCs, the stub ",
+    "traits provide default implementations of each method. In the client ",
+    "libraries, all implementations of the traits override all methods. ",
+    "Therefore, this error should not appear in normal code using the ",
+    "client libraries. The only expected context for this error is test ",
+    "code mocking the client libraries. If that is how you got this ",
+    "error, verify that you have mocked all methods used in your test. ",
+    "Otherwise, please open a bug at ",
+    "https://github.com/googleapis/google-cloud-rust/issues"
+);
+
 pub async fn unimplemented_stub<T: Send>() -> gax::Result<gax::response::Response<T>> {
-    unimplemented!(concat!(
-        "to prevent breaking changes as services gain new RPCs, the stub ",
-        "traits provide default implementations of each method. In the client ",
-        "libraries, all implementations of the traits override all methods. ",
-        "Therefore, this error should not appear in normal code using the ",
-        "client libraries. The only expected context for this error is test ",
-        "code mocking the client libraries. If that is how you got this ",
-        "error, verify that you have mocked all methods used in your test. ",
-        "Otherwise, please open a bug at ",
-        "https://github.com/googleapis/google-cloud-rust/issues"
-    ));
+    unimplemented!("{UNIMPLEMENTED}");
 }

--- a/src/storage/src/model_ext.rs
+++ b/src/storage/src/model_ext.rs
@@ -293,6 +293,16 @@ enum Range {
     Segment { offset: u64, limit: u64 },
 }
 
+/// Represents the parameters of a `WriteObject` request
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+// TODO(#2041) - make public
+#[allow(dead_code)]
+pub(crate) struct WriteObjectRequest {
+    pub spec: crate::model::WriteObjectSpec,
+    pub params: Option<crate::model::CommonObjectRequestParams>,
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,6 +18,9 @@ pub(crate) mod perform_upload;
 pub(crate) mod read_object;
 pub(crate) mod request_options;
 pub mod streaming_source;
+// TODO(#2041) - make the stub public
+#[allow(dead_code)]
+pub(crate) mod stub;
 pub(crate) mod v1;
 pub(crate) mod write_object;
 

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::model::{Object, ReadObjectRequest};
+use crate::model_ext::WriteObjectRequest;
+use crate::read_object::ReadObjectResponse;
+use crate::storage::request_options::RequestOptions;
+use crate::streaming_source::{Seek, StreamingSource};
+
+/// Defines the trait used to implement [crate::client::Storage].
+///
+/// Application developers may need to implement this trait to mock
+/// `client::Storage`. In other use-cases, application developers only
+/// use `client::Storage` and need not be concerned with this trait or
+/// its implementations.
+///
+/// Services gain new RPCs routinely. Consequently, this trait gains new methods
+/// too. To avoid breaking applications the trait provides a default
+/// implementation of each method. Most of these implementations just return an
+/// error.
+pub trait Storage: std::fmt::Debug + Send + Sync {
+    /// Implements [crate::client::Storage::read_object].
+    fn read_object(
+        &self,
+        _req: ReadObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<ReadObjectResponse>> + Send {
+        unimplemented_stub::<ReadObjectResponse>()
+    }
+    /// Implements [crate::client::Storage::write_object].
+    fn write_object_buffered<P>(
+        &self,
+        _payload: P,
+        _req: WriteObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<Object>> + Send
+    where
+        P: StreamingSource + Send + Sync + 'static,
+    {
+        unimplemented_stub::<Object>()
+    }
+    /// Implements [crate::client::Storage::write_object].
+    fn write_object_unbuffered<P>(
+        &self,
+        _payload: P,
+        _req: WriteObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<Object>> + Send
+    where
+        P: StreamingSource + Seek + Send + Sync + 'static,
+    {
+        unimplemented_stub::<Object>()
+    }
+}
+
+async fn unimplemented_stub<T>() -> gax::Result<T> {
+    unimplemented!(concat!(
+        "to prevent breaking changes as services gain new RPCs, the stub ",
+        "traits provide default implementations of each method. In the client ",
+        "libraries, all implementations of the traits override all methods. ",
+        "Therefore, this error should not appear in normal code using the ",
+        "client libraries. The only expected context for this error is test ",
+        "code mocking the client libraries. If that is how you got this ",
+        "error, verify that you have mocked all methods used in your test. ",
+        "Otherwise, please open a bug at ",
+        "https://github.com/googleapis/google-cloud-rust/issues"
+    ));
+}

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -18,6 +18,7 @@ use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::request_options::RequestOptions;
 use crate::streaming_source::{Seek, StreamingSource};
+use gaxi::unimplemented::UNIMPLEMENTED;
 
 /// Defines the trait used to implement [crate::client::Storage].
 ///
@@ -66,15 +67,5 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
 }
 
 async fn unimplemented_stub<T>() -> gax::Result<T> {
-    unimplemented!(concat!(
-        "to prevent breaking changes as services gain new RPCs, the stub ",
-        "traits provide default implementations of each method. In the client ",
-        "libraries, all implementations of the traits override all methods. ",
-        "Therefore, this error should not appear in normal code using the ",
-        "client libraries. The only expected context for this error is test ",
-        "code mocking the client libraries. If that is how you got this ",
-        "error, verify that you have mocked all methods used in your test. ",
-        "Otherwise, please open a bug at ",
-        "https://github.com/googleapis/google-cloud-rust/issues"
-    ));
+    unimplemented!("{UNIMPLEMENTED}");
 }


### PR DESCRIPTION
Part of the work for #2041 

My plan is to
- put the stub in place
- introduce the `transport::Storage` stub and implement `read_object` with it
- implement `write_object` with the `transport::Storage` stub
- plumb the `transport::Storage` stub from the client to the builders
- replace the `transport::Storage` stub with a generic `T: crate::stub::Storage`
- add the `client::Storage::from_stub()` and mock tests. Make sure everything that needs to be public is public.

We could template the client and the builders with a placeholder earlier.