### PR TITLE
fix: support locational endpoints

### DIFF
--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -51,7 +51,7 @@ wkt.workspace         = true
 package          = "google-cloud-aiplatform-v1"
 path             = "../../src/generated/cloud/aiplatform/v1"
 default-features = false
-features         = ["prediction-service"]
+features         = ["model-service", "prediction-service"]
 
 [dependencies.bigquery]
 package = "google-cloud-bigquery-v2"

--- a/src/integration-tests/src/aiplatform.rs
+++ b/src/integration-tests/src/aiplatform.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+
+pub async fn locational_endpoint() -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    let project_id = crate::project_id()?;
+    let location_id = "us-central1";
+    let client = aiplatform::client::ModelService::builder()
+        .with_endpoint(format!("https://{location_id}-aiplatform.googleapis.com"))
+        .with_tracing()
+        .build()
+        .await?;
+
+    tracing::info!("Listing models in {location_id}...");
+    let models = client
+        .list_models()
+        .set_parent(format!("projects/{project_id}/locations/{location_id}"))
+        .send()
+        .await?;
+    tracing::info!("Successfully listed models in {location_id}: {models:#?}");
+
+    Ok(())
+}

--- a/src/integration-tests/src/lib.rs
+++ b/src/integration-tests/src/lib.rs
@@ -16,6 +16,7 @@ use anyhow::Error;
 use rand::{Rng, distr::Alphanumeric};
 
 pub type Result<T> = anyhow::Result<T>;
+pub mod aiplatform;
 pub mod bigquery;
 pub mod compute;
 pub mod error_details;

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -26,6 +26,13 @@ mod driver {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_aiplatform() -> integration_tests::Result<()> {
+        integration_tests::aiplatform::locational_endpoint()
+            .await
+            .map_err(integration_tests::report_error)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_bigquery_dataset_service() -> integration_tests::Result<()> {
         integration_tests::bigquery::dataset_admin()
             .await


### PR DESCRIPTION
Part of the work for #3375. (The other half is gRPC).

When a client is configured to use a locational / regional endpoints, use them as the host, instead of the default host (global).

The client library detects these automatically. (Whereas, in C++, we decided to expose an `AuthorityOption`). If you have more test cases for custom endpoints, I will happily add them.

Adds an integration test that fails without the corresponding changes to the `gaxi` client.

I did not think about whether we should do the same thing for gRPC based clients. The answer is probably. It would be easy enough to refactor `host_from_endpoint` and the related tests.