### PR TITLE
test(gax-internal): Add tracing test for connection error

### DIFF
--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -53,4 +53,63 @@ mod tests {
 
         Ok(())
     }
+
+    #[cfg(all(test, google_cloud_unstable_tracing, feature = "_internal-http-client"))]
+    mod tracing_tests {
+        use super::*;
+        use google_cloud_gax_internal::http::ReqwestClient;
+        use google_cloud_gax_internal::observability::attributes::error_type_values::CLIENT_CONNECTION_ERROR;
+        use google_cloud_gax_internal::options::ClientConfig;
+        use google_cloud_test_utils::test_layer::TestLayer;
+        use opentelemetry_semantic_conventions::trace as semconv;
+
+        #[tokio::test]
+        async fn test_connection_error_with_tracing_on() -> Result<()> {
+            use serde_json::Value;
+            let endpoint = "http://localhost:1"; // Non-existent port
+            let mut config = ClientConfig::default();
+            config.tracing = true;
+            config.cred = Some(test_credentials());
+            let client = ReqwestClient::new(config, endpoint).await?;
+
+            let guard = TestLayer::initialize();
+
+            let builder = client.builder(reqwest::Method::GET, "/".into());
+            let result = client
+                .execute::<Value, Value>(builder, Option::<Value>::None, RequestOptions::default())
+                .await;
+
+            assert!(result.is_err(), "Expected connection error");
+
+            let spans = TestLayer::capture(&guard);
+            assert_eq!(spans.len(), 1, "Expected 1 span, got: {:?}", spans);
+
+            let span = &spans[0];
+            let attributes = &span.attributes;
+            assert_eq!(
+                span.name, "http_request",
+                "Span name mismatch: {:?}, all attributes: {:?}",
+                span, attributes
+            );
+
+            let expected_error_type = CLIENT_CONNECTION_ERROR.to_string();
+            assert_eq!(
+                attributes.get(semconv::ERROR_TYPE),
+                Some(&expected_error_type),
+                "Span 0: '{}' mismatch, expected: {:?}, got: {:?}, all attributes: {:?}",
+                semconv::ERROR_TYPE,
+                Some(&expected_error_type),
+                attributes.get(semconv::ERROR_TYPE),
+                attributes
+            );
+            assert!(
+                !attributes.contains_key(semconv::HTTP_RESPONSE_STATUS_CODE),
+                "Span 0: '{}' should not be present on connection error, all attributes: {:?}",
+                semconv::HTTP_RESPONSE_STATUS_CODE,
+                attributes
+            );
+
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
This PR adds an integration test to verify OpenTelemetry span emission when an HTTP client connection error occurs.

Specifically, this test ensures that:
-   A single span named `http_request` is emitted.
-   The `error.type` attribute is correctly set to `CLIENT_CONNECTION_ERROR`.
-   The `http.response.status_code` attribute is not present, as no response was received.

This test case helps ensure that network-level connection failures are properly instrumented.
