### PR TITLE
cleanup(rustdocfx): always use embedded templates

### DIFF
--- a/doc/rustdocfx/generate.go
+++ b/doc/rustdocfx/generate.go
@@ -466,10 +466,10 @@ func newDocfxManagedReference(c *crate, id string) (*docfxManagedReference, erro
 	return r, nil
 }
 
-func generate(c *crate, projectRoot string, outDir string) error {
+func generate(c *crate, outDir string) error {
 	var errs []error
 
-	if err := renderMetadata(c, projectRoot, outDir); err != nil {
+	if err := renderMetadata(c, outDir); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/doc/rustdocfx/main.go
+++ b/doc/rustdocfx/main.go
@@ -108,7 +108,7 @@ func main() {
 			crateOutDir := filepath.Join(*projectRoot, *out, crate.Name)
 			os.MkdirAll(crateOutDir, 0777) // Ignore errors
 
-			err = generate(&crate, *projectRoot, crateOutDir)
+			err = generate(&crate, crateOutDir)
 			if err != nil {
 				log.Fatalf("failed to generate for crate %s: %v\n", crate.Name, err)
 			}

--- a/doc/rustdocfx/render_metadata.go
+++ b/doc/rustdocfx/render_metadata.go
@@ -21,16 +21,20 @@ import (
 	"github.com/cbroglie/mustache"
 )
 
-func renderMetadata(c *crate, projectRoot, outDir string) error {
+func renderMetadata(c *crate, outDir string) error {
 	m, err := newDocfxMetadata(c)
 	if err != nil {
 		return err
 	}
-	s, err := mustache.RenderFile(filepath.Join(projectRoot, "doc/rustdocfx/templates/docs.metadata.mustache"), m)
+	contents, err := templatesProvider("docs.metadata.mustache")
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(outDir, "docs.metadata"), []byte(s), 0666); err != nil {
+	output, err := mustache.RenderPartials(contents, &mustacheProvider{}, m)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "docs.metadata"), []byte(output), 0644); err != nil {
 		return err
 	}
 	return nil

--- a/doc/rustdocfx/render_metadata_test.go
+++ b/doc/rustdocfx/render_metadata_test.go
@@ -33,7 +33,7 @@ func TestRenderMetadata(t *testing.T) {
 		},
 	}
 	outDir := t.TempDir()
-	if err := renderMetadata(input, "../..", outDir); err != nil {
+	if err := renderMetadata(input, outDir); err != nil {
 		t.Fatal(err)
 	}
 	contents, err := os.ReadFile(ospath.Join(outDir, "docs.metadata"))


### PR DESCRIPTION
Embedded templates make it easier to redistribute the binary, or use
it from outside its repository.

Fixes #3211
