### PR TITLE
ci: integration test with unstable flags

### DIFF
--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -24,6 +24,7 @@ options:
     - SCCACHE_GCS_RW_MODE=READ_WRITE
     - SCCACHE_GCS_KEY_PREFIX=sccache/integration
     - RUSTC_WRAPPER=/workspace/.bin/sccache
+    - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
   - name: 'gcr.io/cloud-builders/curl'


### PR DESCRIPTION
Create a new build with the unstable flags. Required a bit of refactoring in the terraform manifests.