### PR TITLE
feat(gax-internal): Add with_instrumentation to grpc::Client

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -45,6 +45,7 @@ pub struct Client {
     retry_throttler: SharedRetryThrottler,
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
+    instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
 }
 
 impl Client {
@@ -76,7 +77,17 @@ impl Client {
             polling_backoff_policy: config
                 .polling_backoff_policy
                 .unwrap_or_else(|| Arc::new(ExponentialBackoff::default())),
+            instrumentation: None,
         })
+    }
+
+    /// Sets the instrumentation client info.
+    pub fn with_instrumentation(
+        mut self,
+        instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
+    ) -> Self {
+        self.instrumentation = instrumentation;
+        self
     }
 
     /// Sends a request.
@@ -302,4 +313,26 @@ where
         gax::response::Parts::new().set_headers(metadata.into_headers()),
         body.cnv().map_err(Error::deser)?,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::InstrumentationClientInfo;
+
+    #[tokio::test]
+    async fn test_with_instrumentation() {
+        let config = crate::options::ClientConfig::default();
+        let client = Client::new(config, "http://example.com").await.unwrap();
+        assert!(client.instrumentation.is_none());
+        static TEST_INFO: InstrumentationClientInfo = InstrumentationClientInfo {
+            service_name: "test-service",
+            client_version: "1.0.0",
+            client_artifact: "test-artifact",
+            default_host: "example.com",
+        };
+        let client = client.with_instrumentation(Some(&TEST_INFO));
+        assert!(client.instrumentation.is_some());
+        assert_eq!(client.instrumentation.unwrap().service_name, "test-service");
+    }
 }


### PR DESCRIPTION
Add the instrumentation field to the grpc::Client struct and a `with_instrumentation` builder method to set it. This allows passing client library metadata for tracing purposes.