### PR TITLE
fix(test): clean up assertion messages in http tests

### DIFF
--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -82,7 +82,7 @@ mod tests {
             assert!(result.is_err(), "Expected connection error");
 
             let spans = TestLayer::capture(&guard);
-            assert_eq!(spans.len(), 1, "Expected 1 span, got: {:?}", spans);
+            assert_eq!(spans.len(), 1, "Should capture one span: {:?}", spans);
 
             let span = &spans[0];
             let attributes = &span.attributes;
@@ -96,10 +96,8 @@ mod tests {
             assert_eq!(
                 attributes.get(semconv::ERROR_TYPE),
                 Some(&expected_error_type),
-                "Span 0: '{}' mismatch, expected: {:?}, got: {:?}, all attributes: {:?}",
+                "Span 0: '{}' mismatch, all attributes: {:?}",
                 semconv::ERROR_TYPE,
-                Some(&expected_error_type),
-                attributes.get(semconv::ERROR_TYPE),
                 attributes
             );
             assert!(
@@ -146,7 +144,7 @@ mod tests {
             assert!(result.is_err(), "Expected redirect error");
 
             let spans = TestLayer::capture(&guard);
-            assert_eq!(spans.len(), 1, "Expected 1 span, got: {:?}", spans);
+            assert_eq!(spans.len(), 1, "Should capture one span: {:?}", spans);
 
             let span = &spans[0];
             let attributes = &span.attributes;
@@ -160,10 +158,8 @@ mod tests {
             assert_eq!(
                 attributes.get(semconv::ERROR_TYPE),
                 Some(&expected_error_type),
-                "Span 0: {} mismatch, expected: {:?}, got: {:?}, all attributes: {:?}",
+                "Span 0: {} mismatch, all attributes: {:?}",
                 semconv::ERROR_TYPE,
-                Some(&expected_error_type),
-                attributes.get(semconv::ERROR_TYPE),
                 attributes
             );
             assert!(

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -141,7 +141,7 @@ mod tests {
         assert_eq!(
             spans.len(),
             3,
-            "Expected 3 spans for 3 attempts, got: {:?}",
+            "Should capture 3 spans for 3 attempts: {:?}",
             spans
         );
 
@@ -152,9 +152,8 @@ mod tests {
 
         assert!(
             attributes0.get(HTTP_REQUEST_RESEND_COUNT).is_none(),
-            "Span 0: '{}' should not be present, got: {:?}, all attributes: {:?}",
+            "Span 0: '{}' should not be present, all attributes: {:?}",
             HTTP_REQUEST_RESEND_COUNT,
-            attributes0.get(HTTP_REQUEST_RESEND_COUNT),
             attributes0
         );
 
@@ -167,10 +166,8 @@ mod tests {
         assert_eq!(
             attributes1.get(HTTP_REQUEST_RESEND_COUNT),
             Some(&expected_resend_count),
-            "Span 1: '{}' mismatch, expected: {:?}, got: {:?}, all attributes: {:?}",
+            "Span 1: '{}' mismatch, all attributes: {:?}",
             HTTP_REQUEST_RESEND_COUNT,
-            Some(&expected_resend_count),
-            attributes1.get(HTTP_REQUEST_RESEND_COUNT),
             attributes1
         );
 
@@ -183,10 +180,8 @@ mod tests {
         assert_eq!(
             attributes2.get(HTTP_REQUEST_RESEND_COUNT),
             Some(&expected_resend_count),
-            "Span 2: '{}' mismatch, expected: {:?}, got: {:?}, all attributes: {:?}",
+            "Span 2: '{}' mismatch, all attributes: {:?}",
             HTTP_REQUEST_RESEND_COUNT,
-            Some(&expected_resend_count),
-            attributes2.get(HTTP_REQUEST_RESEND_COUNT),
             attributes2
         );
 

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -257,7 +257,7 @@ mod tests {
             assert_eq!(
                 spans.len(),
                 1,
-                "Expected 1 span for a timeout, got: {:?}",
+                "Should capture one span for a timeout: {:?}",
                 spans
             );
             let span = &spans[0];
@@ -275,10 +275,8 @@ mod tests {
             assert_eq!(
                 attributes.get(semconv::ERROR_TYPE),
                 Some(&expected_error_type),
-                "Span 0: '{}' mismatch, expected: {:?}, got: {:?}, all attributes: {:?}",
+                "Span 0: '{}' mismatch, all attributes: {:?}",
                 semconv::ERROR_TYPE,
-                Some(&expected_error_type),
-                attributes.get(semconv::ERROR_TYPE),
                 attributes
             );
 


### PR DESCRIPTION
Removed redundant "expected/got" from assert_eq! messages in various HTTP client tests to improve clarity of test output on failure.