### PR TITLE
chore(pubsub): update version for preview release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "0.1.0-preview"
+version = "0.31.0-preview"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-pubsub"
-version     = "0.1.0-preview"
+version     = "0.31.0-preview"
 description = "Google Cloud Client Libraries for Rust - Pub/Sub"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
Previous google-cloud-pubsub version was 0.30.0.