### PR TITLE
impl(auth): simplify invalid verification error fn into one

### DIFF
--- a/src/auth/src/credentials/idtoken/verifier.rs
+++ b/src/auth/src/credentials/idtoken/verifier.rs
@@ -236,12 +236,7 @@ impl Error {
 
     /// A problem validating JWT token accordingly to set criteria.
     pub fn is_invalid(&self) -> bool {
-        matches!(self.0, ErrorKind::Invalid(_))
-    }
-
-    /// A problem validating JWT token on a specific field.
-    pub fn is_invalid_field(&self) -> bool {
-        matches!(self.0, ErrorKind::InvalidField(_, _))
+        matches!(self.0, ErrorKind::Invalid(_)) || matches!(self.0, ErrorKind::InvalidField(_, _))
     }
 
     /// A problem fetching certificates to validate the JWT token.
@@ -250,7 +245,7 @@ impl Error {
     }
 
     /// A problem to decode the JWT token.
-    pub(crate) fn decode<T>(source: T) -> Error
+    fn decode<T>(source: T) -> Error
     where
         T: Into<BoxError>,
     {
@@ -258,7 +253,7 @@ impl Error {
     }
 
     /// A problem fetching certificates to validate the JWT token.
-    pub(crate) fn load_cert<T>(source: T) -> Error
+    fn load_cert<T>(source: T) -> Error
     where
         T: Into<BoxError>,
     {
@@ -266,7 +261,7 @@ impl Error {
     }
 
     /// Validation error of the JWT Token.
-    pub(crate) fn invalid<T>(source: T) -> Error
+    fn invalid<T>(source: T) -> Error
     where
         T: Into<BoxError>,
     {
@@ -274,7 +269,7 @@ impl Error {
     }
 
     /// Validation error of the JWT Token on a specific field.
-    pub(crate) fn invalid_field<S: Into<String>, T>(field: S, source: T) -> Error
+    fn invalid_field<S: Into<String>, T>(field: S, source: T) -> Error
     where
         T: Into<BoxError>,
     {
@@ -374,7 +369,7 @@ pub(crate) mod tests {
 
         let result = verifier.verify(token).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_field());
+        assert!(result.unwrap_err().is_invalid());
 
         Ok(())
     }
@@ -424,7 +419,7 @@ pub(crate) mod tests {
 
         let result = verifier.verify(token).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_field());
+        assert!(result.unwrap_err().is_invalid());
 
         Ok(())
     }
@@ -483,7 +478,7 @@ pub(crate) mod tests {
 
         let result = verifier.verify(token).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_field());
+        assert!(result.unwrap_err().is_invalid());
         Ok(())
     }
 
@@ -538,7 +533,7 @@ pub(crate) mod tests {
 
         let result = verifier.verify(token).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_field());
+        assert!(result.unwrap_err().is_invalid());
         Ok(())
     }
 
@@ -600,7 +595,7 @@ pub(crate) mod tests {
 
         let result = verifier.verify(&token).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_field());
+        assert!(result.unwrap_err().is_invalid());
 
         Ok(())
     }


### PR DESCRIPTION
After team review, we discussed that `is_invalid_field` vs `is_invalid` is not much different and actionable from the user standpoint. We are gonna introduce later a `is_retryable` (which is tracked in #3592), which is more actionable and can cover more cases like token expiration, failed to load certs and etc. For now `is_invalid` cover all invalid use cases and the debug msg can have extra information for the `InvalidField` variant, which is gonna be maintained.

Towards #3449 