### PR TITLE
impl(docfx): filter examples

### DIFF
--- a/doc/rustdocfx/workspace.go
+++ b/doc/rustdocfx/workspace.go
@@ -101,7 +101,7 @@ func (c *crate) getName(id string) string {
 }
 
 func (c *crate) getDocString(id string) (string, error) {
-	return c.Index[id].Docs, nil
+	return processDocString(c.Index[id].Docs)
 }
 
 type kind int


### PR DESCRIPTION
Fixes #3213

Start processing the doc string comments. As of now, the only processing is to filter out lines of Rust code in examples that start with a `#`.

Before:
<img width="1872" height="1644" alt="image" src="https://github.com/user-attachments/assets/ab121824-aae5-4ab5-8162-7cf10cc63fb9" />

After:
<img width="1872" height="1644" alt="image" src="https://github.com/user-attachments/assets/55237de9-a606-422f-9fe2-f89897faf01a" />