### PR TITLE
fix(storage): retry connection errors

### DIFF
--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -18,6 +18,7 @@ use super::{
     handle_object_response, v1,
 };
 use futures::stream::unfold;
+use gaxi::http::map_send_error;
 use std::sync::Arc;
 
 impl<S> PerformUpload<S>
@@ -98,7 +99,7 @@ where
             .map_err(Error::ser)?;
         let payload = self.payload_to_body().await?;
         let builder = builder.body(payload);
-        let response = builder.send().await.map_err(Self::send_err)?;
+        let response = builder.send().await.map_err(map_send_error)?;
         let object = self::handle_object_response(response).await?;
         self.validate_response_object(object).await
     }
@@ -125,7 +126,7 @@ where
 
     async fn single_shot_attempt(&self, hint: SizeHint) -> Result<Object> {
         let builder = self.single_shot_builder(hint).await?;
-        let response = builder.send().await.map_err(Self::send_err)?;
+        let response = builder.send().await.map_err(map_send_error)?;
         let object = super::handle_object_response(response).await?;
         self.validate_response_object(object).await
     }

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -23,6 +23,7 @@ use crate::read_object::ReadObjectResponse;
 use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::checksum::details::Md5;
 use crate::storage::request_options::RequestOptions;
+use gaxi::http::map_send_error;
 
 /// The request builder for [Storage::read_object][crate::client::Storage::read_object] calls.
 ///
@@ -420,7 +421,7 @@ impl Reader {
 
     async fn read_attempt(&self) -> Result<reqwest::Response> {
         let builder = self.http_request_builder().await?;
-        let response = builder.send().await.map_err(Error::io)?;
+        let response = builder.send().await.map_err(map_send_error)?;
         if !response.status().is_success() {
             return gaxi::http::to_http_error(response).await;
         }


### PR DESCRIPTION
Part of the work for #3640 

Standardize converting `reqwest::Error` -> `gax::Error` in storage client. This also adds classifying errors as timeouts (altho I am not sure we ever set deadlines) or connect errors.