### PR TITLE
impl(gax): Define concrete TransportSpanInfo struct

### DIFF
--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -33,6 +33,9 @@ rust-version.workspace = true
 # We want to generate documentation for streaming APIs, gated by this feature.
 features = ["unstable-stream"]
 
+[lints]
+workspace = true
+
 [dependencies]
 base64.workspace      = true
 bytes.workspace       = true


### PR DESCRIPTION
Defines the TransportSpanInfo struct within the internal module to propagate transport-level details.