### PR TITLE
fix(pubsub): hide publisher request builder

### DIFF
--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -34,6 +34,7 @@ pub use gax::error::Error;
 pub mod builder {
     pub use crate::generated::gapic::builder::*;
     pub mod publisher {
+        #[doc(hidden)]
         pub use crate::generated::gapic_dataplane::builder::publisher::*;
         pub use crate::publisher::client::ClientBuilder;
         pub use crate::publisher::publisher::PublisherBuilder;


### PR DESCRIPTION
Actually fixing this will require an update to the library generator. Attempting to make the type `pub(crate)` breaks the doc tests. For now, we can just hide it in the documentation.

For #3695 