### PR TITLE
refactor(storage): client is templated on stubs

### DIFF
--- a/src/storage/src/model_ext.rs
+++ b/src/storage/src/model_ext.rs
@@ -293,12 +293,11 @@ enum Range {
     Segment { offset: u64, limit: u64 },
 }
 
-/// Represents the parameters of a `WriteObject` request
+/// Represents the parameters of a `WriteObject` request for use in mocks
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
-// TODO(#2041) - make public
 #[allow(dead_code)]
-pub(crate) struct WriteObjectRequest {
+pub struct WriteObjectRequest {
     pub spec: crate::model::WriteObjectSpec,
     pub params: Option<crate::model::CommonObjectRequestParams>,
 }

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -62,15 +62,21 @@ use serde_with::DeserializeAs;
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct ReadObject {
-    stub: std::sync::Arc<crate::storage::transport::Storage>,
+pub struct ReadObject<S = crate::storage::transport::Storage>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    stub: std::sync::Arc<S>,
     request: crate::model::ReadObjectRequest,
     options: RequestOptions,
 }
 
-impl ReadObject {
+impl<S> ReadObject<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
     pub(crate) fn new<B, O>(
-        stub: std::sync::Arc<crate::storage::transport::Storage>,
+        stub: std::sync::Arc<S>,
         bucket: B,
         object: O,
         options: RequestOptions,
@@ -357,7 +363,6 @@ impl ReadObject {
 
     /// Sends the request.
     pub async fn send(self) -> Result<ReadObjectResponse> {
-        use crate::storage::stub::Storage;
         self.stub.read_object(self.request, self.options).await
     }
 }

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -22,7 +22,7 @@ use gax::{
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
-pub(crate) struct RequestOptions {
+pub struct RequestOptions {
     pub(crate) retry_policy: Arc<dyn RetryPolicy>,
     pub(crate) backoff_policy: Arc<dyn BackoffPolicy>,
     pub(crate) retry_throttler: SharedRetryThrottler,


### PR DESCRIPTION
Part of the work for #2041 

Template the `client::Storage` on the `stub::Storage` implementing it. I use `S` for `Stub`, and because no other generics used `S`. That kept the diff in check.

The default template is a `transport::Storage` in the client and the builders. This means code like: `let client: Storage = Storage::builder().build().await` keeps working as before.

The `builder()` method is only available on the "real" client. It only ever gives you a real client.

We need to make the default template type public, although it does not need to be name-able by applications.

The next PR will add the `client::Storage::from_stub()` method and make sure all types like `RequestOptions` are name-able outside of the crate.