### PR TITLE
refactor(o11y): use cfg flag instead of feature

### DIFF
--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -31,9 +31,10 @@ rust-version.workspace = true
 # are implementation details, and subject to change without notice.
 features = []
 
+[lints]
+workspace = true
+
 [features]
-# unstable feature flag for a new observability feature
-_unstable-o12y = []
 _internal-http-client = [
   "_internal-common",
   "dep:auth",

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -26,7 +26,7 @@ use gax::retry_throttler::SharedRetryThrottler;
 use http::{Extensions, Method};
 use std::sync::Arc;
 use std::time::Duration;
-#[cfg(feature = "_unstable-o12y")]
+#[cfg(google_cloud_unstable_tracing)]
 use tracing::Instrument;
 
 #[derive(Clone, Debug)]
@@ -177,7 +177,7 @@ impl ReqwestClient {
 
         let request = builder.build().map_err(Self::map_send_error)?;
 
-        #[cfg(feature = "_unstable-o12y")]
+        #[cfg(google_cloud_unstable_tracing)]
         let response_result = if self._tracing_enabled {
             let mut span_info = crate::observability::HttpSpanInfo::from_request(
                 &request,
@@ -196,7 +196,7 @@ impl ReqwestClient {
         } else {
             self.inner.execute(request).await
         };
-        #[cfg(not(feature = "_unstable-o12y"))]
+        #[cfg(not(google_cloud_unstable_tracing))]
         let response_result = self.inner.execute(request).await;
 
         let response = response_result.map_err(Self::map_send_error)?;

--- a/src/gax-internal/src/lib.rs
+++ b/src/gax-internal/src/lib.rs
@@ -36,7 +36,7 @@ pub mod query_parameter;
 #[cfg(feature = "_internal-http-client")]
 pub mod http;
 
-#[cfg(all(feature = "_internal-http-client", feature = "_unstable-o12y"))]
+#[cfg(feature = "_internal-http-client")]
 pub mod observability;
 
 #[cfg(feature = "_internal-grpc-client")]

--- a/src/gax-internal/src/observability.rs
+++ b/src/gax-internal/src/observability.rs
@@ -20,4 +20,5 @@
 mod attributes;
 mod http_tracing;
 
+#[cfg(google_cloud_unstable_tracing)]
 pub(crate) use http_tracing::HttpSpanInfo;

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -34,9 +34,9 @@ mod tests {
     use serde_json::json;
     use std::time::Duration;
 
-    #[cfg(feature = "_unstable-o12y")]
+    #[cfg(google_cloud_unstable_tracing)]
     use google_cloud_test_utils::test_layer::TestLayer;
-    #[cfg(feature = "_unstable-o12y")]
+    #[cfg(google_cloud_unstable_tracing)]
     use opentelemetry_semantic_conventions::trace::HTTP_REQUEST_RESEND_COUNT;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -111,7 +111,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "_unstable-o12y")]
+    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn retry_loop_retry_success_with_tracing_on() -> Result<()> {
         let guard = TestLayer::initialize();


### PR DESCRIPTION
This commit refactors the observability code to use #[cfg(google_cloud_unstable_tracing)] instead of the Cargo feature _unstable-o12y for gating unstable tracing features.