### PR TITLE
chore(workflows/v1): bump patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workflows-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/generated/cloud/workflows/v1/.sidekick.toml
+++ b/src/generated/cloud/workflows/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/workflows/v1'
 service-config       = 'google/cloud/workflows/v1/workflows_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 # TODO(#1285) - remove `redundant_explicit_links` workaround when no longer needed
 # TODO(#742) - remove `broken_intro_doc_links` workaround when no longer needed

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workflows-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Workflows API"
 edition.workspace      = true
 authors.workspace      = true


### PR DESCRIPTION
Manually bump the patch version to account for the documentation changes. A minor version bump seems like overkill.