### PR TITLE
fix(pubsub): cleanup exported types in pubsub crate

### DIFF
--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -34,6 +34,7 @@ pub use gax::error::Error;
 pub mod builder {
     pub use crate::generated::gapic::builder::*;
     pub mod publisher {
+        pub use crate::generated::gapic_dataplane::builder::publisher::*;
         pub use crate::publisher::client::ClientBuilder;
         pub use crate::publisher::publisher::PublisherBuilder;
     }


### PR DESCRIPTION
This change removes some builders that were exported in the client module.