### PR TITLE
chore(secretmanager/v1): bump patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-secretmanager-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/generated/cloud/secretmanager/v1/.sidekick.toml
+++ b/src/generated/cloud/secretmanager/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/cloud/secretmanager/v1'
 service-config = 'google/cloud/secretmanager/v1/secretmanager_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2024'
 generate-setter-samples = 'true'

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-secretmanager-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Secret Manager API"
 edition.workspace      = true
 authors.workspace      = true


### PR DESCRIPTION
Manually bump the patch version to account for the documentation changes. A minor version bump seems like overkill.