### PR TITLE
chore: bump versions for gax-internal 0.6.0

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -233,7 +233,7 @@ jobs:
           set -e
           rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
           rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
-          cargo install cargo-minimal-versions cargo-hack@0.6.37 cargo-minimal-versions@0.1.31 --locked
+          cargo install --locked cargo-semver-checks@0.42.0
       - name: Display Cargo version
         run: cargo version
       - name: Display rustc version
@@ -241,20 +241,20 @@ jobs:
       - run: |
           set -e
           cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-wkt
-          cargo semver-checks --all-features --baseline-version 0.4.4 -p google-cloud-api
-          cargo semver-checks --all-features --baseline-version 0.4.4 -p google-cloud-rpc
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-api
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-rpc
           cargo semver-checks --all-features --baseline-version 0.24.0 -p google-cloud-gax
-          cargo semver-checks --all-features --baseline-version 0.22.0 -p google-cloud-auth
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-gax-internal
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-type
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-iam-v1
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-location
-          cargo semver-checks --all-features --baseline-version 0.25.0 -p google-cloud-longrunning
-          cargo semver-checks --all-features --baseline-version 0.3.0 -p google-cloud-lro
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-kms-v1
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-language-v2
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-secretmanager-v1
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-speech-v2
+          cargo semver-checks --all-features --baseline-version 0.23.0 -p google-cloud-auth
+          cargo semver-checks --all-features --baseline-version 0.6.0 -p google-cloud-gax-internal
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-type
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-iam-v1
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-location
+          cargo semver-checks --all-features --baseline-version 0.26.0 -p google-cloud-longrunning
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-lro
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-kms-v1
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-language-v2
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-secretmanager-v1
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-speech-v2
           cargo semver-checks --all-features --baseline-version 0.25.0 -p google-cloud-storage
 
   showcase:

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -240,22 +240,22 @@ jobs:
         run: rustup show active-toolchain -v
       - run: |
           set -e
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-wkt
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-api
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-rpc
-          cargo semver-checks --all-features --baseline-version 0.24.0 -p google-cloud-gax
-          cargo semver-checks --all-features --baseline-version 0.23.0 -p google-cloud-auth
-          cargo semver-checks --all-features --baseline-version 0.6.0 -p google-cloud-gax-internal
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-type
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-iam-v1
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-location
-          cargo semver-checks --all-features --baseline-version 0.26.0 -p google-cloud-longrunning
-          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-lro
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-kms-v1
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-language-v2
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-secretmanager-v1
-          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-speech-v2
-          cargo semver-checks --all-features --baseline-version 0.25.0 -p google-cloud-storage
+          cargo semver-checks --all-features -p google-cloud-wkt
+          cargo semver-checks --all-features -p google-cloud-api
+          cargo semver-checks --all-features -p google-cloud-rpc
+          cargo semver-checks --all-features -p google-cloud-gax
+          cargo semver-checks --all-features -p google-cloud-auth
+          cargo semver-checks --all-features -p google-cloud-gax-internal
+          cargo semver-checks --all-features -p google-cloud-type
+          cargo semver-checks --all-features -p google-cloud-iam-v1
+          cargo semver-checks --all-features -p google-cloud-location
+          cargo semver-checks --all-features -p google-cloud-longrunning
+          cargo semver-checks --all-features -p google-cloud-lro
+          cargo semver-checks --all-features -p google-cloud-kms-v1
+          cargo semver-checks --all-features -p google-cloud-language-v2
+          cargo semver-checks --all-features -p google-cloud-secretmanager-v1
+          cargo semver-checks --all-features -p google-cloud-speech-v2
+          cargo semver-checks --all-features -p google-cloud-storage
 
   showcase:
     runs-on: ubuntu-24.04

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -216,6 +216,47 @@ jobs:
           cargo minimal-versions test --package google-cloud-gax
           cargo minimal-versions test --package google-cloud-wkt
 
+  semver-checks:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        rust-version: ['rust:current']
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}
+      - name: Setup Rust ${{ matrix.rust-version }}
+        run: |
+          set -e
+          rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          cargo install cargo-minimal-versions cargo-hack@0.6.37 cargo-minimal-versions@0.1.31 --locked
+      - name: Display Cargo version
+        run: cargo version
+      - name: Display rustc version
+        run: rustup show active-toolchain -v
+      - run: |
+          set -e
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-wkt
+          cargo semver-checks --all-features --baseline-version 0.4.4 -p google-cloud-api
+          cargo semver-checks --all-features --baseline-version 0.4.4 -p google-cloud-rpc
+          cargo semver-checks --all-features --baseline-version 0.24.0 -p google-cloud-gax
+          cargo semver-checks --all-features --baseline-version 0.22.0 -p google-cloud-auth
+          cargo semver-checks --all-features --baseline-version 0.5.0 -p google-cloud-gax-internal
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-type
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-iam-v1
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-location
+          cargo semver-checks --all-features --baseline-version 0.25.0 -p google-cloud-longrunning
+          cargo semver-checks --all-features --baseline-version 0.3.0 -p google-cloud-lro
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-kms-v1
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-language-v2
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-secretmanager-v1
+          cargo semver-checks --all-features --baseline-version 0.4.0 -p google-cloud-speech-v2
+          cargo semver-checks --all-features --baseline-version 0.25.0 -p google-cloud-storage
+
   showcase:
     runs-on: ubuntu-24.04
     strategy:
@@ -401,7 +442,7 @@ jobs:
           sudo unzip -x /tmp/protoc.zip
           protoc --version
       - name: Regenerate all the code
-        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.1.2-0.20250827183345-8f409cc46adc refreshall -project-root .
+        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.1.2-0.20250827183345-8f409cc46adc refreshall
       - run: cargo fmt
         # If there is any difference between the generated code and the
         # committed code that is an error. All the inputs should be pinned,

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -41,7 +41,7 @@ conformance-sha256          = '008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2
 [codec]
 # The default version for all crates. This can be overridden in the crate's
 # `.sidekick.toml` file.
-version = "0.4.5"
+version = "0.5.0"
 # The default release level for all crates.
 release-level = "preview"
 # Disable a number of warnings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "google-cloud-accessapproval-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-advisorynotifications-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-aiplatform-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-alloydb-connectors-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-alloydb-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-cloudquotas-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicecontrol-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicecontrol-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicemanagement-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-serviceusage-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apigateway-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apigeeconnect-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apihub-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apikeys-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-appengine-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apphub-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-calendar"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-docs"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-drive"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-gmail"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-sheets"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apps-script-type-slides"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-apps-script-type",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-artifactregistry-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-asset-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-assuredworkloads-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.22.4"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-backupdr-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-baremetalsolution-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1369,7 +1369,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-beyondcorp-appconnections-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-appconnectors-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-appgateways-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-clientconnectorservices-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-clientgateways-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1483,7 +1483,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-bigquery-analyticshub-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-connection-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-datapolicies-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-datapolicies-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-datatransfer-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-migration-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-reservation-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1643,7 +1643,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-bigtable-admin-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-billing-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-binaryauthorization-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-build-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-build-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-certificatemanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-chronicle-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-cloudcontrolspartner-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-clouddms-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-cloudsecuritycompliance-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-commerce-consumer-procurement-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-common"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-confidentialcomputing-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-config-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-configdelivery-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-connectors-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-contactcenterinsights-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-container-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-containeranalysis-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datacatalog-lineage-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datacatalog-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataform-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datafusion-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataplex-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataproc-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2163,7 +2163,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-datastore-admin-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datastream-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-deploy-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-developerconnect-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-devicestreaming-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-cx-v3"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-discoveryengine-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-documentai-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-domains-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-edgecontainer-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-edgenetwork-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-essentialcontacts-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-eventarc-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-filestore-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-financialservices-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-firestore-admin-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-functions-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkebackup-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkeconnect-gateway-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-configmanagement-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-multiclusteringress-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkemulticloud-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkerecommender-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-grafeas-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gsuiteaddons-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-admin-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-credentials-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v3"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iap-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-identity-accesscontextmanager-type"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-identity-accesscontextmanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-ids-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-kms-inventory-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-kms-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-language-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-licensemanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-location"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-logging-type"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-logging-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-longrunning"
-version = "0.25.5"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lro"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lustre-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedidentities-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedkafka-schemaregistry-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedkafka-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-memcache-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-memorystore-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-metastore-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-migrationcenter-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-modelarmor-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-dashboard-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-metricsscope-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-v3"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-netapp-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkconnectivity-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkmanagement-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networksecurity-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkservices-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-notebooks-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-optimization-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oracledatabase-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orchestration-airflow-service-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orgpolicy-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orgpolicy-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-osconfig-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oslogin-common"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oslogin-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-parallelstore-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-parametermanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policysimulator-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policytroubleshooter-iam-v3"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policytroubleshooter-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privacy-dlp-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privilegedaccessmanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-profiler-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rapidmigrationassessment-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-recaptchaenterprise-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-recommender-logging-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-recommender-v1",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-recommender-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-redis-cluster-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-redis-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-resourcemanager-v3"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-retail-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc-context"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-run-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-scheduler-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-secretmanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securesourcemanager-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-security-privateca-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-security-publicca-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securitycenter-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securityposture-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-servicedirectory-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-servicehealth-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-shell-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-showcase-v1beta1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4312,7 +4312,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-spanner-admin-database-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-spanner-admin-instance-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-speech-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-sql-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storagebatchoperations-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storageinsights-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storagetransfer-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-support-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-talent-v4"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-tasks-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-telcoautomation-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-texttospeech-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-timeseriesinsights-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-tpu-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-trace-v2"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-translation-v3"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-type"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-livestream-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-stitcher-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-transcoder-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-videointelligence-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vision-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vmmigration-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vmwareengine-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vpcaccess-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-webrisk-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-websecurityscanner-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workflows-executions-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workflows-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workstations-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6385,7 +6385,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secretmanager-openapi-v1"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,52 +349,52 @@ tokio-stream   = { default-features = false, version = "0.1" }
 tokio-test     = { default-features = false, version = "0.4" }
 
 # Local packages used as dependencies
-auth                          = { version = "0.22.4", path = "src/auth", package = "google-cloud-auth" }
-google-cloud-auth             = { version = "0.22.4", path = "src/auth" }
+auth                          = { version = "0.23", path = "src/auth", package = "google-cloud-auth" }
+google-cloud-auth             = { version = "0.23", path = "src/auth" }
 gax                           = { version = "0.24", path = "src/gax", package = "google-cloud-gax" }
 google-cloud-gax              = { version = "0.24", path = "src/gax" }
-gaxi                          = { version = "0.5.1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
-iam_v1                        = { version = "0.4.4", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
-google-cloud-iam-v1           = { version = "0.4.4", path = "src/generated/iam/v1" }
-location                      = { version = "0.4.4", path = "src/generated/cloud/location", package = "google-cloud-location" }
-longrunning                   = { version = "0.25.4", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
-google-cloud-longrunning      = { version = "0.25.4", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
-lro                           = { version = "0.3.5", path = "src/lro", package = "google-cloud-lro" }
-google-cloud-lro              = { version = "0.3.5", path = "src/lro", package = "google-cloud-lro" }
+gaxi                          = { version = "0.6.0", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+iam_v1                        = { version = "0.5", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
+google-cloud-iam-v1           = { version = "0.5", path = "src/generated/iam/v1" }
+location                      = { version = "0.5", path = "src/generated/cloud/location", package = "google-cloud-location" }
+longrunning                   = { version = "0.26", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+google-cloud-longrunning      = { version = "0.26", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+lro                           = { version = "0.4", path = "src/lro", package = "google-cloud-lro" }
+google-cloud-lro              = { version = "0.4", path = "src/lro", package = "google-cloud-lro" }
 wkt                           = { version = "0.5.4", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-wkt              = { version = "0.5.4", path = "src/wkt", package = "google-cloud-wkt" }
-api                           = { version = "0.4.4", path = "src/generated/api/types", package = "google-cloud-api" }
-cloud_common                  = { version = "0.4.4", path = "src/generated/cloud/common", package = "google-cloud-common" }
-gtype                         = { version = "0.4.4", path = "src/generated/type", package = "google-cloud-type" }
-google-cloud-type             = { version = "0.4.4", path = "src/generated/type" }
-grafeas                       = { version = "0.4.4", path = "src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
-logging_type                  = { version = "0.4.4", path = "src/generated/logging/type", package = "google-cloud-logging-type" }
-rpc                           = { version = "0.4.4", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
-google-cloud-rpc              = { version = "0.4.4", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
-rpc_context                   = { version = "0.4.4", path = "src/generated/rpc/context", package = "google-cloud-rpc-context" }
-apps_script_type              = { version = "0.4.4", path = "src/generated/apps/script/gtype", package = "google-cloud-apps-script-type" }
-accesscontextmanager_v1       = { version = "0.4.4", path = "src/generated/identity/accesscontextmanager/v1", package = "google-cloud-identity-accesscontextmanager-v1" }
-orgpolicy_v1                  = { version = "0.4.4", path = "src/generated/cloud/orgpolicy/v1", package = "google-cloud-orgpolicy-v1" }
-orgpolicy_v2                  = { version = "0.4.4", path = "src/generated/cloud/orgpolicy/v2", package = "google-cloud-orgpolicy-v2" }
-osconfig_v1                   = { version = "0.4.4", path = "src/generated/cloud/osconfig/v1", package = "google-cloud-osconfig-v1" }
-gkehub_configmanagement_v1    = { version = "0.4.4", path = "src/generated/cloud/gkehub/configmanagement/v1", package = "google-cloud-gkehub-configmanagement-v1" }
-gkehub_multiclusteringress_v1 = { version = "0.4.4", path = "src/generated/cloud/gkehub/multiclusteringress/v1", package = "google-cloud-gkehub-multiclusteringress-v1" }
-apps_script_calendar          = { version = "0.4.4", path = "src/generated/apps/script/calendar", package = "google-cloud-apps-script-type-calendar" }
-apps_script_docs              = { version = "0.4.4", path = "src/generated/apps/script/docs", package = "google-cloud-apps-script-type-docs" }
-apps_script_drive             = { version = "0.4.4", path = "src/generated/apps/script/drive", package = "google-cloud-apps-script-type-drive" }
-apps_script_gmail             = { version = "0.4.4", path = "src/generated/apps/script/gmail", package = "google-cloud-apps-script-type-gmail" }
-apps_script_sheets            = { version = "0.4.4", path = "src/generated/apps/script/sheets", package = "google-cloud-apps-script-type-sheets" }
-apps_script_slides            = { version = "0.4.4", path = "src/generated/apps/script/slides", package = "google-cloud-apps-script-type-slides" }
-kms                           = { version = "0.4.4", path = "src/generated/cloud/kms/v1", package = "google-cloud-kms-v1" }
-oslogin_common                = { version = "0.4.4", path = "src/generated/oslogin/common", package = "google-cloud-oslogin-common" }
-iam_v2                        = { version = "0.4.4", path = "src/generated/iam/v2", package = "google-cloud-iam-v2" }
-recommender                   = { version = "0.4.4", path = "src/generated/cloud/recommender/v1", package = "google-cloud-recommender-v1" }
-accesscontextmanager_type     = { version = "0.4.4", path = "src/generated/identity/accesscontextmanager/type", package = "google-cloud-identity-accesscontextmanager-type" }
-google-cloud-language-v2      = { version = "0.4.4", path = "src/generated/cloud/language/v2" }
-google-cloud-speech-v2        = { version = "0.4.4", path = "src/generated/cloud/speech/v2" }
-google-cloud-secretmanager-v1 = { version = "0.4.4", path = "src/generated/cloud/secretmanager/v1" }
-google-cloud-aiplatform-v1    = { version = "0.4.5", default-features = false, path = "src/generated/cloud/aiplatform/v1" }
-google-cloud-storage          = { version = "0.25.0", path = "src/storage" }
+api                           = { version = "0.5", path = "src/generated/api/types", package = "google-cloud-api" }
+cloud_common                  = { version = "0.5", path = "src/generated/cloud/common", package = "google-cloud-common" }
+gtype                         = { version = "0.5", path = "src/generated/type", package = "google-cloud-type" }
+google-cloud-type             = { version = "0.5", path = "src/generated/type" }
+grafeas                       = { version = "0.5", path = "src/generated/grafeas/v1", package = "google-cloud-grafeas-v1" }
+logging_type                  = { version = "0.5", path = "src/generated/logging/type", package = "google-cloud-logging-type" }
+rpc                           = { version = "0.5", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
+google-cloud-rpc              = { version = "0.5", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
+rpc_context                   = { version = "0.5", path = "src/generated/rpc/context", package = "google-cloud-rpc-context" }
+apps_script_type              = { version = "0.5", path = "src/generated/apps/script/gtype", package = "google-cloud-apps-script-type" }
+accesscontextmanager_v1       = { version = "0.5", path = "src/generated/identity/accesscontextmanager/v1", package = "google-cloud-identity-accesscontextmanager-v1" }
+orgpolicy_v1                  = { version = "0.5", path = "src/generated/cloud/orgpolicy/v1", package = "google-cloud-orgpolicy-v1" }
+orgpolicy_v2                  = { version = "0.5", path = "src/generated/cloud/orgpolicy/v2", package = "google-cloud-orgpolicy-v2" }
+osconfig_v1                   = { version = "0.5", path = "src/generated/cloud/osconfig/v1", package = "google-cloud-osconfig-v1" }
+gkehub_configmanagement_v1    = { version = "0.5", path = "src/generated/cloud/gkehub/configmanagement/v1", package = "google-cloud-gkehub-configmanagement-v1" }
+gkehub_multiclusteringress_v1 = { version = "0.5", path = "src/generated/cloud/gkehub/multiclusteringress/v1", package = "google-cloud-gkehub-multiclusteringress-v1" }
+apps_script_calendar          = { version = "0.5", path = "src/generated/apps/script/calendar", package = "google-cloud-apps-script-type-calendar" }
+apps_script_docs              = { version = "0.5", path = "src/generated/apps/script/docs", package = "google-cloud-apps-script-type-docs" }
+apps_script_drive             = { version = "0.5", path = "src/generated/apps/script/drive", package = "google-cloud-apps-script-type-drive" }
+apps_script_gmail             = { version = "0.5", path = "src/generated/apps/script/gmail", package = "google-cloud-apps-script-type-gmail" }
+apps_script_sheets            = { version = "0.5", path = "src/generated/apps/script/sheets", package = "google-cloud-apps-script-type-sheets" }
+apps_script_slides            = { version = "0.5", path = "src/generated/apps/script/slides", package = "google-cloud-apps-script-type-slides" }
+kms                           = { version = "0.5", path = "src/generated/cloud/kms/v1", package = "google-cloud-kms-v1" }
+oslogin_common                = { version = "0.5", path = "src/generated/oslogin/common", package = "google-cloud-oslogin-common" }
+iam_v2                        = { version = "0.5", path = "src/generated/iam/v2", package = "google-cloud-iam-v2" }
+recommender                   = { version = "0.5", path = "src/generated/cloud/recommender/v1", package = "google-cloud-recommender-v1" }
+accesscontextmanager_type     = { version = "0.5", path = "src/generated/identity/accesscontextmanager/type", package = "google-cloud-identity-accesscontextmanager-type" }
+google-cloud-language-v2      = { version = "0.5", path = "src/generated/cloud/language/v2" }
+google-cloud-speech-v2        = { version = "0.5", path = "src/generated/cloud/speech/v2" }
+google-cloud-secretmanager-v1 = { version = "0.5", path = "src/generated/cloud/secretmanager/v1" }
+google-cloud-aiplatform-v1    = { version = "0.5", default-features = false, path = "src/generated/cloud/aiplatform/v1" }
+google-cloud-storage          = { version = "0.25.1", path = "src/storage" }
 
 # Local test package
 integration-tests = { path = "src/integration-tests" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-auth"
-version     = "0.22.4"
+version     = "0.23.0"
 description = "Google Cloud Client Libraries for Rust - Authentication"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.5.1"
+version     = "0.6.0"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apikeys-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - API Keys API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/cloudquotas/v1/Cargo.toml
+++ b/src/generated/api/cloudquotas/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-cloudquotas-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Quotas API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicecontrol/v1/Cargo.toml
+++ b/src/generated/api/servicecontrol/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicecontrol-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Control API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicecontrol-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Control API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicemanagement-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-serviceusage-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Usage API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/types/Cargo.toml
+++ b/src/generated/api/types/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Config API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-appengine-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - App Engine Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/calendar/Cargo.toml
+++ b/src/generated/apps/script/calendar/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-calendar"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/docs/Cargo.toml
+++ b/src/generated/apps/script/docs/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-docs"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/drive/Cargo.toml
+++ b/src/generated/apps/script/drive/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-drive"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/gmail/Cargo.toml
+++ b/src/generated/apps/script/gmail/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-gmail"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/gtype/Cargo.toml
+++ b/src/generated/apps/script/gtype/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/sheets/Cargo.toml
+++ b/src/generated/apps/script/sheets/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-sheets"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/apps/script/slides/Cargo.toml
+++ b/src/generated/apps/script/slides/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apps-script-type-slides"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Apps Script Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigtable-admin-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Bigtable Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/accessapproval/v1/Cargo.toml
+++ b/src/generated/cloud/accessapproval/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-accessapproval-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Access Approval API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/advisorynotifications/v1/Cargo.toml
+++ b/src/generated/cloud/advisorynotifications/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-advisorynotifications-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Advisory Notifications API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-aiplatform-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/connectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-alloydb-connectors-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - AlloyDB connectors"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-alloydb-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - AlloyDB API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apigateway-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - API Gateway API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apigeeconnect/v1/Cargo.toml
+++ b/src/generated/cloud/apigeeconnect/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apigeeconnect-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Apigee Connect API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apihub-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - API hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apphub-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - App Hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-asset-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Asset API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-assuredworkloads-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Assured Workloads API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-backupdr-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Backup and DR Service API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-baremetalsolution-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Bare Metal Solution API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appconnections-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appconnectors-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appgateways-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-clientconnectorservices-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-clientgateways-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-analyticshub-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Analytics Hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/connection/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/connection/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-connection-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Connection API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-datapolicies-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Data Policy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/datapolicies/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-datapolicies-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Data Policy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-datatransfer-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Data Transfer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/migration/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/migration/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-migration-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-reservation-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery Reservation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - BigQuery API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/billing/v1/Cargo.toml
+++ b/src/generated/cloud/billing/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-billing-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Billing API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/binaryauthorization/v1/Cargo.toml
+++ b/src/generated/cloud/binaryauthorization/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-binaryauthorization-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Binary Authorization API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-certificatemanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Certificate Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/chronicle/v1/Cargo.toml
+++ b/src/generated/cloud/chronicle/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-chronicle-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Chronicle API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-cloudcontrolspartner-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Controls Partner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-clouddms-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Database Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/cloudsecuritycompliance/v1/Cargo.toml
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-cloudsecuritycompliance-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Security Compliance API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-commerce-consumer-procurement-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Commerce Consumer Procurement API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/common/Cargo.toml
+++ b/src/generated/cloud/common/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-common"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Common Operation Metadata type"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-confidentialcomputing-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Confidential Computing API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-config-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Infrastructure Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/configdelivery/v1/Cargo.toml
+++ b/src/generated/cloud/configdelivery/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-configdelivery-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Config Delivery API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-connectors-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Connectors API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-contactcenterinsights-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Contact Center AI Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datacatalog-lineage-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Data Lineage API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datacatalog-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Data Catalog API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataform/v1/Cargo.toml
+++ b/src/generated/cloud/dataform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataform-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Dataform API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datafusion-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Data Fusion API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataplex/v1/Cargo.toml
+++ b/src/generated/cloud/dataplex/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataplex-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataplex API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataproc-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataproc API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datastream-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Datastream API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-deploy-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Deploy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-developerconnect-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Developer Connect API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/devicestreaming/v1/Cargo.toml
+++ b/src/generated/cloud/devicestreaming/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-devicestreaming-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Device Streaming API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-cx-v3"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-discoveryengine-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Discovery Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-documentai-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Document AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-domains-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Domains API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-edgecontainer-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Distributed Cloud Edge Container API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-edgenetwork-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Distributed Cloud Edge Network API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/essentialcontacts/v1/Cargo.toml
+++ b/src/generated/cloud/essentialcontacts/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-essentialcontacts-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Essential Contacts API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-eventarc-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Eventarc API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-filestore-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Filestore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-financialservices-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Financial Services API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-functions-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Functions API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkebackup-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Backup for GKE API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkeconnect-gateway-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Connect Gateway API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/configmanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-configmanagement-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/multiclusteringress/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-multiclusteringress-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkemulticloud-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - GKE Multi-Cloud API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkerecommender/v1/Cargo.toml
+++ b/src/generated/cloud/gkerecommender/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkerecommender-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - GKE Recommender API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gsuiteaddons-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Workspace add-ons API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/iap/v1/Cargo.toml
+++ b/src/generated/cloud/iap/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iap-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Identity-Aware Proxy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-ids-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud IDS API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/kms/inventory/v1/Cargo.toml
+++ b/src/generated/cloud/kms/inventory/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-kms-inventory-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - KMS Inventory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-kms-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Key Management Service (KMS) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/language/v2/Cargo.toml
+++ b/src/generated/cloud/language/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-language-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Natural Language API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/licensemanager/v1/Cargo.toml
+++ b/src/generated/cloud/licensemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-licensemanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - License Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-location"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Metadata API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/lustre/v1/Cargo.toml
+++ b/src/generated/cloud/lustre/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-lustre-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Managed Lustre API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedidentities-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Microsoft Active Directory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/Cargo.toml
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedkafka-schemaregistry-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Apache Kafka API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedkafka/v1/Cargo.toml
+++ b/src/generated/cloud/managedkafka/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedkafka-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Apache Kafka API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-memcache-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Memorystore for Memcached API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-memorystore-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Memorystore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-metastore-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Dataproc Metastore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-migrationcenter-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Migration Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/modelarmor/v1/Cargo.toml
+++ b/src/generated/cloud/modelarmor/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-modelarmor-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Model Armor API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-netapp-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - NetApp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkconnectivity-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Network Connectivity API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkmanagement-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Network Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networksecurity-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Network Security API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkservices-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Network Services API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-notebooks-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Notebooks API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-optimization-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Optimization API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oracledatabase-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Oracle Database@Google Cloud API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orchestration-airflow-service-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Composer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orgpolicy/v1/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orgpolicy-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Organization Policy Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orgpolicy/v2/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orgpolicy-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Organization Policy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-osconfig-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - OS Config API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/oslogin/v1/Cargo.toml
+++ b/src/generated/cloud/oslogin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oslogin-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud OS Login API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-parallelstore-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Parallelstore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/parametermanager/v1/Cargo.toml
+++ b/src/generated/cloud/parametermanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-parametermanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Parameter Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policysimulator-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Policy Simulator API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policytroubleshooter-iam-v3"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Policy Troubleshooter API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policytroubleshooter-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Policy Troubleshooter API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privilegedaccessmanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Privileged Access Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rapidmigrationassessment-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Rapid Migration Assessment API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-recaptchaenterprise-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - reCAPTCHA Enterprise API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/recommender/logging/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/logging/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-recommender-logging-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Recommender API Logging"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/recommender/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-recommender-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Recommender API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-redis-cluster-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Memorystore for Redis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-redis-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Memorystore for Redis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-resourcemanager-v3"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Resource Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-retail-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI Search for commerce API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-run-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Run Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/scheduler/v1/Cargo.toml
+++ b/src/generated/cloud/scheduler/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-scheduler-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Scheduler API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-secretmanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Secret Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securesourcemanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Secure Source Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-security-privateca-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Certificate Authority API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/security/publicca/v1/Cargo.toml
+++ b/src/generated/cloud/security/publicca/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-security-publicca-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Public Certificate Authority API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securitycenter-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Security Command Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securityposture-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Security Posture API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/servicedirectory/v1/Cargo.toml
+++ b/src/generated/cloud/servicedirectory/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-servicedirectory-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Directory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/servicehealth/v1/Cargo.toml
+++ b/src/generated/cloud/servicehealth/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-servicehealth-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Service Health API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-shell-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Shell API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-speech-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Speech-to-Text API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-sql-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud SQL Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
+++ b/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storagebatchoperations-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Storage Batch Operations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storageinsights-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Storage Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/support/v2/Cargo.toml
+++ b/src/generated/cloud/support/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-support-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Support API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-talent-v4"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Talent Solution API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/tasks/v2/Cargo.toml
+++ b/src/generated/cloud/tasks/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-tasks-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Tasks API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-telcoautomation-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Telco Automation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-texttospeech-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Text-to-Speech API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-timeseriesinsights-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Timeseries Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-tpu-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud TPU API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-translation-v3"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Translation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-livestream-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Live Stream API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-stitcher-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Video Stitcher API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/transcoder/v1/Cargo.toml
+++ b/src/generated/cloud/video/transcoder/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-transcoder-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Transcoder API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-videointelligence-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Video Intelligence API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vision-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Vision API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vmmigration-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - VM Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vmwareengine-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - VMware Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vpcaccess-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Serverless VPC Access API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-webrisk-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Web Risk API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/websecurityscanner/v1/Cargo.toml
+++ b/src/generated/cloud/websecurityscanner/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-websecurityscanner-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Web Security Scanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workflows/executions/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/executions/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workflows-executions-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Workflow Executions API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workflows-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Workflows API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workstations-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Workstations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/container/v1/Cargo.toml
+++ b/src/generated/container/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-container-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Kubernetes Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datastore-admin-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Datastore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-artifactregistry-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Artifact Registry API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-build-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Build API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-build-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Build API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudprofiler/v2/Cargo.toml
+++ b/src/generated/devtools/cloudprofiler/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-profiler-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Profiler API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-trace-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Stackdriver Trace API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/containeranalysis/v1/Cargo.toml
+++ b/src/generated/devtools/containeranalysis/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-containeranalysis-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Container Analysis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-firestore-admin-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Firestore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/grafeas/v1/Cargo.toml
+++ b/src/generated/grafeas/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-grafeas-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Container Analysis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/admin/v1/Cargo.toml
+++ b/src/generated/iam/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-admin-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/credentials/v1/Cargo.toml
+++ b/src/generated/iam/credentials/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-credentials-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - IAM Service Account Credentials API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - IAM Meta API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v3"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/identity/accesscontextmanager/type/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-identity-accesscontextmanager-type"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Access Context Manager Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-identity-accesscontextmanager-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Access Context Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/logging/type/Cargo.toml
+++ b/src/generated/logging/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-logging-type"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Logging types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-logging-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Logging API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -36,6 +36,6 @@ operations.
 [codec]
 # We inherited an existing crate for `google-cloud-longrunning`. We need to use
 # version numbers higher than the existing releases until we hit 1.0.
-version               = "0.25.5"
+version               = "0.26.0"
 copyright-year        = '2024'
 'package:longrunning' = 'ignore=true'

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-longrunning"
-version                = "0.25.5"
+version                = "0.26.0"
 description            = "Google Cloud Client Libraries for Rust - Long Running Operations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/dashboard/v1/Cargo.toml
+++ b/src/generated/monitoring/dashboard/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-dashboard-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-metricsscope-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/v3/Cargo.toml
+++ b/src/generated/monitoring/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-v3"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "secretmanager-openapi-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Secret Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/oslogin/common/Cargo.toml
+++ b/src/generated/oslogin/common/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oslogin-common"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud OS Login Common Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privacy-dlp-v2"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Sensitive Data Protection (DLP)"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/rpc/context/Cargo.toml
+++ b/src/generated/rpc/context/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rpc-context"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - RPC Audit and Logging Attributes"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/rpc/types/Cargo.toml
+++ b/src/generated/rpc/types/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rpc"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Google RPC Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/showcase/Cargo.toml
+++ b/src/generated/showcase/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-showcase-v1beta1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Client Libraries Showcase API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-spanner-admin-database-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Spanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-spanner-admin-instance-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Spanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storagetransfer-v1"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Storage Transfer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-type"
-version                = "0.4.5"
+version                = "0.5.0"
 description            = "Google Cloud Client Libraries for Rust - Common Types"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "Google Cloud Client Libraries for Rust - LRO Helpers"
 name        = "google-cloud-lro"
-version     = "0.3.5"
+version     = "0.4.0"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-storage"
-version     = "0.25.0"
+version     = "0.25.1"
 description = "Google Cloud Client Libraries for Rust - Storage"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
Part of the work for #3237
