### PR TITLE
ci: Easy notifications for non GH Action checks

### DIFF
--- a/.github/workflows/non-gha-notifications.yaml
+++ b/.github/workflows/non-gha-notifications.yaml
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Notifications for non GH Actions checks
+permissions: read-all
+on:
+  # We can easily get notifications for GH Actions but not for anything else.
+  # This does not trigger for GH Actions but it will trigger for other checks,
+  # effectively chaining a GH Action after completion of any other checks.
+  # We can use the continuation GH Action to receive notifications about the original check.
+  # Note: we are using check_suite as a means to get a single notification for all
+  # non-GH Action checks per commit per GH App. We can use check_run if we need more
+  # granularity.
+  check_suite:
+    types: [completed]
+
+jobs:
+  gcb-notify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check GCB checks to have completed
+        # This is a way to trigger notifications for GCB workflows.
+        run: |
+          set -eu
+          CONCLUSION="${{ github.event.check_suite.conclusion }}"
+          APP_NAME="${{ github.event.check_suite.app.name }}"
+
+          echo "The check suite triggered by app: '${APP_NAME}' finished with status: '${CONCLUSION}'"
+
+          if [[ "${CONCLUSION}" != "success" ]]; then
+            exit 1 # Fails the step and the job
+          fi


### PR DESCRIPTION
Closes #3908.

See this working on my fork: https://github.com/amanda-tarafa/google-cloud-rust/runs/56582051719