### PR TITLE
cleanup(auth): remove default from idtoken builders

### DIFF
--- a/src/auth/src/credentials/idtoken/mds.rs
+++ b/src/auth/src/credentials/idtoken/mds.rs
@@ -108,7 +108,6 @@ where
 
 /// Creates [`IDTokenCredentials`] instances that fetch ID tokens from the
 /// metadata service.
-#[derive(Debug, Default)]
 pub struct Builder {
     endpoint: Option<String>,
     format: Option<String>,

--- a/src/auth/src/credentials/idtoken/verifier.rs
+++ b/src/auth/src/credentials/idtoken/verifier.rs
@@ -42,7 +42,6 @@ pub use serde_json::{Map, Value};
 use std::time::Duration;
 
 /// Builder is used construct a [Verifier] of id tokens.
-#[derive(Debug, Default)]
 pub struct Builder {
     audience: String,
     email: Option<String>,
@@ -56,7 +55,9 @@ impl Builder {
     pub fn new<S: Into<String>>(audience: S) -> Self {
         Self {
             audience: audience.into(),
-            ..Self::default()
+            clock_skew: None,
+            email: None,
+            jwks_url: None,
         }
     }
 


### PR DESCRIPTION
Towards #3449 