### PR TITLE
fix(gax-internal): alternative endpoints for gRPC

### DIFF
--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -55,7 +55,7 @@ mod tests {
     async fn override_endpoint() -> anyhow::Result<()> {
         let (endpoint, _server) = start_echo_server().await?;
 
-        let client = builder("unused")
+        let client = builder("https://test-only.googleapis.com")
             .with_endpoint(endpoint)
             .with_credentials(test_credentials())
             .build()

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -128,7 +128,6 @@ pub async fn objects(builder: storage::builder::storage::ClientBuilder) -> Resul
     let (control, bucket) = create_test_bucket().await?;
 
     let client = builder.build().await?;
-
     tracing::info!("testing insert_object()");
     const CONTENTS: &str = "the quick brown fox jumps over the lazy dog";
     let insert = client

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -105,6 +105,7 @@ mod driver {
 
     #[test_case(StorageControl::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
     #[test_case(StorageControl::builder().with_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(StorageControl::builder().with_endpoint("https://www.googleapis.com"); "with alternative endpoint")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_control_buckets(
         builder: storage::builder::storage_control::ClientBuilder,
@@ -115,6 +116,7 @@ mod driver {
     }
 
     #[test_case(Storage::builder(); "default")]
+    #[test_case(Storage::builder().with_endpoint("https://www.googleapis.com"); "with alternative endpoint")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects(
         builder: storage::builder::storage::ClientBuilder,


### PR DESCRIPTION
When using alternative endpoints with gRPC clients we need to include
the original endpoint in the `:authority` header. With tonic + hyper
this is done by setting the `origin()` attribute.

Fixes #3192 