### PR TITLE
cleanup(auth): use write-only for secrets in terraform

### DIFF
--- a/src/auth/.gcb/builds/api_key_test/main.tf
+++ b/src/auth/.gcb/builds/api_key_test/main.tf
@@ -69,8 +69,8 @@ resource "google_secret_manager_secret" "test-api-key-secret" {
 
 # Store the test API key in secret manager.
 resource "google_secret_manager_secret_version" "test-api-key-secret-version" {
-  secret      = google_secret_manager_secret.test-api-key-secret.id
-  secret_data = google_apikeys_key.test-api-key.key_string
+  secret         = google_secret_manager_secret.test-api-key-secret.id
+  secret_data_wo = google_apikeys_key.test-api-key.key_string
 }
 
 output "secret" {

--- a/src/auth/.gcb/builds/service_account_test/main.tf
+++ b/src/auth/.gcb/builds/service_account_test/main.tf
@@ -51,8 +51,8 @@ resource "google_secret_manager_secret" "test-sa-creds-json-secret" {
 
 # Store the test service account key in secret manager.
 resource "google_secret_manager_secret_version" "test-sa-creds-json-secret-version" {
-  secret      = google_secret_manager_secret.test-sa-creds-json-secret.id
-  secret_data = base64decode(google_service_account_key.test-sa-creds-principal-key.private_key)
+  secret         = google_secret_manager_secret.test-sa-creds-json-secret.id
+  secret_data_wo = base64decode(google_service_account_key.test-sa-creds-principal-key.private_key)
 }
 
 # The "secret" that will be accessed by the principal testing service account
@@ -76,7 +76,7 @@ resource "google_secret_manager_secret_version" "test-sa-creds-secret-version" {
   secret = google_secret_manager_secret.test-sa-creds-secret.id
 
   # We do not care that the value is public. We are just testing ACLs.
-  secret_data = "service_account"
+  secret_data_wo = "service_account"
 }
 
 # Set up secret permissions for service account credentials.


### PR DESCRIPTION
Terraform warns us that we can use write-only for private data like secrets to avoid storing their values in the terraform state. Terraform is right, this is a good idea.