### PR TITLE
docs: update maintenance how-to

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -161,6 +161,7 @@ Wait for the PR to be approved and merged.
 Then finish your PR in `google-cloud-rust`.
 
 1. Update the default librarian version:
+
    ```bash
    GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main >.sidekick-version.txt
    ```


### PR DESCRIPTION
I like to run the same version of `sidekick` as the CI does. It is easier to do that now.

Updating the librarian version also got more mechanical, update the instructions too.