### PR TITLE
refactor(storage): use stub for write_object

### DIFF
--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -237,6 +237,7 @@ mod single_shot_tests;
 mod tests {
     use crate::builder::storage::WriteObject;
     use crate::storage::client::tests::{test_builder, test_inner_client};
+    use crate::storage::perform_upload::tests::perform_upload;
     use test_case::test_case;
 
     type Result = anyhow::Result<()>;
@@ -255,8 +256,8 @@ mod tests {
     #[tokio::test]
     async fn test_percent_encoding_object_name(want: &str) -> Result {
         let inner = test_inner_client(test_builder());
-        let request = WriteObject::new(inner, "projects/_/buckets/bucket", want, "hello")
-            .build()
+        let builder = WriteObject::new(inner.clone(), "projects/_/buckets/bucket", want, "hello");
+        let request = perform_upload(inner, builder)
             .start_resumable_upload_request()
             .await?
             .build()?;

--- a/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
@@ -728,8 +728,7 @@ async fn start_resumable_upload_request_retry_options() -> Result {
         .with_retry_policy(retry.with_attempt_limit(3))
         .with_backoff_policy(backoff)
         .with_retry_throttler(throttler)
-        .build()
-        .send_buffered_resumable(SizeHint::default())
+        .send_buffered()
         .await
         .expect_err("request should fail after 3 retry attempts");
     assert_eq!(err.http_status_code(), Some(503), "{err:?}");


### PR DESCRIPTION
Part of the work for #2041 

Implement `WriteObject` using the `transport::Storage` stub.

Similarly to the `ReadObject` change, we had test helpers on the builder that would no longer have access to the real implementation details (the `StorageInner`, hidden in the transport stub). Again, we take the request and options from the builder, and combine it with an `inner` from outside the builder.