### PR TITLE
ci: pin mdbook version to fix ci

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -460,7 +460,7 @@ jobs:
           set -e
           rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
           rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
-          cargo install mdbook
+          cargo install mdbook@0.4.52
       - name: Display Cargo version
         run: cargo version
       - name: Display rustc version


### PR DESCRIPTION
This appears to be an issue with the newly released version of mdbook. Pin to an older version until this is resolved.

For #3835 