### PR TITLE
feat(storage): request types for mocking

### DIFF
--- a/src/storage/src/generated/gapic/.sidekick.toml
+++ b/src/storage/src/generated/gapic/.sidekick.toml
@@ -47,8 +47,4 @@ package-name-override     = 'google-cloud-storage'
 name-overrides            = '.google.storage.v2.Storage=StorageControl'
 include-grpc-only-methods = 'true'
 has-veneer                = 'true'
-internal-types            = """\
-    .google.storage.v2.ReadObjectRequest,\
-    .google.storage.v2.WriteObjectSpec\
-    """
 routing-required          = 'true'

--- a/src/storage/src/generated/gapic/model.rs
+++ b/src/storage/src/generated/gapic/model.rs
@@ -3957,7 +3957,7 @@ impl std::fmt::Debug for RestoreObjectRequest {
 /// Request message for ReadObject.
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub(crate) struct ReadObjectRequest {
+pub struct ReadObjectRequest {
     /// Required. The name of the bucket containing the object to read.
     pub bucket: std::string::String,
 
@@ -5235,7 +5235,7 @@ impl std::fmt::Debug for GetObjectRequest {
 /// Describes an attempt to insert an object, possibly over multiple requests.
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub(crate) struct WriteObjectSpec {
+pub struct WriteObjectSpec {
     /// Required. Destination object, including its name and its metadata.
     pub resource: std::option::Option<crate::model::Object>,
 


### PR DESCRIPTION
Part of the work for #2041 

These request types will factor into our mock interfaces. We need to make them public.