### PR TITLE
refactor(pubsub)!: rename the PublisherClient

### DIFF
--- a/src/integration-tests/src/pubsub.rs
+++ b/src/integration-tests/src/pubsub.rs
@@ -15,7 +15,7 @@
 use crate::{Error, Result};
 
 use futures::future::join_all;
-use pubsub::client::PublisherClient;
+use pubsub::client::PublisherFactory;
 use pubsub::model::PubsubMessage;
 pub use pubsub_samples::{cleanup_test_topic, create_test_topic};
 
@@ -23,7 +23,7 @@ pub async fn basic_publisher() -> Result<()> {
     let (topic_admin, topic) = create_test_topic().await?;
 
     tracing::info!("testing publish()");
-    let client = PublisherClient::builder().build().await?;
+    let client = PublisherFactory::builder().build().await?;
     let publisher = client.publisher(topic.name.clone()).build();
     let messages: [PubsubMessage; 2] = [
         PubsubMessage::new().set_data("Hello"),

--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -50,7 +50,7 @@ pub mod model_ext {
 
 pub mod client {
     pub use crate::generated::gapic::client::*;
-    pub use crate::publisher::client::PublisherClient;
+    pub use crate::publisher::client::PublisherFactory;
     pub use crate::publisher::publisher::Publisher;
 }
 pub mod stub {

--- a/src/pubsub/src/publisher/client.rs
+++ b/src/pubsub/src/publisher/client.rs
@@ -16,18 +16,18 @@ use crate::publisher::publisher::PublisherBuilder;
 
 /// Client for publishing messages to Pub/Sub topics.
 #[derive(Clone, Debug)]
-pub struct PublisherClient {
+pub struct PublisherFactory {
     pub(crate) inner: crate::generated::gapic_dataplane::client::Publisher,
 }
 
-/// A builder for [PublisherClient].
+/// A builder for [PublisherFactory].
 ///
 /// ```
 /// # async fn sample() -> anyhow::Result<()> {
 /// # use google_cloud_pubsub::*;
 /// # use builder::publisher::ClientBuilder;
-/// # use client::PublisherClient;
-/// let builder : ClientBuilder = PublisherClient::builder();
+/// # use client::PublisherFactory;
+/// let builder : ClientBuilder = PublisherFactory::builder();
 /// let client = builder
 ///     .with_endpoint("https://pubsub.googleapis.com")
 ///     .build().await?;
@@ -39,11 +39,11 @@ pub type ClientBuilder =
     gax::client_builder::ClientBuilder<client_builder::Factory, gaxi::options::Credentials>;
 
 pub(crate) mod client_builder {
-    use super::PublisherClient;
+    use super::PublisherFactory;
 
     pub struct Factory;
     impl gax::client_builder::internal::ClientFactory for Factory {
-        type Client = PublisherClient;
+        type Client = PublisherFactory;
         type Credentials = gaxi::options::Credentials;
         #[allow(unused_mut)]
         async fn build(
@@ -56,13 +56,13 @@ pub(crate) mod client_builder {
     }
 }
 
-impl PublisherClient {
-    /// Returns a builder for [PublisherClient].
+impl PublisherFactory {
+    /// Returns a builder for [PublisherFactory].
     ///
     /// ```no_run
     /// # tokio_test::block_on(async {
-    /// # use google_cloud_pubsub::client::PublisherClient;
-    /// let client = PublisherClient::builder().build().await?;
+    /// # use google_cloud_pubsub::client::PublisherFactory;
+    /// let client = PublisherFactory::builder().build().await?;
     /// # gax::client_builder::Result::<()>::Ok(()) });
     /// ```
     pub fn builder() -> ClientBuilder {
@@ -83,9 +83,9 @@ impl PublisherClient {
     /// # async fn sample() -> anyhow::Result<()> {
     /// # use google_cloud_pubsub::*;
     /// # use builder::publisher::ClientBuilder;
-    /// # use client::PublisherClient;
+    /// # use client::PublisherFactory;
     /// # use model::PubsubMessage;
-    /// let client = PublisherClient::builder()
+    /// let client = PublisherFactory::builder()
     ///     .with_endpoint("https://pubsub.googleapis.com")
     ///     .build().await?;
     /// let publisher = client.publisher("projects/my-project/topics/my-topic").build();
@@ -102,11 +102,11 @@ impl PublisherClient {
 
 #[cfg(test)]
 mod tests {
-    use super::PublisherClient;
+    use super::PublisherFactory;
 
     #[tokio::test]
     async fn builder() -> anyhow::Result<()> {
-        let client = PublisherClient::builder()
+        let client = PublisherFactory::builder()
             .with_credentials(auth::credentials::anonymous::Builder::new().build())
             .build()
             .await?;

--- a/src/pubsub/src/publisher/publisher.rs
+++ b/src/pubsub/src/publisher/publisher.rs
@@ -23,9 +23,9 @@ use tokio::sync::{mpsc, oneshot};
 /// # async fn sample() -> anyhow::Result<()> {
 /// # use google_cloud_pubsub::*;
 /// # use builder::publisher::ClientBuilder;
-/// # use client::PublisherClient;
+/// # use client::PublisherFactory;
 /// # use model::PubsubMessage;
-/// let client = PublisherClient::builder()
+/// let client = PublisherFactory::builder()
 ///     .with_endpoint("https://pubsub.googleapis.com")
 ///     .build().await?;
 /// let publisher = client.publisher("projects/my-project/topics/my-topic").build();
@@ -67,9 +67,9 @@ impl Publisher {
 /// # async fn sample() -> anyhow::Result<()> {
 /// # use google_cloud_pubsub::*;
 /// # use builder::publisher::ClientBuilder;
-/// # use client::PublisherClient;
+/// # use client::PublisherFactory;
 /// # use options::publisher::BatchingOptions;
-/// let builder : ClientBuilder = PublisherClient::builder();
+/// let builder : ClientBuilder = PublisherFactory::builder();
 /// let client = builder
 ///     .with_endpoint("https://pubsub.googleapis.com")
 ///     .build().await?;
@@ -182,7 +182,7 @@ impl Worker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{client::PublisherClient, publisher::options::BatchingOptions};
+    use crate::{client::PublisherFactory, publisher::options::BatchingOptions};
     use crate::{
         generated::gapic_dataplane::client::Publisher as GapicPublisher,
         model::{PublishResponse, PubsubMessage},
@@ -267,7 +267,7 @@ mod tests {
 
     #[tokio::test]
     async fn builder() -> anyhow::Result<()> {
-        let client = PublisherClient::builder().build().await?;
+        let client = PublisherFactory::builder().build().await?;
         let builder = client.publisher("projects/my-project/topics/my-topic".to_string());
         let publisher = builder
             .with_batching(BatchingOptions::new().set_message_count_threshold(1_u32))
@@ -278,7 +278,7 @@ mod tests {
 
     #[tokio::test]
     async fn default_batching() -> anyhow::Result<()> {
-        let client = PublisherClient::builder().build().await?;
+        let client = PublisherFactory::builder().build().await?;
         let publisher = client
             .publisher("projects/my-project/topics/my-topic".to_string())
             .build();


### PR DESCRIPTION
A lot of the Pub/Sub documentation refers to a "publisher client". This most closely corresponds to the Publisher type in our library. Renaming the PublisherClient to something else will hopefully make this less confusing.

Fixes #3680 