### PR TITLE
fix(storage): `StorageImpl` nameable outside crate

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -69,7 +69,7 @@ pub mod model_ext;
 pub mod stub {
     pub use crate::control::stub::*;
     pub use crate::storage::stub::*;
-    pub use crate::storage::transport::Storage as StorageImpl;
+    pub use crate::storage::transport::Storage as DefaultStorage;
 }
 
 #[allow(dead_code)]

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -20,7 +20,7 @@ pub(crate) mod read_object;
 pub mod request_options;
 pub mod streaming_source;
 pub mod stub;
-pub mod transport;
+pub(crate) mod transport;
 pub(crate) mod v1;
 pub(crate) mod write_object;
 

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -89,7 +89,7 @@ use std::sync::Arc;
 /// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
 /// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 #[derive(Clone, Debug)]
-pub struct Storage<S = crate::stub::StorageImpl>
+pub struct Storage<S = crate::stub::DefaultStorage>
 where
     S: crate::stub::Storage + 'static,
 {

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -34,8 +34,8 @@ use std::sync::Arc;
 /// ```
 /// # async fn sample() -> anyhow::Result<()> {
 /// use google_cloud_storage::client::Storage;
-/// use google_cloud_storage::stub::StorageImpl;
-/// let client: Storage<StorageImpl> = Storage::builder().build().await?;
+/// use google_cloud_storage::stub::DefaultStorage;
+/// let client: Storage<DefaultStorage> = Storage::builder().build().await?;
 /// # Ok(()) }
 /// ```
 #[derive(Clone, Debug)]
@@ -50,6 +50,7 @@ impl Storage {
 }
 
 impl super::stub::Storage for Storage {
+    /// Implements [crate::client::Storage::read_object].
     async fn read_object(
         &self,
         req: ReadObjectRequest,


### PR DESCRIPTION
Fixes #3663 

Make the default stub implementation name-able from outside the crate. This lets applications provide a default implementation for their own generics.

Note that this type is not constructible from outside the crate. It has no public fields. Its only public fns are its impl of `stub::Storage`.

I think this type belongs in the `stub` module. I called it `StorageImpl`.

If we are happy with these names, I will clean up the internal wiring, either in this PR or in a follow up.