### PR TITLE
refactor(storage): move client info constants

### DIFF
--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -27,3 +27,21 @@ pub(crate) mod write_object;
 use crate::model::Object;
 use crate::streaming_source::Payload;
 use crate::{Error, Result};
+
+/// The default host used by the service.
+const DEFAULT_HOST: &str = "https://storage.googleapis.com";
+
+pub(crate) mod info {
+    const NAME: &str = env!("CARGO_PKG_NAME");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    lazy_static::lazy_static! {
+        pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
+            let ac = gaxi::api_header::XGoogApiClient{
+                name:          NAME,
+                version:       VERSION,
+                library_type:  gaxi::api_header::GCCL,
+            };
+            ac.grpc_header_value()
+        };
+    }
+}

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -248,7 +248,7 @@ impl Storage {
                 .build()
                 .map_err(Error::cred)?
         };
-        let endpoint = endpoint.unwrap_or_else(|| self::DEFAULT_HOST.to_string());
+        let endpoint = endpoint.unwrap_or_else(|| super::DEFAULT_HOST.to_string());
         let inner = Arc::new(StorageInner::new(client, cred, endpoint, options));
         let options = inner.options.clone();
         let stub = crate::storage::transport::Storage::new(inner);
@@ -571,24 +571,6 @@ impl ClientBuilder {
         let request_options =
             RequestOptions::new_with_client_config(&self.config, self.common_options);
         (self.config.cred, self.config.endpoint, request_options)
-    }
-}
-
-/// The default host used by the service.
-const DEFAULT_HOST: &str = "https://storage.googleapis.com";
-
-pub(crate) mod info {
-    const NAME: &str = env!("CARGO_PKG_NAME");
-    const VERSION: &str = env!("CARGO_PKG_VERSION");
-    lazy_static::lazy_static! {
-        pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
-            let ac = gaxi::api_header::XGoogApiClient{
-                name:          NAME,
-                version:       VERSION,
-                library_type:  gaxi::api_header::GCCL,
-            };
-            ac.grpc_header_value()
-        };
     }
 }
 

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -16,7 +16,7 @@ use super::client::{StorageInner, apply_customer_supplied_encryption_headers};
 use crate::model::Object;
 use crate::retry_policy::ContinueOn308;
 use crate::storage::checksum::details::ChecksummedSource;
-use crate::storage::client::info::X_GOOG_API_CLIENT_HEADER;
+use crate::storage::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
 use crate::streaming_source::{IterSource, Seek, SizeHint, StreamingSource};
 use crate::{Error, Result};


### PR DESCRIPTION
It will be easier to access them from the (temporary) Bidi client.

Motivated by #3626 