### PR TITLE
refactor(storage): Inherit workspace lints

### DIFF
--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -25,6 +25,9 @@ keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace      = true
 base64.workspace           = true


### PR DESCRIPTION
This allows us to use cfg flags like `google_cloud_unstable_tracing`