### PR TITLE
impl(storage): add `ObjectDescriptor` struct

### DIFF
--- a/src/storage/src/read_object.rs
+++ b/src/storage/src/read_object.rs
@@ -37,6 +37,11 @@ impl ReadObjectResponse {
         Self { inner }
     }
 
+    #[cfg(google_cloud_unstable_storage_bidi)]
+    pub(crate) fn from_dyn(inner: Box<dyn dynamic::ReadObjectResponse + Send>) -> Self {
+        Self { inner }
+    }
+
     /// Create a ReadObjectResponse, given a data source.
     ///
     /// Use this method to mock the return type of

--- a/src/storage/src/storage/bidi.rs
+++ b/src/storage/src/storage/bidi.rs
@@ -16,6 +16,7 @@ mod active_read;
 mod builder;
 mod connector;
 mod normalized_range;
+mod object_descriptor;
 mod range_reader;
 mod redirect;
 mod remaining_range;

--- a/src/storage/src/storage/bidi/object_descriptor.rs
+++ b/src/storage/src/storage/bidi/object_descriptor.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::stub::dynamic::ObjectDescriptor as ObjectDescriptorStub;
+use crate::model::Object;
+use crate::model_ext::ReadRange;
+use crate::read_object::ReadObjectResponse;
+
+#[derive(Debug)]
+pub struct ObjectDescriptor {
+    inner: Box<dyn ObjectDescriptorStub>,
+}
+
+impl ObjectDescriptor {
+    pub fn new<T>(inner: T) -> Self
+    where
+        T: ObjectDescriptorStub + 'static,
+    {
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
+    pub fn object(&self) -> &Object {
+        self.inner.object()
+    }
+
+    pub async fn read_range(&self, range: ReadRange) -> ReadObjectResponse {
+        let inner = self.inner.read_range(range).await;
+        ReadObjectResponse::from_dyn(inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_ext::ObjectHighlights;
+    use crate::read_object::dynamic::ReadObjectResponse;
+    use mockall::mock;
+
+    #[tokio::test]
+    async fn can_be_mocked() -> anyhow::Result<()> {
+        let object = Object::new().set_name("test-object").set_generation(123456);
+        let mut mock = MockDescriptor::new();
+        mock.expect_object().times(1).return_const(object.clone());
+        mock.expect_read_range()
+            .times(1)
+            .withf(|range| range.0 == ReadRange::segment(100, 200).0)
+            .returning(|_| Box::new(MockResponse::new()));
+
+        let descriptor = ObjectDescriptor::new(mock);
+        assert_eq!(descriptor.object(), &object);
+
+        let _reader = descriptor.read_range(ReadRange::segment(100, 200)).await;
+        Ok(())
+    }
+
+    mock! {
+        #[derive(Debug)]
+        Descriptor {}
+
+        impl super::super::stub::ObjectDescriptor for Descriptor {
+            fn object(&self) -> &Object;
+            async fn read_range(&self, range: ReadRange) -> Box<dyn ReadObjectResponse + Send>;
+        }
+    }
+
+    mock! {
+        #[derive(Debug)]
+        Response {}
+
+        #[async_trait::async_trait]
+        impl crate::read_object::dynamic::ReadObjectResponse for Response {
+            fn object(&self) -> ObjectHighlights;
+            async fn next(&mut self) -> Option<crate::Result<bytes::Bytes>>;
+        }
+    }
+}


### PR DESCRIPTION
An object descriptor is (or will be) the result of calling `open_object()` to start a bidi streaming read session. Applications can issue one or more ranged reads on an object descriptor.

There are some breadcumbs to help me build a mocking layer, but they are not fully functional.

Part of the work for #3740 