### PR TITLE
feat(gax): Add Response Extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,6 +2588,7 @@ dependencies = [
  "http",
  "http-body-util",
  "httptest",
+ "hyper-util",
  "mockall",
  "opentelemetry-semantic-conventions",
  "percent-encoding",
@@ -5202,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,6 +338,7 @@ anyhow            = { default-features = false, version = "1.0.100", features = 
 axum              = { default-features = false, version = "0.8" }
 flate2            = { default-features = false, version = "1" }
 httptest          = { default-features = false, version = "0.16.3" }
+hyper-util        = { default-features = false, version = "0.1.17" }
 md5               = { default-features = false, version = "0.8" }
 mockall           = { default-features = false, version = "0.13" }
 multer            = { default-features = false, version = "3" }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -93,6 +93,7 @@ anyhow.workspace                  = true
 bytes.workspace                   = true
 google-cloud-test-utils.workspace = true
 httptest.workspace                = true
+hyper-util.workspace              = true
 mockall.workspace                 = true
 scoped-env.workspace              = true
 serde_with.workspace              = true

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -297,9 +297,12 @@ pub fn to_gax_response<T, G>(response: tonic::Response<T>) -> Result<gax::respon
 where
     T: crate::prost::FromProto<G>,
 {
-    let (metadata, body, _extensions) = response.into_parts();
+    let (metadata, body, extensions) = response.into_parts();
+    let mut parts = gax::response::Parts::default();
+    parts.headers = metadata.into_headers();
+    *parts.extensions.lock().unwrap() = extensions;
     Ok(gax::response::Response::from_parts(
-        gax::response::Parts::new().set_headers(metadata.into_headers()),
+        parts,
         body.cnv().map_err(Error::deser)?,
     ))
 }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -300,7 +300,12 @@ where
     let (metadata, body, extensions) = response.into_parts();
     let mut parts = gax::response::Parts::default();
     parts.headers = metadata.into_headers();
-    *parts.extensions.lock().unwrap() = extensions;
+    let mut lock = parts
+        .extensions
+        .lock()
+        .expect("Extensions mutex is not poisoned");
+    *lock = extensions;
+    drop(lock); // Ensure the lock is dropped before parts is moved
     Ok(gax::response::Response::from_parts(
         parts,
         body.cnv().map_err(Error::deser)?,

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -299,7 +299,6 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
 ) -> Result<Response<O>> {
     // 204 No Content has no body and throws EOF error if we try to parse with serde::json
     let no_content_status = response.status() == reqwest::StatusCode::NO_CONTENT;
-    let extensions = Arc::new(Mutex::new(response.extensions().clone()));
     let response = http::Response::from(response);
     let (parts, body) = response.into_parts();
 
@@ -314,7 +313,7 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
 
     let mut parts_out = Parts::default();
     parts_out.headers = parts.headers;
-    parts_out.extensions = extensions;
+    parts_out.extensions = Arc::new(Mutex::new(parts.extensions));
     Ok(Response::from_parts(parts_out, response))
 }
 


### PR DESCRIPTION
This PR introduces a mechanism to pass extensions from transport layers (like HTTP and gRPC) up to the higher levels of the GAX crate, primarily for observability purposes.

**Key Changes:**

1.  **`Arc<Mutex<http::Extensions>>` in `Parts`:** The `google_cloud_gax::response::Parts` struct now includes an `extensions` field of type `Arc<Mutex<http::Extensions>>`. This allows storing arbitrary type-safe data. The `Arc<Mutex<>>` wrapper is used to maintain the `UnwindSafe` guarantee of `Response<T>`, as `http::Extensions` itself is not `UnwindSafe`. See issue #3463 for more details on this decision.
2.  **`extensions()` and `extensions_mut()` Methods:** New methods `extensions()` and `extensions_mut()` are added to `Response<T>`. These methods provide locked access to the underlying `http::Extensions` by returning a `MutexGuard`. They panic if the mutex is poisoned. These replace the previous `insert_extension` and `get_extension` methods.
3.  **Transport Layer Updates:**
    *   In `gax-internal/src/http.rs`, the `to_http_response` function is updated to move the extensions from the `reqwest::Response` into the new `Parts.extensions` field efficiently, avoiding unnecessary clones.
    *   In `gax-internal/src/grpc.rs`, the `to_gax_response` function is updated to move extensions from `tonic::Response` into `Parts.extensions`.

This change enables lower-level transport code to attach data (like observability summaries) to the response, which can then be accessed by higher-level wrappers or the end-user.