### PR TITLE
impl(docfx): handle HTML blocks in comments

### DIFF
--- a/doc/rustdocfx/process_docs.go
+++ b/doc/rustdocfx/process_docs.go
@@ -78,6 +78,7 @@ func processDocString(contents string) (string, error) {
 		switch node.Kind() {
 		case ast.KindCodeBlock,
 			ast.KindFencedCodeBlock,
+			ast.KindHTMLBlock,
 			ast.KindHeading,
 			ast.KindList,
 			ast.KindListItem,
@@ -93,8 +94,9 @@ func processDocString(contents string) (string, error) {
 		switch node.Kind() {
 		case ast.KindDocument:
 			// The root block. There is nothing to render.
-		case ast.KindTextBlock,
-			ast.KindParagraph:
+		case ast.KindHTMLBlock,
+			ast.KindParagraph,
+			ast.KindTextBlock:
 			// We will dump the contents from these blocks, skipping
 			// any children. This saves us from having to parse all
 			// inline blocks, e.g. an **emphasis** block.

--- a/doc/rustdocfx/process_docs_test.go
+++ b/doc/rustdocfx/process_docs_test.go
@@ -34,6 +34,18 @@ More text`
 	}
 }
 
+func TestPreserveHTML(t *testing.T) {
+	input := "Google APIs eXtensions for Rust.\n\nThis crate contains a number of types and functions used in the\nimplementation of the Google Cloud Client Libraries for Rust.\n\n<div class=\"warning\">\nAll the types, traits, and functions defined in any module with `internal`\nin its name are <b>not</b> intended for general use. Such symbols will\nremain unstable for the foreseeable future, even if used in stable SDKs.\nWe (the Google Cloud Client Libraries for Rust team) control both and will\nchange both if needed.\n</div>"
+	want := input
+	got, err := processDocString(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in processDocString for lists (-want, +got)\n:%s", diff)
+	}
+}
+
 func TestPreserveLinks(t *testing.T) {
 	input := `[This is a link](www.example.com).
 


### PR DESCRIPTION
Part of the work for #3213 

I missed that HTML blocks are a thing. Noticed when running `rustdocfx` on all crates.

The unit test uses the actual doc string from `google-cloud-gax`.