### PR TITLE
impl(storage): use stub for read_object

### DIFF
--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -19,8 +19,8 @@ pub(crate) mod read_object;
 pub(crate) mod request_options;
 pub mod streaming_source;
 // TODO(#2041) - make the stub public
-#[allow(dead_code)]
 pub(crate) mod stub;
+pub(crate) mod transport;
 pub(crate) mod v1;
 pub(crate) mod write_object;
 

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -62,7 +62,7 @@ use serde_with::DeserializeAs;
 /// ```
 #[derive(Clone, Debug)]
 pub struct ReadObject {
-    inner: std::sync::Arc<StorageInner>,
+    stub: std::sync::Arc<crate::storage::transport::Storage>,
     request: crate::model::ReadObjectRequest,
     options: super::request_options::RequestOptions,
 }
@@ -75,7 +75,7 @@ impl ReadObject {
     {
         let options = inner.options.clone();
         ReadObject {
-            inner,
+            stub: crate::storage::transport::Storage::new(inner),
             request: crate::model::ReadObjectRequest::new()
                 .set_bucket(bucket)
                 .set_object(object),
@@ -352,11 +352,20 @@ impl ReadObject {
 
     /// Sends the request.
     pub async fn send(self) -> Result<ReadObjectResponse> {
-        let read = self.clone().read().await?;
-        let inner = ReadObjectResponseImpl::new(self, read)?;
-        Ok(ReadObjectResponse::new(Box::new(inner)))
+        use crate::storage::stub::Storage;
+        self.stub.read_object(self.request, self.options).await
     }
+}
 
+// A convenience struct that saves the request conditions and performs the read.
+#[derive(Clone, Debug)]
+pub(crate) struct Reader {
+    pub inner: std::sync::Arc<StorageInner>,
+    pub request: crate::model::ReadObjectRequest,
+    pub options: super::request_options::RequestOptions,
+}
+
+impl Reader {
     async fn read(self) -> Result<reqwest::Response> {
         let throttler = self.options.retry_throttler.clone();
         let retry = self.options.retry_policy.clone();
@@ -496,26 +505,29 @@ fn headers_to_md5_hash(headers: &http::HeaderMap) -> Vec<u8> {
 
 /// A response to a [Storage::read_object] request.
 #[derive(Debug)]
-struct ReadObjectResponseImpl {
-    inner: Option<reqwest::Response>,
+pub(crate) struct ReadObjectResponseImpl {
+    reader: Reader,
+    response: Option<reqwest::Response>,
     highlights: ObjectHighlights,
     // Fields for tracking the crc checksum checks.
     response_checksums: ObjectChecksums,
     // Fields for resuming a read request.
     range: ReadRange,
     generation: i64,
-    builder: ReadObject,
     resume_count: u32,
 }
 
 impl ReadObjectResponseImpl {
-    fn new(builder: ReadObject, inner: reqwest::Response) -> Result<Self> {
-        let full = builder.request.read_offset == 0 && builder.request.read_limit == 0;
-        let response_checksums = checksums_from_response(full, inner.status(), inner.headers());
-        let range = response_range(&inner).map_err(Error::deser)?;
-        let generation = response_generation(&inner).map_err(Error::deser)?;
+    pub(crate) async fn new(reader: Reader) -> Result<Self> {
+        let response = reader.clone().read().await?;
 
-        let headers = inner.headers();
+        let full = reader.request.read_offset == 0 && reader.request.read_limit == 0;
+        let response_checksums =
+            checksums_from_response(full, response.status(), response.headers());
+        let range = response_range(&response).map_err(Error::deser)?;
+        let generation = response_generation(&response).map_err(Error::deser)?;
+
+        let headers = response.headers();
         let get_as_i64 = |header_name: &str| -> i64 {
             headers
                 .get(header_name)
@@ -548,14 +560,14 @@ impl ReadObjectResponseImpl {
         };
 
         Ok(Self {
-            inner: Some(inner),
+            reader,
+            response: Some(response),
             highlights,
             // Fields for computing checksums.
             response_checksums,
             // Fields for resuming a read request.
             range,
             generation,
-            builder,
             resume_count: 0,
         })
     }
@@ -580,11 +592,11 @@ impl crate::read_object::dynamic::ReadObjectResponse for ReadObjectResponseImpl 
 
 impl ReadObjectResponseImpl {
     async fn next_attempt(&mut self) -> Option<Result<bytes::Bytes>> {
-        let inner = self.inner.as_mut()?;
-        let res = inner.chunk().await.map_err(Error::io);
+        let response = self.response.as_mut()?;
+        let res = response.chunk().await.map_err(Error::io);
         match res {
             Ok(Some(chunk)) => {
-                self.builder
+                self.reader
                     .options
                     .checksum
                     .update(self.range.start, &chunk);
@@ -603,7 +615,7 @@ impl ReadObjectResponseImpl {
                 if self.range.limit != 0 {
                     return Some(Err(Error::io(ReadError::ShortRead(self.range.limit))));
                 }
-                let computed = self.builder.options.checksum.finalize();
+                let computed = self.reader.options.checksum.finalize();
                 let res = validate(&self.response_checksums, &Some(computed));
                 match res {
                     Err(e) => Some(Err(Error::deser(ReadError::ChecksumMismatch(e)))),
@@ -619,11 +631,11 @@ impl ReadObjectResponseImpl {
         use crate::read_resume_policy::{ResumeQuery, ResumeResult};
 
         // The existing read is no longer valid.
-        self.inner = None;
+        self.response = None;
         self.resume_count += 1;
         let query = ResumeQuery::new(self.resume_count);
         match self
-            .builder
+            .reader
             .options
             .read_resume_policy
             .on_error(&query, error)
@@ -632,10 +644,10 @@ impl ReadObjectResponseImpl {
             ResumeResult::Permanent(e) => return Some(Err(e)),
             ResumeResult::Exhausted(e) => return Some(Err(e)),
         };
-        self.builder.request.read_offset = self.range.start as i64;
-        self.builder.request.read_limit = self.range.limit as i64;
-        self.builder.request.generation = self.generation;
-        self.inner = match self.builder.clone().read().await {
+        self.reader.request.read_offset = self.range.start as i64;
+        self.reader.request.read_limit = self.range.limit as i64;
+        self.reader.request.generation = self.generation;
+        self.response = match self.reader.clone().read().await {
             Ok(r) => Some(r),
             Err(e) => return Some(Err(e)),
         };
@@ -759,9 +771,22 @@ mod tests {
     use httptest::{Expectation, Server, matchers::*, responders::status_code};
     use std::collections::HashMap;
     use std::error::Error;
+    use std::sync::Arc;
     use test_case::test_case;
 
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    async fn http_request_builder(
+        inner: Arc<StorageInner>,
+        builder: ReadObject,
+    ) -> crate::Result<reqwest::RequestBuilder> {
+        let reader = Reader {
+            inner,
+            request: builder.request,
+            options: builder.options,
+        };
+        reader.http_request_builder().await
+    }
 
     // Verify `read_object()` meets normal Send, Sync, requirements.
     #[tokio::test]
@@ -1138,10 +1163,8 @@ mod tests {
     #[tokio::test]
     async fn read_object() -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object");
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
@@ -1156,8 +1179,8 @@ mod tests {
         let inner = test_inner_client(
             test_builder().with_credentials(auth::credentials::testing::error_credentials(false)),
         );
-        let _ = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .http_request_builder()
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object");
+        let _ = http_request_builder(inner, builder)
             .await
             .inspect_err(|e| assert!(e.is_authentication()))
             .expect_err("invalid credentials should err");
@@ -1167,8 +1190,8 @@ mod tests {
     #[tokio::test]
     async fn read_object_bad_bucket() -> Result {
         let inner = test_inner_client(test_builder());
-        ReadObject::new(inner, "malformed", "object")
-            .http_request_builder()
+        let builder = ReadObject::new(inner.clone(), "malformed", "object");
+        let _ = http_request_builder(inner, builder)
             .await
             .expect_err("malformed bucket string should error");
         Ok(())
@@ -1177,15 +1200,13 @@ mod tests {
     #[tokio::test]
     async fn read_object_query_params() -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object")
             .set_generation(5)
             .set_if_generation_match(10)
             .set_if_generation_not_match(20)
             .set_if_metageneration_match(30)
-            .set_if_metageneration_not_match(40)
-            .http_request_builder()
-            .await?
-            .build()?;
+            .set_if_metageneration_not_match(40);
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         let want_pairs: HashMap<String, String> = [
@@ -1216,11 +1237,9 @@ mod tests {
 
         // The API takes the unencoded byte array.
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .set_key(KeyAes256::new(&key)?)
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object")
+            .set_key(KeyAes256::new(&key)?);
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
@@ -1251,11 +1270,9 @@ mod tests {
     #[tokio::test]
     async fn range_header(input: ReadRange, want: Option<&http::HeaderValue>) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", "object")
-            .set_read_range(input.clone())
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", "object")
+            .set_read_range(input.clone());
+        let request = http_request_builder(inner, builder).await?.build()?;
 
         assert_eq!(request.method(), reqwest::Method::GET);
         assert_eq!(
@@ -1282,10 +1299,8 @@ mod tests {
     #[tokio::test]
     async fn test_percent_encoding_object_name(name: &str, want: &str) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = ReadObject::new(inner, "projects/_/buckets/bucket", name)
-            .http_request_builder()
-            .await?
-            .build()?;
+        let builder = ReadObject::new(inner.clone(), "projects/_/buckets/bucket", name);
+        let request = http_request_builder(inner, builder).await?.build()?;
         let got = request.url().path_segments().unwrap().next_back().unwrap();
         assert_eq!(got, want);
         Ok(())

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -40,7 +40,9 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
     ) -> impl std::future::Future<Output = Result<ReadObjectResponse>> + Send {
         unimplemented_stub::<ReadObjectResponse>()
     }
+
     /// Implements [crate::client::Storage::write_object].
+    #[allow(dead_code)] // TODO(#2041) - implement writes
     fn write_object_buffered<P>(
         &self,
         _payload: P,
@@ -52,7 +54,9 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
     {
         unimplemented_stub::<Object>()
     }
+
     /// Implements [crate::client::Storage::write_object].
+    #[allow(dead_code)] // TODO(#2041) - implement writes
     fn write_object_unbuffered<P>(
         &self,
         _payload: P,

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::model::ReadObjectRequest;
+use crate::read_object::ReadObjectResponse;
+use crate::storage::client::StorageInner;
+use crate::storage::read_object::{ReadObjectResponseImpl, Reader};
+use crate::storage::request_options::RequestOptions;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct Storage {
+    inner: Arc<StorageInner>,
+}
+
+impl Storage {
+    pub(crate) fn new(inner: Arc<StorageInner>) -> Arc<Self> {
+        Arc::new(Self { inner })
+    }
+}
+
+impl super::stub::Storage for Storage {
+    async fn read_object(
+        &self,
+        req: ReadObjectRequest,
+        options: RequestOptions,
+    ) -> Result<ReadObjectResponse> {
+        let reader = Reader {
+            inner: self.inner.clone(),
+            request: req,
+            options,
+        };
+        let inner = ReadObjectResponseImpl::new(reader).await?;
+        Ok(ReadObjectResponse::new(Box::new(inner)))
+    }
+}


### PR DESCRIPTION
Part of the work for #2041 

Introduce the `transport::Storage` stub, with an implementation for `read_object`.

Refactor `ReadObject` to write the implementation in terms of the `stub`, not the `inner`.

We start by naming the `transport::Storage` stub explicitly in `ReadObject`. Eventually it will get replaced by a `T: stub::Storage`, when we are ready.

`ReadObject` can't know about the `http_request_builder` any more. (That is only known by the specific transport stub implementation, which will eventually be a generic stub implementation). So in tests, we use the `ReadObject` builder to give us a request and options. We use those to construct something that knows about `http_request_builder`.