### PR TITLE
DO NOT REVIEW feat(storage): mocking for write_object

### DIFF
--- a/src/storage/src/generated/gapic/.sidekick.toml
+++ b/src/storage/src/generated/gapic/.sidekick.toml
@@ -47,8 +47,4 @@ package-name-override     = 'google-cloud-storage'
 name-overrides            = '.google.storage.v2.Storage=StorageControl'
 include-grpc-only-methods = 'true'
 has-veneer                = 'true'
-internal-types            = """\
-    .google.storage.v2.ReadObjectRequest,\
-    .google.storage.v2.WriteObjectSpec\
-    """
 routing-required          = 'true'

--- a/src/storage/src/generated/gapic/model.rs
+++ b/src/storage/src/generated/gapic/model.rs
@@ -3957,7 +3957,7 @@ impl std::fmt::Debug for RestoreObjectRequest {
 /// Request message for ReadObject.
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub(crate) struct ReadObjectRequest {
+pub struct ReadObjectRequest {
     /// Required. The name of the bucket containing the object to read.
     pub bucket: std::string::String,
 
@@ -5235,7 +5235,7 @@ impl std::fmt::Debug for GetObjectRequest {
 /// Describes an attempt to insert an object, possibly over multiple requests.
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub(crate) struct WriteObjectSpec {
+pub struct WriteObjectSpec {
     /// Required. Destination object, including its name and its metadata.
     pub resource: std::option::Option<crate::model::Object>,
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -41,6 +41,7 @@ pub mod backoff_policy;
 pub mod read_object;
 pub mod read_resume_policy;
 pub mod retry_policy;
+pub use crate::storage::request_options;
 pub use crate::storage::streaming_source;
 
 mod control;
@@ -69,7 +70,10 @@ pub mod error;
 /// The messages and enums that are part of this client library.
 pub use crate::control::model;
 pub mod model_ext;
-pub use crate::control::stub;
+pub mod stub {
+    pub use crate::control::stub::*;
+    pub use crate::storage::stub::*;
+}
 
 #[allow(dead_code)]
 pub(crate) mod generated;

--- a/src/storage/src/model_ext.rs
+++ b/src/storage/src/model_ext.rs
@@ -293,12 +293,11 @@ enum Range {
     Segment { offset: u64, limit: u64 },
 }
 
-/// Represents the parameters of a `WriteObject` request
+/// Represents the parameters of a `WriteObject` request for use in mocks
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
-// TODO(#2041) - make public
 #[allow(dead_code)]
-pub(crate) struct WriteObjectRequest {
+pub struct WriteObjectRequest {
     pub spec: crate::model::WriteObjectSpec,
     pub params: Option<crate::model::CommonObjectRequestParams>,
 }

--- a/src/storage/src/model_ext.rs
+++ b/src/storage/src/model_ext.rs
@@ -293,6 +293,16 @@ enum Range {
     Segment { offset: u64, limit: u64 },
 }
 
+/// Represents the parameters of a `WriteObject` request
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+// TODO(#2041) - make public
+#[allow(dead_code)]
+pub(crate) struct WriteObjectRequest {
+    pub spec: crate::model::WriteObjectSpec,
+    pub params: Option<crate::model::CommonObjectRequestParams>,
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -16,10 +16,9 @@ pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;
-pub(crate) mod request_options;
+pub mod request_options;
 pub mod streaming_source;
-// TODO(#2041) - make the stub public
-pub(crate) mod stub;
+pub mod stub;
 pub(crate) mod transport;
 pub(crate) mod v1;
 pub(crate) mod write_object;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -19,8 +19,8 @@ pub(crate) mod read_object;
 pub(crate) mod request_options;
 pub mod streaming_source;
 // TODO(#2041) - make the stub public
-#[allow(dead_code)]
 pub(crate) mod stub;
+pub(crate) mod transport;
 pub(crate) mod v1;
 pub(crate) mod write_object;
 

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,6 +18,9 @@ pub(crate) mod perform_upload;
 pub(crate) mod read_object;
 pub(crate) mod request_options;
 pub mod streaming_source;
+// TODO(#2041) - make the stub public
+#[allow(dead_code)]
+pub(crate) mod stub;
 pub(crate) mod v1;
 pub(crate) mod write_object;
 

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -121,6 +121,20 @@ impl<S> Storage<S>
 where
     S: crate::storage::stub::Storage + 'static,
 {
+    /// Creates a new client from the provided stub.
+    ///
+    /// The most common case for calling this function is in tests mocking the
+    /// client's behavior.
+    pub fn from_stub(stub: S) -> Self
+    where
+        S: super::stub::Storage + 'static,
+    {
+        Self {
+            stub: std::sync::Arc::new(stub),
+            options: RequestOptions::new(),
+        }
+    }
+
     /// Write an object using a local buffer.
     ///
     /// If the data source does **not** implement [Seek] the client library must

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -15,7 +15,7 @@
 use super::client::{StorageInner, apply_customer_supplied_encryption_headers};
 use crate::model::Object;
 use crate::retry_policy::ContinueOn308;
-use crate::storage::checksum::details::{Checksum, ChecksummedSource};
+use crate::storage::checksum::details::ChecksummedSource;
 use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
 use crate::streaming_source::{IterSource, Seek, SizeHint, StreamingSource};
@@ -43,13 +43,13 @@ pub struct PerformUpload<S> {
 
 impl<S> PerformUpload<S> {
     pub(crate) fn new(
-        checksum: Checksum,
         payload: S,
         inner: Arc<StorageInner>,
         spec: crate::model::WriteObjectSpec,
         params: Option<crate::model::CommonObjectRequestParams>,
         options: super::request_options::RequestOptions,
     ) -> Self {
+        let checksum = options.checksum.clone();
         Self {
             payload: Arc::new(Mutex::new(ChecksummedSource::new(checksum, payload))),
             inner,

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -256,7 +256,9 @@ mod tests {
     #[tokio::test]
     async fn test_percent_encoding_object_name(want: &str) -> Result {
         let inner = test_inner_client(test_builder());
-        let builder = WriteObject::new(inner.clone(), "projects/_/buckets/bucket", want, "hello");
+        let options = inner.options.clone();
+        let stub = crate::storage::transport::Storage::new(inner.clone());
+        let builder = WriteObject::new(stub, "projects/_/buckets/bucket", want, "hello", options);
         let request = perform_upload(inner, builder)
             .start_resumable_upload_request()
             .await?

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -237,6 +237,7 @@ mod single_shot_tests;
 mod tests {
     use crate::builder::storage::WriteObject;
     use crate::storage::client::tests::{test_builder, test_inner_client};
+    use crate::storage::perform_upload::tests::perform_upload;
     use test_case::test_case;
 
     type Result = anyhow::Result<()>;
@@ -255,8 +256,8 @@ mod tests {
     #[tokio::test]
     async fn test_percent_encoding_object_name(want: &str) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = WriteObject::new(inner, "projects/_/buckets/bucket", want, "hello")
-            .build()
+        let builder = WriteObject::new(inner.clone(), "projects/_/buckets/bucket", want, "hello");
+        let request = perform_upload(inner, builder)
             .start_resumable_upload_request()
             .await?
             .build()?;

--- a/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
@@ -728,8 +728,7 @@ async fn start_resumable_upload_request_retry_options() -> Result {
         .with_retry_policy(retry.with_attempt_limit(3))
         .with_backoff_policy(backoff)
         .with_retry_throttler(throttler)
-        .build()
-        .send_buffered_resumable(SizeHint::default())
+        .send_buffered()
         .await
         .expect_err("request should fail after 3 retry attempts");
     assert_eq!(err.http_status_code(), Some(503), "{err:?}");

--- a/src/storage/src/storage/perform_upload/tests.rs
+++ b/src/storage/src/storage/perform_upload/tests.rs
@@ -53,11 +53,14 @@ pub(crate) fn perform_upload<T>(
 #[tokio::test]
 async fn start_resumable_upload() -> Result {
     let inner = test_inner_client(test_builder());
+    let options = inner.options.clone();
+    let stub = crate::storage::transport::Storage::new(inner.clone());
     let builder = WriteObject::new(
-        inner.clone(),
+        stub,
         "projects/_/buckets/bucket",
         "object",
         "hello",
+        options,
     );
     let mut request = perform_upload(inner, builder)
         .start_resumable_upload_request()
@@ -82,11 +85,14 @@ async fn start_resumable_upload_headers() -> Result {
     let (key, key_base64, _, key_sha256_base64) = create_key_helper();
 
     let inner = test_inner_client(test_builder());
+    let options = inner.options.clone();
+    let stub = crate::storage::transport::Storage::new(inner.clone());
     let builder = WriteObject::new(
-        inner.clone(),
+        stub,
         "projects/_/buckets/bucket",
         "object",
         "hello",
+        options,
     )
     .set_key(KeyAes256::new(&key)?);
     let request = perform_upload(inner, builder)
@@ -118,7 +124,9 @@ async fn start_resumable_upload_headers() -> Result {
 #[tokio::test]
 async fn start_resumable_upload_bad_bucket() -> Result {
     let inner = test_inner_client(test_builder());
-    let builder = WriteObject::new(inner.clone(), "malformed", "object", "hello");
+    let options = inner.options.clone();
+    let stub = crate::storage::transport::Storage::new(inner.clone());
+    let builder = WriteObject::new(stub, "malformed", "object", "hello", options);
     let _ = perform_upload(inner, builder)
         .start_resumable_upload_request()
         .await
@@ -130,7 +138,9 @@ async fn start_resumable_upload_bad_bucket() -> Result {
 async fn start_resumable_upload_metadata_in_request() -> Result {
     use crate::model::ObjectAccessControl;
     let inner = test_inner_client(test_builder());
-    let builder = WriteObject::new(inner.clone(), "projects/_/buckets/bucket", "object", "")
+    let options = inner.options.clone();
+    let stub = crate::storage::transport::Storage::new(inner.clone());
+    let builder = WriteObject::new(stub, "projects/_/buckets/bucket", "object", "", options)
         .set_if_generation_match(10)
         .set_if_generation_not_match(20)
         .set_if_metageneration_match(30)
@@ -213,11 +223,14 @@ async fn start_resumable_upload_credentials() -> Result {
     let inner = test_inner_client(
         test_builder().with_credentials(auth::credentials::testing::error_credentials(false)),
     );
+    let options = inner.options.clone();
+    let stub = crate::storage::transport::Storage::new(inner.clone());
     let builder = WriteObject::new(
-        inner.clone(),
+        stub,
         "projects/_/buckets/bucket",
         "object",
         "hello",
+        options,
     );
     let _ = perform_upload(inner, builder)
         .start_resumable_upload_request()

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -62,7 +62,7 @@ use serde_with::DeserializeAs;
 /// ```
 #[derive(Clone, Debug)]
 pub struct ReadObject {
-    inner: std::sync::Arc<StorageInner>,
+    stub: std::sync::Arc<crate::storage::transport::Storage>,
     request: crate::model::ReadObjectRequest,
     options: super::request_options::RequestOptions,
 }
@@ -75,7 +75,7 @@ impl ReadObject {
     {
         let options = inner.options.clone();
         ReadObject {
-            inner,
+            stub: crate::storage::transport::Storage::new(inner),
             request: crate::model::ReadObjectRequest::new()
                 .set_bucket(bucket)
                 .set_object(object),
@@ -352,11 +352,20 @@ impl ReadObject {
 
     /// Sends the request.
     pub async fn send(self) -> Result<ReadObjectResponse> {
-        let read = self.clone().read().await?;
-        let inner = ReadObjectResponseImpl::new(self, read)?;
-        Ok(ReadObjectResponse::new(Box::new(inner)))
+        use crate::storage::stub::Storage;
+        self.stub.read_object(self.request, self.options).await
     }
+}
 
+// A convenience struct that saves the request conditions and performs the read.
+#[derive(Clone, Debug)]
+pub(crate) struct Reader {
+    pub inner: std::sync::Arc<StorageInner>,
+    pub request: crate::model::ReadObjectRequest,
+    pub options: super::request_options::RequestOptions,
+}
+
+impl Reader {
     async fn read(self) -> Result<reqwest::Response> {
         let throttler = self.options.retry_throttler.clone();
         let retry = self.options.retry_policy.clone();
@@ -496,26 +505,29 @@ fn headers_to_md5_hash(headers: &http::HeaderMap) -> Vec<u8> {
 
 /// A response to a [Storage::read_object] request.
 #[derive(Debug)]
-struct ReadObjectResponseImpl {
-    inner: Option<reqwest::Response>,
+pub(crate) struct ReadObjectResponseImpl {
+    reader: Reader,
+    response: Option<reqwest::Response>,
     highlights: ObjectHighlights,
     // Fields for tracking the crc checksum checks.
     response_checksums: ObjectChecksums,
     // Fields for resuming a read request.
     range: ReadRange,
     generation: i64,
-    builder: ReadObject,
     resume_count: u32,
 }
 
 impl ReadObjectResponseImpl {
-    fn new(builder: ReadObject, inner: reqwest::Response) -> Result<Self> {
-        let full = builder.request.read_offset == 0 && builder.request.read_limit == 0;
-        let response_checksums = checksums_from_response(full, inner.status(), inner.headers());
-        let range = response_range(&inner).map_err(Error::deser)?;
-        let generation = response_generation(&inner).map_err(Error::deser)?;
+    pub(crate) async fn new(reader: Reader) -> Result<Self> {
+        let response = reader.clone().read().await?;
 
-        let headers = inner.headers();
+        let full = reader.request.read_offset == 0 && reader.request.read_limit == 0;
+        let response_checksums =
+            checksums_from_response(full, response.status(), response.headers());
+        let range = response_range(&response).map_err(Error::deser)?;
+        let generation = response_generation(&response).map_err(Error::deser)?;
+
+        let headers = response.headers();
         let get_as_i64 = |header_name: &str| -> i64 {
             headers
                 .get(header_name)
@@ -548,14 +560,14 @@ impl ReadObjectResponseImpl {
         };
 
         Ok(Self {
-            inner: Some(inner),
+            reader,
+            response: Some(response),
             highlights,
             // Fields for computing checksums.
             response_checksums,
             // Fields for resuming a read request.
             range,
             generation,
-            builder,
             resume_count: 0,
         })
     }
@@ -580,11 +592,11 @@ impl crate::read_object::dynamic::ReadObjectResponse for ReadObjectResponseImpl 
 
 impl ReadObjectResponseImpl {
     async fn next_attempt(&mut self) -> Option<Result<bytes::Bytes>> {
-        let inner = self.inner.as_mut()?;
-        let res = inner.chunk().await.map_err(Error::io);
+        let response = self.response.as_mut()?;
+        let res = response.chunk().await.map_err(Error::io);
         match res {
             Ok(Some(chunk)) => {
-                self.builder
+                self.reader
                     .options
                     .checksum
                     .update(self.range.start, &chunk);
@@ -603,7 +615,7 @@ impl ReadObjectResponseImpl {
                 if self.range.limit != 0 {
                     return Some(Err(Error::io(ReadError::ShortRead(self.range.limit))));
                 }
-                let computed = self.builder.options.checksum.finalize();
+                let computed = self.reader.options.checksum.finalize();
                 let res = validate(&self.response_checksums, &Some(computed));
                 match res {
                     Err(e) => Some(Err(Error::deser(ReadError::ChecksumMismatch(e)))),
@@ -619,11 +631,11 @@ impl ReadObjectResponseImpl {
         use crate::read_resume_policy::{ResumeQuery, ResumeResult};
 
         // The existing read is no longer valid.
-        self.inner = None;
+        self.response = None;
         self.resume_count += 1;
         let query = ResumeQuery::new(self.resume_count);
         match self
-            .builder
+            .reader
             .options
             .read_resume_policy
             .on_error(&query, error)
@@ -632,10 +644,10 @@ impl ReadObjectResponseImpl {
             ResumeResult::Permanent(e) => return Some(Err(e)),
             ResumeResult::Exhausted(e) => return Some(Err(e)),
         };
-        self.builder.request.read_offset = self.range.start as i64;
-        self.builder.request.read_limit = self.range.limit as i64;
-        self.builder.request.generation = self.generation;
-        self.inner = match self.builder.clone().read().await {
+        self.reader.request.read_offset = self.range.start as i64;
+        self.reader.request.read_limit = self.range.limit as i64;
+        self.reader.request.generation = self.generation;
+        self.response = match self.reader.clone().read().await {
             Ok(r) => Some(r),
             Err(e) => return Some(Err(e)),
         };
@@ -759,9 +771,22 @@ mod tests {
     use httptest::{Expectation, Server, matchers::*, responders::status_code};
     use std::collections::HashMap;
     use std::error::Error;
+    use std::sync::Arc;
     use test_case::test_case;
 
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    async fn http_request_builder(
+        inner: Arc<StorageInner>,
+        builder: ReadObject,
+    ) -> crate::Result<reqwest::RequestBuilder> {
+        let reader = Reader {
+            inner,
+            request: builder.request,
+            options: builder.options,
+        };
+        reader.http_request_builder().await
+    }
 
     // Verify `read_object()` meets normal Send, Sync, requirements.
     #[tokio::test]
@@ -1138,10 +1163,8 @@ mod tests {
     #[tokio::test]
     async fn read_object() -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object");
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
@@ -1156,8 +1179,8 @@ mod tests {
         let inner = test_inner_client(
             test_builder().with_credentials(auth::credentials::testing::error_credentials(false)),
         );
-        let _ = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .http_request_builder()
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object");
+        let _ = http_request_builder(inner, builder)
             .await
             .inspect_err(|e| assert!(e.is_authentication()))
             .expect_err("invalid credentials should err");
@@ -1167,8 +1190,8 @@ mod tests {
     #[tokio::test]
     async fn read_object_bad_bucket() -> Result {
         let inner = test_inner_client(test_builder());
-        ReadObject::new(inner, "malformed", "object")
-            .http_request_builder()
+        let builder = ReadObject::new(inner.clone(), "malformed", "object");
+        let _ = http_request_builder(inner, builder)
             .await
             .expect_err("malformed bucket string should error");
         Ok(())
@@ -1177,15 +1200,13 @@ mod tests {
     #[tokio::test]
     async fn read_object_query_params() -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object")
             .set_generation(5)
             .set_if_generation_match(10)
             .set_if_generation_not_match(20)
             .set_if_metageneration_match(30)
-            .set_if_metageneration_not_match(40)
-            .http_request_builder()
-            .await?
-            .build()?;
+            .set_if_metageneration_not_match(40);
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         let want_pairs: HashMap<String, String> = [
@@ -1216,11 +1237,9 @@ mod tests {
 
         // The API takes the unencoded byte array.
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .set_key(KeyAes256::new(&key)?)
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object")
+            .set_key(KeyAes256::new(&key)?);
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
@@ -1251,11 +1270,9 @@ mod tests {
     #[tokio::test]
     async fn range_header(input: ReadRange, want: Option<&http::HeaderValue>) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .set_read_range(input.clone())
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object")
+            .set_read_range(input.clone());
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
@@ -1282,10 +1299,8 @@ mod tests {
     #[tokio::test]
     async fn test_percent_encoding_object_name(name: &str, want: &str) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", name)
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", name);
+        let request = http_request_builder(inner, builder).await?.build()?;
         let got = request.url().path_segments().unwrap().next_back().unwrap();
         assert_eq!(got, want);
         Ok(())

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -62,15 +62,21 @@ use serde_with::DeserializeAs;
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct ReadObject {
-    stub: std::sync::Arc<crate::storage::transport::Storage>,
+pub struct ReadObject<S = crate::storage::transport::Storage>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    stub: std::sync::Arc<S>,
     request: crate::model::ReadObjectRequest,
     options: RequestOptions,
 }
 
-impl ReadObject {
+impl<S> ReadObject<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
     pub(crate) fn new<B, O>(
-        stub: std::sync::Arc<crate::storage::transport::Storage>,
+        stub: std::sync::Arc<S>,
         bucket: B,
         object: O,
         options: RequestOptions,
@@ -357,7 +363,6 @@ impl ReadObject {
 
     /// Sends the request.
     pub async fn send(self) -> Result<ReadObjectResponse> {
-        use crate::storage::stub::Storage;
         self.stub.read_object(self.request, self.options).await
     }
 }

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -22,7 +22,7 @@ use gax::{
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
-pub(crate) struct RequestOptions {
+pub struct RequestOptions {
     pub(crate) retry_policy: Arc<dyn RetryPolicy>,
     pub(crate) backoff_policy: Arc<dyn BackoffPolicy>,
     pub(crate) retry_throttler: SharedRetryThrottler,

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::read_resume_policy::{ReadResumePolicy, Recommended};
+use crate::storage::checksum::details::{Checksum, Crc32c};
 use gax::{
     backoff_policy::BackoffPolicy,
     retry_policy::RetryPolicy,
@@ -22,13 +23,14 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub(crate) struct RequestOptions {
-    pub retry_policy: Arc<dyn RetryPolicy>,
-    pub backoff_policy: Arc<dyn BackoffPolicy>,
-    pub retry_throttler: SharedRetryThrottler,
-    pub read_resume_policy: Arc<dyn ReadResumePolicy>,
-    pub resumable_upload_threshold: usize,
-    pub resumable_upload_buffer_size: usize,
-    pub idempotency: Option<bool>,
+    pub(crate) retry_policy: Arc<dyn RetryPolicy>,
+    pub(crate) backoff_policy: Arc<dyn BackoffPolicy>,
+    pub(crate) retry_throttler: SharedRetryThrottler,
+    pub(crate) read_resume_policy: Arc<dyn ReadResumePolicy>,
+    pub(crate) resumable_upload_threshold: usize,
+    pub(crate) resumable_upload_buffer_size: usize,
+    pub(crate) idempotency: Option<bool>,
+    pub(crate) checksum: Checksum,
 }
 
 const MIB: usize = 1024 * 1024_usize;
@@ -51,6 +53,10 @@ impl RequestOptions {
             resumable_upload_threshold: RESUMABLE_UPLOAD_THRESHOLD,
             resumable_upload_buffer_size: RESUMABLE_UPLOAD_TARGET_CHUNK,
             idempotency: None,
+            checksum: Checksum {
+                crc32c: Some(Crc32c::default()),
+                md5_hash: None,
+            },
         }
     }
 }

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::model::{Object, ReadObjectRequest};
+use crate::model_ext::WriteObjectRequest;
+use crate::read_object::ReadObjectResponse;
+use crate::storage::request_options::RequestOptions;
+use crate::streaming_source::{Seek, StreamingSource};
+
+/// Defines the trait used to implement [crate::client::Storage].
+///
+/// Application developers may need to implement this trait to mock
+/// `client::Storage`. In other use-cases, application developers only
+/// use `client::Storage` and need not be concerned with this trait or
+/// its implementations.
+///
+/// Services gain new RPCs routinely. Consequently, this trait gains new methods
+/// too. To avoid breaking applications the trait provides a default
+/// implementation of each method. Most of these implementations just return an
+/// error.
+pub trait Storage: std::fmt::Debug + Send + Sync {
+    /// Implements [crate::client::Storage::read_object].
+    fn read_object(
+        &self,
+        _req: ReadObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<ReadObjectResponse>> + Send {
+        unimplemented_stub::<ReadObjectResponse>()
+    }
+    /// Implements [crate::client::Storage::write_object].
+    fn write_object_buffered<P>(
+        &self,
+        _payload: P,
+        _req: WriteObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<Object>> + Send
+    where
+        P: StreamingSource + Send + Sync + 'static,
+    {
+        unimplemented_stub::<Object>()
+    }
+    /// Implements [crate::client::Storage::write_object].
+    fn write_object_unbuffered<P>(
+        &self,
+        _payload: P,
+        _req: WriteObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<Object>> + Send
+    where
+        P: StreamingSource + Seek + Send + Sync + 'static,
+    {
+        unimplemented_stub::<Object>()
+    }
+}
+
+async fn unimplemented_stub<T>() -> gax::Result<T> {
+    unimplemented!(concat!(
+        "to prevent breaking changes as services gain new RPCs, the stub ",
+        "traits provide default implementations of each method. In the client ",
+        "libraries, all implementations of the traits override all methods. ",
+        "Therefore, this error should not appear in normal code using the ",
+        "client libraries. The only expected context for this error is test ",
+        "code mocking the client libraries. If that is how you got this ",
+        "error, verify that you have mocked all methods used in your test. ",
+        "Otherwise, please open a bug at ",
+        "https://github.com/googleapis/google-cloud-rust/issues"
+    ));
+}

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -40,6 +40,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         unimplemented_stub::<ReadObjectResponse>()
     }
     /// Implements [crate::client::Storage::write_object].
+    #[allow(dead_code)] // TODO(#2041) - implement writes
     fn write_object_buffered<P>(
         &self,
         _payload: P,
@@ -52,6 +53,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         unimplemented_stub::<Object>()
     }
     /// Implements [crate::client::Storage::write_object].
+    #[allow(dead_code)] // TODO(#2041) - implement writes
     fn write_object_unbuffered<P>(
         &self,
         _payload: P,

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::model::ReadObjectRequest;
+use crate::read_object::ReadObjectResponse;
+use crate::storage::client::StorageInner;
+use crate::storage::read_object::{ReadObjectResponseImpl, Reader};
+use crate::storage::request_options::RequestOptions;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct Storage {
+    inner: Arc<StorageInner>,
+}
+
+impl super::stub::Storage for Storage {
+    async fn read_object(
+        &self,
+        req: ReadObjectRequest,
+        options: RequestOptions,
+    ) -> Result<ReadObjectResponse> {
+        let reader = Reader {
+            inner: self.inner.clone(),
+            request: req,
+            options,
+        };
+        let inner = ReadObjectResponseImpl::new(reader).await?;
+        Ok(ReadObjectResponse::new(Box::new(inner)))
+    }
+}
+
+// This is the actual class impl
+impl Storage {
+    pub fn new(inner: Arc<StorageInner>) -> Arc<Self> {
+        Arc::new(Self { inner })
+    }
+}

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -75,7 +75,7 @@ impl super::stub::Storage for Storage {
 
 // This is the actual class impl
 impl Storage {
-    pub fn new(inner: Arc<StorageInner>) -> Arc<Self> {
+    pub(crate) fn new(inner: Arc<StorageInner>) -> Arc<Self> {
         Arc::new(Self { inner })
     }
 }

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 use crate::Result;
-use crate::model::ReadObjectRequest;
+use crate::model::{Object, ReadObjectRequest};
+use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
+use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::{ReadObjectResponseImpl, Reader};
 use crate::storage::request_options::RequestOptions;
+use crate::storage::streaming_source::{Seek, StreamingSource};
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
@@ -38,6 +41,35 @@ impl super::stub::Storage for Storage {
         };
         let inner = ReadObjectResponseImpl::new(reader).await?;
         Ok(ReadObjectResponse::new(Box::new(inner)))
+    }
+
+    /// Implements [crate::client::Storage::write_object].
+    async fn write_object_buffered<P>(
+        &self,
+        payload: P,
+        req: WriteObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object>
+    where
+        P: StreamingSource + Send + Sync + 'static,
+    {
+        PerformUpload::new(payload, self.inner.clone(), req.spec, req.params, options)
+            .send()
+            .await
+    }
+    /// Implements [crate::client::Storage::write_object].
+    async fn write_object_unbuffered<P>(
+        &self,
+        payload: P,
+        req: WriteObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object>
+    where
+        P: StreamingSource + Seek + Send + Sync + 'static,
+    {
+        PerformUpload::new(payload, self.inner.clone(), req.spec, req.params, options)
+            .send_unbuffered()
+            .await
     }
 }
 


### PR DESCRIPTION
I am just seeing if the builds pass.

The only thing left would be to make `ReadObjectResponse` constructible. I did that in a dev branch: https://github.com/googleapis/google-cloud-rust/compare/main...dbolduc:google-cloud-rust:try-concrete-stub?expand=1