### PR TITLE
fix(gax-internal): Remove gRPC status attributes from HTTP error spans

### DIFF
--- a/src/gax-internal/src/observability/errors.rs
+++ b/src/gax-internal/src/observability/errors.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gax::error::rpc::Code;
 use http::StatusCode;
 
 use super::attributes::error_type_values::*;
@@ -94,39 +93,6 @@ impl ErrorType {
             ErrorType::Internal => INTERNAL.to_string(),
         }
     }
-
-    pub(crate) fn grpc_code(&self) -> Code {
-        match self {
-            ErrorType::HttpError { code, .. } => match code.as_u16() {
-                200 => Code::Ok,
-                400 => Code::InvalidArgument,
-                401 => Code::Unauthenticated,
-                403 => Code::PermissionDenied,
-                404 => Code::NotFound,
-                409 => Code::Aborted,
-                429 => Code::ResourceExhausted,
-                499 => Code::Cancelled,
-                501 => Code::Unimplemented,
-                503 => Code::Unavailable,
-                504 => Code::DeadlineExceeded,
-                _ if code.is_success() => Code::Ok,
-                _ if code.is_client_error() => Code::FailedPrecondition,
-                _ if code.is_server_error() => Code::Internal,
-                _ => Code::Unknown,
-            },
-            ErrorType::ClientTimeout => Code::DeadlineExceeded,
-            ErrorType::ClientConnectionError => Code::Unavailable,
-            ErrorType::ClientRequestError => Code::InvalidArgument,
-            ErrorType::ClientRequestBodyError => Code::InvalidArgument,
-            ErrorType::ClientResponseDecodeError => Code::Internal,
-            ErrorType::ClientRedirectError => Code::Aborted,
-            ErrorType::Internal => Code::Internal,
-        }
-    }
-
-    pub(crate) fn grpc_status(&self) -> String {
-        self.grpc_code().name().to_string()
-    }
 }
 
 #[cfg(test)]
@@ -166,51 +132,35 @@ pub(crate) mod tests {
         }
     }
 
-    #[test_case(ErrorType::HttpError { code: StatusCode::OK, reason: None }, "200", Code::Ok; "OK")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::BAD_REQUEST, reason: None }, "400", Code::InvalidArgument; "Bad Request")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::UNAUTHORIZED, reason: None }, "401", Code::Unauthenticated; "Unauthorized")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::FORBIDDEN, reason: None }, "403", Code::PermissionDenied; "Forbidden")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::NOT_FOUND, reason: None }, "404", Code::NotFound; "Not Found")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::CONFLICT, reason: None }, "409", Code::Aborted; "Conflict")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::TOO_MANY_REQUESTS, reason: None }, "429", Code::ResourceExhausted; "Too Many Requests")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::INTERNAL_SERVER_ERROR, reason: None }, "500", Code::Internal; "Internal Server Error")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::NOT_IMPLEMENTED, reason: None }, "501", Code::Unimplemented; "Not Implemented")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::SERVICE_UNAVAILABLE, reason: None }, "503", Code::Unavailable; "Service Unavailable")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::GATEWAY_TIMEOUT, reason: None }, "504", Code::DeadlineExceeded; "Gateway Timeout")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::IM_A_TEAPOT, reason: None }, "418", Code::FailedPrecondition; "I'm a teapot")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::CREATED, reason: None }, "201", Code::Ok; "Created")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::METHOD_NOT_ALLOWED, reason: None }, "405", Code::FailedPrecondition; "Method Not Allowed")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::BAD_GATEWAY, reason: None }, "502", Code::Internal; "Bad Gateway")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::from_u16(499).unwrap(), reason: None }, "499", Code::Cancelled; "Client Closed Request")]
-    #[test_case(ErrorType::HttpError { code: StatusCode::BAD_REQUEST, reason: Some("REASON".to_string()) }, "REASON", Code::InvalidArgument; "Bad Request with Reason")]
-    #[test_case(ErrorType::ClientTimeout, CLIENT_TIMEOUT, Code::DeadlineExceeded; "Client Timeout")]
-    #[test_case(ErrorType::ClientConnectionError, CLIENT_CONNECTION_ERROR, Code::Unavailable; "Client Connection Error")]
-    #[test_case(ErrorType::ClientRequestError, CLIENT_REQUEST_ERROR, Code::InvalidArgument; "Client Request Error")]
-    #[test_case(ErrorType::ClientRequestBodyError, CLIENT_REQUEST_BODY_ERROR, Code::InvalidArgument; "Client Request Body Error")]
-    #[test_case(ErrorType::ClientResponseDecodeError, CLIENT_RESPONSE_DECODE_ERROR, Code::Internal; "Client Response Decode Error")]
-    #[test_case(ErrorType::ClientRedirectError, CLIENT_REDIRECT_ERROR, Code::Aborted; "Client Redirect Error")]
-    #[test_case(ErrorType::Internal, INTERNAL, Code::Internal; "Internal")]
-    fn test_error_type_conversions(
-        error_type: ErrorType,
-        expected_as_str: &str,
-        expected_grpc_code: Code,
-    ) {
+    #[test_case(ErrorType::HttpError { code: StatusCode::OK, reason: None }, "200"; "OK")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::BAD_REQUEST, reason: None }, "400"; "Bad Request")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::UNAUTHORIZED, reason: None }, "401"; "Unauthorized")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::FORBIDDEN, reason: None }, "403"; "Forbidden")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::NOT_FOUND, reason: None }, "404"; "Not Found")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::CONFLICT, reason: None }, "409"; "Conflict")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::TOO_MANY_REQUESTS, reason: None }, "429"; "Too Many Requests")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::INTERNAL_SERVER_ERROR, reason: None }, "500"; "Internal Server Error")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::NOT_IMPLEMENTED, reason: None }, "501"; "Not Implemented")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::SERVICE_UNAVAILABLE, reason: None }, "503"; "Service Unavailable")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::GATEWAY_TIMEOUT, reason: None }, "504"; "Gateway Timeout")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::IM_A_TEAPOT, reason: None }, "418"; "I'm a teapot")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::CREATED, reason: None }, "201"; "Created")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::METHOD_NOT_ALLOWED, reason: None }, "405"; "Method Not Allowed")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::BAD_GATEWAY, reason: None }, "502"; "Bad Gateway")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::from_u16(499).unwrap(), reason: None }, "499"; "Client Closed Request")]
+    #[test_case(ErrorType::HttpError { code: StatusCode::BAD_REQUEST, reason: Some("REASON".to_string()) }, "REASON"; "Bad Request with Reason")]
+    #[test_case(ErrorType::ClientTimeout, CLIENT_TIMEOUT; "Client Timeout")]
+    #[test_case(ErrorType::ClientConnectionError, CLIENT_CONNECTION_ERROR; "Client Connection Error")]
+    #[test_case(ErrorType::ClientRequestError, CLIENT_REQUEST_ERROR; "Client Request Error")]
+    #[test_case(ErrorType::ClientRequestBodyError, CLIENT_REQUEST_BODY_ERROR; "Client Request Body Error")]
+    #[test_case(ErrorType::ClientResponseDecodeError, CLIENT_RESPONSE_DECODE_ERROR; "Client Response Decode Error")]
+    #[test_case(ErrorType::ClientRedirectError, CLIENT_REDIRECT_ERROR; "Client Redirect Error")]
+    #[test_case(ErrorType::Internal, INTERNAL; "Internal")]
+    fn test_error_type_conversions(error_type: ErrorType, expected_as_str: &str) {
         assert_eq!(
             error_type.as_str(),
             expected_as_str,
             "expected as_str for {:?}",
-            error_type
-        );
-        assert_eq!(
-            error_type.grpc_code(),
-            expected_grpc_code,
-            "grpc_code for {:?}",
-            error_type
-        );
-        assert_eq!(
-            error_type.grpc_status(),
-            expected_grpc_code.name().to_string(),
-            "grpc_status for {:?}",
             error_type
         );
     }

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -145,19 +145,14 @@ mod tests {
         assert_eq!(captured.len(), 0, "Should capture no spans: {captured:?}");
     }
 
-    #[test_case(StatusCode::BAD_REQUEST, "400", 3, "INVALID_ARGUMENT"; "400 Bad Request")]
-    #[test_case(StatusCode::UNAUTHORIZED, "401", 16, "UNAUTHENTICATED"; "401 Unauthorized")]
-    #[test_case(StatusCode::FORBIDDEN, "403", 7, "PERMISSION_DENIED"; "403 Forbidden")]
-    #[test_case(StatusCode::NOT_FOUND, "404", 5, "NOT_FOUND"; "404 Not Found")]
-    #[test_case(StatusCode::INTERNAL_SERVER_ERROR, "500", 13, "INTERNAL"; "500 Internal Server Error")]
-    #[test_case(StatusCode::SERVICE_UNAVAILABLE, "503", 14, "UNAVAILABLE"; "503 Service Unavailable")]
+    #[test_case(StatusCode::BAD_REQUEST, "400"; "400 Bad Request")]
+    #[test_case(StatusCode::UNAUTHORIZED, "401"; "401 Unauthorized")]
+    #[test_case(StatusCode::FORBIDDEN, "403"; "403 Forbidden")]
+    #[test_case(StatusCode::NOT_FOUND, "404"; "404 Not Found")]
+    #[test_case(StatusCode::INTERNAL_SERVER_ERROR, "500"; "500 Internal Server Error")]
+    #[test_case(StatusCode::SERVICE_UNAVAILABLE, "503"; "503 Service Unavailable")]
     #[tokio::test]
-    async fn test_error_responses(
-        http_status_code: StatusCode,
-        expected_error_type: &str,
-        expected_grpc_code: i64,
-        expected_grpc_status: &str,
-    ) {
+    async fn test_error_responses(http_status_code: StatusCode, expected_error_type: &str) {
         let server = Server::run();
         let server_addr = server.addr();
         let server_url = format!("http://{}", server_addr);
@@ -200,20 +195,6 @@ mod tests {
             attrs.get(KEY_OTEL_STATUS),
             Some(&"Error".into()),
             "otel.status mismatch, attrs: {:?}",
-            attrs
-        );
-
-        assert_eq!(
-            attrs.get(otel_attr::RPC_GRPC_STATUS_CODE),
-            Some(&expected_grpc_code.into()),
-            "rpc.grpc.status_code mismatch, attrs: {:?}",
-            attrs
-        );
-
-        assert_eq!(
-            attrs.get(google_cloud_gax_internal::observability::attributes::KEY_GRPC_STATUS),
-            Some(&expected_grpc_status.into()),
-            "grpc.status mismatch, attrs: {:?}",
             attrs
         );
     }


### PR DESCRIPTION
Aligns T4 HTTP span attributes with go/clo:product-requirements-v1. Removes rpc.grpc.status_code and grpc.status from being recorded for errors originating from HTTP status codes.