### PR TITLE
fix(gax-internal): better gRPC error messages

### DIFF
--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -142,6 +142,9 @@ mod tests {
             .and_then(|e| e.downcast_ref::<tonic::Status>())
             .expect("want a tonic::Status as source().source()");
         assert_eq!(source.code(), tonic::Code::Internal);
+
+        let fmt = format!("{got}");
+        assert!(fmt.contains("should start with application/grpc"), "fmt={fmt}, got={got:?}");
     }
 
     #[test]

--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -52,8 +52,29 @@ pub fn to_gax_error(status: tonic::Status) -> Error {
         return Error::transport(headers, status);
     }
 
+    let content_type = headers.get("content-type").map(|v| v.as_bytes());
+    if content_type.is_some_and(|v| !v.starts_with("application/grpc".as_bytes())) {
+        return Error::transport(headers, GrpcError::BadContentType(status));
+    }
+
     let gax_status = to_gax_status(&status);
     gax::error::Error::service_with_http_metadata(gax_status, None, Some(headers))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum GrpcError {
+    BadContentType(#[source] tonic::Status),
+}
+
+impl std::fmt::Display for GrpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadContentType(_status) => write!(
+                f,
+                "unexpected value in content-type header, should start with application/grpc. In Google Cloud, this is a common problem when using an invalid endpoint, or an endpoint that does not support the target gRPC service."
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -87,11 +108,40 @@ mod tests {
 
     #[test]
     fn gax_error() {
-        let status = tonic::Status::invalid_argument("test-only");
+        let mut status = tonic::Status::invalid_argument("test-only");
+        status.metadata_mut().append(
+            "content-type",
+            tonic::metadata::AsciiMetadataValue::from_static("application/grpc"),
+        );
         let got = to_gax_error(status);
+        assert!(got.status().is_some(), "{got:?}");
         let status = got.status().unwrap();
         assert_eq!(status.code, Code::InvalidArgument);
         assert_eq!(&status.message, "test-only");
+    }
+
+    #[test]
+    fn gax_error_bad_content_type() {
+        let mut status = tonic::Status::internal("oh noes");
+        status.metadata_mut().append(
+            "content-type",
+            tonic::metadata::AsciiMetadataValue::from_static("application/xml; charset=UTF-8"),
+        );
+        let got = to_gax_error(status);
+        assert!(got.is_transport(), "{got:?}");
+        assert!(got.status().is_none(), "{got:?}");
+        let source = got
+            .source()
+            .and_then(|e| e.downcast_ref::<GrpcError>())
+            .expect("want a GrpcError as source");
+        assert!(matches!(source, GrpcError::BadContentType(_)), "{source:?}");
+
+        let source = got
+            .source()
+            .and_then(|e| e.source())
+            .and_then(|e| e.downcast_ref::<tonic::Status>())
+            .expect("want a tonic::Status as source().source()");
+        assert_eq!(source.code(), tonic::Code::Internal);
     }
 
     #[test]

--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -144,7 +144,10 @@ mod tests {
         assert_eq!(source.code(), tonic::Code::Internal);
 
         let fmt = format!("{got}");
-        assert!(fmt.contains("should start with application/grpc"), "fmt={fmt}, got={got:?}");
+        assert!(
+            fmt.contains("should start with application/grpc"),
+            "fmt={fmt}, got={got:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The Google Cloud load balancer can respond with HTML or XML messages if
the target endpoint is invalid, e.g. `not-a-service.googleapis.com`, or
if the target endpoint does not match the service, e.g. using
`pubsub.googleapis.com` to call Cloud Storage RPCs.

This change generates a better error message in these cases, which we
hope makes troubleshooting easier.

----
Fixes #3460

From:

```
ERROR the service reports an error with code INTERNAL described as: protocol error: received message with invalid compression flag: 60 (valid flags are 0 and 1) while receiving response with status: 400 Bad Request
```

To:

```
ERROR the transport reports an error: unexpected value in content-type header, should start with application/grpc. In Google Cloud, this is a common problem when using an invalid endpoint, or an endpoint that does not support the target gRPC service.

Caused by:
    0: unexpected value in content-type header, should start with application/grpc. In Google Cloud, this is a common problem when using an invalid endpoint, or an endpoint that does not support the target gRPC service.
    1: status: 'Internal error', self: "protocol error: received message with invalid compression flag: 60 (valid flags are 0 and 1) while receiving response with status: 400 Bad Request", metadata: {"content-type": "application/xml; charset=UTF-8", "x-guploader-uploadid": "AAwnv3KXwY3MPyo1Mv2r0U5jhIh9oftiE8kgrHNLgCM_vHJ1MCChboJ5lUjvIfDU2RSqFcgLnUQoKr8", "content-length": "203", "date": "Mon, 06 Oct 2025 13:58:59 GMT", "server": "UploadServer", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"}
```
