### PR TITLE
ci: speed up integration tests

### DIFF
--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 options:
-  machineType: E2_HIGHCPU_32
+  machineType: E2_HIGHCPU_8
   dynamic_substitutions: true
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Consolidate the test steps to avoid recompiling the code.

Use `E2_HIGHCPU_8` machines to get more parallelism.
Tried using `E2_HIGHCPU_32`, but those take too long to
schedule.
