### PR TITLE
impl(o11y): add gcp.grpc.resend.count attribute to gRPC spans

### DIFF
--- a/src/gax-internal/src/observability/attributes.rs
+++ b/src/gax-internal/src/observability/attributes.rs
@@ -61,6 +61,10 @@ pub mod keys {
     ///
     /// Example: //pubsub.googleapis.com/projects/my-project/topics/my-topic
     pub const GCP_RESOURCE_NAME: &str = "gcp.resource.name";
+    /// The number of times this same gRPC request has been resent due to retries.
+    ///
+    /// 1 for the first retry.
+    pub const GCP_GRPC_RESEND_COUNT: &str = "gcp.grpc.resend_count";
 }
 
 /// Value for [keys::OTEL_KIND].


### PR DESCRIPTION
This commit implements the tracking and injection of the retry attempt count for gRPC requests.
