### PR TITLE
chore(pubsub): mark pubsub crate ready to publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "0.0.0"
+version = "0.1.0-preview"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -14,8 +14,7 @@
 
 [package]
 name        = "google-cloud-pubsub"
-publish     = false
-version     = "0.0.0"
+version     = "0.1.0-preview"
 description = "Google Cloud Client Libraries for Rust - Pub/Sub"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
Prepare for the preview release. Confirmed pubsub is now included with `$ cargo workspaces plan | grep pubsub`.

Fixes #3729