### PR TITLE
chore: bump versions for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ auth                          = { version = "1.1", path = "src/auth", package = 
 google-cloud-auth             = { version = "1.1", path = "src/auth" }
 gax                           = { version = "1.3", path = "src/gax", package = "google-cloud-gax" }
 google-cloud-gax              = { version = "1.3", path = "src/gax" }
-gaxi                          = { version = "0.7.4", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                          = { version = "0.7.5", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "1", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 google-cloud-iam-v1           = { version = "1", path = "src/generated/iam/v1" }
 location                      = { version = "1", path = "src/generated/cloud/location", package = "google-cloud-location" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -18,7 +18,7 @@ name = "google-cloud-auth"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version     = "1.1.1"
+version     = "1.2.0"
 description = "Google Cloud Client Libraries for Rust - Authentication"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.7.4"
+version     = "0.7.5"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -18,7 +18,7 @@ name = "google-cloud-gax"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version     = "1.3.0"
+version     = "1.3.1"
 description = "Google Cloud Client Libraries for Rust"
 # Inherit other attributes from the workspace.
 authors.workspace      = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-storage"
-version     = "1.3.1"
+version     = "1.4.0"
 description = "Google Cloud Client Libraries for Rust - Storage"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
Use `sidekick rust-bump-versions` to bump the versions for the release.

I made some changes to the output:
- gaxi 0.8.0 -> 0.7.5

Summary of non-patch updates:
- auth is bumped to 1.2.0 with some jsonwebtoken changes
- storage is bumped with changes to ReadObject cloning.

For #3793 