### PR TITLE
refactor(auth): service account access token generation

### DIFF
--- a/src/auth/src/credentials/service_account/jws.rs
+++ b/src/auth/src/credentials/service_account/jws.rs
@@ -42,6 +42,8 @@ pub struct JwsClaims {
     pub typ: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sub: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_audience: Option<String>,
 }
 
 impl JwsClaims {
@@ -102,6 +104,7 @@ mod tests {
             iat: now,
             typ: None,
             sub: None,
+            target_audience: None,
         };
 
         let encoded = claims.encode().unwrap();
@@ -135,6 +138,7 @@ mod tests {
             iat: now,
             typ: Some("test_typ".to_string()),
             sub: Some("test_sub".to_string()),
+            target_audience: None,
         };
 
         let encoded = claims.encode().unwrap();
@@ -168,6 +172,7 @@ mod tests {
             iat: now,
             typ: None,
             sub: None,
+            target_audience: None,
         };
         let expected_error_message = "must be later than issued time";
         assert!(
@@ -190,6 +195,7 @@ mod tests {
             iat: now,
             typ: None,
             sub: None,
+            target_audience: None,
         };
         let expected_error_message = "expecting only 1 of them to be set";
         assert!(


### PR DESCRIPTION
Create reusable `ServiceAccountTokenGenerator` to be used by both access token provider and id token provider. Also add `target_audience` to `JwsClaims`, which is needed for ID Tokens. The generator is used for two purposes:
* For Access Token provider passes `scopes` and `audience` configurable by user. The generated access token is returned to consumer. The `target_audience` field is not used.
* For ID Token provider pass `audience = "https://oauth2.googleapis.com/token"` and `target_audience` is the end audience for the id token. The generated access token then is used to request a ID Token on `https://oauth2.googleapis.com/token`. The `scopes` field is not used.

Towards #3449 https://github.com/googleapis/google-cloud-rust/issues/3589
Part of #3496 