### PR TITLE
impl(docfx): handle code blocks in comments

### DIFF
--- a/doc/rustdocfx/process_docs.go
+++ b/doc/rustdocfx/process_docs.go
@@ -168,6 +168,19 @@ func processDocString(contents string) (string, error) {
 			// Restore the marker, which might have been cleared if the
 			// item has multi-line text blocks.
 			print_marker = true
+		case ast.KindCodeBlock:
+			// https://spec.commonmark.org/0.31.2/#indented-code-block
+			if entering {
+				state.Indent += 4
+				states = append(states, state)
+				for i := 0; i < node.Lines().Len(); i++ {
+					line := node.Lines().At(i)
+					line_str := string(line.Value(documentationBytes))
+					add_line(line_str)
+				}
+			} else {
+				states = states[:len(states)-1]
+			}
 		default:
 			if entering {
 				fmt.Printf("\n\nKind: %d", node.Kind())

--- a/doc/rustdocfx/process_docs_test.go
+++ b/doc/rustdocfx/process_docs_test.go
@@ -98,6 +98,27 @@ More text`
 	}
 }
 
+func TestPreserveCodeBlocks(t *testing.T) {
+	input := `Leading text
+
+    An old-school code block.
+    These are represented by
+    lines of text with at least
+    4 leading whitespaces.
+        The lines are allowed
+      to be indented.
+
+More text`
+	want := input
+	got, err := processDocString(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in processDocString for code blocks (-want, +got)\n:%s", diff)
+	}
+}
+
 func TestFilterCodeBlockComments(t *testing.T) {
 	input := `Leading text
 


### PR DESCRIPTION
Part of the work for #3213 

Handle indented code blocks. Leave them as-is, instead of wrapping them in a fenced code block.

I do not think these currently occur in our docs. We would have to use one in a handwritten comment. (the sidekick proto comment parser converts these to fenced code blocks). I already wrote the code and a test though, so let's commit it.