### PR TITLE
chore: update longrunning version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,8 +380,8 @@ gaxi                          = { version = "0.7.4", path = "src/gax-internal", 
 iam_v1                        = { version = "1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "1", path = "src/generated/iam/v1" }
 location                      = { version = "1", path = "src/generated/cloud/location", package = "google-cloud-location" }
-longrunning                   = { version = "1", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
-google-cloud-longrunning      = { version = "1", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning                   = { version = "1.2", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+google-cloud-longrunning      = { version = "1.2", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
 lro                           = { version = "1.1", path = "src/lro", package = "google-cloud-lro" }
 google-cloud-lro              = { version = "1.1", path = "src/lro", package = "google-cloud-lro" }
 wkt                           = { version = "1", path = "src/wkt", package = "google-cloud-wkt" }


### PR DESCRIPTION
Generated code for our crates depends on the new code in longrunning v1.2.