### PR TITLE
feat(auth): implement id tokens with MDS source

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -26,6 +26,7 @@ pub mod anonymous;
 pub mod api_key_credentials;
 pub mod external_account;
 pub(crate) mod external_account_sources;
+pub(crate) mod idtoken; 
 pub mod impersonated;
 pub(crate) mod internal;
 pub mod mds;

--- a/src/auth/src/credentials/idtoken.rs
+++ b/src/auth/src/credentials/idtoken.rs
@@ -1,0 +1,88 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::token::Token;
+use std::future::Future;
+use std::sync::Arc;
+
+/// Represents an `IDTokenCredentials` used to obtain an ID token.
+///
+/// `IDTokenCredentials` provide a way to obtain OIDC ID tokens, which are
+/// commonly used for authenticating to services like Cloud Run or Identity-Aware
+/// Proxy (IAP). Unlike access tokens, ID tokens are not used to authorize access
+// to Google Cloud APIs but to verify the identity of a principal.
+///
+/// This struct serves as a wrapper around different credential types that can
+/// produce ID tokens, such as service accounts or metadata server credentials.
+#[derive(Clone, Debug)]
+pub struct IDTokenCredentials {
+    pub(crate) inner: Arc<dyn dynamic::IDTokenCredentialsProvider>,
+}
+
+impl<T> From<T> for IDTokenCredentials
+where
+    T: IDTokenCredentialsProvider + Send + Sync + 'static,
+{
+    fn from(value: T) -> Self {
+        Self {
+            inner: Arc::new(value),
+        }
+    }
+}
+
+impl IDTokenCredentials {
+    /// Asynchronously retrieves an ID token.
+    ///
+    /// This method will contact the underlying credential source to obtain a
+    /// fresh ID token if a valid one is not already cached.
+    pub async fn id_token(&self) -> Result<Token> {
+        self.inner.id_token().await
+    }
+}
+
+/// A trait for credential types that can provide OIDC ID tokens.
+///
+/// Implement this trait to create custom ID token providers. This is useful for
+/// testing or for integrating with authentication systems not natively
+/// supported by this library.
+pub trait IDTokenCredentialsProvider: std::fmt::Debug {
+    /// Asynchronously retrieves an ID token.
+    fn id_token(&self) -> impl Future<Output = Result<Token>> + Send;
+}
+
+/// A module containing the dynamically-typed, object-safe version of the
+/// `IDTokenCredentialsProvider` trait. This is an internal implementation detail.
+pub(crate) mod dynamic {
+    use crate::Result;
+    use crate::token::Token;
+
+    /// A dyn-compatible, crate-private version of `IDTokenCredentialsProvider`.
+    #[async_trait::async_trait]
+    pub trait IDTokenCredentialsProvider: Send + Sync + std::fmt::Debug {
+        /// Asynchronously retrieves an ID token.
+        async fn id_token(&self) -> Result<Token>;
+    }
+
+    /// The public `IDTokenCredentialsProvider` implements the dyn-compatible `IDTokenCredentialsProvider`.
+    #[async_trait::async_trait]
+    impl<T> IDTokenCredentialsProvider for T
+    where
+        T: super::IDTokenCredentialsProvider + Send + Sync,
+    {
+        async fn id_token(&self) -> Result<Token> {
+            T::id_token(self).await
+        }
+    }
+}


### PR DESCRIPTION
Adds base ID Token credential trait to be followed by other implementations. Add MDS implementation as initial one.

Towards #3449