### PR TITLE
Switch to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,7 +325,7 @@ thiserror             = { default-features = false, version = "2" }
 time                  = { default-features = false, version = "0.3.44" }
 tokio                 = { default-features = false, version = "1" }
 tokio-metrics         = { default-features = false, version = "0.4.5" }
-tonic                 = { default-features = false, version = "0.14.1", features = ["tls-native-roots", "tls-ring"] }
+tonic                 = { default-features = false, version = "0.14.1", features = ["tls-ring", "tls-webpki-roots"] }
 tonic-prost           = { default-features = false, version = "0.14.2" }
 tonic-prost-build     = { default-features = false, version = "0.14.1" }
 tower                 = { default-features = false, version = "0.5", features = ["util"] }


### PR DESCRIPTION
Replace native-tls (OpenSSL) with rustls-tls in the workspace reqwest
dependency to enable cross-compilation to musl targets without requiring
OpenSSL cross-compilation toolchain.

This change adds `rustls-tls` and `rustls-tls-webpki-roots` features to
the reqwest workspace dependency, which propagates to all crates that
use reqwest via the workspace, including google-cloud-gax-internal.

Benefits:
- Eliminates OpenSSL dependency and cross-compilation complexity
- Enables musl target builds without vendored OpenSSL or cargo-zigbuild
- Reduces binary size (rustls is pure Rust, no C dependencies)
- Improves musl compatibility and static linking support

The change maintains API compatibility as reqwest's rustls backend
provides equivalent functionality to native-tls for HTTP client operations.