### PR TITLE
impl(storage): `OpenObjectRequest` is `non_exhaustive`

### DIFF
--- a/src/storage/src/model_ext/open_object_request.rs
+++ b/src/storage/src/model_ext/open_object_request.rs
@@ -24,6 +24,7 @@ use gaxi::prost::ToProto;
 // Implementation note: this type exclude some fields from the proto, such as
 // the read handle and routing token, as these cannot be set by the application.
 #[derive(Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
 pub struct OpenObjectRequest {
     /// The bucket containing the target object.
     pub bucket: String,


### PR DESCRIPTION
Also part of #3838 