### PR TITLE
ci(auth): reenable terraform pubsub trigger

### DIFF
--- a/src/auth/.gcb/builds/triggers/main.tf
+++ b/src/auth/.gcb/builds/triggers/main.tf
@@ -261,3 +261,22 @@ resource "google_cloud_scheduler_job" "job" {
     data       = base64encode("sync")
   }
 }
+
+resource "google_cloudbuild_trigger" "pubsub-trigger" {
+  location = var.region
+  name     = "gcb-pubsub-terraform"
+  filename = "src/auth/.gcb/terraform.yaml"
+  tags     = ["scheduler", "name:terraform"]
+
+  service_account = data.google_service_account.terraform-runner.id
+
+  pubsub_config {
+    topic = google_pubsub_topic.terraform_runner_topic.id
+  }
+
+  source_to_build {
+    repository = google_cloudbuildv2_repository.main.id
+    ref        = "refs/heads/main"
+    repo_type  = "GITHUB"
+  }
+}


### PR DESCRIPTION
Reverting #3510 with fix to trigger filename to the correct "src/auth/.gcb/terraform.yaml".