### PR TITLE
refactor(ci): update CI for unstable flags

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -24,6 +24,9 @@ on:
 env:
   GHA_RUST_VERSIONS: '{ "rust:msrv": "1.85", "rust:current": "1.90", "rust:nightly": "nightly" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.0" }'
+  # Define the unstable flags once
+  UNSTABLE_CFGS: &unstable_cfgs "--cfg google_cloud_unstable_tracing"
+
 jobs:
   build:
     strategy:
@@ -34,6 +37,8 @@ jobs:
           - os: 'ubuntu-24.04'
             rust-version: 'rust:msrv'
     runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: *unstable_cfgs
     steps:
       - uses: actions/checkout@v5
       - uses: actions/cache@v4
@@ -156,11 +161,60 @@ jobs:
           cargo clippy --no-deps --package google-cloud-storage --all-targets -- --deny warnings
           cargo clippy --no-deps --package google-cloud-storage --all-features --all-targets --profile=test -- --deny warnings
 
+  test-unstable-cfg:
+    strategy:
+      matrix:
+        os: ['ubuntu-24.04']
+        rust-version: ['rust:current']
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: *unstable_cfgs
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}-unstable
+      - name: Setup Rust ${{ matrix.rust-version }}
+        run: |
+          set -e
+          rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup component add clippy
+      - run: rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+      - name: Display Cargo version
+        run: cargo version
+      - name: Display rustc version
+        run: rustup show active-toolchain -v
+      - name: Test key crates and integration tests with Unstable CFGs
+        run: |
+          set -e
+          echo "RUSTFLAGS in test-unstable-cfg: $RUSTFLAGS"
+
+          # Key crates
+          KEY_CRATES=("google-cloud-gax" "google-cloud-gax-internal" "google-cloud-test-utils")
+          for crate in "${KEY_CRATES[@]}"; do
+            cargo clean
+            echo "==== ${crate} (UNSTABLE - No Default Features) ===="
+            cargo test --package ${crate} --no-default-features
+
+            cargo clean
+            echo "==== ${crate} (UNSTABLE - All Features) ===="
+            cargo test --package ${crate} --all-features
+          done
+
+          # Integration tests
+          echo "==== integration-tests (UNSTABLE) ===="
+          cargo test -p integration-tests --features run-showcase-tests
+
   coverage:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust-version: ['rust:current']
+    env:
+      RUSTFLAGS: *unstable_cfgs
     steps:
       - uses: actions/checkout@v5
       - uses: actions/cache@v4
@@ -190,6 +244,8 @@ jobs:
     strategy:
       matrix:
         rust-version: ['rust:current']
+    env:
+      RUSTFLAGS: *unstable_cfgs
     steps:
       - uses: actions/checkout@v5
       - uses: actions/cache@v4
@@ -467,6 +523,35 @@ jobs:
       - run: cargo clippy --workspace --all-targets --profile=test -- --deny warnings
       - run: cargo fmt
       - run: git diff --exit-code
+
+  lint-unstable:
+    runs-on: ubuntu-24.04
+    env:
+      RUSTFLAGS: *unstable_cfgs
+    strategy:
+      matrix:
+        rust-version: ['rust:current']
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}
+      - name: Setup Rust ${{ matrix.rust-version }}
+        run: |
+          set -e
+          rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup component add clippy rustfmt
+      - name: Display Cargo version
+        run: cargo version
+      - name: Display rustc version
+        run: rustup show active-toolchain -v
+      - run: cargo clippy --workspace --all-targets --profile=test -- --deny warnings
+      - run: cargo fmt
+      - run: git diff --exit-code
+
   regenerate:
     # Verifies the generated code has not been tampered with. Or maybe that the
     # code requires no tampering.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,3 +408,6 @@ google-cloud-storage          = { version = "1", path = "src/storage" }
 google-cloud-test-utils = { path = "src/test-utils" }
 integration-tests       = { path = "src/integration-tests" }
 storage-samples         = { path = "src/storage/examples" }
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(google_cloud_unstable_tracing)'] }


### PR DESCRIPTION
  This PR updates the GitHub Actions workflow to introduce a testing strategy for unstable features gated by --cfg flags.

   - Defines a central UNSTABLE_CFGS env variable for all active unstable flags.
   - Enables these flags in build, minimal-versions, and coverage jobs to test combined effects.
   - Adds a new test-unstable-cfg job to run key crate and integration tests with all unstable flags active.
   - Adds a new lint-unstable job to lint the workspace with all unstable flags active.
   - Other jobs test the stable configuration.

This ensures that unstable features are continuously tested without disrupting stable checks, and provides a clear signal on their impact.