### PR TITLE
impl(gax-internal): define InstrumentationClientInfo for tracing

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -39,7 +39,7 @@ pub struct ReqwestClient {
     retry_throttler: SharedRetryThrottler,
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
-    instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
+    instrumentation: Option<crate::options::InstrumentationClientInfo>,
 }
 
 impl ReqwestClient {
@@ -86,7 +86,7 @@ impl ReqwestClient {
 
     pub fn with_instrumentation(
         mut self,
-        instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
+        instrumentation: Option<crate::options::InstrumentationClientInfo>,
     ) -> Self {
         self.instrumentation = instrumentation;
         self
@@ -443,7 +443,7 @@ mod tests {
             .unwrap();
         assert!(client.instrumentation.is_none());
 
-        let client = client.with_instrumentation(Some(&TEST_INSTRUMENTATION_INFO));
+        let client = client.with_instrumentation(Some(TEST_INSTRUMENTATION_INFO));
         assert!(client.instrumentation.is_some());
         let info = client.instrumentation.unwrap();
         assert_eq!(info.service_name, "test-service");

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -19,6 +19,19 @@ pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>
 
 pub(crate) const LOGGING_VAR: &str = "GOOGLE_CLOUD_RUST_LOGGING";
 
+/// Information about the client library used for instrumentation.
+#[derive(Clone, Debug)]
+pub struct InstrumentationClientInfo {
+    /// The short service name, e.g., "appengine", "run", "firestore".
+    pub service_name: &'static str,
+    /// The version of the client library.
+    pub client_version: &'static str,
+    /// The name of the client library artifact (e.g., crate name).
+    pub client_artifact: &'static str,
+    /// The default hostname of the service.
+    pub default_host: &'static str,
+}
+
 // Returns true if the environment or client configuration enables tracing.
 pub fn tracing_enabled(config: &ClientConfig) -> bool {
     if config.tracing {

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -20,7 +20,7 @@ pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>
 pub(crate) const LOGGING_VAR: &str = "GOOGLE_CLOUD_RUST_LOGGING";
 
 /// Information about the client library used for instrumentation.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct InstrumentationClientInfo {
     /// The short service name, e.g., "appengine", "run", "firestore".
     pub service_name: &'static str,


### PR DESCRIPTION
This structure forms an API to be populated and added by the generator (like the implementation of x-goog-api-client.)

It will be used by instrumentation to describe the client library itself, for #3239 