### PR TITLE
cleanup(auth): remove bool parameter for including email claim

### DIFF
--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -643,7 +643,7 @@ pub mod unstable {
             &target_principal_email,
             source_sa_creds,
         )
-        .with_include_email(true)
+        .with_include_email()
         .build()
         .expect("failed to setup id token credentials");
 

--- a/src/auth/src/credentials/idtoken/impersonated.rs
+++ b/src/auth/src/credentials/idtoken/impersonated.rs
@@ -144,8 +144,8 @@ impl Builder {
     }
 
     /// Should include email claims in the ID Token.
-    pub fn with_include_email(mut self, include_email: bool) -> Self {
-        self.include_email = Some(include_email);
+    pub fn with_include_email(mut self) -> Self {
+        self.include_email = Some(true);
         self
     }
 
@@ -428,7 +428,7 @@ mod tests {
         });
         let creds = Builder::new("test-audience", impersonated_credential)
             .with_delegates(vec!["delegate1", "delegate2"])
-            .with_include_email(true)
+            .with_include_email()
             .build()?;
 
         let token = creds.id_token().await?;


### PR DESCRIPTION
Inline with changes on #3763, in which the ADC flow will have a method to just enable email claims.

Towards #3449 