### PR TITLE
feat: Indicate the dart and client version in x-goog-api-client

### DIFF
--- a/dart/packages/google_cloud_gax/lib/gax.dart
+++ b/dart/packages/google_cloud_gax/lib/gax.dart
@@ -14,13 +14,16 @@
 
 import 'dart:convert';
 
+import 'package:google_cloud_gax/src/versions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:http/http.dart' as http;
 
 export 'dart:typed_data' show Uint8List;
 
 const String _clientKey = 'x-goog-api-client';
-const String _clientName = 'dart-gax-client';
+
+// `'0'` is a special version string indicating that the version isn't known.
+final String _clientName = 'gl-dart/${dartVersion ?? '0'} gax/$gaxVersion';
 
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';
@@ -67,12 +70,7 @@ class ServiceClient {
   ServiceClient({required this.client});
 
   Future<Map<String, dynamic>> get(Uri url) async {
-    final response = await client.get(
-      url,
-      headers: {
-        _clientKey: _clientName,
-      },
-    );
+    final response = await client.get(url, headers: {_clientKey: _clientName});
     return _processResponse(response);
   }
 
@@ -115,9 +113,7 @@ class ServiceClient {
   Future<Map<String, dynamic>> delete(Uri url) async {
     final response = await client.delete(
       url,
-      headers: {
-        _clientKey: _clientName,
-      },
+      headers: {_clientKey: _clientName},
     );
     return _processResponse(response);
   }
@@ -142,7 +138,8 @@ class ServiceClient {
     } catch (_) {
       // Return a general HTTP exception if we can't parse the Status response.
       throw http.ClientException(
-          '${response.statusCode}: ${response.reasonPhrase}');
+        '${response.statusCode}: ${response.reasonPhrase}',
+      );
     }
 
     throw status;

--- a/dart/packages/google_cloud_gax/lib/src/versions.dart
+++ b/dart/packages/google_cloud_gax/lib/src/versions.dart
@@ -1,0 +1,23 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'web.dart' if (dart.library.io) 'vm.dart' show dartVersion;
+
+/// The version of this package.
+//
+// Keep these versions in sync:
+// * CHANGELOG.yaml
+// * pubspec.yaml
+// * lib/src/versions.dart
+const gaxVersion = '0.1.0';

--- a/dart/packages/google_cloud_gax/lib/src/vm.dart
+++ b/dart/packages/google_cloud_gax/lib/src/vm.dart
@@ -1,0 +1,24 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// VM-specific implementations.
+library;
+
+import 'dart:io';
+
+// ignore: unnecessary_nullable_for_final_variable_declarations
+final String? dartVersion = Platform.version
+    .split(RegExp('[^0-9]+'))
+    .take(3)
+    .join('.');

--- a/dart/packages/google_cloud_gax/lib/src/web.dart
+++ b/dart/packages/google_cloud_gax/lib/src/web.dart
@@ -1,0 +1,18 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Web-specific implementations.
+library;
+
+final String? dartVersion = null;

--- a/dart/packages/google_cloud_gax/pubspec.yaml
+++ b/dart/packages/google_cloud_gax/pubspec.yaml
@@ -14,6 +14,10 @@
 
 name: google_cloud_gax
 description: Common code for the Google Cloud client library packages.
+# Keep these versions in sync:
+# * CHANGELOG.yaml
+# * pubspec.yaml
+# * lib/src/versions.dart
 version: 0.1.0
 
 environment:

--- a/dart/packages/google_cloud_gax/test/client_test.dart
+++ b/dart/packages/google_cloud_gax/test/client_test.dart
@@ -54,7 +54,9 @@ void main() {
 
           expect(actualRequest.method, method);
           expect(actualRequest.url, sampleUrl);
-          expect(actualRequest.headers, {'x-goog-api-client': anything});
+          expect(actualRequest.headers, {
+            'x-goog-api-client': matches(r'gl-dart/3\.\d+\.\d+ gax/0.1.0'),
+          });
           expect(actualRequest.body, isEmpty);
         });
       }
@@ -81,7 +83,7 @@ void main() {
           expect(actualRequest.url, sampleUrl);
           expect(actualRequest.headers, {
             'content-type': 'application/json',
-            'x-goog-api-client': anything,
+            'x-goog-api-client': matches(r'gl-dart/3\.\d+\.\d+ gax/0.1.0'),
           });
           expect(actualRequest.body, '"<test payload>"');
         });
@@ -154,7 +156,9 @@ void main() {
 
           expect(actualRequest.method, method);
           expect(actualRequest.url, Uri.parse('http://example.com/?alt=sse'));
-          expect(actualRequest.headers, {'x-goog-api-client': anything});
+          expect(actualRequest.headers, {
+            'x-goog-api-client': matches(r'gl-dart/3\.\d+\.\d+ gax/0.1.0'),
+          });
           expect(actualRequest.body, isEmpty);
         });
       }
@@ -184,7 +188,7 @@ void main() {
           expect(actualRequest.url, Uri.parse('http://example.com/?alt=sse'));
           expect(actualRequest.headers, {
             'content-type': 'application/json',
-            'x-goog-api-client': anything,
+            'x-goog-api-client': matches(r'gl-dart/3\.\d+\.\d+ gax/0.1.0'),
           });
           expect(actualRequest.body, '"<test payload>"');
         });


### PR DESCRIPTION
The `'x-goog-api-client'` header now looks like `'gl-dart/3.9.2 gax/0.1.0'`
