### PR TITLE
refactor(storage): move `ReadObjectResponse` initialization

### DIFF
--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -22,7 +22,6 @@ use crate::read_object::ReadObjectResponse;
 use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::checksum::details::Md5;
 use crate::storage::request_options::RequestOptions;
-pub(crate) use resumable::ReadObjectResponseImpl;
 
 /// The request builder for [Storage::read_object][crate::client::Storage::read_object] calls.
 ///
@@ -486,6 +485,13 @@ impl Reader {
         };
 
         self.inner.apply_auth_headers(builder).await
+    }
+
+    pub(crate) async fn response(self) -> Result<ReadObjectResponse> {
+        let response = self.clone().read().await?;
+        Ok(ReadObjectResponse::new(Box::new(
+            resumable::ReadObjectResponseImpl::new(self, response)?,
+        )))
     }
 }
 

--- a/src/storage/src/storage/read_object/resumable.rs
+++ b/src/storage/src/storage/read_object/resumable.rs
@@ -34,9 +34,7 @@ pub(crate) struct ReadObjectResponseImpl {
 }
 
 impl ReadObjectResponseImpl {
-    pub(crate) async fn new(reader: Reader) -> Result<Self> {
-        let response = reader.clone().read().await?;
-
+    pub(crate) fn new(reader: Reader, response: reqwest::Response) -> Result<Self> {
         let full = reader.request.read_offset == 0 && reader.request.read_limit == 0;
         let headers = response.headers();
         let response_checksums = checksums_from_response(full, response.status(), headers);

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -18,7 +18,7 @@ use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
 use crate::storage::perform_upload::PerformUpload;
-use crate::storage::read_object::{ReadObjectResponseImpl, Reader};
+use crate::storage::read_object::Reader;
 use crate::storage::request_options::RequestOptions;
 use crate::storage::streaming_source::{Seek, StreamingSource};
 use std::sync::Arc;
@@ -45,8 +45,7 @@ impl super::stub::Storage for Storage {
             request: req,
             options,
         };
-        let inner = ReadObjectResponseImpl::new(reader).await?;
-        Ok(ReadObjectResponse::new(Box::new(inner)))
+        reader.response().await
     }
 
     /// Implements [crate::client::Storage::write_object].


### PR DESCRIPTION
Part of the work for #3511 and #2051 