### PR TITLE
cleanup(auth): remove `test_credentials()`

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -576,38 +576,12 @@ fn adc_well_known_path() -> Option<String> {
 #[cfg_attr(test, mutants::skip)]
 #[doc(hidden)]
 pub mod testing {
-    use super::{CacheableResource, EntityTag};
+    use super::CacheableResource;
     use crate::Result;
     use crate::credentials::Credentials;
     use crate::credentials::dynamic::CredentialsProvider;
     use http::{Extensions, HeaderMap};
     use std::sync::Arc;
-
-    /// A simple credentials implementation to use in tests where authentication does not matter.
-    ///
-    /// Always returns a "Bearer" token, with "test-only-token" as the value.
-    pub fn test_credentials() -> Credentials {
-        Credentials {
-            inner: Arc::from(TestCredentials {}),
-        }
-    }
-
-    #[derive(Debug)]
-    struct TestCredentials;
-
-    #[async_trait::async_trait]
-    impl CredentialsProvider for TestCredentials {
-        async fn headers(&self, _extensions: Extensions) -> Result<CacheableResource<HeaderMap>> {
-            Ok(CacheableResource::New {
-                entity_tag: EntityTag::default(),
-                data: HeaderMap::new(),
-            })
-        }
-
-        async fn universe_domain(&self) -> Option<String> {
-            None
-        }
-    }
 
     /// A simple credentials implementation to use in tests.
     ///

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -26,7 +26,6 @@ mod tests {
     use google_cloud_auth::credentials::EntityTag;
     use google_cloud_auth::credentials::mds::Builder as MdsBuilder;
     use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBuilder;
-    use google_cloud_auth::credentials::testing::test_credentials;
     use google_cloud_auth::credentials::user_account::Builder as UserAccountCredentialBuilder;
     use google_cloud_auth::credentials::{
         Builder as AccessTokenCredentialBuilder, CacheableResource, Credentials,
@@ -492,23 +491,6 @@ mod tests {
         };
         assert_eq!(creds.universe_domain().await.unwrap(), universe_domain);
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn testing_credentials() -> Result<()> {
-        let creds = test_credentials();
-        let cached_headers = creds.headers(Extensions::new()).await?;
-        match cached_headers {
-            CacheableResource::New { entity_tag, data } => {
-                assert_eq!(entity_tag, EntityTag::default());
-                assert!(data.is_empty());
-            }
-            CacheableResource::NotModified => {
-                unreachable!("Expecting a header to be present");
-            }
-        };
-        assert_eq!(creds.universe_domain().await, None);
         Ok(())
     }
 

--- a/src/gax-internal/tests/grpc_client_polling.rs
+++ b/src/gax-internal/tests/grpc_client_polling.rs
@@ -14,11 +14,14 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use auth::credentials::testing::test_credentials;
     use gax::polling_state::PollingState;
     use grpc_server::{builder, start_echo_server};
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
 
     /// A test policy, the only interesting bit is the name, which is included
     /// in debug messages and used in the tests.
@@ -90,7 +93,7 @@ mod tests {
     async fn request_options_polling_policies() -> TestResult {
         let (endpoint, _server) = start_echo_server().await?;
         let client = builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .with_polling_error_policy(TestErrorPolicy {
                 _name: "client-polling-error".to_string(),
             })

--- a/src/gax-internal/tests/grpc_retry_loop.rs
+++ b/src/gax-internal/tests/grpc_retry_loop.rs
@@ -14,12 +14,15 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use auth::credentials::testing::test_credentials;
     use gax::options::*;
     use gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_gax_internal::grpc;
     use grpc_server::google::test::v1::EchoResponse;
     use grpc_server::{builder, google, start_fixed_responses};
+
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
 
     #[tokio::test]
     async fn no_retry_immediate_success() -> anyhow::Result<()> {

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -14,10 +14,13 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use auth::credentials::testing::test_credentials;
     use gax::options::*;
     use google_cloud_gax_internal::grpc;
     use grpc_server::{builder, google, start_echo_server};
+
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn default_endpoint() -> anyhow::Result<()> {

--- a/src/gax-internal/tests/grpc_timeout.rs
+++ b/src/gax-internal/tests/grpc_timeout.rs
@@ -15,7 +15,6 @@
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
     use anyhow::Result;
-    use auth::credentials::testing::test_credentials;
     use gax::options::*;
     use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     use gax::retry_state::RetryState;
@@ -24,6 +23,10 @@ mod tests {
     use grpc_server::{builder, google, start_echo_server};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
+
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
 
     #[tokio::test(start_paused = true)]
     async fn test_no_timeout() -> Result<()> {

--- a/src/gax-internal/tests/grpc_user_agent.rs
+++ b/src/gax-internal/tests/grpc_user_agent.rs
@@ -18,11 +18,15 @@ mod test {
     use google_cloud_gax_internal::grpc;
     use grpc_server::{builder, google, start_echo_server};
 
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_user_agent() -> anyhow::Result<()> {
         let (endpoint, _server) = start_echo_server().await?;
         let client = builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .build()
             .await?;
 

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -19,13 +19,17 @@ mod tests {
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_error_with_status() -> Result<()> {
         use serde_json::Value;
         let (endpoint, _server) = echo_server::start().await?;
 
         let client = echo_server::builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .build()
             .await?;
 

--- a/src/gax-internal/tests/http_client_polling.rs
+++ b/src/gax-internal/tests/http_client_polling.rs
@@ -18,6 +18,10 @@ mod tests {
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
 
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
+
     /// A test policy, the only interesting bit is the name, which is included
     /// in debug messages and used in the tests.
     #[derive(Debug)]
@@ -48,7 +52,7 @@ mod tests {
     async fn default_polling_policies() -> TestResult {
         let (endpoint, _server) = echo_server::start().await?;
         let client = echo_server::builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .build()
             .await?;
 
@@ -64,7 +68,7 @@ mod tests {
     async fn client_config_polling_policies() -> TestResult {
         let (endpoint, _server) = echo_server::start().await?;
         let client = echo_server::builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .with_polling_error_policy(TestErrorPolicy {
                 _name: "client-polling-error".to_string(),
             })
@@ -89,7 +93,7 @@ mod tests {
     async fn request_options_polling_policies() -> TestResult {
         let (endpoint, _server) = echo_server::start().await?;
         let client = echo_server::builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .with_polling_error_policy(TestErrorPolicy {
                 _name: "client-polling-error".to_string(),
             })

--- a/src/gax-internal/tests/http_metadata.rs
+++ b/src/gax-internal/tests/http_metadata.rs
@@ -59,8 +59,9 @@ mod tests {
     }
 
     fn test_config() -> ClientConfig {
+        let cred = auth::credentials::anonymous::Builder::new().build();
         ClientConfig {
-            cred: auth::credentials::testing::test_credentials().into(),
+            cred: cred.into(),
             ..Default::default()
         }
     }

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -157,7 +157,7 @@ mod tests {
 
     fn test_config() -> ClientConfig {
         ClientConfig {
-            cred: auth::credentials::testing::test_credentials().into(),
+            cred: auth::credentials::anonymous::Builder::new().build().into(),
             ..ClientConfig::default()
         }
     }

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -249,7 +249,7 @@ mod tests {
 
     fn test_config() -> ClientConfig {
         ClientConfig {
-            cred: auth::credentials::testing::test_credentials().into(),
+            cred: auth::credentials::anonymous::Builder::new().build().into(),
             ..Default::default()
         }
     }

--- a/src/gax-internal/tests/http_user_agent.rs
+++ b/src/gax-internal/tests/http_user_agent.rs
@@ -19,11 +19,15 @@ mod tests {
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+    fn test_credentials() -> auth::credentials::Credentials {
+        auth::credentials::anonymous::Builder::new().build()
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_user_agent() -> Result<()> {
         let (endpoint, _server) = echo_server::start().await?;
         let client = echo_server::builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .build()
             .await?;
 
@@ -42,7 +46,7 @@ mod tests {
     async fn test_user_agent_with_prefix() -> Result<()> {
         let (endpoint, _server) = echo_server::start().await?;
         let client = echo_server::builder(endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(test_credentials())
             .build()
             .await?;
 

--- a/src/integration-tests/src/showcase.rs
+++ b/src/integration-tests/src/showcase.rs
@@ -99,7 +99,7 @@ async fn install() -> Result<String> {
 async fn wait_until_ready() -> Result<()> {
     let client = showcase::client::Testing::builder()
         .with_endpoint("http://localhost:7469")
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .with_tracing()
         .build()
         .await?;

--- a/src/integration-tests/src/showcase/compliance.rs
+++ b/src/integration-tests/src/showcase/compliance.rs
@@ -21,7 +21,7 @@ use std::error::Error as _;
 pub async fn run() -> Result<()> {
     let client = showcase::client::Compliance::builder()
         .with_endpoint("http://localhost:7469")
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .with_retry_policy(gax::retry_policy::NeverRetry)
         .with_tracing()
         .build()

--- a/src/integration-tests/src/showcase/echo.rs
+++ b/src/integration-tests/src/showcase/echo.rs
@@ -42,7 +42,7 @@ perish from the earth.
 pub async fn run() -> Result<()> {
     let client = showcase::client::Echo::builder()
         .with_endpoint("http://localhost:7469")
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .with_retry_policy(gax::retry_policy::NeverRetry)
         .with_tracing()
         .build()

--- a/src/integration-tests/src/showcase/identity.rs
+++ b/src/integration-tests/src/showcase/identity.rs
@@ -18,7 +18,7 @@ use showcase::model::*;
 pub async fn run() -> Result<()> {
     let client = showcase::client::Identity::builder()
         .with_endpoint("http://localhost:7469")
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .with_retry_policy(gax::retry_policy::NeverRetry)
         .with_tracing()
         .build()

--- a/src/integration-tests/tests/bindings.rs
+++ b/src/integration-tests/tests/bindings.rs
@@ -71,7 +71,7 @@ mod bindings {
     impl TestService {
         pub async fn new() -> Self {
             let config = gaxi::options::ClientConfig {
-                cred: auth::credentials::testing::test_credentials().into(),
+                cred: auth::credentials::anonymous::Builder::new().build().into(),
                 ..Default::default()
             };
             let inner = gaxi::http::ReqwestClient::new(config, "https://test.googleapis.com")

--- a/src/integration-tests/tests/requests.rs
+++ b/src/integration-tests/tests/requests.rs
@@ -26,7 +26,7 @@ mod requests {
 
         let client = aiplatform::client::PredictionService::builder()
             .with_endpoint(&endpoint)
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(auth::credentials::anonymous::Builder::new().build())
             .build()
             .await?;
 

--- a/src/lro/tests/integration.rs
+++ b/src/lro/tests/integration.rs
@@ -28,7 +28,7 @@ mod tests {
 
     async fn new_client(endpoint: String) -> Result<client::Client> {
         let client = client::Client::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(auth::credentials::anonymous::Builder::new().build())
             .with_endpoint(endpoint)
             .build()
             .await?;

--- a/src/storage/src/control/client.rs
+++ b/src/storage/src/control/client.rs
@@ -133,7 +133,7 @@ mod tests {
     #[tokio::test]
     async fn builder() -> anyhow::Result<()> {
         let _ = StorageControl::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(auth::credentials::anonymous::Builder::new().build())
             .build()
             .await?;
         Ok(())

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -647,7 +647,7 @@ pub(crate) mod tests {
 
     pub(crate) fn test_builder() -> ClientBuilder {
         ClientBuilder::new()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(auth::credentials::anonymous::Builder::new().build())
             .with_endpoint("http://private.googleapis.com")
             .with_backoff_policy(
                 gax::exponential_backoff::ExponentialBackoffBuilder::new()

--- a/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/resumable_tests.rs
@@ -350,7 +350,7 @@ async fn source_next_error() -> Result {
 
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .build()
         .await?;
     use crate::streaming_source::tests::MockSimpleSource;

--- a/src/storage/src/storage/perform_upload/buffered/single_shot_tests.rs
+++ b/src/storage/src/storage/perform_upload/buffered/single_shot_tests.rs
@@ -48,7 +48,7 @@ async fn upload_object_buffered() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .with_resumable_upload_threshold(4 * RESUMABLE_UPLOAD_QUANTUM)
         .build()
         .await?;
@@ -72,7 +72,7 @@ async fn single_shot_source_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .build()
         .await?;
     use crate::streaming_source::tests::MockSimpleSource;

--- a/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/resumable_tests.rs
@@ -316,7 +316,7 @@ async fn source_seek_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .build()
         .await?;
     use crate::streaming_source::tests::MockSeekSource;
@@ -362,7 +362,7 @@ async fn source_next_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(auth::credentials::anonymous::Builder::new().build())
         .build()
         .await?;
     use crate::streaming_source::tests::MockSeekSource;

--- a/src/storage/src/storage/perform_upload/unbuffered/single_shot_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/single_shot_tests.rs
@@ -25,6 +25,7 @@ use crate::storage::client::{
 use crate::storage::perform_upload::tests::perform_upload;
 use crate::streaming_source::IterSource;
 use crate::streaming_source::SizeHint;
+use auth::credentials::anonymous::Builder as Anonymous;
 use gax::retry_policy::RetryPolicyExt;
 use http_body_util::BodyExt;
 use httptest::{Expectation, Server, matchers::*, responders::*};
@@ -46,7 +47,7 @@ async fn http_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let err = client
@@ -73,7 +74,7 @@ async fn http_308_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let err = client
@@ -100,7 +101,7 @@ async fn deserialization() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let err = client
@@ -119,7 +120,7 @@ async fn source_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     use crate::streaming_source::tests::MockSeekSource;
@@ -159,7 +160,7 @@ async fn seek_error() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     use crate::streaming_source::tests::MockSeekSource;
@@ -410,7 +411,7 @@ async fn send_unbuffered() -> Result {
 
     let client = Storage::builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let response = client

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -777,6 +777,7 @@ mod tests {
     use super::*;
     use crate::error::ChecksumMismatch;
     use crate::model_ext::{KeyAes256, ReadRange, tests::create_key_helper};
+    use auth::credentials::anonymous::Builder as Anonymous;
     use futures::TryStreamExt;
     use httptest::{Expectation, Server, matchers::*, responders::status_code};
     use std::collections::HashMap;
@@ -802,7 +803,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_is_send_and_static() -> Result {
         let client = Storage::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
 
@@ -840,7 +841,7 @@ mod tests {
 
         let client = Storage::builder()
             .with_endpoint(format!("http://{}", server.addr()))
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let mut reader = client
@@ -887,7 +888,7 @@ mod tests {
         let endpoint = server.url("");
         let client = Storage::builder()
             .with_endpoint(endpoint.to_string())
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let reader = client
@@ -928,7 +929,7 @@ mod tests {
 
         let client = Storage::builder()
             .with_endpoint(format!("http://{}", server.addr()))
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let response = client
@@ -971,7 +972,7 @@ mod tests {
 
         let client = Storage::builder()
             .with_endpoint(format!("http://{}", server.addr()))
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
 
@@ -1008,7 +1009,7 @@ mod tests {
 
         let client = Storage::builder()
             .with_endpoint(format!("http://{}", server.addr()))
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let err = client
@@ -1044,7 +1045,7 @@ mod tests {
 
         let client = Storage::builder()
             .with_endpoint(format!("http://{}", server.addr()))
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let mut response = client
@@ -1140,7 +1141,7 @@ mod tests {
 
         let client = Storage::builder()
             .with_endpoint(format!("http://{}", server.addr()))
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let mut response = client

--- a/src/storage/src/storage/read_object/resume_tests.rs
+++ b/src/storage/src/storage/read_object/resume_tests.rs
@@ -55,6 +55,7 @@ use crate::{
         MockBackoffPolicy, MockReadResumePolicy, MockRetryPolicy, MockRetryThrottler, test_builder,
     },
 };
+use auth::credentials::anonymous::Builder as Anonymous;
 use gax::retry_policy::RetryPolicyExt;
 use gax::retry_result::RetryResult;
 use httptest::{Expectation, Server, matchers::*, responders::*};
@@ -81,7 +82,7 @@ async fn start_retry_normal() -> Result {
 
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -113,7 +114,7 @@ async fn start_permanent_error() -> Result {
 
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let err = client
@@ -139,7 +140,7 @@ async fn start_too_many_transients() -> Result {
 
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let err = client
@@ -337,7 +338,7 @@ async fn long_read_error() -> Result {
 
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -404,7 +405,7 @@ async fn resume_after_start() -> Result {
     );
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -475,7 +476,7 @@ async fn resume_after_start_range() -> Result {
     );
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -530,7 +531,7 @@ async fn resume_after_start_permanent() -> Result {
     );
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -558,7 +559,7 @@ async fn request_after_start_too_many_transients() -> Result {
     return_fragments(&server, 10, 5);
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -758,7 +759,7 @@ async fn request_resume_options() -> Result {
     return_fragments(&server, 10, 10);
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .build()
         .await?;
     let mut reader = client
@@ -792,7 +793,7 @@ async fn client_resume_options() -> Result {
     return_fragments(&server, 10, 10);
     let client = test_builder()
         .with_endpoint(format!("http://{}", server.addr()))
-        .with_credentials(auth::credentials::testing::test_credentials())
+        .with_credentials(Anonymous::new().build())
         .with_read_resume_policy(resume)
         .build()
         .await?;

--- a/src/storage/src/storage/write_object.rs
+++ b/src/storage/src/storage/write_object.rs
@@ -1061,6 +1061,7 @@ mod tests {
     use crate::model::{ObjectChecksums, WriteObjectSpec};
     use crate::storage::checksum::details::{Crc32c, Md5};
     use crate::streaming_source::tests::MockSeekSource;
+    use auth::credentials::anonymous::Builder as Anonymous;
     use std::error::Error as _;
     use std::io::{Error as IoError, ErrorKind};
 
@@ -1085,7 +1086,7 @@ mod tests {
         }
 
         let client = Storage::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let _ = client.write_object("projects/_/buckets/test-bucket", "test-object", Source);
@@ -1105,7 +1106,7 @@ mod tests {
         }
 
         let client = Storage::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
         let _ = client.write_object("projects/_/buckets/test-bucket", "test-object", Source);
@@ -1116,7 +1117,7 @@ mod tests {
     #[tokio::test]
     async fn test_upload_is_send_and_static() -> Result {
         let client = Storage::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
 

--- a/src/storage/tests/binding.rs
+++ b/src/storage/tests/binding.rs
@@ -14,6 +14,7 @@
 
 #[cfg(test)]
 mod tests {
+    use auth::credentials::anonymous::Builder as Anonymous;
     use gax::error::binding::*;
     use google_cloud_storage as gcs;
     use std::error::Error as _;
@@ -21,7 +22,7 @@ mod tests {
     #[tokio::test]
     async fn useful_binding_error() -> anyhow::Result<()> {
         let client = gcs::client::StorageControl::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
 
@@ -84,7 +85,7 @@ mod tests {
     #[tokio::test]
     async fn binding_error_or() -> anyhow::Result<()> {
         let client = gcs::client::StorageControl::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
 
@@ -133,7 +134,7 @@ mod tests {
     #[tokio::test]
     async fn binding_error_and() -> anyhow::Result<()> {
         let client = gcs::client::StorageControl::builder()
-            .with_credentials(auth::credentials::testing::test_credentials())
+            .with_credentials(Anonymous::new().build())
             .build()
             .await?;
 


### PR DESCRIPTION
This is now redundant, `anonymous::Builder` can do the same thing.

This is non-breaking. The function was `#[doc(hidden)]`, and those are
not part of the public API. In any case, we bumped the version for other
reasons