### PR TITLE
chore: bump all crates depending on longrunning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-aiplatform-v1"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-alloydb-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicemanagement-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-serviceusage-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apigateway-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apihub-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apikeys-v2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-appengine-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apphub-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-artifactregistry-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-asset-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-assuredworkloads-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-backupdr-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-baremetalsolution-v2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1424,7 +1424,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-beyondcorp-appconnections-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-appconnectors-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-appgateways-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-clientconnectorservices-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-beyondcorp-clientgateways-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1538,7 +1538,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-bigquery-analyticshub-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1699,7 +1699,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-bigtable-admin-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-build-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-build-v2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-certificatemanager-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-chronicle-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-clouddms-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-cloudsecuritycompliance-v1"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-commerce-consumer-procurement-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-config-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-configdelivery-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-connectors-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-contactcenterinsights-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datacatalog-lineage-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datacatalog-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datafusion-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataplex-v1"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dataproc-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2240,7 +2240,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-datastore-admin-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-datastream-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-deploy-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-developerconnect-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-cx-v3"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-v2"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-discoveryengine-v1"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-documentai-v1"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-domains-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-edgecontainer-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-edgenetwork-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-eventarc-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-filestore-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-financialservices-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-firestore-admin-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-functions-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkebackup-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkehub-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gkemulticloud-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v3"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-identity-accesscontextmanager-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-ids-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-kms-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-licensemanager-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-logging-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lro"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lustre-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedidentities-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedkafka-schemaregistry-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-managedkafka-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-memcache-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-memorystore-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-metastore-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-migrationcenter-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-monitoring-metricsscope-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-netapp-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkconnectivity-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkmanagement-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networksecurity-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-networkservices-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-notebooks-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-optimization-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-oracledatabase-v1"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-orchestration-airflow-service-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-osconfig-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-parallelstore-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-policysimulator-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-privilegedaccessmanager-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rapidmigrationassessment-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-redis-cluster-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-redis-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-resourcemanager-v3"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-retail-v2"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-run-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securesourcemanager-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-security-privateca-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securitycenter-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securityposture-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-shell-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4425,7 +4425,7 @@ version = "0.0.0"
 
 [[package]]
 name = "google-cloud-spanner-admin-database-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-spanner-admin-instance-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-speech-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storagebatchoperations-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storageinsights-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storagetransfer-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-talent-v4"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-telcoautomation-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-texttospeech-v1"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-tpu-v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-translation-v3"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-livestream-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-video-stitcher-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-videointelligence-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4920,7 +4920,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vision-v1"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vmmigration-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vmwareengine-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vpcaccess-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-webrisk-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workflows-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-workstations-v1"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/generated/api/apikeys/v2/.sidekick.toml
+++ b/src/generated/api/apikeys/v2/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/api/apikeys/v2'
 service-config = 'google/api/apikeys/v2/apikeys_v2.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 package-name-override = 'google-cloud-apikeys-v2'

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apikeys-v2"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - API Keys API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicemanagement/v1/.sidekick.toml
+++ b/src/generated/api/servicemanagement/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/api/servicemanagement/v1'
 service-config = 'google/api/servicemanagement/v1/servicemanagement_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicemanagement-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Service Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/serviceusage/v1/.sidekick.toml
+++ b/src/generated/api/serviceusage/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/api/serviceusage/v1'
 service-config = 'google/api/serviceusage/v1/serviceusage_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-serviceusage-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Service Usage API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/appengine/v1/.sidekick.toml
+++ b/src/generated/appengine/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/appengine/v1'
 service-config = 'google/appengine/v1/appengine_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-appengine-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - App Engine Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/bigtable/admin/v2/.sidekick.toml
+++ b/src/generated/bigtable/admin/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/bigtable/admin/v2'
 service-config = 'google/bigtable/admin/v2/bigtableadmin_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigtable-admin-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Bigtable Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/aiplatform/v1/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/aiplatform/v1'
 service-config       = 'google/cloud/aiplatform/v1/aiplatform_v1.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year = '2025'
 # TODO(#893) - handle the bad HTML tags in this library.
 disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links,invalid_html_tags"

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-aiplatform-v1"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/alloydb/v1/.sidekick.toml
+++ b/src/generated/cloud/alloydb/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/alloydb/v1'
 service-config = 'google/cloud/alloydb/v1/alloydb_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-alloydb-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - AlloyDB API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apigateway/v1/.sidekick.toml
+++ b/src/generated/cloud/apigateway/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/apigateway/v1'
 service-config = 'google/cloud/apigateway/v1/apigateway_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apigateway-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - API Gateway API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apihub/v1/.sidekick.toml
+++ b/src/generated/cloud/apihub/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/apihub/v1'
 service-config = 'google/cloud/apihub/v1/apihub_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apihub-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - API hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apphub/v1/.sidekick.toml
+++ b/src/generated/cloud/apphub/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/apphub/v1'
 service-config = 'google/cloud/apphub/v1/apphub_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apphub-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - App Hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/asset/v1/.sidekick.toml
+++ b/src/generated/cloud/asset/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/asset/v1'
 service-config = 'google/cloud/asset/v1/cloudasset_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 'package:accesscontextmanager_v1' = 'package=google-cloud-identity-accesscontextmanager-v1,source=google.identity.accesscontextmanager.v1'
 'package:orgpolicy_v1' = 'package=google-cloud-orgpolicy-v1,source=google.cloud.orgpolicy.v1'

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-asset-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Asset API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/assuredworkloads/v1/.sidekick.toml
+++ b/src/generated/cloud/assuredworkloads/v1/.sidekick.toml
@@ -17,5 +17,5 @@ service-config = 'google/cloud/assuredworkloads/v1/assuredworkloads_v1.yaml'
 specification-source = 'google/cloud/assuredworkloads/v1'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-assuredworkloads-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Assured Workloads API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/backupdr/v1/.sidekick.toml
+++ b/src/generated/cloud/backupdr/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/backupdr/v1'
 service-config = 'google/cloud/backupdr/v1/backupdr_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-backupdr-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Backup and DR Service API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/baremetalsolution/v2/.sidekick.toml
+++ b/src/generated/cloud/baremetalsolution/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/baremetalsolution/v2'
 service-config = 'google/cloud/baremetalsolution/v2/baremetalsolution_v2.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-baremetalsolution-v2"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Bare Metal Solution API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appconnections/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/beyondcorp/appconnections/v1'
 service-config = 'google/cloud/beyondcorp/appconnections/v1/beyondcorp_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appconnections-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/beyondcorp/appconnectors/v1'
 service-config = 'google/cloud/beyondcorp/appconnectors/v1/beyondcorp_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appconnectors-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/appgateways/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/beyondcorp/appgateways/v1'
 service-config = 'google/cloud/beyondcorp/appgateways/v1/beyondcorp_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-appgateways-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/beyondcorp/clientconnectorservices/v1'
 service-config = 'google/cloud/beyondcorp/clientconnectorservices/v1/beyondcorp_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-clientconnectorservices-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/beyondcorp/clientgateways/v1'
 service-config = 'google/cloud/beyondcorp/clientgateways/v1/beyondcorp_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-beyondcorp-clientgateways-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - BeyondCorp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/bigquery/analyticshub/v1/.sidekick.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/bigquery/analyticshub/v1'
 service-config = 'google/cloud/bigquery/analyticshub/v1/analyticshub_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-analyticshub-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Analytics Hub API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/certificatemanager/v1/.sidekick.toml
+++ b/src/generated/cloud/certificatemanager/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/certificatemanager/v1'
 service-config = 'google/cloud/certificatemanager/v1/certificatemanager_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-certificatemanager-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Certificate Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/chronicle/v1/.sidekick.toml
+++ b/src/generated/cloud/chronicle/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/chronicle/v1'
 service-config = 'google/cloud/chronicle/v1/chronicle_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/chronicle/v1/Cargo.toml
+++ b/src/generated/cloud/chronicle/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-chronicle-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Chronicle API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/clouddms/v1/.sidekick.toml
+++ b/src/generated/cloud/clouddms/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/clouddms/v1'
 service-config = 'google/cloud/clouddms/v1/datamigration_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-clouddms-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Database Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/cloudsecuritycompliance/v1/.sidekick.toml
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/cloudsecuritycompliance/v1'
 service-config = 'google/cloud/cloudsecuritycompliance/v1/cloudsecuritycompliance_v1.yaml'
 
 [codec]
-version        = '2.1.0'
+version        = '2.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/cloudsecuritycompliance/v1/Cargo.toml
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-cloudsecuritycompliance-v1"
-version                = "2.1.0"
+version                = "2.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Security Compliance API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/commerce/consumer/procurement/v1/.sidekick.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/commerce/consumer/procurement/v1'
 service-config = 'google/cloud/commerce/consumer/procurement/v1/cloudcommerceconsumerprocurement_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-commerce-consumer-procurement-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Commerce Consumer Procurement API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/config/v1/.sidekick.toml
+++ b/src/generated/cloud/config/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/config/v1'
 service-config = 'google/cloud/config/v1/config_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-config-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Infrastructure Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/configdelivery/v1/.sidekick.toml
+++ b/src/generated/cloud/configdelivery/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/configdelivery/v1'
 service-config = 'google/cloud/configdelivery/v1/configdelivery_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/configdelivery/v1/Cargo.toml
+++ b/src/generated/cloud/configdelivery/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-configdelivery-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Config Delivery API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/connectors/v1/.sidekick.toml
+++ b/src/generated/cloud/connectors/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/connectors/v1'
 service-config = 'google/cloud/connectors/v1/connectors_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-connectors-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Connectors API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/contactcenterinsights/v1/.sidekick.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/contactcenterinsights/v1'
 service-config = 'google/cloud/contactcenterinsights/v1/contactcenterinsights_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-contactcenterinsights-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Contact Center AI Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datacatalog/lineage/v1/.sidekick.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/datacatalog/lineage/v1'
 service-config = 'google/cloud/datacatalog/lineage/v1/datalineage_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datacatalog-lineage-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Data Lineage API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datacatalog/v1/.sidekick.toml
+++ b/src/generated/cloud/datacatalog/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/datacatalog/v1'
 service-config = 'google/cloud/datacatalog/v1/datacatalog_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datacatalog-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Data Catalog API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datafusion/v1/.sidekick.toml
+++ b/src/generated/cloud/datafusion/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/datafusion/v1'
 service-config = 'google/cloud/datafusion/v1/datafusion_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datafusion-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Data Fusion API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataplex/v1/.sidekick.toml
+++ b/src/generated/cloud/dataplex/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/dataplex/v1'
 service-config = 'google/cloud/dataplex/v1/dataplex_v1.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year = '2025'

--- a/src/generated/cloud/dataplex/v1/Cargo.toml
+++ b/src/generated/cloud/dataplex/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataplex-v1"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataplex API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dataproc/v1/.sidekick.toml
+++ b/src/generated/cloud/dataproc/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/dataproc/v1'
 service-config = 'google/cloud/dataproc/v1/dataproc_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dataproc-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Dataproc API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/datastream/v1/.sidekick.toml
+++ b/src/generated/cloud/datastream/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/datastream/v1'
 service-config = 'google/cloud/datastream/v1/datastream_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datastream-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Datastream API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/deploy/v1/.sidekick.toml
+++ b/src/generated/cloud/deploy/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/deploy/v1'
 service-config = 'google/cloud/deploy/v1/clouddeploy_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-deploy-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Deploy API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/developerconnect/v1/.sidekick.toml
+++ b/src/generated/cloud/developerconnect/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/developerconnect/v1'
 service-config = 'google/cloud/developerconnect/v1/developerconnect_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'
 
 [[documentation-overrides]]

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-developerconnect-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Developer Connect API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/cx/v3/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/cloud/dialogflow/cx/v3'
 service-config       = 'google/cloud/dialogflow/cx/v3/dialogflow_v3.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year       = '2025'
 per-service-features = 'true'

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-cx-v3"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/v2/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/v2/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/dialogflow/v2'
 service-config       = 'google/cloud/dialogflow/v2/dialogflow_v2.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year       = '2025'
 per-service-features = 'true'
 

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-v2"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/discoveryengine/v1/.sidekick.toml
+++ b/src/generated/cloud/discoveryengine/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/cloud/discoveryengine/v1'
 service-config       = 'google/cloud/discoveryengine/v1/discoveryengine_v1.yaml'
 
 [codec]
-version        = '2.2.0'
+version        = '2.2.1'
 copyright-year       = '2025'
 per-service-features = 'true'

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-discoveryengine-v1"
-version                = "2.2.0"
+version                = "2.2.1"
 description            = "Google Cloud Client Libraries for Rust - Discovery Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/documentai/v1/.sidekick.toml
+++ b/src/generated/cloud/documentai/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/documentai/v1'
 service-config = 'google/cloud/documentai/v1/documentai_v1.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year = '2025'

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-documentai-v1"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Document AI API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/domains/v1/.sidekick.toml
+++ b/src/generated/cloud/domains/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/domains/v1'
 service-config = 'google/cloud/domains/v1/domains_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-domains-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Domains API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/edgecontainer/v1/.sidekick.toml
+++ b/src/generated/cloud/edgecontainer/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/edgecontainer/v1'
 service-config = 'google/cloud/edgecontainer/v1/edgecontainer_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-edgecontainer-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Distributed Cloud Edge Container API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/edgenetwork/v1/.sidekick.toml
+++ b/src/generated/cloud/edgenetwork/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/edgenetwork/v1'
 service-config = 'google/cloud/edgenetwork/v1/edgenetwork_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-edgenetwork-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Distributed Cloud Edge Network API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/eventarc/v1/.sidekick.toml
+++ b/src/generated/cloud/eventarc/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/eventarc/v1'
 service-config = 'google/cloud/eventarc/v1/eventarc_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-eventarc-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Eventarc API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/filestore/v1/.sidekick.toml
+++ b/src/generated/cloud/filestore/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/filestore/v1'
 service-config = 'google/cloud/filestore/v1/file_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-filestore-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Filestore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/financialservices/v1/.sidekick.toml
+++ b/src/generated/cloud/financialservices/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/financialservices/v1'
 service-config = 'google/cloud/financialservices/v1/financialservices_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-financialservices-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Financial Services API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/functions/v2/.sidekick.toml
+++ b/src/generated/cloud/functions/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/functions/v2'
 service-config = 'google/cloud/functions/v2/cloudfunctions_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-functions-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Functions API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkebackup/v1/.sidekick.toml
+++ b/src/generated/cloud/gkebackup/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/gkebackup/v1'
 service-config = 'google/cloud/gkebackup/v1/gkebackup_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkebackup-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Backup for GKE API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkehub/v1/.sidekick.toml
+++ b/src/generated/cloud/gkehub/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/gkehub/v1'
 service-config = 'google/cloud/gkehub/v1/gkehub_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'
 'package:gkehub_configmanagement_v1' = 'package=google-cloud-gkehub-configmanagement-v1,source=google.cloud.gkehub.configmanagement.v1'
 'package:gkehub_multiclusteringress_v1' = 'package=google-cloud-gkehub-multiclusteringress-v1,source=google.cloud.gkehub.multiclusteringress.v1'

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkehub-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - GKE Hub"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/gkemulticloud/v1/.sidekick.toml
+++ b/src/generated/cloud/gkemulticloud/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/gkemulticloud/v1'
 service-config = 'google/cloud/gkemulticloud/v1/gkemulticloud_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-gkemulticloud-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - GKE Multi-Cloud API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/ids/v1/.sidekick.toml
+++ b/src/generated/cloud/ids/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/ids/v1'
 service-config = 'google/cloud/ids/v1/ids_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-ids-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud IDS API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/kms/v1/.sidekick.toml
+++ b/src/generated/cloud/kms/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/kms/v1'
 service-config = 'google/cloud/kms/v1/cloudkms_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-kms-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Key Management Service (KMS) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/licensemanager/v1/.sidekick.toml
+++ b/src/generated/cloud/licensemanager/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/licensemanager/v1'
 service-config = 'google/cloud/licensemanager/v1/licensemanager_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/licensemanager/v1/Cargo.toml
+++ b/src/generated/cloud/licensemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-licensemanager-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - License Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/lustre/v1/.sidekick.toml
+++ b/src/generated/cloud/lustre/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/lustre/v1'
 service-config = 'google/cloud/lustre/v1/lustre_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/lustre/v1/Cargo.toml
+++ b/src/generated/cloud/lustre/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-lustre-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Managed Lustre API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedidentities/v1/.sidekick.toml
+++ b/src/generated/cloud/managedidentities/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/managedidentities/v1'
 service-config = 'google/cloud/managedidentities/v1/managedidentities_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedidentities-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Microsoft Active Directory API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/.sidekick.toml
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/managedkafka/schemaregistry/v1'
 service-config = 'google/cloud/managedkafka/schemaregistry/v1/managedkafka_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/Cargo.toml
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedkafka-schemaregistry-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Apache Kafka API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/managedkafka/v1/.sidekick.toml
+++ b/src/generated/cloud/managedkafka/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/managedkafka/v1'
 service-config = 'google/cloud/managedkafka/v1/managedkafka_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/managedkafka/v1/Cargo.toml
+++ b/src/generated/cloud/managedkafka/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-managedkafka-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Managed Service for Apache Kafka API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/memcache/v1/.sidekick.toml
+++ b/src/generated/cloud/memcache/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/memcache/v1'
 service-config = 'google/cloud/memcache/v1/memcache_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-memcache-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Memorystore for Memcached API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/memorystore/v1/.sidekick.toml
+++ b/src/generated/cloud/memorystore/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/memorystore/v1'
 service-config = 'google/cloud/memorystore/v1/memorystore_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-memorystore-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Memorystore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/metastore/v1/.sidekick.toml
+++ b/src/generated/cloud/metastore/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/metastore/v1'
 service-config = 'google/cloud/metastore/v1/metastore_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-metastore-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Dataproc Metastore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/migrationcenter/v1/.sidekick.toml
+++ b/src/generated/cloud/migrationcenter/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/migrationcenter/v1'
 service-config = 'google/cloud/migrationcenter/v1/migrationcenter_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-migrationcenter-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Migration Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/netapp/v1/.sidekick.toml
+++ b/src/generated/cloud/netapp/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/netapp/v1'
 service-config = 'google/cloud/netapp/v1/netapp_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-netapp-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - NetApp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkconnectivity/v1/.sidekick.toml
+++ b/src/generated/cloud/networkconnectivity/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/networkconnectivity/v1'
 service-config = 'google/cloud/networkconnectivity/v1/networkconnectivity_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkconnectivity-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Network Connectivity API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkmanagement/v1/.sidekick.toml
+++ b/src/generated/cloud/networkmanagement/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/networkmanagement/v1'
 service-config = 'google/cloud/networkmanagement/v1/networkmanagement_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkmanagement-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Network Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networksecurity/v1/.sidekick.toml
+++ b/src/generated/cloud/networksecurity/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/networksecurity/v1'
 service-config = 'google/cloud/networksecurity/v1/networksecurity_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networksecurity-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Network Security API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/networkservices/v1/.sidekick.toml
+++ b/src/generated/cloud/networkservices/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/networkservices/v1'
 service-config = 'google/cloud/networkservices/v1/networkservices_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'
 
 [[documentation-overrides]]

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-networkservices-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Network Services API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/notebooks/v2/.sidekick.toml
+++ b/src/generated/cloud/notebooks/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/notebooks/v2'
 service-config = 'google/cloud/notebooks/v2/notebooks_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-notebooks-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Notebooks API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/optimization/v1/.sidekick.toml
+++ b/src/generated/cloud/optimization/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/optimization/v1'
 service-config = 'google/cloud/optimization/v1/cloudoptimization_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-optimization-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Optimization API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/oracledatabase/v1/.sidekick.toml
+++ b/src/generated/cloud/oracledatabase/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/oracledatabase/v1'
 service-config = 'google/cloud/oracledatabase/v1/oracledatabase_v1.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year = '2025'

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-oracledatabase-v1"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Oracle Database@Google Cloud API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/orchestration/airflow/service/v1/.sidekick.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/orchestration/airflow/service/v1'
 service-config = 'google/cloud/orchestration/airflow/service/v1/composer_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-orchestration-airflow-service-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Composer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/osconfig/v1/.sidekick.toml
+++ b/src/generated/cloud/osconfig/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/cloud/osconfig/v1'
 service-config = 'google/cloud/osconfig/v1/osconfig_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links,bare_urls,invalid_html_tags"

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-osconfig-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - OS Config API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/parallelstore/v1/.sidekick.toml
+++ b/src/generated/cloud/parallelstore/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/parallelstore/v1'
 service-config = 'google/cloud/parallelstore/v1/parallelstore_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-parallelstore-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Parallelstore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/policysimulator/v1/.sidekick.toml
+++ b/src/generated/cloud/policysimulator/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/cloud/policysimulator/v1'
 service-config = 'google/cloud/policysimulator/v1/policysimulator_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year         = '2025'
 'package:orgpolicy_v2' = 'package=google-cloud-orgpolicy-v2,source=google.cloud.orgpolicy.v2'

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-policysimulator-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Policy Simulator API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/privilegedaccessmanager/v1/.sidekick.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/privilegedaccessmanager/v1'
 service-config = 'google/cloud/privilegedaccessmanager/v1/privilegedaccessmanager_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-privilegedaccessmanager-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Privileged Access Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/rapidmigrationassessment/v1/.sidekick.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/rapidmigrationassessment/v1'
 service-config = 'google/cloud/rapidmigrationassessment/v1/rapidmigrationassessment_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-rapidmigrationassessment-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Rapid Migration Assessment API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/redis/cluster/v1/.sidekick.toml
+++ b/src/generated/cloud/redis/cluster/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/redis/cluster/v1'
 service-config = 'google/cloud/redis/cluster/v1/redis_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-redis-cluster-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Memorystore for Redis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/redis/v1/.sidekick.toml
+++ b/src/generated/cloud/redis/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/redis/v1'
 service-config = 'google/cloud/redis/v1/redis_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-redis-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Google Cloud Memorystore for Redis API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/resourcemanager/v3/.sidekick.toml
+++ b/src/generated/cloud/resourcemanager/v3/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/resourcemanager/v3'
 service-config = 'google/cloud/resourcemanager/v3/cloudresourcemanager_v3.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-resourcemanager-v3"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Resource Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/retail/v2/.sidekick.toml
+++ b/src/generated/cloud/retail/v2/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/retail/v2'
 service-config       = 'google/cloud/retail/v2/retail_v2.yaml'
 
 [codec]
-version        = '2.1.0'
+version        = '2.1.1'
 copyright-year = '2025'
 
 [[documentation-overrides]]

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-retail-v2"
-version                = "2.1.0"
+version                = "2.1.1"
 description            = "Google Cloud Client Libraries for Rust - Vertex AI Search for commerce API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/run/v2/.sidekick.toml
+++ b/src/generated/cloud/run/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/run/v2'
 service-config = 'google/cloud/run/v2/run_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-run-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Run Admin API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securesourcemanager/v1/.sidekick.toml
+++ b/src/generated/cloud/securesourcemanager/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/securesourcemanager/v1'
 service-config = 'google/cloud/securesourcemanager/v1/securesourcemanager_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securesourcemanager-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Secure Source Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/security/privateca/v1/.sidekick.toml
+++ b/src/generated/cloud/security/privateca/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/security/privateca/v1'
 service-config = 'google/cloud/security/privateca/v1/privateca_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-security-privateca-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Certificate Authority API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securitycenter/v2/.sidekick.toml
+++ b/src/generated/cloud/securitycenter/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/securitycenter/v2'
 service-config = 'google/cloud/securitycenter/v2/securitycenter_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securitycenter-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Security Command Center API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securityposture/v1/.sidekick.toml
+++ b/src/generated/cloud/securityposture/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/securityposture/v1'
 service-config = 'google/cloud/securityposture/v1/securityposture_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securityposture-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Security Posture API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/shell/v1/.sidekick.toml
+++ b/src/generated/cloud/shell/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/shell/v1'
 service-config = 'google/cloud/shell/v1/cloudshell_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-shell-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Shell API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/speech/v2/.sidekick.toml
+++ b/src/generated/cloud/speech/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/speech/v2'
 service-config = 'google/cloud/speech/v2/speech_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-speech-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Speech-to-Text API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/storagebatchoperations/v1/.sidekick.toml
+++ b/src/generated/cloud/storagebatchoperations/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/storagebatchoperations/v1'
 service-config       = 'google/cloud/storagebatchoperations/v1/storagebatchoperations_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
+++ b/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storagebatchoperations-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Storage Batch Operations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/storageinsights/v1/.sidekick.toml
+++ b/src/generated/cloud/storageinsights/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/storageinsights/v1'
 service-config = 'google/cloud/storageinsights/v1/storageinsights_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'
 name-overrides    = """\
 .google.cloud.storageinsights.v1.DatasetConfig.cloud_storage_buckets=CloudStorageBucketsOneOf,\

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storageinsights-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Storage Insights API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/talent/v4/.sidekick.toml
+++ b/src/generated/cloud/talent/v4/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/talent/v4'
 service-config = 'google/cloud/talent/v4/jobs_v4.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-talent-v4"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Talent Solution API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/telcoautomation/v1/.sidekick.toml
+++ b/src/generated/cloud/telcoautomation/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/telcoautomation/v1'
 service-config = 'google/cloud/telcoautomation/v1/telcoautomation_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-telcoautomation-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Telco Automation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/texttospeech/v1/.sidekick.toml
+++ b/src/generated/cloud/texttospeech/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/texttospeech/v1'
 service-config = 'google/cloud/texttospeech/v1/texttospeech_v1.yaml'
 
 [codec]
-version        = '1.3.0'
+version        = '1.3.1'
 copyright-year = '2025'

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-texttospeech-v1"
-version                = "1.3.0"
+version                = "1.3.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Text-to-Speech API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/tpu/v2/.sidekick.toml
+++ b/src/generated/cloud/tpu/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/tpu/v2'
 service-config = 'google/cloud/tpu/v2/tpu_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-tpu-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud TPU API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/translate/v3/.sidekick.toml
+++ b/src/generated/cloud/translate/v3/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/translate/v3'
 service-config = 'google/cloud/translate/v3/translate_v3.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-translation-v3"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Translation API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/livestream/v1/.sidekick.toml
+++ b/src/generated/cloud/video/livestream/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/video/livestream/v1'
 service-config = 'google/cloud/video/livestream/v1/livestream_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-livestream-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Live Stream API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/video/stitcher/v1/.sidekick.toml
+++ b/src/generated/cloud/video/stitcher/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/video/stitcher/v1'
 service-config = 'google/cloud/video/stitcher/v1/videostitcher_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-video-stitcher-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Video Stitcher API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/videointelligence/v1/.sidekick.toml
+++ b/src/generated/cloud/videointelligence/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/videointelligence/v1'
 service-config = 'google/cloud/videointelligence/v1/videointelligence_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-videointelligence-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Video Intelligence API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vision/v1/.sidekick.toml
+++ b/src/generated/cloud/vision/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/vision/v1'
 service-config = 'google/cloud/vision/v1/vision_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vision-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Vision API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vmmigration/v1/.sidekick.toml
+++ b/src/generated/cloud/vmmigration/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/vmmigration/v1'
 service-config = 'google/cloud/vmmigration/v1/vmmigration_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vmmigration-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - VM Migration API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vmwareengine/v1/.sidekick.toml
+++ b/src/generated/cloud/vmwareengine/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/vmwareengine/v1'
 service-config = 'google/cloud/vmwareengine/v1/vmwareengine_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vmwareengine-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - VMware Engine API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vpcaccess/v1/.sidekick.toml
+++ b/src/generated/cloud/vpcaccess/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/vpcaccess/v1'
 service-config = 'google/cloud/vpcaccess/v1/vpcaccess_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vpcaccess-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Serverless VPC Access API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/webrisk/v1/.sidekick.toml
+++ b/src/generated/cloud/webrisk/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/webrisk/v1'
 service-config = 'google/cloud/webrisk/v1/webrisk_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-webrisk-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Web Risk API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workflows/v1/.sidekick.toml
+++ b/src/generated/cloud/workflows/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/cloud/workflows/v1'
 service-config       = 'google/cloud/workflows/v1/workflows_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'
 # TODO(#1285) - remove `redundant_explicit_links` workaround when no longer needed
 # TODO(#742) - remove `broken_intro_doc_links` workaround when no longer needed

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workflows-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Workflows API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/workstations/v1/.sidekick.toml
+++ b/src/generated/cloud/workstations/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/cloud/workstations/v1'
 service-config = 'google/cloud/workstations/v1/workstations_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-workstations-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Workstations API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/datastore/admin/v1/.sidekick.toml
+++ b/src/generated/datastore/admin/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/datastore/admin/v1'
 service-config = 'google/datastore/admin/v1/datastore_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-datastore-admin-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Datastore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/artifactregistry/v1/.sidekick.toml
+++ b/src/generated/devtools/artifactregistry/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/devtools/artifactregistry/v1'
 service-config = 'google/devtools/artifactregistry/v1/artifactregistry_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 package-name-override = 'google-cloud-artifactregistry-v1'

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-artifactregistry-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Artifact Registry API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudbuild/v1/.sidekick.toml
+++ b/src/generated/devtools/cloudbuild/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/devtools/cloudbuild/v1'
 service-config = 'google/devtools/cloudbuild/v1/cloudbuild_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 package-name-override = 'google-cloud-build-v1'

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-build-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Build API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/devtools/cloudbuild/v2/.sidekick.toml
+++ b/src/generated/devtools/cloudbuild/v2/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/devtools/cloudbuild/v2'
 service-config = 'google/devtools/cloudbuild/v2/cloudbuild_v2.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 package-name-override = 'google-cloud-build-v2'

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-build-v2"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Build API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/firestore/admin/v1/.sidekick.toml
+++ b/src/generated/firestore/admin/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/firestore/admin/v1'
 service-config = 'google/firestore/admin/v1/firestore_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-firestore-admin-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Firestore API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v2/.sidekick.toml
+++ b/src/generated/iam/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/iam/v2'
 service-config = 'google/iam/v2/iam_v2.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v2"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/iam/v3/.sidekick.toml
+++ b/src/generated/iam/v3/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/iam/v3'
 service-config = 'google/iam/v3/iam_v3.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-iam-v3"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Identity and Access Management (IAM) API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/identity/accesscontextmanager/v1/.sidekick.toml
+++ b/src/generated/identity/accesscontextmanager/v1/.sidekick.toml
@@ -17,6 +17,6 @@ specification-source = 'google/identity/accesscontextmanager/v1'
 service-config = 'google/identity/accesscontextmanager/v1/accesscontextmanager_v1.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'
 'package:accesscontextmanager_type' = 'package=google-cloud-identity-accesscontextmanager-type,source=google.identity.accesscontextmanager.type'

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-identity-accesscontextmanager-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Access Context Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/logging/v2/.sidekick.toml
+++ b/src/generated/logging/v2/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/logging/v2'
 service-config = 'google/logging/v2/logging_v2.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-logging-v2"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Logging API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/monitoring/metricsscope/v1/.sidekick.toml
+++ b/src/generated/monitoring/metricsscope/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/monitoring/metricsscope/v1'
 service-config = 'google/monitoring/metricsscope/v1/monitoring.yaml'
 
 [codec]
-version        = '1.1.0'
+version        = '1.1.1'
 copyright-year = '2025'

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-monitoring-metricsscope-v1"
-version                = "1.1.0"
+version                = "1.1.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Monitoring API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/spanner/admin/database/v1/.sidekick.toml
+++ b/src/generated/spanner/admin/database/v1/.sidekick.toml
@@ -17,7 +17,7 @@ specification-source = 'google/spanner/admin/database/v1'
 service-config = 'google/spanner/admin/database/v1/spanner.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year       = '2025'
 
 [source]

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-spanner-admin-database-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Spanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/spanner/admin/instance/v1/.sidekick.toml
+++ b/src/generated/spanner/admin/instance/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/spanner/admin/instance/v1'
 service-config = 'google/spanner/admin/instance/v1/spanner.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-spanner-admin-instance-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Cloud Spanner API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/storagetransfer/v1/.sidekick.toml
+++ b/src/generated/storagetransfer/v1/.sidekick.toml
@@ -17,5 +17,5 @@ specification-source = 'google/storagetransfer/v1'
 service-config = 'google/storagetransfer/v1/storagetransfer_v1.yaml'
 
 [codec]
-version        = '1.2.0'
+version        = '1.2.1'
 copyright-year = '2025'

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-storagetransfer-v1"
-version                = "1.2.0"
+version                = "1.2.1"
 description            = "Google Cloud Client Libraries for Rust - Storage Transfer API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -19,7 +19,7 @@ name        = "google-cloud-lro"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version = "1.1.0"
+version = "1.1.1"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-storage"
-version     = "1.3.0"
+version     = "1.3.1"
 description = "Google Cloud Client Libraries for Rust - Storage"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
This may be too eager, but we bumped the version of longrunning in the workspace Cargo.toml and many of these crates depend on features in the upgraded version.

There are 122 files containing "longrunning.workspace". 119 of those are changed in this PR. The other files are the user-guide-samples, integration-tests, and google-cloud-showcase-v1beta1 crates, and these are marked as publish=false so did not need a change.

For #3793