### PR TITLE
test(storage): fixes in random access benchmark

### DIFF
--- a/src/storage/benchmarks/random/README.md
+++ b/src/storage/benchmarks/random/README.md
@@ -41,7 +41,7 @@ TS=$(date +%s); cargo run --release --package storage-random -- \
     --min-range-size 8KiB --max-range-size 8KiB \
     --min-batch-size 16 --max-batch-size 16 \
     --task-count=4 \
-    --min-sample-count=1000  >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
+    --min-sample-count=1000 bidi  >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
 ```
 
 Wait for the program to finish.
@@ -61,8 +61,8 @@ Then upload the results of the experiment:
 
 ```shell
 bq load --source_format CSV --skip_leading_rows 1 \
-    ${GOOGLE_CLOUD_PROJECT}:random.small001 bm-${TS}.txt \
-    Task:int64,Iteration:int64,IterationStart:int64,RangeId:int64,RangeCount:int64,RangeSize:int64,Protocol,TtfbMicroseconds:int64,TtlbMicroseconds:int64,Object,Details
+    ${GOOGLE_CLOUD_PROJECT}:random.bm-${TS} bm-${TS}.txt \
+    Task:int64,Iteration:int64,IterationStart:int64,RangeId:int64,RangeCount:int64,RangeOffset:int64,RangeSize:int64,Protocol,TransferSize:int64,TtfbMicroseconds:int64,TtlbMicroseconds:int64,Object,Details
 ```
 
 [compute-optimized]: https://cloud.google.com/compute/docs/compute-optimized-machines

--- a/src/storage/benchmarks/random/src/bidi.rs
+++ b/src/storage/benchmarks/random/src/bidi.rs
@@ -64,14 +64,16 @@ impl Runner {
             );
         };
         let mut reader = descriptor
-            .read_range(ReadRange::segment(range.read_offset, range.read_offset))
+            .read_range(ReadRange::segment(range.read_offset, range.read_length))
             .await;
         let mut ttfb = None;
-        while reader.next().await.transpose()?.is_some() {
+        let mut size = 0;
+        while let Some(b) = reader.next().await.transpose()? {
             let _ = ttfb.get_or_insert(Instant::now() - start);
+            size += b.len();
         }
         let ttlb = Instant::now() - start;
         let ttfb = ttfb.unwrap_or(ttlb);
-        Ok(Attempt { ttfb, ttlb })
+        Ok(Attempt { size, ttfb, ttlb })
     }
 }

--- a/src/storage/benchmarks/random/src/json.rs
+++ b/src/storage/benchmarks/random/src/json.rs
@@ -47,12 +47,15 @@ impl Runner {
         let mut reader = self
             .client
             .read_object(range.bucket_name.clone(), range.object_name.clone())
-            .set_read_range(ReadRange::segment(range.read_offset, range.read_offset))
+            .set_read_range(ReadRange::segment(range.read_offset, range.read_length))
             .send()
             .await?;
         let ttfb = Instant::now() - start;
-        while reader.next().await.transpose()?.is_some() {}
+        let mut size = 0;
+        while let Some(b) = reader.next().await.transpose()? {
+            size += b.len();
+        }
         let ttlb = Instant::now() - start;
-        Ok(Attempt { ttfb, ttlb })
+        Ok(Attempt { size, ttfb, ttlb })
     }
 }

--- a/src/storage/benchmarks/random/src/main.rs
+++ b/src/storage/benchmarks/random/src/main.rs
@@ -123,15 +123,16 @@ async fn runner(
                 .zip(experiment.ranges)
                 .enumerate()
                 .map(|(i, (result, range))| {
-                    let (ttfb, ttlb, details) = match result {
-                        Ok(a) => (a.ttfb, a.ttlb, "OK"),
+                    let (size, ttfb, ttlb, details) = match result {
+                        Ok(a) => (a.size, a.ttfb, a.ttlb, "OK"),
                         Err(e) => {
                             tracing::error!("error on range {i}: {e:?}");
-                            (elapsed, elapsed, "ERROR")
+                            (0, elapsed, elapsed, "ERROR")
                         }
                     };
                     Sample {
                         protocol,
+                        transfer_size: size,
                         ttfb,
                         ttlb,
                         details: details.to_string(),
@@ -140,6 +141,7 @@ async fn runner(
                         range_id: i,
                         range_count,
                         start: relative_start,
+                        range_offset: range.read_offset,
                         range_length: range.read_length,
                         object: range.object_name,
                     }

--- a/src/storage/benchmarks/random/src/sample.rs
+++ b/src/storage/benchmarks/random/src/sample.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 #[derive(Clone, Debug)]
 pub struct Attempt {
+    pub size: usize,
     pub ttfb: Duration,
     pub ttlb: Duration,
 }
@@ -27,7 +28,9 @@ pub struct Sample {
     pub start: Duration,
     pub range_id: usize,
     pub range_count: usize,
+    pub range_offset: u64,
     pub range_length: u64,
+    pub transfer_size: usize,
     pub protocol: Protocol,
     pub ttfb: Duration,
     pub ttlb: Duration,
@@ -38,20 +41,23 @@ pub struct Sample {
 impl Sample {
     pub const HEADER: &str = concat!(
         "Task,Iteration,IterationStart,RangeId,RangeCount",
-        ",RangeSize,Protocol,TtfbMicroseconds,TtlbMicroseconds",
+        ",RangeOffset,RangeSize,Protocol",
+        ",TransferSize,TtfbMicroseconds,TtlbMicroseconds",
         ",Object,Details"
     );
 
     pub fn to_row(&self) -> String {
         format!(
-            "{},{},{},{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{},{},{},{},{}",
             self.task,
             self.iteration,
             self.start.as_micros(),
             self.range_id,
             self.range_count,
+            self.range_offset,
             self.range_length,
             self.protocol.name(),
+            self.transfer_size,
             self.ttfb.as_micros(),
             self.ttlb.as_micros(),
             self.object,


### PR DESCRIPTION
Report the range offset, in case it impacts the results (does not seem to). Also report the bytes transferred, which helped be find a bug on the transfer length.