### PR TITLE
docs(storage): add move file example

### DIFF
--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -400,6 +400,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
         "compose-source-object-1",
         "compose-source-object-2",
         "update-storage-class",
+        "object-to-move",
     ]
     .into_iter()
     .for_each(|name| writers.push(make_object(&client, &id, name)));
@@ -462,6 +463,9 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     objects::change_file_storage_class::sample(&control, &id).await?;
     tracing::info!("running compose_file example");
     objects::compose_file::sample(&control, &id).await?;
+
+    tracing::info!("running move_file example");
+    objects::move_file::sample(&control, &id, &id).await?;
 
     Ok(())
 }

--- a/src/storage/examples/src/objects.rs
+++ b/src/storage/examples/src/objects.rs
@@ -23,6 +23,7 @@ pub mod file_upload_from_memory;
 pub mod generate_encryption_key;
 pub mod list_files;
 pub mod list_files_with_prefix;
+pub mod move_file;
 pub mod release_event_based_hold;
 pub mod release_temporary_hold;
 pub mod set_event_based_hold;

--- a/src/storage/examples/src/objects/move_file.rs
+++ b/src/storage/examples/src/objects/move_file.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_move_file]
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(
+    client: &StorageControl,
+    source_bucket_id: &str,
+    dest_bucket_id: &str,
+) -> anyhow::Result<()> {
+    const SOURCE_NAME: &str = "object-to-move";
+    const DEST_NAME: &str = "moved-object";
+    let mut builder = client
+        .rewrite_object()
+        .set_source_bucket(format!("projects/_/buckets/{source_bucket_id}"))
+        .set_source_object(SOURCE_NAME)
+        .set_destination_bucket(format!("projects/_/buckets/{dest_bucket_id}"))
+        .set_destination_name(DEST_NAME);
+
+    // For more details on this loop, see the "Rewriting objects" section of the
+    // user guide:
+    // https://googleapis.github.io/google-cloud-rust/storage/rewrite_object.html
+    let moved = loop {
+        let resp = builder.clone().send().await?;
+        if resp.done {
+            break resp.resource;
+        }
+        builder = builder.set_rewrite_token(resp.rewrite_token);
+    };
+
+    client
+        .delete_object()
+        .set_bucket(format!("projects/_/buckets/{source_bucket_id}"))
+        .set_object(SOURCE_NAME)
+        .send()
+        .await?;
+    println!(
+        "successfully moved {source_bucket_id}/{SOURCE_NAME} to {dest_bucket_id}/{DEST_NAME}: {moved:?}"
+    );
+
+    Ok(())
+}
+// [END storage_move_file]


### PR DESCRIPTION
This is for the example on https://cloud.google.com/storage/docs/copying-renaming-moving-objects#move-by-copying.

Identical to #3184, with an added delete line.

Fixes #3096 