### PR TITLE
feat(o12y): adding tracing details for http.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost",
+ "tracing",
 ]
 
 [[package]]

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -44,6 +44,7 @@ _internal-http-client = [
   "dep:serde",
   "dep:serde_json",
   "dep:tokio",
+  "dep:tracing",
 ]
 _internal-grpc-client = [
   "_internal-common",
@@ -76,6 +77,7 @@ thiserror        = { workspace = true, optional = true }
 tokio            = { workspace = true, optional = true, features = ["macros", "rt-multi-thread"] }
 tonic            = { workspace = true, optional = true }
 tonic-prost      = { workspace = true, optional = true }
+tracing          = { workspace = true, optional = true }
 # Local crates
 auth = { workspace = true, optional = true }
 gax  = { workspace = true, optional = true }


### PR DESCRIPTION
DO NOT MERGE.  This is a prototype of instrumenting the HTTP client with detailed and structured trace information.

Depends on https://github.com/googleapis/librarian/pull/1981

For #3239 