### PR TITLE
impl(rustdocfx): introduce markdown parsing for comments

### DIFF
--- a/doc/rustdocfx/go.mod
+++ b/doc/rustdocfx/go.mod
@@ -7,4 +7,3 @@ require (
 	github.com/google/go-cmp v0.7.0
         github.com/yuin/goldmark v1.7.13
 )
-

--- a/doc/rustdocfx/go.mod
+++ b/doc/rustdocfx/go.mod
@@ -5,6 +5,6 @@ go 1.24.4
 require (
 	github.com/cbroglie/mustache v1.4.0
 	github.com/google/go-cmp v0.7.0
+        github.com/yuin/goldmark v1.7.13
 )
 
-require github.com/yuin/goldmark v1.7.13 // indirect

--- a/doc/rustdocfx/go.mod
+++ b/doc/rustdocfx/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/cbroglie/mustache v1.4.0
 	github.com/google/go-cmp v0.7.0
 )
+
+require github.com/yuin/goldmark v1.7.13 // indirect

--- a/doc/rustdocfx/go.sum
+++ b/doc/rustdocfx/go.sum
@@ -2,3 +2,5 @@ github.com/cbroglie/mustache v1.4.0 h1:Azg0dVhxTml5me+7PsZ7WPrQq1Gkf3WApcHMjMprY
 github.com/cbroglie/mustache v1.4.0/go.mod h1:SS1FTIghy0sjse4DUVGV1k/40B1qE1XkD9DtDsHo9iM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/doc/rustdocfx/process_docs.go
+++ b/doc/rustdocfx/process_docs.go
@@ -80,7 +80,7 @@ func processDocString(contents string) (string, error) {
 				for i := 0; i < node.Lines().Len(); i++ {
 					line := node.Lines().At(i)
 					line_str := string(line.Value(documentationBytes))
-                                        add_line(line_str)
+					add_line(line_str)
 				}
 			}
 			return ast.WalkSkipChildren, nil

--- a/doc/rustdocfx/process_docs.go
+++ b/doc/rustdocfx/process_docs.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+type State struct {
+	Indent int
+	Marker string
+}
+
+func processDocString(contents string) (string, error) {
+	var results []string
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithExtensions(),
+	)
+	documentationBytes := []byte(contents)
+	doc := md.Parser().Parse(text.NewReader(documentationBytes))
+
+	// A flag for when we need an extra line break between blocks.
+	print_previous_blank := false
+
+	// Write a new line, given the current state.
+	add_line := func(l string) {
+		results = append(results, l)
+		// We wrote something. Accept an extra line break between blocks.
+		print_previous_blank = true
+	}
+
+	err := ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		// First handle blank lines between blocks
+		switch node.Kind() {
+		case ast.KindCodeBlock,
+			ast.KindFencedCodeBlock,
+			ast.KindHeading,
+			ast.KindList,
+			ast.KindListItem,
+			ast.KindParagraph,
+			ast.KindTextBlock:
+			if entering && node.HasBlankPreviousLines() && print_previous_blank {
+				results = append(results, "")
+				// Disallow consecutive empty lines.
+				print_previous_blank = false
+			}
+		}
+
+		switch node.Kind() {
+		case ast.KindDocument:
+			// The root block. There is nothing to render.
+		case ast.KindTextBlock,
+			ast.KindParagraph:
+			// We will dump the contents from these blocks, skipping
+			// any children. This saves us from having to parse all
+			// inline blocks, e.g. an **emphasis** block.
+			if entering {
+				for i := 0; i < node.Lines().Len(); i++ {
+					line := node.Lines().At(i)
+					line_str := string(line.Value(documentationBytes))
+                                        add_line(line_str)
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		default:
+			if entering {
+				fmt.Printf("\n\nKind: %d", node.Kind())
+				node.Dump(documentationBytes, 2)
+				return ast.WalkStop, fmt.Errorf("Encountered unknown NodeKind: %s", node.Kind().String())
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	for i, line := range results {
+		// Many lines end in a newline, but we are handling new lines
+		// manually. So we trim any extra space on the right.
+		results[i] = strings.TrimRightFunc(line, unicode.IsSpace)
+	}
+	return strings.Join(results, "\n"), nil
+}

--- a/doc/rustdocfx/process_docs.go
+++ b/doc/rustdocfx/process_docs.go
@@ -88,7 +88,7 @@ func processDocString(contents string) (string, error) {
 			if entering {
 				fmt.Printf("\n\nKind: %d", node.Kind())
 				node.Dump(documentationBytes, 2)
-				return ast.WalkStop, fmt.Errorf("Encountered unknown NodeKind: %s", node.Kind().String())
+				return ast.WalkStop, fmt.Errorf("encountered unknown NodeKind: %s", node.Kind().String())
 			}
 		}
 		return ast.WalkContinue, nil

--- a/doc/rustdocfx/process_docs_test.go
+++ b/doc/rustdocfx/process_docs_test.go
@@ -30,6 +30,6 @@ More text`
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch in processDocString for paragrapsh (-want, +got)\n:%s", diff)
+		t.Errorf("mismatch in processDocString for paragraphs (-want, +got)\n:%s", diff)
 	}
 }

--- a/doc/rustdocfx/process_docs_test.go
+++ b/doc/rustdocfx/process_docs_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPreserveParagraphs(t *testing.T) {
+	input := `Leading text
+
+More text`
+	want := input
+	got, err := processDocString(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in processDocString for paragrapsh (-want, +got)\n:%s", diff)
+	}
+}


### PR DESCRIPTION
Part of the work for #3226 

Introduce a simple parser for markdown. We will use these on the doc strings.

---

For context, this is where we are going: https://github.com/dbolduc/google-cloud-rust/commit/84636a719ce3ed82e70f234546c98a54832619f9

I plan to add the node kinds one at a time to make the reviews easier. But some of the code along the way may seem like overkill.