### PR TITLE
test(storage): consistent gc label

### DIFF
--- a/src/integration-tests/src/compute.rs
+++ b/src/integration-tests/src/compute.rs
@@ -371,7 +371,7 @@ pub async fn lro_errors() -> Result<()> {
         .set_machine_type(format!("zones/{zone_id}/machineTypes/{MACHINE_TYPE}"))
         .set_name(&id)
         .set_description("A test VM created by the Rust client library.")
-        .set_labels([("integration-tests", "true")])
+        .set_labels([("integration-test", "true")])
         .set_disks([AttachedDisk::new()
             .set_initialize_params(
                 AttachedDiskInitializeParams::new()

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -67,7 +67,7 @@ pub async fn run_anywhere_cache_examples(buckets: &mut Vec<String>) -> anyhow::R
                 .set_iam_config(IamConfig::new().set_uniform_bucket_level_access(
                     UniformBucketLevelAccess::new().set_enabled(true),
                 ))
-                .set_labels([("integration-tests", "true")]),
+                .set_labels([("integration-test", "true")]),
         )
         .send()
         .await?;
@@ -547,7 +547,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
                 ))
                 .set_object_retention(ObjectRetention::new().set_enabled(true))
                 // Enable garbage collection.
-                .set_labels([("integration-tests", "true")]),
+                .set_labels([("integration-test", "true")]),
         )
         .send()
         .await?;
@@ -650,7 +650,7 @@ async fn create_bucket_kms_key(
             google_cloud_storage::model::Bucket::new()
                 .set_project(format!("projects/{project_id}"))
                 .set_location("US-CENTRAL1")
-                .set_labels([("integration-tests", "true")]),
+                .set_labels([("integration-test", "true")]),
         )
         .send()
         .await?;
@@ -670,13 +670,13 @@ pub async fn cleanup_bucket(client: StorageControl, name: String) -> anyhow::Res
     let current = client.get_bucket().set_name(&name).send().await?;
     if current
         .labels
-        .get("integration-tests")
+        .get("integration-test")
         .is_none_or(|v| v != "true")
     {
         let mut updated = current.clone();
         updated
             .labels
-            .insert("integration-tests".to_string(), "true".to_string());
+            .insert("integration-test".to_string(), "true".to_string());
         if let Err(e) = client
             .update_bucket()
             .set_bucket(updated)


### PR DESCRIPTION
We GC all buckets with the `integration-test` label, but sometimes used the plural form to stage the bucket for GC.

Part of the work for #3565 