### PR TITLE
chore(cloudsecuritycompliance/v1): bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-cloudsecuritycompliance-v1"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/generated/cloud/cloudsecuritycompliance/v1/.sidekick.toml
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/cloudsecuritycompliance/v1'
 service-config = 'google/cloud/cloudsecuritycompliance/v1/cloudsecuritycompliance_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '2.0.0'
 copyright-year = '2025'

--- a/src/generated/cloud/cloudsecuritycompliance/v1/Cargo.toml
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-cloudsecuritycompliance-v1"
-version                = "1.1.0"
+version                = "2.0.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Security Compliance API"
 edition.workspace      = true
 authors.workspace      = true


### PR DESCRIPTION
The service removed RPCs. Since the functions are not used, the service
remains at v1, but since we need to follow semver for Rust, we bump the
library to 2.0.