### PR TITLE
tests: Mark some examples as compile_fail

### DIFF
--- a/src/gax-internal/src/observability/client_tracing.rs
+++ b/src/gax-internal/src/observability/client_tracing.rs
@@ -26,7 +26,7 @@ use tracing::{Span, field};
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```compile_fail
 /// let span = create_client_request_span(
 ///     "google_cloud_storage::client::Client::upload_chunk",
 ///     "upload_chunk",

--- a/src/storage/src/storage/bidi/builder.rs
+++ b/src/storage/src/storage/bidi/builder.rs
@@ -22,7 +22,7 @@ use gaxi::prost::ToProto;
 /// A request builder for `open_object()`.
 ///
 /// # Example
-/// ```ignore
+/// ```compile_fail
 /// use google_cloud_storage::client::Storage;
 /// use google_cloud_storage::retry_policy::RetryableErrors;
 /// async fn sample(client: &Storage) -> anyhow::Result<()> {
@@ -75,7 +75,7 @@ impl OpenObject {
     /// opposed to the latest version, the default).
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
@@ -95,7 +95,7 @@ impl OpenObject {
     /// matches the given value.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
@@ -119,7 +119,7 @@ impl OpenObject {
     /// fails.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
@@ -142,7 +142,7 @@ impl OpenObject {
     /// metageneration matches the given value.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
@@ -165,7 +165,7 @@ impl OpenObject {
     /// metageneration does not match the given value.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};
@@ -188,7 +188,7 @@ impl OpenObject {
     /// feature. In raw bytes format (not base64-encoded).
     ///
     /// Example:
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::{model_ext::KeyAes256, client::Storage};
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let key: &[u8] = &[97; 32];
@@ -211,7 +211,7 @@ impl OpenObject {
     /// The retry policy used for this request.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::retry_policy::RetryableErrors;
@@ -237,7 +237,7 @@ impl OpenObject {
     /// The backoff policy used for this request.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use std::time::Duration;
@@ -266,7 +266,7 @@ impl OpenObject {
     /// requests.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let response = client
@@ -296,7 +296,7 @@ impl OpenObject {
     /// treated as retryable.
     ///
     /// # Example
-    /// ```ignore
+    /// ```compile_fail
     /// # use google_cloud_storage::client::Storage;
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// use google_cloud_storage::read_resume_policy::{AlwaysResume, ReadResumePolicyExt};


### PR DESCRIPTION
We will mark generated examples as ignore because they take a long time to build. Still we want to test them weekly using `--ignored` which builds and runs all ignored examples.

The examples on this PR were previously marked as ignore because they don't build by design. If we keep them as are they will fail when we use `--ignored` to run ignore samples, so we mark them as compile_fail instead.

Towards #2808