### PR TITLE
impl(gax): add path_template to RequestOptions

### DIFF
--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -50,7 +50,6 @@ pub struct RequestOptions {
     polling_error_policy: Option<Arc<dyn PollingErrorPolicy>>,
     polling_backoff_policy: Option<Arc<dyn PollingBackoffPolicy>>,
     path_template: Option<String>,
-    prior_attempt_count: u32,
 }
 
 impl RequestOptions {
@@ -165,16 +164,6 @@ impl RequestOptions {
     pub(crate) fn set_path_template(&mut self, v: Option<String>) {
         self.path_template = v;
     }
-
-    /// Get the current prior attempt count.
-    pub(crate) fn prior_attempt_count(&self) -> u32 {
-        self.prior_attempt_count
-    }
-
-    /// Sets the prior attempt count for the request.
-    pub(crate) fn set_prior_attempt_count(&mut self, v: u32) {
-        self.prior_attempt_count = v;
-    }
 }
 
 /// Implementations of this trait provide setters to configure request options.
@@ -244,11 +233,6 @@ pub mod internal {
 
     pub fn get_path_template(options: &RequestOptions) -> Option<&str> {
         options.path_template()
-    }
-
-    pub fn increment_prior_attempt_count(mut options: RequestOptions) -> RequestOptions {
-        options.set_prior_attempt_count(options.prior_attempt_count() + 1);
-        options
     }
 }
 
@@ -355,15 +339,6 @@ mod tests {
 
         opts.set_path_template(Some("test".to_string()));
         assert_eq!(opts.path_template(), Some("test"));
-
-        // default should be 0.
-        assert_eq!(opts.prior_attempt_count(), 0);
-
-        opts.set_prior_attempt_count(0);
-        assert_eq!(opts.prior_attempt_count(), 0);
-
-        opts.set_prior_attempt_count(2);
-        assert_eq!(opts.prior_attempt_count(), 2);
     }
 
     #[test]
@@ -377,14 +352,6 @@ mod tests {
         assert_eq!(opts.idempotent(), Some(false));
         let opts = set_default_idempotency(opts, true);
         assert_eq!(opts.idempotent(), Some(false));
-    }
-
-    #[test]
-    fn request_options_attempt_count() {
-        let opts = RequestOptions::default();
-        assert_eq!(opts.prior_attempt_count(), 0);
-        let opts = increment_prior_attempt_count(opts);
-        assert_eq!(opts.prior_attempt_count(), 1);
     }
 
     #[test]

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -157,22 +157,22 @@ impl RequestOptions {
     }
 
     /// Get the current path template, if any.
-    pub fn path_template(&self) -> Option<&str> {
+    pub(crate) fn path_template(&self) -> Option<&str> {
         self.path_template.as_deref()
     }
 
     /// Sets the path template for the request URL.
-    pub fn set_path_template(&mut self, v: Option<String>) {
+    pub(crate) fn set_path_template(&mut self, v: Option<String>) {
         self.path_template = v;
     }
 
     /// Get the current prior attempt count.
-    pub fn prior_attempt_count(&self) -> u32 {
+    pub(crate) fn prior_attempt_count(&self) -> u32 {
         self.prior_attempt_count
     }
 
     /// Sets the prior attempt count for the request.
-    pub fn set_prior_attempt_count(&mut self, v: u32) {
+    pub(crate) fn set_prior_attempt_count(&mut self, v: u32) {
         self.prior_attempt_count = v;
     }
 }
@@ -242,11 +242,14 @@ pub mod internal {
         options
     }
 
-    pub fn set_prior_attempt_count(
-        mut options: RequestOptions,
-        prior_attempt_count: u32,
+    pub fn get_path_template(options: &RequestOptions) -> Option<&str> {
+        options.path_template()
+    }
+
+    pub fn increment_prior_attempt_count(
+        mut options: RequestOptions
     ) -> RequestOptions {
-        options.set_prior_attempt_count(prior_attempt_count);
+        options.set_prior_attempt_count(options.prior_attempt_count() + 1);
         options
     }
 }

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -246,9 +246,7 @@ pub mod internal {
         options.path_template()
     }
 
-    pub fn increment_prior_attempt_count(
-        mut options: RequestOptions
-    ) -> RequestOptions {
+    pub fn increment_prior_attempt_count(mut options: RequestOptions) -> RequestOptions {
         options.set_prior_attempt_count(options.prior_attempt_count() + 1);
         options
     }
@@ -358,10 +356,10 @@ mod tests {
         opts.set_path_template(Some("test".to_string()));
         assert_eq!(opts.path_template(), Some("test"));
 
-        opts.set_prior_attempt_count(0);
+        // default should be 0.
         assert_eq!(opts.prior_attempt_count(), 0);
 
-        // default should be 0.
+        opts.set_prior_attempt_count(0);
         assert_eq!(opts.prior_attempt_count(), 0);
 
         opts.set_prior_attempt_count(2);
@@ -379,6 +377,22 @@ mod tests {
         assert_eq!(opts.idempotent(), Some(false));
         let opts = set_default_idempotency(opts, true);
         assert_eq!(opts.idempotent(), Some(false));
+    }
+
+    #[test]
+    fn request_options_attempt_count() {
+        let opts = RequestOptions::default();
+        assert_eq!(opts.prior_attempt_count(), 0);
+        let opts = increment_prior_attempt_count(opts);
+        assert_eq!(opts.prior_attempt_count(), 1);
+    }
+
+    #[test]
+    fn request_options_path_template() {
+        let opts = RequestOptions::default();
+        assert_eq!(opts.path_template(), None);
+        let opts = set_path_template(opts, Some("test".to_string()));
+        assert_eq!(opts.path_template(), Some("test"));
     }
 
     #[test]

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -210,12 +210,6 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
 
     /// Sets the polling backoff policy configuration.
     fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(self, v: V) -> Self;
-
-    /// Sets the path template for the request URL.
-    fn with_path_template(self, v: Option<String>) -> Self;
-
-    /// Sets the prior attempt count for the request.
-    fn with_prior_attempt_count(self, v: u32) -> Self;
 }
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
@@ -237,6 +231,22 @@ pub mod internal {
 
     pub fn set_default_idempotency(mut options: RequestOptions, default: bool) -> RequestOptions {
         options.set_default_idempotency(default);
+        options
+    }
+
+    pub fn set_path_template(
+        mut options: RequestOptions,
+        path_template: Option<String>,
+    ) -> RequestOptions {
+        options.set_path_template(path_template);
+        options
+    }
+
+    pub fn set_prior_attempt_count(
+        mut options: RequestOptions,
+        prior_attempt_count: u32,
+    ) -> RequestOptions {
+        options.set_prior_attempt_count(prior_attempt_count);
         options
     }
 }
@@ -283,16 +293,6 @@ where
 
     fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(mut self, v: V) -> Self {
         self.request_options().set_polling_backoff_policy(v);
-        self
-    }
-
-    fn with_path_template(mut self, v: Option<String>) -> Self {
-        self.request_options().set_path_template(v);
-        self
-    }
-
-    fn with_prior_attempt_count(mut self, v: u32) -> Self {
-        self.request_options().set_prior_attempt_count(v);
         self
     }
 }
@@ -351,6 +351,18 @@ mod tests {
 
         opts.set_polling_backoff_policy(ExponentialBackoffBuilder::new().clamp());
         assert!(opts.polling_backoff_policy().is_some(), "{opts:?}");
+
+        opts.set_path_template(Some("test".to_string()));
+        assert_eq!(opts.path_template(), Some("test"));
+
+        opts.set_prior_attempt_count(0);
+        assert_eq!(opts.prior_attempt_count(), 0);
+
+        // default should be 0.
+        assert_eq!(opts.prior_attempt_count(), 0);
+
+        opts.set_prior_attempt_count(2);
+        assert_eq!(opts.prior_attempt_count(), 2);
     }
 
     #[test]
@@ -421,12 +433,6 @@ mod tests {
             builder.request_options().polling_backoff_policy().is_some(),
             "{builder:?}"
         );
-
-        let mut builder = TestBuilder::default().with_path_template(Some("test".to_string()));
-        assert_eq!(builder.request_options().path_template(), Some("test"));
-
-        let mut builder = TestBuilder::default().with_prior_attempt_count(5);
-        assert_eq!(builder.request_options().prior_attempt_count(), 5);
 
         Ok(())
     }


### PR DESCRIPTION
This sets up request-level details for #3239 to select a low cardinality path template to include in span names etc.; the path template is part of the contract for sidekick to populate.