### PR TITLE
test(auth): raise error when id token generation fails

### DIFF
--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -516,7 +516,8 @@ async fn generate_id_token(
             "projects/-/serviceAccounts/{target_principal_email}"
         )])
         .send()
-        .await?;
+        .await
+        .expect("failed to generate id token");
 
     Ok(res.token)
 }

--- a/src/auth/integration-tests/tests/driver.rs
+++ b/src/auth/integration-tests/tests/driver.rs
@@ -14,6 +14,7 @@
 
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod driver {
+    #[cfg(all(test, feature = "run-byoid-integration-tests"))]
     use test_case::test_case;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
Minor improvement on the external account integration test, where it was not explicitly raising the error when failing to generate id tokens. I was setting up accounts to run those tests locally and the error was not showing up. 

This PR also fixes a warning on importing the `test_case` crate only on when `run-byoid-integration-tests` feature is enabled.