### PR TITLE
refactor(gax-internal): Update InstrumentationClientInfo handling

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -39,7 +39,7 @@ pub struct ReqwestClient {
     retry_throttler: SharedRetryThrottler,
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
-    instrumentation: Option<crate::options::InstrumentationClientInfo>,
+    instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
 }
 
 impl ReqwestClient {
@@ -86,9 +86,9 @@ impl ReqwestClient {
 
     pub fn with_instrumentation(
         mut self,
-        instrumentation: Option<crate::options::InstrumentationClientInfo>,
+        instrumentation: &'static crate::options::InstrumentationClientInfo,
     ) -> Self {
-        self.instrumentation = instrumentation;
+        self.instrumentation = Some(instrumentation);
         self
     }
 
@@ -443,15 +443,12 @@ mod tests {
             .unwrap();
         assert!(client.instrumentation.is_none());
 
-        let client = client.with_instrumentation(Some(TEST_INSTRUMENTATION_INFO));
+        let client = client.with_instrumentation(&TEST_INSTRUMENTATION_INFO);
         assert!(client.instrumentation.is_some());
         let info = client.instrumentation.unwrap();
         assert_eq!(info.service_name, "test-service");
         assert_eq!(info.client_version, "1.2.3");
         assert_eq!(info.client_artifact, "test-artifact");
         assert_eq!(info.default_host, "test.googleapis.com");
-
-        let client = client.with_instrumentation(None);
-        assert!(client.instrumentation.is_none());
     }
 }

--- a/src/gax-internal/src/observability.rs
+++ b/src/gax-internal/src/observability.rs
@@ -211,7 +211,7 @@ impl HttpSpanInfo {
     pub(crate) fn from_request(
         request: &reqwest::Request,
         options: &RequestOptions,
-        instrumentation: Option<&InstrumentationClientInfo>,
+        instrumentation: Option<&'static InstrumentationClientInfo>,
         prior_attempt_count: u32,
     ) -> Self {
         let url = request.url();

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -20,7 +20,8 @@ pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>
 pub(crate) const LOGGING_VAR: &str = "GOOGLE_CLOUD_RUST_LOGGING";
 
 /// Information about the client library used for instrumentation.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct InstrumentationClientInfo {
     /// The short service name, e.g., "appengine", "run", "firestore".
     pub service_name: &'static str,


### PR DESCRIPTION
- Store InstrumentationClientInfo as Option<&'static ...> in ReqwestClient.
- Pass as &'static ... to with_instrumentation.
- Accept as Option<&'static ...> in HttpSpanInfo::from_request
- mark non-exhaustive so we can add fields in the future as needed (default to "")