### PR TITLE
cleanup: remove stale `.gitignore` entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,6 @@
 
 # Rust places its build artifacts in target/ directories.
 /target/
-**/target/
-
-# We create lockfiles when generating code via Prost+Tonic, but we do not want
-# to save these.
-**/Cargo.lock
 
 # We use a few Python tools for development [^1]. Reserve `.env/` to install
 # these tools in a local Python virtual environment.


### PR DESCRIPTION
We no longer generate `Cargo.lock` files in subdirectories, nor do we
generate `target/` directories in subdirectories.

Incidentally, this removes some blockers for `release-plz` updating our
version numbers.