### PR TITLE
cleanup: reduce integration test matrix wrt client config

### DIFF
--- a/src/integration-tests/src/bigquery.rs
+++ b/src/integration-tests/src/bigquery.rs
@@ -19,9 +19,7 @@ use rand::{Rng, distr::Alphanumeric};
 
 const INSTANCE_LABEL: &str = "rust-sdk-integration-test";
 
-pub async fn dataset_admin(
-    builder: bigquery::builder::dataset_service::ClientBuilder,
-) -> Result<()> {
+pub async fn dataset_admin() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -37,7 +35,10 @@ pub async fn dataset_admin(
     };
 
     let project_id = crate::project_id()?;
-    let client: bigquery::client::DatasetService = builder.build().await?;
+    let client = bigquery::client::DatasetService::builder()
+        .with_tracing()
+        .build()
+        .await?;
     cleanup_stale_datasets(&client, &project_id).await?;
 
     let dataset_id = random_dataset_id();
@@ -187,7 +188,7 @@ fn extract_dataset_id(project_id: &str, id: &str) -> Option<String> {
         .map(|v| v.to_string())
 }
 
-pub async fn job_service(builder: bigquery::builder::job_service::ClientBuilder) -> Result<()> {
+pub async fn job_service() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -203,7 +204,10 @@ pub async fn job_service(builder: bigquery::builder::job_service::ClientBuilder)
     };
 
     let project_id = crate::project_id()?;
-    let client: bigquery::client::JobService = builder.build().await?;
+    let client = bigquery::client::JobService::builder()
+        .with_tracing()
+        .build()
+        .await?;
     cleanup_stale_jobs(&client, &project_id).await?;
 
     let job_id = random_job_id();

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -16,7 +16,7 @@ use crate::Result;
 use gax::paginator::Paginator;
 use rand::{Rng, distr::Alphanumeric};
 
-pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -> Result<()> {
+pub async fn run() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -37,7 +37,10 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
         .map(char::from)
         .collect();
 
-    let client = builder.build().await?;
+    let client = smo::client::SecretManagerService::builder()
+        .with_tracing()
+        .build()
+        .await?;
 
     println!("\nTesting create_secret()");
     let create = client

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -15,7 +15,7 @@
 use crate::Result;
 use rand::{Rng, distr::Alphanumeric};
 
-pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -> Result<()> {
+pub async fn run() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -40,7 +40,11 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
     // We must override the configuration to use a regional endpoint.
     let location_id = "us-central1".to_string();
     let endpoint = format!("https://secretmanager.{location_id}.rep.googleapis.com");
-    let client = builder.with_endpoint(endpoint).build().await?;
+    let client = smo::client::SecretManagerService::builder()
+        .with_tracing()
+        .with_endpoint(endpoint)
+        .build()
+        .await?;
 
     cleanup_stale_secrets(&client, &project_id, &location_id).await?;
 

--- a/src/integration-tests/src/sql.rs
+++ b/src/integration-tests/src/sql.rs
@@ -19,9 +19,7 @@ use rand::Rng;
 use sql::model;
 use storage_samples::RandomChars;
 
-pub async fn run_sql_instances_service(
-    builder: sql::builder::sql_instances_service::ClientBuilder,
-) -> Result<()> {
+pub async fn run_sql_instances_service() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -38,7 +36,10 @@ pub async fn run_sql_instances_service(
 
     let project_id = crate::project_id()?;
     let name = random_sql_instance_name(&project_id);
-    let client: sql::client::SqlInstancesService = builder.build().await?;
+    let client = sql::client::SqlInstancesService::builder()
+        .with_tracing()
+        .build()
+        .await?;
 
     cleanup_stale_sql_instances(&client, &project_id).await?;
 
@@ -168,9 +169,7 @@ async fn cleanup_stale_sql_instances(
     Ok(())
 }
 
-pub async fn run_sql_tiers_service(
-    builder: sql::builder::sql_tiers_service::ClientBuilder,
-) -> Result<()> {
+pub async fn run_sql_tiers_service() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -186,7 +185,10 @@ pub async fn run_sql_tiers_service(
     };
 
     let project_id = crate::project_id()?;
-    let client: sql::client::SqlTiersService = builder.build().await?;
+    let client = sql::client::SqlTiersService::builder()
+        .with_tracing()
+        .build()
+        .await?;
 
     let list = client.list().set_project(&project_id).send().await?;
 

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -19,7 +19,7 @@ use gax::paginator::ItemPaginator as _;
 use lro::Poller;
 use std::time::Duration;
 
-pub async fn until_done(builder: wf::builder::workflows::ClientBuilder) -> Result<()> {
+pub async fn until_done() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -38,7 +38,10 @@ pub async fn until_done(builder: wf::builder::workflows::ClientBuilder) -> Resul
     let location_id = crate::region_id();
     let workflows_runner = crate::workflows_runner()?;
 
-    let client = builder.build().await?;
+    let client = wf::client::Workflows::builder()
+        .with_tracing()
+        .build()
+        .await?;
     cleanup_stale_workflows(&client, &project_id, &location_id).await?;
 
     let source_contents = r###"# Test only workflow
@@ -81,7 +84,7 @@ main:
     Ok(())
 }
 
-pub async fn explicit_loop(builder: wf::builder::workflows::ClientBuilder) -> Result<()> {
+pub async fn explicit_loop() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -100,7 +103,10 @@ pub async fn explicit_loop(builder: wf::builder::workflows::ClientBuilder) -> Re
     let location_id = crate::region_id();
     let workflows_runner = crate::workflows_runner()?;
 
-    let client = builder.build().await?;
+    let client = wf::client::Workflows::builder()
+        .with_tracing()
+        .build()
+        .await?;
     cleanup_stale_workflows(&client, &project_id, &location_id).await?;
 
     let source_contents = r###"# Test only workflow
@@ -238,7 +244,10 @@ pub async fn manual(
     workflow_id: String,
     workflow: wf::model::Workflow,
 ) -> Result<()> {
-    let client = wf::client::Workflows::builder().build().await?;
+    let client = wf::client::Workflows::builder()
+        .with_tracing()
+        .build()
+        .await?;
 
     println!("\n\nStart create_workflow() LRO and poll it to completion");
     let create = client

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -21,7 +21,7 @@ use lro::Poller;
 use std::time::Duration;
 
 // Verify enum query parameters are serialized correctly.
-pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()> {
+pub async fn list() -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
     #[cfg(feature = "log-integration-tests")]
@@ -40,7 +40,10 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
     // workflows integration tests to delete it if something fails or crashes
     // in this test.
     let parent = create_test_workflow().await?;
-    let client = builder.build().await?;
+    let client = wfe::client::Executions::builder()
+        .with_tracing()
+        .build()
+        .await?;
 
     // Create an execution with a label. The label is not returned for the `BASIC` view.
     let start = client

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -25,34 +25,23 @@ mod driver {
             .with_attempt_limit(5)
     }
 
-    #[test_case(bigquery::client::DatasetService::builder().with_tracing().with_retry_policy(retry_policy()); "with [tracing, retry] enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_bigquery_dataset_service(
-        builder: bigquery::builder::dataset_service::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::bigquery::dataset_admin(builder)
+    async fn run_bigquery_dataset_service() -> integration_tests::Result<()> {
+        integration_tests::bigquery::dataset_admin()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(bigquery::client::JobService::builder().with_tracing().with_retry_policy(retry_policy()); "with [tracing, retry] enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_bigquery_job_service(
-        builder: bigquery::builder::job_service::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::bigquery::job_service(builder)
+    async fn run_bigquery_job_service() -> integration_tests::Result<()> {
+        integration_tests::bigquery::job_service()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(firestore::client::Firestore::builder(); "default")]
-    #[test_case(firestore::client::Firestore::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(firestore::client::Firestore::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_firestore(
-        builder: firestore::builder::firestore::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::firestore::basic(builder)
+    async fn run_firestore() -> integration_tests::Result<()> {
+        integration_tests::firestore::basic()
             .await
             .map_err(integration_tests::report_error)
     }
@@ -77,52 +66,35 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(smo::client::SecretManagerService::builder(); "default")]
-    #[test_case(smo::client::SecretManagerService::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(smo::client::SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_secretmanager_openapi(
-        builder: smo::builder::secret_manager_service::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::secret_manager::openapi::run(builder)
+    async fn run_secretmanager_openapi() -> integration_tests::Result<()> {
+        integration_tests::secret_manager::openapi::run()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(smo::client::SecretManagerService::builder(); "default")]
-    #[test_case(smo::client::SecretManagerService::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(smo::client::SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_secretmanager_openapi_locational(
-        builder: smo::builder::secret_manager_service::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::secret_manager::openapi_locational::run(builder)
+    async fn run_secretmanager_openapi_locational() -> integration_tests::Result<()> {
+        integration_tests::secret_manager::openapi_locational::run()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(sql::client::SqlInstancesService::builder().with_tracing().with_retry_policy(retry_policy()); "with [tracing, retry] enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_sql(
-        builder: sql::builder::sql_instances_service::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::sql::run_sql_instances_service(builder)
+    async fn run_sql() -> integration_tests::Result<()> {
+        integration_tests::sql::run_sql_instances_service()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(sql::client::SqlTiersService::builder().with_tracing().with_retry_policy(retry_policy()); "with [tracing, retry] enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_sql_tiers_service(
-        builder: sql::builder::sql_tiers_service::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::sql::run_sql_tiers_service(builder)
+    async fn run_sql_tiers_service() -> integration_tests::Result<()> {
+        integration_tests::sql::run_sql_tiers_service()
             .await
             .map_err(integration_tests::report_error)
     }
 
     #[test_case(StorageControl::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
-    #[test_case(StorageControl::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[test_case(StorageControl::builder().with_endpoint("https://www.googleapis.com"); "with alternative endpoint")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_control_buckets(
@@ -257,7 +229,7 @@ mod driver {
         result
     }
 
-    #[test_case(Storage::builder().with_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(Storage::builder(); "default")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects_with_key(
         builder: storage::builder::storage::ClientBuilder,
@@ -267,88 +239,58 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(ta::client::TelcoAutomation::builder().with_tracing(); "with tracing enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_error_details_http(
-        builder: ta::builder::telco_automation::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::error_details::error_details_http(builder)
+    async fn run_error_details_http() -> integration_tests::Result<()> {
+        integration_tests::error_details::error_details_http()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(StorageControl::builder().with_tracing(); "with tracing enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_error_details_grpc(
-        builder: storage::builder::storage_control::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::error_details::error_details_grpc(builder)
+    async fn run_error_details_grpc() -> integration_tests::Result<()> {
+        integration_tests::error_details::error_details_grpc()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_check_code_for_http(
-        builder: wf::builder::workflows::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::error_details::check_code_for_http(builder)
+    async fn run_check_code_for_http() -> integration_tests::Result<()> {
+        integration_tests::error_details::check_code_for_http()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(StorageControl::builder().with_tracing(); "with tracing enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_check_code_for_grpc(
-        builder: storage::builder::storage_control::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::error_details::check_code_for_grpc(builder)
+    async fn run_check_code_for_grpc() -> integration_tests::Result<()> {
+        integration_tests::error_details::check_code_for_grpc()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(wf::client::Workflows::builder(); "default")]
-    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(wf::client::Workflows::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_until_done(
-        builder: wf::builder::workflows::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::workflows::until_done(builder)
+    async fn workflows_until_done() -> integration_tests::Result<()> {
+        integration_tests::workflows::until_done()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(wf::client::Workflows::builder(); "default")]
-    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(wf::client::Workflows::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_explicit(
-        builder: wf::builder::workflows::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::workflows::explicit_loop(builder)
+    async fn workflows_explicit() -> integration_tests::Result<()> {
+        integration_tests::workflows::explicit_loop()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(wf::client::Workflows::builder(); "default")]
-    #[test_case(wf::client::Workflows::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(wf::client::Workflows::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_manual(
-        builder: wf::builder::workflows::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::workflows::until_done(builder)
+    async fn workflows_manual() -> integration_tests::Result<()> {
+        integration_tests::workflows::until_done()
             .await
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(wfe::client::Executions::builder().with_retry_policy(retry_policy()).with_tracing(); "with tracing and retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_executions(
-        builder: wfe::builder::executions::ClientBuilder,
-    ) -> integration_tests::Result<()> {
-        integration_tests::workflows_executions::list(builder)
+    async fn workflows_executions() -> integration_tests::Result<()> {
+        integration_tests::workflows_executions::list()
             .await
             .map_err(integration_tests::report_error)
     }


### PR DESCRIPTION
Instead of testing every client with/without tracing, and with/without a custom retry policy, just test these dimensions in `secretmanager`, `storagecontrol`.

By default, enable tracing in the clients. We would like to know if anything goes wrong.

Note that we don't need to set the retry policy, as clients come with a default policy now.