### PR TITLE
impl(gax): prevent `ClientConfig` breaking changes

### DIFF
--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -41,10 +41,9 @@ mod tests {
         let _e = ScopedEnv::remove(LOGGING_VAR);
         let config = ClientConfig::default();
         assert!(!tracing_enabled(&config), "expected tracing to be disabled");
-        let config = ClientConfig {
-            tracing: true,
-            ..ClientConfig::default()
-        };
+        let mut config = ClientConfig::default();
+        config.tracing = true;
+        let config = config;
         assert!(tracing_enabled(&config), "expected tracing to be enabled");
 
         let _e = ScopedEnv::set(LOGGING_VAR, "true");

--- a/src/gax-internal/tests/http_metadata.rs
+++ b/src/gax-internal/tests/http_metadata.rs
@@ -59,10 +59,8 @@ mod tests {
     }
 
     fn test_config() -> ClientConfig {
-        let cred = auth::credentials::anonymous::Builder::new().build();
-        ClientConfig {
-            cred: cred.into(),
-            ..Default::default()
-        }
+        let mut config = ClientConfig::default();
+        config.cred = auth::credentials::anonymous::Builder::new().build().into();
+        config
     }
 }

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -156,10 +156,9 @@ mod tests {
     }
 
     fn test_config() -> ClientConfig {
-        ClientConfig {
-            cred: auth::credentials::anonymous::Builder::new().build().into(),
-            ..ClientConfig::default()
-        }
+        let mut config = ClientConfig::default();
+        config.cred = auth::credentials::anonymous::Builder::new().build().into();
+        config
     }
 
     fn test_backoff() -> impl BackoffPolicy {

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -248,9 +248,8 @@ mod tests {
     }
 
     fn test_config() -> ClientConfig {
-        ClientConfig {
-            cred: auth::credentials::anonymous::Builder::new().build().into(),
-            ..Default::default()
-        }
+        let mut config = ClientConfig::default();
+        config.cred = auth::credentials::anonymous::Builder::new().build().into();
+        config
     }
 }

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -413,6 +413,7 @@ pub mod internal {
     /// override the default endpoint, the default authentication credentials,
     /// the retry policies, and/or other behaviors of the client.
     #[derive(Clone, Debug)]
+    #[non_exhaustive]
     pub struct ClientConfig<Cr> {
         pub endpoint: Option<String>,
         pub cred: Option<Cr>,

--- a/src/integration-tests/tests/bindings.rs
+++ b/src/integration-tests/tests/bindings.rs
@@ -70,10 +70,8 @@ mod bindings {
 
     impl TestService {
         pub async fn new() -> Self {
-            let config = gaxi::options::ClientConfig {
-                cred: auth::credentials::anonymous::Builder::new().build().into(),
-                ..Default::default()
-            };
+            let mut config = gaxi::options::ClientConfig::default();
+            config.cred = auth::credentials::anonymous::Builder::new().build().into();
             let inner = gaxi::http::ReqwestClient::new(config, "https://test.googleapis.com")
                 .await
                 .expect("test credentials can never fail");


### PR DESCRIPTION
This type is in the internal namespace, and `#[doc(hidden)]` so it is
not part of the public API for two reasons. However, nothing prevented
us from using the type in a way that can introduce breaking changes.

Making the type `#[non_exhaustive]` forces us to use the type in more
backwards compatible ways.

FWIW, I reviewed `RequestOptions` and it does not have public fields, so it is not subject to this problem.
