### PR TITLE
fix(auth)!: Remove universe domain builder method for mds

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -32,6 +32,8 @@ pub mod service_account;
 pub mod subject_token;
 pub mod user_account;
 pub(crate) const QUOTA_PROJECT_KEY: &str = "x-goog-user-project";
+
+#[cfg(test)]
 pub(crate) const DEFAULT_UNIVERSE_DOMAIN: &str = "googleapis.com";
 
 /// Represents an Entity Tag for a [CacheableResource].

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -515,15 +515,12 @@ mod tests {
     #[tokio::test]
     async fn get_mds_credentials_from_builder() -> Result<()> {
         let test_quota_project = "test-quota-project";
-        let test_universe_domain = "test-universe-domain";
         let mdcs = MdsBuilder::default()
             .with_quota_project_id(test_quota_project)
-            .with_universe_domain(test_universe_domain)
             .build()?;
         let fmt = format!("{mdcs:?}");
         assert!(fmt.contains("MDSCredentials"));
         assert!(fmt.contains(test_quota_project));
-        assert!(fmt.contains(test_universe_domain));
         Ok(())
     }
 


### PR DESCRIPTION
TPC support is not uniformly added across all credentials. Except MDS, all creds always provide GDU as the Universe Domain when `universe_domain` method is called.

Removing the explicit Universe Domain support for MDS and making it consistent with other cred types.

We can bring back this method after designing TPC support holistically.