### PR TITLE
docs(storage): add read public object example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6649,6 +6649,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-iam-v1",
  "google-cloud-lro",

--- a/src/storage/examples/Cargo.toml
+++ b/src/storage/examples/Cargo.toml
@@ -29,6 +29,7 @@ base64.workspace               = true
 bytes.workspace                = true
 clap                           = { workspace = true, features = ["derive", "std"] }
 futures.workspace              = true
+google-cloud-auth.workspace    = true
 google-cloud-gax.workspace     = true
 google-cloud-iam-v1.workspace  = true
 google-cloud-lro.workspace     = true

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -429,6 +429,12 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     let content = tokio::fs::read_to_string(downloaded_file_path).await?;
     assert_eq!(content, "hello world from file");
 
+    tracing::info!("running download_public_file example");
+    // Public object containing 2B of data.
+    let public_bucket = "gcp-public-data-arco-era5";
+    let public_object = "ar/1959-2022-1h-240x121_equiangular_with_poles_conservative.zarr/.zattrs";
+    objects::download_public_file::sample(public_bucket, public_object).await?;
+
     tracing::info!("running download_byte_range example");
     objects::download_byte_range::sample(&client, &id, "object-to-download.txt", 4, 10).await?;
 

--- a/src/storage/examples/src/objects.rs
+++ b/src/storage/examples/src/objects.rs
@@ -23,6 +23,7 @@ pub mod delete_file_archived_generation;
 pub mod download_byte_range;
 pub mod download_encrypted_file;
 pub mod download_file;
+pub mod download_public_file;
 pub mod file_download_into_memory;
 pub mod file_upload_from_memory;
 pub mod generate_encryption_key;

--- a/src/storage/examples/src/objects/download_public_file.rs
+++ b/src/storage/examples/src/objects/download_public_file.rs
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_download_public_file]
+use google_cloud_auth::credentials::anonymous;
+use google_cloud_storage::client::Storage;
+
+pub async fn sample(bucket: &str, object: &str) -> Result<(), anyhow::Error> {
+    let client = Storage::builder()
+        .with_credentials(anonymous::Builder::new().build())
+        .build()
+        .await?;
+
+    // Download the file.
+    let mut reader = client
+        .read_object(format!("projects/_/buckets/{bucket}"), object)
+        .send()
+        .await?;
+
+    println!("counting newlines {object} in bucket {bucket}");
+    let mut count = 0;
+    while let Some(buffer) = reader.next().await.transpose()? {
+        count += buffer.into_iter().filter(|c| *c == b'\n').count();
+    }
+    println!("Public object {object} in bucket {bucket} contains {count} newlines");
+    Ok(())
+}
+// [END storage_download_public_file]


### PR DESCRIPTION
Use the anonymous credentials to download a public object. Chose a random small object from a publicly available dataset.

Fixes #3073 