### PR TITLE
impl(pubsub): add `Leaser` trait

### DIFF
--- a/src/pubsub/src/subscriber.rs
+++ b/src/pubsub/src/subscriber.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub(crate) mod lease_state;
+pub(crate) mod leaser;

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A trait representing leaser actions
+///
+/// We stub out the interface, in order to test the lease management.
+#[async_trait::async_trait]
+pub(crate) trait Leaser {
+    /// Acknowledge a batch of messages.
+    async fn ack(&self, ack_ids: Vec<String>);
+    /// Negatively acknowledge a batch of messages.
+    async fn nack(&self, ack_ids: Vec<String>);
+    /// Extend lease deadlines for a batch of messages.
+    async fn extend(&self, ack_ids: Vec<String>);
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    mockall::mock! {
+        #[derive(Debug)]
+        pub(crate) Leaser {}
+        #[async_trait::async_trait]
+        impl Leaser for Leaser {
+            async fn ack(&self, ack_ids: Vec<String>);
+            async fn nack(&self, ack_ids: Vec<String>);
+            async fn extend(&self, ack_ids: Vec<String>);
+        }
+    }
+}


### PR DESCRIPTION
Part of the work for #3957 

Add an internal `trait Leaser` which can take actions in the (upcoming) lease loop.

Future PRs will add the concrete implementation of this which will actually send `Acknowledge` and `ModifyAckDeadline` RPCs.