### PR TITLE
fix(storage): respect locational endpoints

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -29,8 +29,6 @@ use gax::polling_error_policy::{Aip194Strict as PollingAip194Strict, PollingErro
 use gax::retry_policy::{Aip194Strict as RetryAip194Strict, RetryPolicy, RetryPolicyExt as _};
 use gax::retry_throttler::SharedRetryThrottler;
 use http::HeaderMap;
-use http::Uri;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -191,7 +189,10 @@ impl Client {
     ) -> gax::client_builder::Result<InnerClient> {
         use tonic::transport::{ClientTlsConfig, Endpoint};
 
-        let origin = Uri::from_str(default_endpoint).map_err(BuilderError::transport)?;
+        let origin =
+            crate::host::from_endpoint(endpoint.as_deref(), default_endpoint, |origin, _host| {
+                origin
+            })?;
         let endpoint =
             Endpoint::from_shared(endpoint.unwrap_or_else(|| default_endpoint.to_string()))
                 .map_err(BuilderError::transport)?

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -51,7 +51,11 @@ impl ReqwestClient {
     ) -> gax::client_builder::Result<Self> {
         let cred = Self::make_credentials(&config).await?;
         let inner = reqwest::Client::new();
-        let host = crate::host::host_from_endpoint(config.endpoint.as_deref(), default_endpoint)?;
+        let host = crate::host::from_endpoint(
+            config.endpoint.as_deref(),
+            default_endpoint,
+            |_origin, host| host,
+        )?;
         let tracing_enabled = crate::options::tracing_enabled(&config);
         let endpoint = config
             .endpoint

--- a/src/gax-internal/src/lib.rs
+++ b/src/gax-internal/src/lib.rs
@@ -54,8 +54,7 @@ pub mod unimplemented;
 #[cfg(feature = "_internal-common")]
 pub mod routing_parameter;
 
-// TODO(#3375) - use host logic in gRPC too.
-#[cfg(feature = "_internal-http-client")]
+#[cfg(any(feature = "_internal-http-client", feature = "_internal-grpc-client"))]
 pub(crate) mod host;
 
 #[cfg(feature = "_internal-grpc-client")]

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -153,7 +153,6 @@ mod driver {
 
     #[test_case(StorageControl::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
     #[test_case(StorageControl::builder().with_endpoint("https://www.googleapis.com"); "with global endpoint")]
-    #[test_case(StorageControl::builder().with_endpoint("https://us-central1-storage.googleapis.com"); "with locational endpoint")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_control_buckets(
         builder: storage::builder::storage_control::ClientBuilder,


### PR DESCRIPTION
Fixes #3375 

Use locational endpoints as the `:authority` field in gRPC requests, instead of the default. An analog to #3402, but for gRPC.

I couldn't reproduce this with GCS. I think it was forgiving of trying to access locational resources from a global endpoint. And I did not want to [restrict global endpoint usage](https://cloud.google.com/assured-workloads/docs/restrict-endpoint-usage) in our test project.

I tested locally with `aiplatform`, and saw the same behavior we see over HTTP. https://github.com/dbolduc/google-cloud-rust/commit/381b5fe4130da304672df7b34a60187b7fb1e80b