### PR TITLE
ci: remove some minimal-versions tests

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -271,13 +271,9 @@ jobs:
           cargo minimal-versions test --package pubsub-samples
           cargo minimal-versions test --package google-cloud-storage
           cargo minimal-versions check --package google-cloud-storage
-          cargo minimal-versions test --package google-cloud-gax-internal
           cargo minimal-versions check --package google-cloud-gax-internal
-          cargo minimal-versions test --package google-cloud-auth
           cargo minimal-versions check --package google-cloud-auth
-          cargo minimal-versions test --package google-cloud-gax
           cargo minimal-versions check --package google-cloud-gax
-          cargo minimal-versions test --package google-cloud-wkt
           cargo minimal-versions check --package google-cloud-wkt
 
   semver-checks:


### PR DESCRIPTION
These tests are failing in ci with disk usage errors. Temporarily remove them to see we can fix them. `test` likely uses more space than `check` since it includes more dependencies.