### PR TITLE
fix(auth)!: Remove support for quota project from API Key creds

### DIFF
--- a/src/auth/src/headers_util.rs
+++ b/src/auth/src/headers_util.rs
@@ -73,12 +73,11 @@ fn build_bearer_headers(
 
 pub(crate) fn build_cacheable_api_key_headers(
     cached_token: &CacheableResource<Token>,
-    quota_project_id: &Option<String>,
 ) -> Result<CacheableResource<HeaderMap>> {
     match cached_token {
         CacheableResource::NotModified => Ok(CacheableResource::NotModified),
         CacheableResource::New { entity_tag, data } => {
-            let headers = build_api_key_headers(data, quota_project_id)?;
+            let headers = build_api_key_headers(data)?;
             Ok(CacheableResource::New {
                 entity_tag: entity_tag.clone(),
                 data: headers,
@@ -88,13 +87,10 @@ pub(crate) fn build_cacheable_api_key_headers(
 }
 
 /// A utility function to create API key headers.
-fn build_api_key_headers(
-    token: &crate::token::Token,
-    quota_project_id: &Option<String>,
-) -> Result<HeaderMap> {
+fn build_api_key_headers(token: &crate::token::Token) -> Result<HeaderMap> {
     build_headers(
         token,
-        quota_project_id,
+        &None,
         HeaderName::from_static(API_KEY_HEADER_KEY),
         |token| HeaderValue::from_str(&token.token).map_err(errors::non_retryable),
     )
@@ -255,7 +251,7 @@ mod tests {
             data: token,
         };
 
-        let result = build_cacheable_api_key_headers(&cacheable_token, &None);
+        let result = build_cacheable_api_key_headers(&cacheable_token);
 
         assert!(result.is_ok());
         let cached_headers = result.unwrap();
@@ -277,7 +273,7 @@ mod tests {
     fn build_cacheable_api_key_headers_basic_not_modified() {
         let cacheable_token = CacheableResource::NotModified;
 
-        let result = build_cacheable_api_key_headers(&cacheable_token, &None);
+        let result = build_cacheable_api_key_headers(&cacheable_token);
 
         assert!(result.is_ok());
         let cached_headers = result.unwrap();
@@ -288,61 +284,9 @@ mod tests {
     }
 
     #[test]
-    fn build_cacheable_api_key_headers_with_quota_project() {
-        let token = create_test_token("api_key_12345", "Bearer");
-        let cacheable_token = CacheableResource::New {
-            entity_tag: EntityTag::default(),
-            data: token,
-        };
-
-        let quota_project_id = Some("test-project-456".to_string());
-        let result = build_cacheable_api_key_headers(&cacheable_token, &quota_project_id);
-
-        assert!(result.is_ok());
-        let cached_headers = result.unwrap();
-        let headers = match cached_headers {
-            CacheableResource::New { data, .. } => data,
-            CacheableResource::NotModified => unreachable!("expecting new headers"),
-        };
-
-        assert_eq!(headers.len(), 2, "{headers:?}");
-
-        let api_key = headers
-            .get(HeaderName::from_static(API_KEY_HEADER_KEY))
-            .unwrap();
-
-        assert_eq!(api_key, HeaderValue::from_static("api_key_12345"));
-        assert!(api_key.is_sensitive());
-
-        let quota_project = headers
-            .get(HeaderName::from_static(QUOTA_PROJECT_KEY))
-            .unwrap();
-        assert_eq!(quota_project, HeaderValue::from_static("test-project-456"));
-    }
-
-    #[test]
     fn build_api_key_headers_invalid_token() {
         let token = create_test_token("api_key with \n invalid chars", "Bearer");
-        let result = build_api_key_headers(&token, &None);
-        let error = result.unwrap_err();
-        assert!(!error.is_transient(), "{error:?}");
-        let source = error
-            .source()
-            .and_then(|e| e.downcast_ref::<http::header::InvalidHeaderValue>());
-        assert!(
-            matches!(source, Some(http::header::InvalidHeaderValue { .. })),
-            "{error:?}"
-        );
-    }
-
-    #[test]
-    fn build_api_key_headers_invalid_quota_project() {
-        let token = create_test_token("api_key_12345", "Bearer");
-
-        let invalid_quota_project = Some("project with \n invalid chars".to_string());
-        let result = build_api_key_headers(&token, &invalid_quota_project);
-
-        assert!(result.is_err());
+        let result = build_api_key_headers(&token);
         let error = result.unwrap_err();
         assert!(!error.is_transient(), "{error:?}");
         let source = error


### PR DESCRIPTION
API Key and Quota Project are not meant to be used together. I

When quota project is passed with an API Key, the error is asking to give IAM permissions for using the quota project but API Key is not a principal to assign IAM Permissions.

(It works if no quota project is passed or if quota project is passed with a user cred)

```
$ curl -X POST \
-H "Content-Type: application/json" \
-H "X-Goog-User-Project: <quota-project>" \
"https://translation.googleapis.com/language/translate/v2?key=<api key>" \
-d '{
  "q": "Hello world!",
  "target": "es"
}'
{
  "error": {
    "code": 403,
    "message": "Caller does not have required permission to use project  <quota-project>. Grant the caller the roles/serviceusage.serviceUsageConsumer role, or a custom role with the serviceusage.services.use permission, by visiting https://console.developers.google.com/iam-admin/iam/project?project=<quota-project> and then retry. Propagation of the new permission may take a few minutes.",
    "errors": [
      {
        "message": "Caller does not have required permission to use project <quota-project> Grant the caller the roles/serviceusage.serviceUsageConsumer role, or a custom role with the serviceusage.services.use permission, by visiting https://console.developers.google.com/iam-admin/iam/project?project=<quota-project> and then retry. Propagation of the new permission may take a few minutes.",
        "domain": "global",
        "reason": "forbidden",
        "debugInfo": "detail: \"Permission denied for user 0 on user project <quota-project>.\"\n"
      }
    ],
    "status": "PERMISSION_DENIED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "USER_PROJECT_DENIED",
        "domain": "googleapis.com",
        "metadata": {
          "service": "translate.googleapis.com",
          "containerInfo": "<quota-project>",
          "consumer": "projects/<quota-project>"
        }
      },
    ]
  }
}
```