### PR TITLE
docs(pubsub): add example to PublishHandle

### DIFF
--- a/src/pubsub/src/publisher/model_ext.rs
+++ b/src/pubsub/src/publisher/model_ext.rs
@@ -36,8 +36,8 @@ use tokio::sync::oneshot;
 ///
 /// // The handle can be awaited later to get the result.
 /// match handle.await {
-///     Ok(message_id) => println!("Message published with ID: {}", message_id),
-///     Err(e) => eprintln!("Failed to publish message: {}", e),
+///     Ok(message_id) => println!("Message published with ID: {message_id}"),
+///     Err(e) => eprintln!("Failed to publish message: {e:?}"),
 /// }
 /// # Ok(())
 /// # }


### PR DESCRIPTION
Add an example to the `PublishHandle` and document the output type to indicated the value of string is a message id.

For #3707 