### PR TITLE
chore: update rust version for ref upload

### DIFF
--- a/.gcb/referenceupload.yaml
+++ b/.gcb/referenceupload.yaml
@@ -31,7 +31,7 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
-  - name: 'rust:1.85-bookworm'
+  - name: 'rust:${_RUST_VERSION}-bookworm'
     script: |
       #!/usr/bin/env bash
       set -e
@@ -46,5 +46,6 @@ steps:
       cargo install --locked cargo-workspaces
       go run ./tools/cmd/docfx -project-root . -staging-bucket ${STAGING_BUCKET}
 substitutions:
+  _RUST_VERSION: '1.91'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'


### PR DESCRIPTION
Tested locally with:

```sh
cd google-cloud-rust
# make PR edits...
gcloud --project rust-sdk-testing builds submit --config .gcb/referenceupload.yaml .
```

https://pantheon.corp.google.com/cloud-build/builds;region=global/465dd694-0a74-4782-b638-021966b673b0;step=1?e=SqlStudioMysqlLaunch::SqlStudioMysqlEnabled&mods=monitoring_api_staging&project=rust-sdk-testing