### PR TITLE
cleanup(gax)!: future proof backoff policy

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -679,11 +679,7 @@ pub(crate) mod tests {
         #[derive(Debug)]
         pub BackoffPolicy {}
         impl BackoffPolicy for BackoffPolicy {
-            fn on_failure(
-                &self,
-                loop_start: std::time::Instant,
-                attempt_count: u32,
-            ) -> std::time::Duration;
+            fn on_failure(&self, state: &RetryState) -> std::time::Duration;
         }
     }
 

--- a/src/auth/src/retry.rs
+++ b/src/auth/src/retry.rs
@@ -198,11 +198,7 @@ mod tests {
     }
 
     impl BackoffPolicy for TestBackoffPolicy {
-        fn on_failure(
-            &self,
-            _loop_start: std::time::Instant,
-            _attempt_count: u32,
-        ) -> std::time::Duration {
+        fn on_failure(&self, _state: &RetryState) -> std::time::Duration {
             self.was_called.store(true, Ordering::SeqCst);
             std::time::Duration::from_millis(1)
         }

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -16,6 +16,7 @@
 mod tests {
     use gax::options::*;
     use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    use gax::retry_state::RetryState;
     use gax::retry_throttler::{CircuitBreaker, RetryThrottlerArg};
     use google_cloud_gax_internal::http::ReqwestClient;
     use google_cloud_gax_internal::options::ClientConfig;
@@ -167,14 +168,10 @@ mod tests {
         }
 
         impl gax::backoff_policy::BackoffPolicy for TestBackoffPolicy {
-            fn on_failure(
-                &self,
-                loop_start: std::time::Instant,
-                attempt_count: u32,
-            ) -> std::time::Duration {
-                if attempt_count == 1 {
+            fn on_failure(&self, state: &RetryState) -> std::time::Duration {
+                if state.attempt_count == 1 {
                     *self.elapsed_on_failure.lock().unwrap() =
-                        Some(tokio::time::Instant::now().into_std() - loop_start);
+                        Some(tokio::time::Instant::now().into_std() - state.start);
                 }
 
                 std::time::Duration::ZERO

--- a/src/gax/src/backoff_policy.rs
+++ b/src/gax/src/backoff_policy.rs
@@ -54,6 +54,7 @@
 //! [Exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff
 //! [idempotent]: https://en.wikipedia.org/wiki/Idempotence
 
+use crate::retry_state::RetryState;
 use std::sync::Arc;
 
 /// Defines the trait implemented by all backoff strategies.
@@ -65,8 +66,7 @@ pub trait BackoffPolicy: Send + Sync + std::fmt::Debug {
     /// * `attempt_count` - the number of attempts. This method is always called
     ///   after the first attempt.
     #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
-    fn on_failure(&self, loop_start: std::time::Instant, attempt_count: u32)
-    -> std::time::Duration;
+    fn on_failure(&self, state: &RetryState) -> std::time::Duration;
 }
 
 /// A helper type to use [BackoffPolicy] in client and request options.

--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -87,7 +87,7 @@ where
                     }
                     ThrottleResult::Continue(e) => e,
                 };
-                let delay = backoff_policy.on_failure(loop_start, attempt_count);
+                let delay = backoff_policy.on_failure(&state);
                 attempt = RetryLoopAttempt::Retry(attempt_count, delay, error);
                 continue;
             }
@@ -104,7 +104,7 @@ where
             }
             Err(e) => {
                 let flow = retry_policy.on_error(&state, e);
-                let delay = backoff_policy.on_failure(loop_start, attempt_count);
+                let delay = backoff_policy.on_failure(&state);
                 retry_throttler
                     .lock()
                     .expect("retry throttler lock is poisoned")
@@ -943,7 +943,7 @@ mod tests {
         #[derive(Debug)]
         BackoffPolicy {}
         impl BackoffPolicy for BackoffPolicy {
-            fn on_failure(&self, loop_start: std::time::Instant, attempt_count: u32) -> Duration;
+            fn on_failure(&self, state: &RetryState) -> Duration;
         }
     }
 

--- a/src/gax/tests/backoff_policy.rs
+++ b/src/gax/tests/backoff_policy.rs
@@ -18,6 +18,7 @@
 mod tests {
     use google_cloud_gax::backoff_policy::*;
     use google_cloud_gax::exponential_backoff::*;
+    use google_cloud_gax::retry_state::RetryState;
     use std::time::Duration;
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
@@ -26,13 +27,18 @@ mod tests {
         // Verify the calls work from outside the crate. The functionality is
         // verified in the unit tests.
         let policy = ExponentialBackoff::default();
-        let now = std::time::Instant::now();
-        assert!(policy.on_failure(now, 1) > Duration::ZERO, "{policy:?}");
+        assert!(
+            policy.on_failure(&RetryState::new(true).set_attempt_count(1_u32)) > Duration::ZERO,
+            "{policy:?}"
+        );
 
         let policy = ExponentialBackoffBuilder::new().build()?;
         let _ = format!("{policy:?}");
         let policy = ExponentialBackoffBuilder::new().build()?;
-        assert!(policy.on_failure(now, 1) > Duration::ZERO, "{policy:?}");
+        assert!(
+            policy.on_failure(&RetryState::new(true).set_attempt_count(1_u32)) > Duration::ZERO,
+            "{policy:?}"
+        );
         let _ = BackoffPolicyArg::from(policy);
 
         let policy = ExponentialBackoffBuilder::new().clamp();

--- a/src/storage/src/backoff_policy.rs
+++ b/src/storage/src/backoff_policy.rs
@@ -33,19 +33,19 @@ pub fn default() -> impl BackoffPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gax::retry_state::RetryState;
 
     #[test]
     fn default() {
-        let now = std::time::Instant::now() - Duration::from_millis(100);
         let policy = super::default();
 
-        let delay = policy.on_failure(now, 1);
+        let delay = policy.on_failure(&RetryState::new(true).set_attempt_count(1_u32));
         assert!(
             delay <= Duration::from_secs(1),
             "{delay:?}, policy={policy:?}"
         );
 
-        let delay = policy.on_failure(now, 2);
+        let delay = policy.on_failure(&RetryState::new(true).set_attempt_count(2_u32));
         assert!(
             delay <= Duration::from_secs(2),
             "{delay:?}, policy={policy:?}"

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -689,7 +689,7 @@ pub(crate) mod tests {
         pub BackoffPolicy {}
 
         impl gax::backoff_policy::BackoffPolicy for BackoffPolicy {
-            fn on_failure(&self, loop_start: std::time::Instant, attempt_count: u32) -> std::time::Duration;
+            fn on_failure(&self, state: &RetryState) -> std::time::Duration;
         }
     }
 


### PR DESCRIPTION
Use a struct as an argument so we can add fields to it without breaking
the trait definition.