### PR TITLE
ci: create KMS resources for integration tests

### DIFF
--- a/.gcb/builds/main.tf
+++ b/.gcb/builds/main.tf
@@ -35,9 +35,10 @@ module "services" {
 
 # Create the resources we will need to run integration tests on.
 module "resources" {
-  source  = "./resources"
-  project = var.project
-  region  = var.region
+  source     = "./resources"
+  project    = var.project
+  region     = var.region
+  depends_on = [module.services]
 }
 
 # Create the service account needed for GCB and grant it the necessary

--- a/.gcb/builds/resources/main.tf
+++ b/.gcb/builds/resources/main.tf
@@ -58,6 +58,31 @@ resource "google_firestore_database" "default" {
   type        = "FIRESTORE_NATIVE"
 }
 
+# Create a KMS Key Ring and key for the storage sample tests.
+resource "google_kms_key_ring" "us-central1" {
+  name     = "us-central1"
+  location = "us-central1"
+}
+
+# A crypto key for the storage examples.
+resource "google_kms_crypto_key" "storage-examples" {
+  name     = "storage-examples"
+  key_ring = google_kms_key_ring.us-central1.id
+  # Rotate every 10 days
+  rotation_period = "864000s"
+}
+
+# Get the service account for Cloud Storage in the current project.
+data "google_storage_project_service_account" "gcs-account" {
+}
+
+# Grant Google Cloud Storage (in the project) permissions to use the example key.
+resource "google_kms_crypto_key_iam_member" "storage-examples" {
+  crypto_key_id = google_kms_crypto_key.storage-examples.id
+  role          = "roles/cloudkms.cryptoKeyEncrypter"
+  member        = "serviceAccount:${data.google_storage_project_service_account.gcs-account.email_address}"
+}
+
 output "build-cache" {
   value = resource.google_storage_bucket.build-cache.id
 }

--- a/.gcb/builds/services/main.tf
+++ b/.gcb/builds/services/main.tf
@@ -50,6 +50,18 @@ resource "google_project_service" "firestore" {
   disable_dependent_services = true
 }
 
+resource "google_project_service" "kms" {
+  project = var.project
+  service = "kms.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}
+
 resource "google_project_service" "secretmanager" {
   project = var.project
   service = "secretmanager.googleapis.com"

--- a/.gcb/builds/services/main.tf
+++ b/.gcb/builds/services/main.tf
@@ -52,7 +52,7 @@ resource "google_project_service" "firestore" {
 
 resource "google_project_service" "kms" {
   project = var.project
-  service = "kms.googleapis.com"
+  service = "cloudkms.googleapis.com"
 
   timeouts {
     create = "30m"


### PR DESCRIPTION
The integration tests for the storage examples will require a KMS crypto
key, which in turns lives in a KMS key ring. And we need the storage
service account to have access to the crypto key too.

part of the work for #3100 and #3101, #3098, #3097 and  probably several other examples.