### PR TITLE
impl(gax-internal): Add gcp.client.language and refactor attribute keys

### DIFF
--- a/src/gax-internal/src/observability/attributes.rs
+++ b/src/gax-internal/src/observability/attributes.rs
@@ -15,43 +15,58 @@
 // OpenTelemetry Semantic Convention Keys
 // See https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 
-/// Span Kind for OpenTelemetry interop.
-///
-/// Always "Client" for a span representing an outbound HTTP request.
-pub const KEY_OTEL_KIND: &str = "otel.kind";
-/// Span Name for OpenTelemetry interop.
-///
-/// If `url.template` is available use "{http.request.method} {url.template}", otherwise use "{http.request.method}".
-pub const KEY_OTEL_NAME: &str = "otel.name";
-/// Span Status Code for OpenTelemetry interop.
-///
-/// Must be one of "UNSET", "OK", or "ERROR".
-pub const KEY_OTEL_STATUS_CODE: &str = "otel.status_code";
-/// Span Status Description for OpenTelemetry interop.
-///
-/// A human-readable description of the status, used when status_code is "ERROR".
-pub const KEY_OTEL_STATUS_DESCRIPTION: &str = "otel.status_description";
+pub mod keys {
+    /// Span Kind for OpenTelemetry interop.
+    ///
+    /// Always "Client" for a span representing an outbound HTTP request.
+    pub const OTEL_KIND: &str = "otel.kind";
+    /// Span Name for OpenTelemetry interop.
+    ///
+    /// If `url.template` is available use "{http.request.method} {url.template}", otherwise use "{http.request.method}".
+    pub const OTEL_NAME: &str = "otel.name";
+    /// Span Status Code for OpenTelemetry interop.
+    ///
+    /// Must be one of "UNSET", "OK", or "ERROR".
+    pub const OTEL_STATUS_CODE: &str = "otel.status_code";
+    /// Span Status Description for OpenTelemetry interop.
+    ///
+    /// A human-readable description of the status, used when status_code is "ERROR".
+    pub const OTEL_STATUS_DESCRIPTION: &str = "otel.status_description";
 
-/// The string representation of the gRPC status code.
-pub const KEY_GRPC_STATUS: &str = "grpc.status";
+    /// The string representation of the gRPC status code.
+    pub const GRPC_STATUS: &str = "grpc.status";
 
-// Custom GCP Attributes
-/// The Google Cloud service name.
-///
-/// Examples: appengine, run, firestore
-pub const KEY_GCP_CLIENT_SERVICE: &str = "gcp.client.service";
-/// The client library version.
-///
-/// Example: v1.0.2
-pub const KEY_GCP_CLIENT_VERSION: &str = "gcp.client.version";
-/// The client library repository.
-///
-/// Always "googleapis/google-cloud-rust".
-pub const KEY_GCP_CLIENT_REPO: &str = "gcp.client.repo";
-/// The client library crate name.
-///
-/// Example: google-cloud-storage
-pub const KEY_GCP_CLIENT_ARTIFACT: &str = "gcp.client.artifact";
+    // Custom GCP Attributes
+    /// The Google Cloud service name.
+    ///
+    /// Examples: appengine, run, firestore
+    pub const GCP_CLIENT_SERVICE: &str = "gcp.client.service";
+    /// The client library version.
+    ///
+    /// Example: v1.0.2
+    pub const GCP_CLIENT_VERSION: &str = "gcp.client.version";
+    /// The client library repository.
+    ///
+    /// Always "googleapis/google-cloud-rust".
+    pub const GCP_CLIENT_REPO: &str = "gcp.client.repo";
+    /// The client library crate name.
+    ///
+    /// Example: google-cloud-storage
+    pub const GCP_CLIENT_ARTIFACT: &str = "gcp.client.artifact";
+    /// The client library language.
+    ///
+    /// Always "rust".
+    pub const GCP_CLIENT_LANGUAGE: &str = "gcp.client.language";
+}
+
+/// Value for [keys::OTEL_KIND].
+pub const OTEL_KIND_CLIENT: &str = "Client";
+/// Value for `rpc.system`.
+pub const RPC_SYSTEM_HTTP: &str = "http";
+/// Value for [keys::GCP_CLIENT_REPO].
+pub const GCP_CLIENT_REPO_GOOGLEAPIS: &str = "googleapis/google-cloud-rust";
+/// Value for [keys::GCP_CLIENT_LANGUAGE].
+pub const GCP_CLIENT_LANGUAGE_RUST: &str = "rust";
 
 /// Values for the OpenTelemetry `error.type` attribute.
 /// See [https://opentelemetry.io/docs/specs/semconv/attributes-registry/error/]

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -130,14 +130,14 @@ mod tests {
 
             assert_eq!(
                 attributes.get(
-                    google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_CODE
+                    google_cloud_gax_internal::observability::attributes::keys::OTEL_STATUS_CODE
                 ),
                 Some(&"ERROR".into()),
                 "Span 0: 'otel.status_code' mismatch, all attributes: {:?}",
                 attributes
             );
             let status_description = attributes
-                .get(google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_DESCRIPTION)
+                .get(google_cloud_gax_internal::observability::attributes::keys::OTEL_STATUS_DESCRIPTION)
                 .unwrap();
             match status_description {
                 google_cloud_test_utils::test_layer::AttributeValue::String(s) => {
@@ -214,14 +214,14 @@ mod tests {
 
             assert_eq!(
                 attributes.get(
-                    google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_CODE
+                    google_cloud_gax_internal::observability::attributes::keys::OTEL_STATUS_CODE
                 ),
                 Some(&"ERROR".into()),
                 "Span 0: 'otel.status_code' mismatch, all attributes: {:?}",
                 attributes
             );
             let status_description = attributes
-                .get(google_cloud_gax_internal::observability::attributes::KEY_OTEL_STATUS_DESCRIPTION)
+                .get(google_cloud_gax_internal::observability::attributes::keys::OTEL_STATUS_DESCRIPTION)
                 .unwrap();
             match status_description {
                 google_cloud_test_utils::test_layer::AttributeValue::String(s) => {

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -17,7 +17,7 @@ mod tests {
     use gax::options::RequestOptions;
     use gax::response::Response;
     use google_cloud_gax_internal::http::{NoBody, ReqwestClient};
-    use google_cloud_gax_internal::observability::attributes::*;
+    use google_cloud_gax_internal::observability::attributes::keys::*;
     use google_cloud_gax_internal::options::{ClientConfig, InstrumentationClientInfo};
     use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer};
     use http::{Method, StatusCode};
@@ -87,19 +87,20 @@ mod tests {
         let attrs = &span.attributes;
 
         let expected_attributes: HashMap<String, AttributeValue> = [
-            (KEY_OTEL_NAME, "GET /test".into()),
-            (KEY_OTEL_KIND, "Client".into()),
+            (OTEL_NAME, "GET /test".into()),
+            (OTEL_KIND, "Client".into()),
             (otel_trace::RPC_SYSTEM, "http".into()),
             (otel_trace::HTTP_REQUEST_METHOD, "GET".into()),
             (otel_trace::URL_SCHEME, "http".into()),
             (otel_attr::URL_TEMPLATE, "/test".into()),
             (otel_attr::URL_DOMAIN, TEST_HOST.into()),
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
-            (KEY_OTEL_STATUS_CODE, "UNSET".into()),
-            (KEY_GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
-            (KEY_GCP_CLIENT_VERSION, TEST_VERSION.into()),
-            (KEY_GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
-            (KEY_GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (OTEL_STATUS_CODE, "UNSET".into()),
+            (GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
+            (GCP_CLIENT_VERSION, TEST_VERSION.into()),
+            (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
+            (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (GCP_CLIENT_LANGUAGE, "rust".into()),
             (otel_trace::HTTP_RESPONSE_BODY_SIZE, 18_i64.into()), // {"hello": "world"} is 18 bytes
             (
                 otel_trace::SERVER_ADDRESS,
@@ -186,14 +187,14 @@ mod tests {
         );
 
         assert_eq!(
-            attrs.get(KEY_OTEL_STATUS_CODE),
+            attrs.get(OTEL_STATUS_CODE),
             Some(&"ERROR".into()),
             "otel.status_code mismatch, attrs: {:?}",
             attrs
         );
 
         assert_eq!(
-            attrs.get(KEY_OTEL_STATUS_DESCRIPTION),
+            attrs.get(OTEL_STATUS_DESCRIPTION),
             Some(&expected_description.into()),
             "otel.status_description mismatch, attrs: {:?}",
             attrs
@@ -230,19 +231,20 @@ mod tests {
         let attrs = &span.attributes;
 
         let expected_attributes: HashMap<String, AttributeValue> = [
-            (KEY_OTEL_NAME, "POST /test".into()),
-            (KEY_OTEL_KIND, "Client".into()),
+            (OTEL_NAME, "POST /test".into()),
+            (OTEL_KIND, "Client".into()),
             (otel_trace::RPC_SYSTEM, "http".into()),
             (otel_trace::HTTP_REQUEST_METHOD, "POST".into()),
             (otel_trace::URL_SCHEME, "http".into()),
             (otel_attr::URL_TEMPLATE, "/test".into()),
             (otel_attr::URL_DOMAIN, TEST_HOST.into()),
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 201_i64.into()),
-            (KEY_OTEL_STATUS_CODE, "UNSET".into()),
-            (KEY_GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
-            (KEY_GCP_CLIENT_VERSION, TEST_VERSION.into()),
-            (KEY_GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
-            (KEY_GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (OTEL_STATUS_CODE, "UNSET".into()),
+            (GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
+            (GCP_CLIENT_VERSION, TEST_VERSION.into()),
+            (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
+            (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (GCP_CLIENT_LANGUAGE, "rust".into()),
             (otel_trace::HTTP_RESPONSE_BODY_SIZE, 20_i64.into()), // {"status":"created"} is 20 bytes
             (
                 otel_trace::SERVER_ADDRESS,
@@ -319,31 +321,26 @@ mod tests {
         );
 
         assert_eq!(
-            attrs.get(KEY_OTEL_STATUS_CODE),
+            attrs.get(OTEL_STATUS_CODE),
             Some(&"ERROR".into()),
             "otel.status_code should be ERROR, attrs: {:?}",
             attrs
         );
 
         let description = attrs
-            .get(KEY_OTEL_STATUS_DESCRIPTION)
-            .unwrap_or_else(|| {
-                panic!(
-                    "{} missing, attrs: {:?}",
-                    KEY_OTEL_STATUS_DESCRIPTION, attrs
-                )
-            })
+            .get(OTEL_STATUS_DESCRIPTION)
+            .unwrap_or_else(|| panic!("{} missing, attrs: {:?}", OTEL_STATUS_DESCRIPTION, attrs))
             .as_string()
             .unwrap_or_else(|| {
                 panic!(
                     "{} not a string, attrs: {:?}",
-                    KEY_OTEL_STATUS_DESCRIPTION, attrs
+                    OTEL_STATUS_DESCRIPTION, attrs
                 )
             });
         assert!(
             description.contains("Invalid API Key"),
             "{} '{}' does not contain 'Invalid API Key', attrs: {:?}",
-            KEY_OTEL_STATUS_DESCRIPTION,
+            OTEL_STATUS_DESCRIPTION,
             description,
             attrs
         );

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -35,8 +35,8 @@ mod tests {
     use std::time::Duration;
 
     #[cfg(google_cloud_unstable_tracing)]
-    use google_cloud_gax_internal::observability::attributes::{
-        KEY_OTEL_STATUS_CODE, KEY_OTEL_STATUS_DESCRIPTION,
+    use google_cloud_gax_internal::observability::attributes::keys::{
+        OTEL_STATUS_CODE, OTEL_STATUS_DESCRIPTION,
     };
     #[cfg(google_cloud_unstable_tracing)]
     use google_cloud_test_utils::test_layer::TestLayer;
@@ -160,10 +160,10 @@ mod tests {
             attributes0
         );
         assert_eq!(
-            attributes0.get(KEY_OTEL_STATUS_CODE),
+            attributes0.get(OTEL_STATUS_CODE),
             Some(&"ERROR".into()),
             "Span 0: '{}' mismatch, all attributes: {:?}",
-            KEY_OTEL_STATUS_CODE,
+            OTEL_STATUS_CODE,
             attributes0
         );
         assert_eq!(
@@ -174,13 +174,13 @@ mod tests {
             attributes0
         );
         assert_eq!(
-            attributes0.get(KEY_OTEL_STATUS_DESCRIPTION),
+            attributes0.get(OTEL_STATUS_DESCRIPTION),
             Some(
                 &"the service reports an error with code UNAVAILABLE described as: try-again"
                     .into()
             ),
             "Span 0: '{}' mismatch, all attributes: {:?}",
-            KEY_OTEL_STATUS_DESCRIPTION,
+            OTEL_STATUS_DESCRIPTION,
             attributes0
         );
 
@@ -196,10 +196,10 @@ mod tests {
             attributes1
         );
         assert_eq!(
-            attributes1.get(KEY_OTEL_STATUS_CODE),
+            attributes1.get(OTEL_STATUS_CODE),
             Some(&"ERROR".into()),
             "Span 1: '{}' mismatch, all attributes: {:?}",
-            KEY_OTEL_STATUS_CODE,
+            OTEL_STATUS_CODE,
             attributes1
         );
         assert_eq!(
@@ -210,13 +210,13 @@ mod tests {
             attributes1
         );
         assert_eq!(
-            attributes1.get(KEY_OTEL_STATUS_DESCRIPTION),
+            attributes1.get(OTEL_STATUS_DESCRIPTION),
             Some(
                 &"the service reports an error with code UNAVAILABLE described as: try-again"
                     .into()
             ),
             "Span 1: '{}' mismatch, all attributes: {:?}",
-            KEY_OTEL_STATUS_DESCRIPTION,
+            OTEL_STATUS_DESCRIPTION,
             attributes1
         );
 
@@ -232,10 +232,10 @@ mod tests {
             attributes2
         );
         assert_eq!(
-            attributes2.get(KEY_OTEL_STATUS_CODE),
+            attributes2.get(OTEL_STATUS_CODE),
             Some(&"UNSET".into()),
             "Span 2: '{}' mismatch, all attributes: {:?}",
-            KEY_OTEL_STATUS_CODE,
+            OTEL_STATUS_CODE,
             attributes2
         );
         assert_eq!(
@@ -246,9 +246,9 @@ mod tests {
             attributes2
         );
         assert!(
-            attributes2.get(KEY_OTEL_STATUS_DESCRIPTION).is_none(),
+            attributes2.get(OTEL_STATUS_DESCRIPTION).is_none(),
             "Span 2: '{}' should not be present, all attributes: {:?}",
-            KEY_OTEL_STATUS_DESCRIPTION,
+            OTEL_STATUS_DESCRIPTION,
             attributes2
         );
 

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -229,7 +229,7 @@ mod tests {
     mod tracing_tests {
         use super::*;
         use google_cloud_gax_internal::observability::attributes::error_type_values::CLIENT_TIMEOUT;
-        use google_cloud_gax_internal::observability::attributes::*;
+        use google_cloud_gax_internal::observability::attributes::keys::*;
         use google_cloud_test_utils::test_layer::TestLayer;
         use opentelemetry_semantic_conventions::trace as semconv;
 
@@ -281,24 +281,24 @@ mod tests {
             );
 
             assert_eq!(
-                attributes.get(KEY_OTEL_STATUS_CODE),
+                attributes.get(OTEL_STATUS_CODE),
                 Some(&"ERROR".into()),
                 "Span 0: '{}' mismatch, all attributes: {:?}",
-                KEY_OTEL_STATUS_CODE,
+                OTEL_STATUS_CODE,
                 attributes
             );
-            let status_description = attributes.get(KEY_OTEL_STATUS_DESCRIPTION).unwrap();
+            let status_description = attributes.get(OTEL_STATUS_DESCRIPTION).unwrap();
             match status_description {
                 google_cloud_test_utils::test_layer::AttributeValue::String(s) => {
                     assert!(
                         s.contains("error sending request"),
                         "Span 0: '{}' should contain 'error sending request', got: {:?}, all attributes: {:?}",
-                        KEY_OTEL_STATUS_DESCRIPTION,
+                        OTEL_STATUS_DESCRIPTION,
                         s,
                         attributes
                     );
                 }
-                _ => panic!("Expected string for {}", KEY_OTEL_STATUS_DESCRIPTION),
+                _ => panic!("Expected string for {}", OTEL_STATUS_DESCRIPTION),
             };
 
             Ok(())


### PR DESCRIPTION
This PR adds the gcp.client.language attribute to T4 HTTP spans, set to "rust".

It also refactors the OpenTelemetry attribute keys in google-cloud-gax-internal into a dedicated keys module within observability::attributes for better organization and to avoid naming conflicts.