### PR TITLE
impl(wkt): workaround for time==0.3.42

### DIFF
--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -300,11 +300,9 @@ impl TryFrom<time::OffsetDateTime> for Timestamp {
     type Error = TimestampError;
 
     fn try_from(value: time::OffsetDateTime) -> Result<Self, Self::Error> {
-        use time::convert::{Nanosecond, Second};
-
+        const SCALE: i128 = 1_000_000_000_i128;
         let seconds = value.unix_timestamp();
-        let nanos = (value.unix_timestamp_nanos()
-            - seconds as i128 * Nanosecond::per(Second) as i128) as i32;
+        let nanos = (value.unix_timestamp_nanos() - seconds as i128 * SCALE) as i32;
         Self::new(seconds, nanos)
     }
 }

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -300,9 +300,8 @@ impl TryFrom<time::OffsetDateTime> for Timestamp {
     type Error = TimestampError;
 
     fn try_from(value: time::OffsetDateTime) -> Result<Self, Self::Error> {
-        const SCALE: i128 = 1_000_000_000_i128;
         let seconds = value.unix_timestamp();
-        let nanos = (value.unix_timestamp_nanos() - seconds as i128 * SCALE) as i32;
+        let nanos = (value.unix_timestamp_nanos() - seconds as i128 * NS) as i32;
         Self::new(seconds, nanos)
     }
 }


### PR DESCRIPTION
It seems like time==0.3.42 has a regression in its Nanosecond -> Second
helpers. This workarounds that problem using a constant value to convert
from nanoseconds to seconds.

More details at: https://github.com/time-rs/time/issues/749

Unblocks #3193 