### PR TITLE
ci: skip some builds on Windows

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -53,10 +53,12 @@ jobs:
       - name: Build full workspace
         # See Cargo.toml for the definition and motivation of this profile
         run: cargo clean && cargo build --profile=ci --workspace
+        if: matrix.os != 'windows-2025'
       - name: Running tests for full workspace
         # See Cargo.toml for the definition and motivation of this profile
         run: cargo clean && cargo test --profile=ci --workspace
         if: github.event_name == 'push'
+
   features:
     strategy:
       matrix:


### PR DESCRIPTION
Building the full workspace is rather slow on Windows, and it is
unlikely to find any problems: the key packages (storage, auth, gax)
already test all the "windows" differences.