### PR TITLE
impl(gax-internal): Add status code and description to HTTP spans

### DIFF
--- a/src/gax-internal/src/observability/attributes.rs
+++ b/src/gax-internal/src/observability/attributes.rs
@@ -23,11 +23,14 @@ pub const KEY_OTEL_KIND: &str = "otel.kind";
 ///
 /// If `url.template` is available use "{http.request.method} {url.template}", otherwise use "{http.request.method}".
 pub const KEY_OTEL_NAME: &str = "otel.name";
-/// Span Status for OpenTelemetry interop.
+/// Span Status Code for OpenTelemetry interop.
 ///
-/// Use "Error" for unrecoverable errors like network issues or 5xx status codes.
-/// Otherwise, leave "Unset" (including for 4xx codes on CLIENT spans).
-pub const KEY_OTEL_STATUS: &str = "otel.status";
+/// Must be one of "UNSET", "OK", or "ERROR".
+pub const KEY_OTEL_STATUS_CODE: &str = "otel.status_code";
+/// Span Status Description for OpenTelemetry interop.
+///
+/// A human-readable description of the status, used when status_code is "ERROR".
+pub const KEY_OTEL_STATUS_DESCRIPTION: &str = "otel.status_description";
 
 /// The string representation of the gRPC status code.
 pub const KEY_GRPC_STATUS: &str = "grpc.status";
@@ -65,37 +68,16 @@ pub mod error_type_values {
     pub const CLIENT_AUTHENTICATION_ERROR: &str = "CLIENT_AUTHENTICATION_ERROR";
     /// Resource exhausted (e.g. retry limit reached).
     pub const CLIENT_RETRY_EXHAUSTED: &str = "CLIENT_RETRY_EXHAUSTED";
-    /// Unexpected issue within the client library's own logic.
-    pub const INTERNAL: &str = "INTERNAL";
     /// Unknown error type.
     pub const UNKNOWN: &str = "UNKNOWN";
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum OtelStatus {
-    Unset,
-    Ok,
-    Error,
-}
-
-impl OtelStatus {
-    pub(crate) fn as_str(&self) -> &'static str {
-        match self {
-            OtelStatus::Unset => "Unset",
-            OtelStatus::Ok => "Ok",
-            OtelStatus::Error => "Error",
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_otel_status_as_str() {
-        assert_eq!(OtelStatus::Unset.as_str(), "Unset");
-        assert_eq!(OtelStatus::Ok.as_str(), "Ok");
-        assert_eq!(OtelStatus::Error.as_str(), "Error");
-    }
+/// Values for the OpenTelemetry `otel.status_code` attribute.
+pub mod otel_status_codes {
+    /// The operation has been validated by an Application developer or Operator to have completed successfully.
+    pub const OK: &str = "OK";
+    /// The operation contains an error.
+    pub const ERROR: &str = "ERROR";
+    /// The default status.
+    pub const UNSET: &str = "UNSET";
 }

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -128,6 +128,29 @@ mod tests {
                 attributes
             );
 
+            assert_eq!(
+                attributes.get(
+                    google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_CODE
+                ),
+                Some(&"ERROR".into()),
+                "Span 0: 'otel.status_code' mismatch, all attributes: {:?}",
+                attributes
+            );
+            let status_description = attributes
+                .get(google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_DESCRIPTION)
+                .unwrap();
+            match status_description {
+                google_cloud_test_utils::test_layer::AttributeValue::String(s) => {
+                    assert!(
+                        s.contains("error sending request"),
+                        "Span 0: 'otel.status_description' should contain 'error sending request', got: {:?}, all attributes: {:?}",
+                        s,
+                        attributes
+                    );
+                }
+                _ => panic!("Expected string for otel.status_description"),
+            };
+
             Ok(())
         }
 
@@ -188,6 +211,29 @@ mod tests {
                 semconv::HTTP_RESPONSE_STATUS_CODE,
                 attributes
             );
+
+            assert_eq!(
+                attributes.get(
+                    google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_CODE
+                ),
+                Some(&"ERROR".into()),
+                "Span 0: 'otel.status_code' mismatch, all attributes: {:?}",
+                attributes
+            );
+            let status_description = attributes
+                .get(google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_DESCRIPTION)
+                .unwrap();
+            match status_description {
+                google_cloud_test_utils::test_layer::AttributeValue::String(s) => {
+                    assert!(
+                        s.contains("error following redirect"),
+                        "Span 0: 'otel.status_description' should contain 'error following redirect', got: {:?}, all attributes: {:?}",
+                        s,
+                        attributes
+                    );
+                }
+                _ => panic!("Expected string for otel.status_description"),
+            };
 
             Ok(())
         }

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -229,6 +229,7 @@ mod tests {
     mod tracing_tests {
         use super::*;
         use google_cloud_gax_internal::observability::attributes::error_type_values::CLIENT_TIMEOUT;
+        use google_cloud_gax_internal::observability::attributes::*;
         use google_cloud_test_utils::test_layer::TestLayer;
         use opentelemetry_semantic_conventions::trace as semconv;
 
@@ -278,6 +279,27 @@ mod tests {
                 semconv::ERROR_TYPE,
                 attributes
             );
+
+            assert_eq!(
+                attributes.get(KEY_OTEL_STATUS_CODE),
+                Some(&"ERROR".into()),
+                "Span 0: '{}' mismatch, all attributes: {:?}",
+                KEY_OTEL_STATUS_CODE,
+                attributes
+            );
+            let status_description = attributes.get(KEY_OTEL_STATUS_DESCRIPTION).unwrap();
+            match status_description {
+                google_cloud_test_utils::test_layer::AttributeValue::String(s) => {
+                    assert!(
+                        s.contains("error sending request"),
+                        "Span 0: '{}' should contain 'error sending request', got: {:?}, all attributes: {:?}",
+                        KEY_OTEL_STATUS_DESCRIPTION,
+                        s,
+                        attributes
+                    );
+                }
+                _ => panic!("Expected string for {}", KEY_OTEL_STATUS_DESCRIPTION),
+            };
 
             Ok(())
         }


### PR DESCRIPTION
This PR enhances the HTTP spans in google-cloud-gax-internal by adding standard OpenTelemetry status attributes, aligning with the specification and internal requirements.

Key Changes:

 * Renamed `otel.status` to `otel.status_code`: Aligns with the OpenTelemetry semantic conventions for span status.
 * Added `otel.status_description`: Records a human-readable description of the error when the status code is set to ERROR.
 * Correct Status Code Semantics (leaves otel.status_code UNSET for successful HTTP responses)
 * Added Status Descriptions based on Error

