### PR TITLE
feat(gax): introduce connect error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -363,8 +363,8 @@ tokio-test        = { default-features = false, version = "0.4" }
 # Local packages used as dependencies
 auth                          = { version = "1.1", path = "src/auth", package = "google-cloud-auth" }
 google-cloud-auth             = { version = "1.1", path = "src/auth" }
-gax                           = { version = "1.2", path = "src/gax", package = "google-cloud-gax" }
-google-cloud-gax              = { version = "1.2", path = "src/gax" }
+gax                           = { version = "1.3", path = "src/gax", package = "google-cloud-gax" }
+google-cloud-gax              = { version = "1.3", path = "src/gax" }
 gaxi                          = { version = "0.7.3", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "1", path = "src/generated/iam/v1" }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -18,7 +18,7 @@ name = "google-cloud-gax"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version     = "1.2.0"
+version     = "1.3.0"
 description = "Google Cloud Client Libraries for Rust"
 # Inherit other attributes from the workspace.
 authors.workspace      = true


### PR DESCRIPTION
Part of the work for #3640

Introduce a connection error kind, which is distinct from `is_io()`.

Note that if we think `is_connect()` should imply `is_transport()`, we can always change the internal representation later.