### PR TITLE
docs(storage): copy file example

### DIFF
--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -395,6 +395,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
         "prefixes/are-not-always/folders-003",
         "prefixes/are-not-always/folders-004/abc",
         "prefixes/are-not-always/folders-004/def",
+        "object-to-copy",
         "object-to-update",
         "deleted-object-name",
         "compose-source-object-1",
@@ -458,6 +459,8 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     objects::release_temporary_hold::sample(&control, &id).await?;
     tracing::info!("running delete_file example");
     objects::delete_file::sample(&control, &id).await?;
+    tracing::info!("running copy_file example");
+    objects::copy_file::sample(&control, &id, &id).await?;
     tracing::info!("running change_file_storage_class example");
     objects::change_file_storage_class::sample(&control, &id).await?;
     tracing::info!("running compose_file example");

--- a/src/storage/examples/src/objects.rs
+++ b/src/storage/examples/src/objects.rs
@@ -14,6 +14,7 @@
 
 pub mod change_file_storage_class;
 pub mod compose_file;
+pub mod copy_file;
 pub mod delete_file;
 pub mod download_byte_range;
 pub mod download_encrypted_file;

--- a/src/storage/examples/src/objects/copy_file.rs
+++ b/src/storage/examples/src/objects/copy_file.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_copy_file]
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(
+    client: &StorageControl,
+    source_bucket_id: &str,
+    dest_bucket_id: &str,
+) -> anyhow::Result<()> {
+    const SOURCE_NAME: &str = "object-to-copy";
+    const DEST_NAME: &str = "copied-object";
+    let mut builder = client
+        .rewrite_object()
+        .set_source_bucket(format!("projects/_/buckets/{source_bucket_id}"))
+        .set_source_object(SOURCE_NAME)
+        .set_destination_bucket(format!("projects/_/buckets/{dest_bucket_id}"))
+        .set_destination_name(DEST_NAME);
+
+    // For more details on this loop, see the "Rewriting objects" section of the
+    // user guide:
+    // https://googleapis.github.io/google-cloud-rust/storage/rewrite_object.html
+    let copied = loop {
+        let resp = builder.clone().send().await?;
+        if resp.done {
+            break resp.resource;
+        }
+        builder = builder.set_rewrite_token(resp.rewrite_token);
+    };
+    println!(
+        "successfully copied {source_bucket_id}/{SOURCE_NAME} to {dest_bucket_id}/{DEST_NAME}: {copied:?}"
+    );
+    Ok(())
+}
+// [END storage_copy_file]


### PR DESCRIPTION
Fixes #3056 

The associated cloud docs are [Copy an object between buckets](https://cloud.google.com/storage/docs/samples/storage-copy-file#whats-next), so...
- I think we need separate parameters for source and destination buckets.
- I think we need to use a rewrite loop. The buckets could be in different regions.

I tried to consolidate the print statement, but it is still super long.