### PR TITLE
impl(docfx): preserve links

### DIFF
--- a/doc/rustdocfx/process_docs.go
+++ b/doc/rustdocfx/process_docs.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -142,5 +143,21 @@ func processDocString(contents string) (string, error) {
 		// manually. So we trim any extra space on the right.
 		results[i] = strings.TrimRightFunc(line, unicode.IsSpace)
 	}
+
+	// Append reference links. These are skipped by the AST.
+	results = append(results, referenceLinks(contents)...)
 	return strings.Join(results, "\n"), nil
+}
+
+var referenceLinkMatcher = regexp.MustCompile(`^\[([^\]]+)\]:\s*(.*)$`)
+
+func referenceLinks(contents string) []string {
+	var results []string
+	lines := strings.Split(contents, "\n")
+	for _, line := range lines {
+		if len(referenceLinkMatcher.FindStringSubmatch(line)) > 0 {
+			results = append(results, line)
+		}
+	}
+	return results
 }

--- a/doc/rustdocfx/process_docs_test.go
+++ b/doc/rustdocfx/process_docs_test.go
@@ -34,6 +34,31 @@ More text`
 	}
 }
 
+func TestPreserveLinks(t *testing.T) {
+	input := `[This is a link](www.example.com).
+
+And here is a [reference link] in the middle of text.
+
+And here is [another link][].
+
+And this is [a link with a title][title].
+
+And this is [a link with a title][but-its-different].
+
+[another link]: www.another-link.com
+[but-its-different]: www.different.com
+[reference link]: www.reference-link.com
+[title]: www.title.com`
+	want := input
+	got, err := processDocString(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in processDocString for links (-want, +got)\n:%s", diff)
+	}
+}
+
 func TestPreserveLists(t *testing.T) {
 	input := `Leading text
 


### PR DESCRIPTION
Part of the work for https://github.com/googleapis/google-cloud-rust/issues/3213

Link is an element of the AST, but here are some observations:
- we only know a link's `Text` and `Destination`
- we lose any references i.e. we could not distinguish between `[foo][bar]` and `[foo][baz]`.

We could choose to write every link inline as `[foo](www.example.com/bar)`. This would force us to process all inline nodes, which is more than we bargained for.

So instead the strategy is to print the raw text as is, and manually look through the source for the references.