### PR TITLE
chore(gax): bump version after future proofing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,8 +351,8 @@ tokio-test     = { default-features = false, version = "0.4" }
 # Local packages used as dependencies
 auth                          = { version = "0.23", path = "src/auth", package = "google-cloud-auth" }
 google-cloud-auth             = { version = "0.23", path = "src/auth" }
-gax                           = { version = "0.24", path = "src/gax", package = "google-cloud-gax" }
-google-cloud-gax              = { version = "0.24", path = "src/gax" }
+gax                           = { version = "0.25", path = "src/gax", package = "google-cloud-gax" }
+google-cloud-gax              = { version = "0.25", path = "src/gax" }
 gaxi                          = { version = "0.6.0", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.5", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "0.5", path = "src/generated/iam/v1" }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax"
-version     = "0.24.0"
+version     = "0.25.0"
 description = "Google Cloud Client Libraries for Rust"
 # Inherit other attributes from the workspace.
 authors.workspace      = true


### PR DESCRIPTION
Changing some traits to be future proof is a breaking change, we need
to bump the version.