### PR TITLE
chore: update sidekick version

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -504,7 +504,7 @@ jobs:
           sudo unzip -x /tmp/protoc.zip
           protoc --version
       - name: Regenerate all the code
-        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.3.1-0.20250926162934-043cf654f8e9 refreshall
+        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.3.1-0.20250926200155-1d83853fa0db refreshall
       - run: cargo fmt
         # If there is any difference between the generated code and the
         # committed code that is an error. All the inputs should be pinned,

--- a/src/generated/cloud/compute/v1/src/lib.rs
+++ b/src/generated/cloud/compute/v1/src/lib.rs
@@ -35,6 +35,7 @@
 //! * [Zones](client/struct.Zones.html)
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![allow(deprecated)]
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]

--- a/src/generated/cloud/compute/v1/src/model.rs
+++ b/src/generated/cloud/compute/v1/src/model.rs
@@ -904,6 +904,7 @@ pub mod machine_type_aggregated_list {
             /// Warning that is present in an external api call
             ExternalApiWarning,
             /// Warning that value of a field has been overridden. Deprecated unused field.
+            #[deprecated]
             FieldValueOverriden,
             /// The operation involved use of an injected kernel, which is deprecated.
             InjectedKernelsDeprecated,
@@ -1499,6 +1500,7 @@ pub mod machine_type_list {
             /// Warning that is present in an external api call
             ExternalApiWarning,
             /// Warning that value of a field has been overridden. Deprecated unused field.
+            #[deprecated]
             FieldValueOverriden,
             /// The operation involved use of an injected kernel, which is deprecated.
             InjectedKernelsDeprecated,
@@ -2044,6 +2046,7 @@ pub mod machine_types_scoped_list {
             /// Warning that is present in an external api call
             ExternalApiWarning,
             /// Warning that value of a field has been overridden. Deprecated unused field.
+            #[deprecated]
             FieldValueOverriden,
             /// The operation involved use of an injected kernel, which is deprecated.
             InjectedKernelsDeprecated,
@@ -2921,6 +2924,7 @@ pub mod zone_list {
             /// Warning that is present in an external api call
             ExternalApiWarning,
             /// Warning that value of a field has been overridden. Deprecated unused field.
+            #[deprecated]
             FieldValueOverriden,
             /// The operation involved use of an injected kernel, which is deprecated.
             InjectedKernelsDeprecated,


### PR DESCRIPTION
This time with support for deprecated elements in a discovery doc
specification.
