### PR TITLE
chore: bump version for gax-internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,7 +353,7 @@ auth                          = { version = "1", path = "src/auth", package = "g
 google-cloud-auth             = { version = "1", path = "src/auth" }
 gax                           = { version = "1", path = "src/gax", package = "google-cloud-gax" }
 google-cloud-gax              = { version = "1", path = "src/gax" }
-gaxi                          = { version = "0.6.0", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                          = { version = "0.7.0", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "1", path = "src/generated/iam/v1" }
 location                      = { version = "1", path = "src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.6.0"
+version     = "0.7.0"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.


### PR DESCRIPTION
Need a new version that depends on gax@1.0.0