### PR TITLE
test(bigquery): handle 404 err when cleaning stale datasets

### DIFF
--- a/src/integration-tests/src/bigquery.rs
+++ b/src/integration-tests/src/bigquery.rs
@@ -116,7 +116,7 @@ async fn cleanup_stale_datasets(
         .filter_map(|r| match r {
             Ok(dataset) => Some(dataset),
             Err(e) if e.status().is_some_and(|s| s.code == Code::NotFound) => None,
-            Err(e) => panic!("expected a successful get_dataset()"),
+            Err(_) => panic!("expected a successful get_dataset()"),
         })
         .filter_map(|dataset| {
             if dataset


### PR DESCRIPTION
When multiple CI steps run in parallel, there is a change of then trying to delete the same dataset (BigQuery metadata service has an eventual consistency model). This PR checks if the error when trying to fetch a Dataset is a 404 and skip it.

Fixes #3572 