### PR TITLE
ci: pin workspaces in refupload build

### DIFF
--- a/.gcb/referenceupload.yaml
+++ b/.gcb/referenceupload.yaml
@@ -43,7 +43,7 @@ steps:
       wget https://go.dev/dl/go1.25.1.linux-amd64.tar.gz
       tar -C /usr/local -xzf ./go1.25.1.linux-amd64.tar.gz
       export PATH=$PATH:/usr/local/go/bin
-      cargo install --locked cargo-workspaces
+      cargo install --locked cargo-workspaces --version 0.4.1
       go run ./tools/cmd/docfx -project-root . -staging-bucket ${STAGING_BUCKET}
 substitutions:
   _SCCACHE_VERSION: 'v0.12.0'


### PR DESCRIPTION
Tested locally with:

```sh
cd google-cloud-rust
# make PR edits...
gcloud --project rust-sdk-testing builds submit --config .gcb/referenceupload.yaml .
```

https://pantheon.corp.google.com/cloud-build/builds;region=global/26f664b3-075c-4257-820d-2463b1a0ca04;step=1?e=SqlStudioMysqlLaunch::SqlStudioMysqlEnabled&mods=monitoring_api_staging&project=rust-sdk-testing