### PR TITLE
ci: minimal version helper should not escape line break

### DIFF
--- a/tools/minimal-version-helper/src/main.rs
+++ b/tools/minimal-version-helper/src/main.rs
@@ -140,7 +140,7 @@ fn prep(is_local: bool) -> Result<()> {
                 }) {
                     println!("Found unpublished crate: {} v{}", name, version);
                     patched.push(name);
-                    patch_content.push_str(&format!(r#"{} = {{ path = "{}" }}\n"#, name, path));
+                    patch_content.push_str(&format!("{} = {{ path = \"{}\" }}\n", name, path));
                 }
             }
             Err(e) => {


### PR DESCRIPTION
When bumping the auth crate, I found this issue when generating the cargo config toml file with versions to patch: 

```
INFO 2025-12-02T20:15:08.877619531Z Step #1: Caused by:
INFO 2025-12-02T20:15:08.877620519Z Step #1: could not parse TOML configuration in `/workspace/.cargo/config.toml`
INFO 2025-12-02T20:15:08.877620849Z Step #1:
INFO 2025-12-02T20:15:08.877621089Z Step #1: Caused by:
INFO 2025-12-02T20:15:08.877621548Z Step #1: TOML parse error at line 3, column 42
INFO 2025-12-02T20:15:08.877622207Z Step #1: |
INFO 2025-12-02T20:15:08.877623026Z Step #1: 3 | google-cloud-auth = { path = "src/auth" }\n
INFO 2025-12-02T20:15:08.877623376Z Step #1: | ^
INFO 2025-12-02T20:15:08.877623535Z Step #1: unexpected key or value, expected newline, `#`
```