### PR TITLE
chore: bump version numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-aiplatform-v1"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-cx-v3"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-v2"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-documentai-v1"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-longrunning"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privacy-dlp-v2"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,7 +361,7 @@ auth                          = { version = "1", path = "src/auth", package = "g
 google-cloud-auth             = { version = "1", path = "src/auth" }
 gax                           = { version = "1.1", path = "src/gax", package = "google-cloud-gax" }
 google-cloud-gax              = { version = "1.1", path = "src/gax" }
-gaxi                          = { version = "0.7.1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                          = { version = "0.7.2", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "1", path = "src/generated/iam/v1" }
 location                      = { version = "1", path = "src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/generated/cloud/aiplatform/v1/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/aiplatform/v1'
 service-config       = 'google/cloud/aiplatform/v1/aiplatform_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.2.0'
 copyright-year = '2025'
 # TODO(#893) - handle the bad HTML tags in this library.
 disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links,invalid_html_tags"

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-aiplatform-v1"
-version                = "1.1.0"
+version                = "1.2.0"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/cx/v3/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/cloud/dialogflow/cx/v3'
 service-config       = 'google/cloud/dialogflow/cx/v3/dialogflow_v3.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.2.0'
 copyright-year       = '2025'
 per-service-features = 'true'

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-cx-v3"
-version                = "1.1.0"
+version                = "1.2.0"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/v2/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/v2/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/dialogflow/v2'
 service-config       = 'google/cloud/dialogflow/v2/dialogflow_v2.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.2.0'
 copyright-year       = '2025'
 per-service-features = 'true'
 

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-v2"
-version                = "1.1.0"
+version                = "1.2.0"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/documentai/v1/.sidekick.toml
+++ b/src/generated/cloud/documentai/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/documentai/v1'
 service-config = 'google/cloud/documentai/v1/documentai_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.2.0'
 copyright-year = '2025'

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-documentai-v1"
-version                = "1.1.0"
+version                = "1.2.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud Document AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -34,6 +34,6 @@ operations.
 [gcloud-longrunning]: https://crates.io/crates/gcloud-longrunning"""
 
 [codec]
-version        = '1.1.0'
+version        = '1.2.0'
 copyright-year        = '2024'
 'package:longrunning' = 'ignore=true'

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-longrunning"
-version                = "1.1.0"
+version                = "1.2.0"
 description            = "Google Cloud Client Libraries for Rust - Long Running Operations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/privacy/dlp/v2/.sidekick.toml
+++ b/src/generated/privacy/dlp/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/privacy/dlp/v2'
 service-config = 'google/privacy/dlp/v2/dlp_v2.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.2.0'
 copyright-year = '2025'

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privacy-dlp-v2"
-version                = "1.1.0"
+version                = "1.2.0"
 description            = "Google Cloud Client Libraries for Rust - Sensitive Data Protection (DLP)"
 edition.workspace      = true
 authors.workspace      = true


### PR DESCRIPTION
Bump versions for automatically generated files.

The new functions in `google-cloud-longrunning` are not used
anywhere, so we do not need to update the top-level
Cargo workspace file.

I decided to punt on the version numbers for hand-crafted files.
