### PR TITLE
test(pubsub): add simple integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,7 @@ dependencies = [
  "google-cloud-iam-v1",
  "google-cloud-longrunning",
  "google-cloud-lro",
+ "google-cloud-pubsub",
  "google-cloud-secretmanager-v1",
  "google-cloud-showcase-v1beta1",
  "google-cloud-sql-v1",

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -60,6 +60,10 @@ path    = "../../src/generated/cloud/bigquery/v2"
 package = "google-cloud-firestore"
 path    = "../../src/firestore"
 
+[dependencies.pubsub]
+package = "google-cloud-pubsub"
+path    = "../../src/pubsub"
+
 [dependencies.showcase]
 package = "google-cloud-showcase-v1beta1"
 path    = "../../src/generated/showcase"

--- a/src/integration-tests/src/lib.rs
+++ b/src/integration-tests/src/lib.rs
@@ -19,6 +19,7 @@ pub type Result<T> = anyhow::Result<T>;
 pub mod bigquery;
 pub mod error_details;
 pub mod firestore;
+pub mod pubsub;
 pub mod secret_manager;
 pub mod showcase;
 pub mod sql;

--- a/src/integration-tests/src/pubsub.rs
+++ b/src/integration-tests/src/pubsub.rs
@@ -32,17 +32,16 @@ pub async fn basic_topic() -> Result<()> {
         tracing::subscriber::set_default(subscriber)
     };
 
-    let project = crate::project_id()?;
     let (client, topic) = create_test_topic().await?;
 
-    tracing::info!("testing list_topics()");
-    let topics = client
-        .list_topics()
-        .set_project(format!("projects/{project}"))
+    tracing::info!("testing get_topic()");
+    let get_topic = client
+        .get_topic()
+        .set_topic(topic.name.clone())
         .send()
         .await?;
-    tracing::info!("success with list_topics={topics:?}");
-    assert!(topics.topics.iter().any(|x| x.name == topic.name));
+    tracing::info!("success with get_topic={get_topic:?}");
+    assert_eq!(get_topic.name, topic.name);
 
     cleanup_test_topic(client, topic.name).await?;
 
@@ -51,7 +50,7 @@ pub async fn basic_topic() -> Result<()> {
 
 pub const TOPIC_ID_LENGTH: usize = 255;
 
-fn random_topic_id(project: String) -> String {
+fn random_topic_name(project: String) -> String {
     let prefix = "topic-";
     let topic_id: String = rand::rng()
         .sample_iter(&Alphanumeric)
@@ -67,7 +66,7 @@ pub async fn create_test_topic() -> Result<(TopicAdmin, Topic)> {
         .with_tracing()
         .build()
         .await?;
-    let topic_id = random_topic_id(project);
+    let topic_id = random_topic_name(project);
 
     tracing::info!("testing create_topic()");
     let topic = client

--- a/src/integration-tests/src/pubsub.rs
+++ b/src/integration-tests/src/pubsub.rs
@@ -66,12 +66,12 @@ pub async fn create_test_topic() -> Result<(TopicAdmin, Topic)> {
         .with_tracing()
         .build()
         .await?;
-    let topic_id = random_topic_name(project);
+    let topic_name = random_topic_name(project);
 
     tracing::info!("testing create_topic()");
     let topic = client
         .create_topic()
-        .set_name(topic_id)
+        .set_name(topic_name)
         .set_labels([("integration-test", "true")])
         .send()
         .await?;

--- a/src/integration-tests/src/pubsub.rs
+++ b/src/integration-tests/src/pubsub.rs
@@ -43,9 +43,9 @@ pub async fn basic_topic(builder: pubsub::builder::topic_admin::ClientBuilder) -
         .send()
         .await?;
     tracing::info!("success with list_topics={topics:?}");
-    assert!(topics.topics.iter().any(|x| x.name == topic.name.clone()));
+    assert!(topics.topics.iter().any(|x| x.name == topic.name));
 
-    cleanup_test_topic(topic_admin, topic.name.clone()).await?;
+    cleanup_test_topic(topic_admin, topic.name).await?;
 
     Ok(())
 }
@@ -68,12 +68,12 @@ pub async fn create_test_topic() -> Result<(TopicAdmin, Topic)> {
         .with_tracing()
         .build()
         .await?;
-    let topic_id = random_topic_id(project.clone());
+    let topic_id = random_topic_id(project);
 
     tracing::info!("testing create_topic()");
     let topic = client
         .create_topic()
-        .set_name(topic_id.clone())
+        .set_name(topic_id)
         .set_labels([("integration-test", "true")])
         .send()
         .await?;

--- a/src/integration-tests/src/pubsub.rs
+++ b/src/integration-tests/src/pubsub.rs
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pubsub::{client::TopicAdmin, model::Topic};
+use rand::{Rng, distr::Alphanumeric};
+
+use crate::Result;
+
+pub async fn basic_topic(builder: pubsub::builder::topic_admin::ClientBuilder) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    let project = crate::project_id()?;
+    let client = builder.build().await?;
+    let (topic_admin, topic) = create_test_topic().await?;
+
+    tracing::info!("testing list_topics()");
+    let topics = client
+        .list_topics()
+        .set_project(format!("projects/{project}"))
+        .send()
+        .await?;
+    tracing::info!("success with list_topics={topics:?}");
+    assert!(topics.topics.iter().any(|x| x.name == topic.name.clone()));
+
+    cleanup_test_topic(topic_admin, topic.name.clone()).await?;
+
+    Ok(())
+}
+
+pub const TOPIC_ID_LENGTH: usize = 255;
+
+fn random_topic_id(project: String) -> String {
+    let prefix = "topic-";
+    let topic_id: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(TOPIC_ID_LENGTH - prefix.len())
+        .map(char::from)
+        .collect();
+    format!("projects/{project}/topics/{prefix}{topic_id}")
+}
+
+pub async fn create_test_topic() -> Result<(TopicAdmin, Topic)> {
+    let project = crate::project_id()?;
+    let client = pubsub::client::TopicAdmin::builder()
+        .with_tracing()
+        .build()
+        .await?;
+    let topic_id = random_topic_id(project.clone());
+
+    tracing::info!("testing create_topic()");
+    let topic = client
+        .create_topic()
+        .set_name(topic_id.clone())
+        .set_labels([("integration-test", "true")])
+        .send()
+        .await?;
+    tracing::info!("success on create_topic: {topic:?}");
+
+    Ok((client, topic))
+}
+
+pub async fn cleanup_test_topic(client: TopicAdmin, topic_name: String) -> Result<()> {
+    tracing::info!("testing delete_topic()");
+    client.delete_topic().set_topic(topic_name).send().await?;
+    tracing::info!("success on delete_topic");
+    Ok(())
+}

--- a/src/integration-tests/src/pubsub.rs
+++ b/src/integration-tests/src/pubsub.rs
@@ -17,7 +17,7 @@ use rand::{Rng, distr::Alphanumeric};
 
 use crate::Result;
 
-pub async fn basic_topic(builder: pubsub::builder::topic_admin::ClientBuilder) -> Result<()> {
+pub async fn basic_topic() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -33,8 +33,7 @@ pub async fn basic_topic(builder: pubsub::builder::topic_admin::ClientBuilder) -
     };
 
     let project = crate::project_id()?;
-    let client = builder.build().await?;
-    let (topic_admin, topic) = create_test_topic().await?;
+    let (client, topic) = create_test_topic().await?;
 
     tracing::info!("testing list_topics()");
     let topics = client
@@ -45,7 +44,7 @@ pub async fn basic_topic(builder: pubsub::builder::topic_admin::ClientBuilder) -
     tracing::info!("success with list_topics={topics:?}");
     assert!(topics.topics.iter().any(|x| x.name == topic.name));
 
-    cleanup_test_topic(topic_admin, topic.name).await?;
+    cleanup_test_topic(client, topic.name).await?;
 
     Ok(())
 }

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -49,11 +49,9 @@ mod driver {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_pubsub_basic_topic() -> integration_tests::Result<()> {
-        integration_tests::pubsub::basic_topic(
-            pubsub::client::TopicAdmin::builder().with_retry_policy(retry_policy()),
-        )
-        .await
-        .map_err(integration_tests::report_error)
+        integration_tests::pubsub::basic_topic()
+            .await
+            .map_err(integration_tests::report_error)
     }
 
     #[test_case(sm::client::SecretManagerService::builder(); "default")]

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -47,16 +47,13 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(pubsub::client::TopicAdmin::builder(); "default")]
-    #[test_case(pubsub::client::TopicAdmin::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(pubsub::client::TopicAdmin::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_pubsub_basic_topic(
-        builder: pubsub::builder::topic_admin::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::pubsub::basic_topic(builder)
-            .await
-            .map_err(integration_tests::report_error)
+    async fn run_pubsub_basic_topic() -> integration_tests::Result<()> {
+        integration_tests::pubsub::basic_topic(
+            pubsub::client::TopicAdmin::builder().with_retry_policy(retry_policy()),
+        )
+        .await
+        .map_err(integration_tests::report_error)
     }
 
     #[test_case(sm::client::SecretManagerService::builder(); "default")]

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -47,6 +47,18 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
+    #[test_case(pubsub::client::TopicAdmin::builder(); "default")]
+    #[test_case(pubsub::client::TopicAdmin::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(pubsub::client::TopicAdmin::builder().with_retry_policy(retry_policy()); "with retry enabled")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_pubsub_basic_topic(
+        builder: pubsub::builder::topic_admin::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::pubsub::basic_topic(builder)
+            .await
+            .map_err(integration_tests::report_error)
+    }
+
     #[test_case(sm::client::SecretManagerService::builder(); "default")]
     #[test_case(sm::client::SecretManagerService::builder().with_tracing(); "with tracing enabled")]
     #[test_case(sm::client::SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]


### PR DESCRIPTION
Adds a very simple integration test for the TopicAdmin client, adding some setup and cleanup functions that will be useful later when testing the publisher and subscriber.

There is still remaining work to cleanup stale topics that are not deleted because the test failed.

For #3355 