### PR TITLE
test(auth): improve IAM signBlob retry test

### DIFF
--- a/src/auth/src/signer/iam.rs
+++ b/src/auth/src/signer/iam.rs
@@ -139,14 +139,30 @@ async fn sign_blob_call(
         }
     };
 
-    client
+    let response = client
         .post(url)
         .header("Content-Type", "application/json")
         .headers(source_headers.clone())
         .json(&body)
         .send()
         .await
-        .map_err(|e| gax::error::Error::transport(source_headers, e))
+        .map_err(gax::error::Error::io)?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let err_headers = response.headers().clone();
+        let err_payload = response
+            .bytes()
+            .await
+            .map_err(|e| gax::error::Error::transport(err_headers.clone(), e))?;
+        return Err(gax::error::Error::http(
+            status.as_u16(),
+            err_headers,
+            err_payload,
+        ));
+    }
+
+    Ok(response)
 }
 
 #[cfg(test)]
@@ -261,9 +277,15 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
     async fn test_iam_sign_retry() -> TestResult {
         let server = Server::run();
         let signed_blob = BASE64_STANDARD.encode("signed_blob");
+        let invalid_res = http::Response::builder()
+            .version(http::Version::HTTP_3) // unsupported version
+            .status(204)
+            .body(Vec::new())
+            .unwrap();
         server.expect(
             Expectation::matching(all_of![request::method_path(
                 "POST",
@@ -271,7 +293,7 @@ mod tests {
             ),])
             .times(3)
             .respond_with(cycle![
-                status_code(503).body("try-again"),
+                invalid_res, // forces i/o error
                 status_code(503).body("try-again"),
                 json_encoded(json!({
                     "signedBlob": signed_blob,
@@ -281,7 +303,7 @@ mod tests {
         let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
 
         let mut mock = MockCredentials::new();
-        mock.expect_headers().return_once(|_extensions| {
+        mock.expect_headers().returning(|_extensions| {
             Ok(CacheableResource::New {
                 entity_tag: EntityTag::default(),
                 data: HeaderMap::new(),


### PR DESCRIPTION
The retry test was not even enabled, so the behavior is fixed here and also improved by adding the I/O error scenario.

Towards #3645 