### PR TITLE
impl(storage-random): consistent TTFB measurement

### DIFF
--- a/src/storage/benchmarks/random/src/experiment.rs
+++ b/src/storage/benchmarks/random/src/experiment.rs
@@ -51,7 +51,7 @@ impl ExperimentGenerator {
     pub fn new(args: &Args, objects: Vec<String>) -> Result<Self> {
         let read_count =
             Uniform::new_inclusive(args.min_concurrent_reads, args.max_concurrent_reads)?;
-        let max_offset = args.min_range_count * args.max_range_size;
+        let max_offset = (args.min_range_count - 1) * args.max_range_size;
         let read_offset = Uniform::new_inclusive(0, max_offset)?;
         let read_length = Uniform::new_inclusive(args.min_range_size, args.max_range_size)?;
         Ok(Self {

--- a/src/storage/benchmarks/random/src/json.rs
+++ b/src/storage/benchmarks/random/src/json.rs
@@ -50,12 +50,14 @@ impl Runner {
             .set_read_range(ReadRange::segment(range.read_offset, range.read_length))
             .send()
             .await?;
-        let ttfb = Instant::now() - start;
+        let mut ttfb = None;
         let mut size = 0;
         while let Some(b) = reader.next().await.transpose()? {
+            let _ = ttfb.get_or_insert(Instant::now() - start);
             size += b.len();
         }
         let ttlb = Instant::now() - start;
+        let ttfb = ttfb.unwrap_or(ttlb);
         Ok(Attempt { size, ttfb, ttlb })
     }
 }


### PR DESCRIPTION
Make it more obvious that the bidi and json measurements for TTFB (Time To First Byte) are doing the same thing.

Fix an off-by-one error in the range offset.