### PR TITLE
chore: bump versions with sidekick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-aiplatform-v1"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apihub-v1"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataplex-v1"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-discoveryengine-v1"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-v1"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-kms-v1"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privacy-dlp-v2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securitycenter-v2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/generated/cloud/aiplatform/v1/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/v1/.sidekick.toml
@@ -17,6 +17,7 @@ specification-source = 'google/cloud/aiplatform/v1'
 service-config       = 'google/cloud/aiplatform/v1/aiplatform_v1.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'
 # TODO(#893) - handle the bad HTML tags in this library.
 disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links,invalid_html_tags"

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-aiplatform-v1"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apihub/v1/.sidekick.toml
+++ b/src/generated/cloud/apihub/v1/.sidekick.toml
@@ -17,4 +17,5 @@ specification-source = 'google/cloud/apihub/v1'
 service-config = 'google/cloud/apihub/v1/apihub_v1.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apihub-v1"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - API hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataplex/v1/.sidekick.toml
+++ b/src/generated/cloud/dataplex/v1/.sidekick.toml
@@ -17,4 +17,5 @@ specification-source = 'google/cloud/dataplex/v1'
 service-config = 'google/cloud/dataplex/v1/dataplex_v1.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'

--- a/src/generated/cloud/dataplex/v1/Cargo.toml
+++ b/src/generated/cloud/dataplex/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataplex-v1"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataplex API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/discoveryengine/v1/.sidekick.toml
+++ b/src/generated/cloud/discoveryengine/v1/.sidekick.toml
@@ -17,5 +17,6 @@ specification-source = 'google/cloud/discoveryengine/v1'
 service-config       = 'google/cloud/discoveryengine/v1/discoveryengine_v1.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year       = '2025'
 per-service-features = 'true'

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-discoveryengine-v1"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - Discovery Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/v1/.sidekick.toml
+++ b/src/generated/cloud/gkehub/v1/.sidekick.toml
@@ -17,6 +17,7 @@ specification-source = 'google/cloud/gkehub/v1'
 service-config = 'google/cloud/gkehub/v1/gkehub_v1.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'
 'package:gkehub_configmanagement_v1' = 'package=google-cloud-gkehub-configmanagement-v1,source=google.cloud.gkehub.configmanagement.v1'
 'package:gkehub_multiclusteringress_v1' = 'package=google-cloud-gkehub-multiclusteringress-v1,source=google.cloud.gkehub.multiclusteringress.v1'

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-v1"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/kms/v1/.sidekick.toml
+++ b/src/generated/cloud/kms/v1/.sidekick.toml
@@ -17,4 +17,5 @@ specification-source = 'google/cloud/kms/v1'
 service-config = 'google/cloud/kms/v1/cloudkms_v1.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-kms-v1"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Key Management Service (KMS) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securitycenter/v2/.sidekick.toml
+++ b/src/generated/cloud/securitycenter/v2/.sidekick.toml
@@ -17,4 +17,5 @@ specification-source = 'google/cloud/securitycenter/v2'
 service-config = 'google/cloud/securitycenter/v2/securitycenter_v2.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securitycenter-v2"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - Security Command Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/privacy/dlp/v2/.sidekick.toml
+++ b/src/generated/privacy/dlp/v2/.sidekick.toml
@@ -17,4 +17,5 @@ specification-source = 'google/privacy/dlp/v2'
 service-config = 'google/privacy/dlp/v2/dlp_v2.yaml'
 
 [codec]
+version        = '1.1.0'
 copyright-year = '2025'

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privacy-dlp-v2"
-version                = "1.0.0"
+version                = "1.1.0"
 description            = "Google Cloud Client Libraries for Rust - Sensitive Data Protection (DLP)"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-storage"
-version     = "1.0.0"
+version     = "1.1.0"
 description = "Google Cloud Client Libraries for Rust - Storage"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
I used the "soon to be released" `rust-bump-versions` sidekick
subcommand. I needed to reformat the storage manifest.