### PR TITLE
feat(gax-internal): Add http.response.body.size to HTTP spans

### DIFF
--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -100,6 +100,7 @@ mod tests {
             (KEY_GCP_CLIENT_VERSION, TEST_VERSION.into()),
             (KEY_GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (KEY_GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (otel_trace::HTTP_RESPONSE_BODY_SIZE, 18_i64.into()), // {"hello": "world"} is 18 bytes
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))


### PR DESCRIPTION
Records the size of the response body from the Content-Length header.