### PR TITLE
fix(gaxi): retry connect errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2564,6 +2564,7 @@ dependencies = [
  "http",
  "http-body-util",
  "httptest",
+ "hyper",
  "lazy_static",
  "mockall",
  "opentelemetry-semantic-conventions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,7 +365,7 @@ auth                          = { version = "1.1", path = "src/auth", package = 
 google-cloud-auth             = { version = "1.1", path = "src/auth" }
 gax                           = { version = "1.3", path = "src/gax", package = "google-cloud-gax" }
 google-cloud-gax              = { version = "1.3", path = "src/gax" }
-gaxi                          = { version = "0.7.3", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                          = { version = "0.7.4", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "1", path = "src/generated/iam/v1" }
 location                      = { version = "1", path = "src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.7.3"
+version     = "0.7.4"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.
@@ -42,6 +42,7 @@ _internal-http-client = [
   "dep:gax",
   "dep:http",
   "dep:http-body-util",
+  "dep:hyper",
   "dep:opentelemetry-semantic-conventions",
   "dep:reqwest",
   "dep:rpc",
@@ -71,6 +72,7 @@ _internal-common = ["dep:auth", "dep:gax", "dep:percent-encoding", "dep:thiserro
 bytes                              = { workspace = true, optional = true, features = ["serde"] }
 http                               = { workspace = true, optional = true }
 http-body-util                     = { workspace = true, optional = true }
+hyper                              = { workspace = true, optional = true }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
 percent-encoding                   = { workspace = true, optional = true }
 prost                              = { workspace = true, optional = true }

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -15,7 +15,10 @@
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
     use gax::options::*;
-    use serde_json::json;
+    use gax::retry_policy::NeverRetry;
+    use google_cloud_gax_internal::http::ReqwestClient;
+    use google_cloud_gax_internal::options::ClientConfig;
+    use serde_json::{Value, json};
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -25,7 +28,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_error_with_status() -> Result<()> {
-        use serde_json::Value;
         let (endpoint, _server) = echo_server::start().await?;
 
         let client = echo_server::builder(endpoint)
@@ -54,12 +56,30 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn connection_error() -> Result<()> {
+        let mut config = ClientConfig::default();
+        config.cred = auth::credentials::anonymous::Builder::new().build().into();
+        let mut options = RequestOptions::default();
+        options.set_retry_policy(NeverRetry);
+        let client = ReqwestClient::new(config, "http://localhost:1").await?;
+
+        let builder = client.builder(reqwest::Method::GET, "/".into());
+        let response = client
+            .execute::<Value, Value>(builder, Some(json!({})), options)
+            .await;
+
+        assert!(
+            matches!(response, Err(ref e) if e.is_connect()),
+            "{response:?}"
+        );
+
+        Ok(())
+    }
     #[cfg(all(test, google_cloud_unstable_tracing, feature = "_internal-http-client"))]
     mod tracing_tests {
         use super::*;
-        use google_cloud_gax_internal::http::ReqwestClient;
         use google_cloud_gax_internal::observability::attributes::error_type_values::CLIENT_CONNECTION_ERROR;
-        use google_cloud_gax_internal::options::ClientConfig;
         use google_cloud_test_utils::test_layer::TestLayer;
         use opentelemetry_semantic_conventions::trace as semconv;
 
@@ -70,13 +90,15 @@ mod tests {
             let mut config = ClientConfig::default();
             config.tracing = true;
             config.cred = Some(test_credentials());
+            let mut options = RequestOptions::default();
+            options.set_retry_policy(NeverRetry);
             let client = ReqwestClient::new(config, endpoint).await?;
 
             let guard = TestLayer::initialize();
 
             let builder = client.builder(reqwest::Method::GET, "/".into());
             let result = client
-                .execute::<Value, Value>(builder, Option::<Value>::None, RequestOptions::default())
+                .execute::<Value, Value>(builder, Option::<Value>::None, options)
                 .await;
 
             assert!(result.is_err(), "Expected connection error");


### PR DESCRIPTION
Part of the work for #3640

This PR effectively starts retrying connect errors, for non-idempotent operations, by default, in GAPICs.

Note that we marked connect errors as `is_transient_and_before_rpc` in #3654. Thus, connect errors would be retried by the default retry policy(`Aip194Strict`)...

... if they existed. But we did not ever classify an error as connect. This PR starts classifying the HTTP connect errors as such.