### PR TITLE
fix(storage): respect locational endpoints

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -191,7 +191,7 @@ impl Client {
     ) -> gax::client_builder::Result<InnerClient> {
         use tonic::transport::{ClientTlsConfig, Endpoint};
 
-        let origin = Uri::from_str(default_endpoint).map_err(BuilderError::transport)?;
+        let origin = crate::host::origin_from_endpoint(endpoint.as_deref(), default_endpoint)?;
         let endpoint =
             Endpoint::from_shared(endpoint.unwrap_or_else(|| default_endpoint.to_string()))
                 .map_err(BuilderError::transport)?

--- a/src/gax-internal/src/lib.rs
+++ b/src/gax-internal/src/lib.rs
@@ -54,8 +54,7 @@ pub mod unimplemented;
 #[cfg(feature = "_internal-common")]
 pub mod routing_parameter;
 
-// TODO(#3375) - use host logic in gRPC too.
-#[cfg(feature = "_internal-http-client")]
+#[cfg(feature = "_internal-common")]
 pub(crate) mod host;
 
 #[cfg(feature = "_internal-grpc-client")]


### PR DESCRIPTION
Fixes #3375 

Use locational endpoints as the `:authority` field in gRPC requests, instead of the default. An analog to #3402, but for gRPC.

I couldn't reproduce this with GCS. I think it was forgiving of trying to access locational resources from a global endpoint. And I did not want to [restrict global endpoint usage](https://cloud.google.com/assured-workloads/docs/restrict-endpoint-usage) in our test project.

I tested locally with `aiplatform`, and saw the same behavior we see over HTTP. https://github.com/dbolduc/google-cloud-rust/commit/381b5fe4130da304672df7b34a60187b7fb1e80b