### PR TITLE
ci(auth): update write-only secret based on rotation time

### DIFF
--- a/src/auth/.gcb/builds/service_account_test/main.tf
+++ b/src/auth/.gcb/builds/service_account_test/main.tf
@@ -51,8 +51,9 @@ resource "google_secret_manager_secret" "test-sa-creds-json-secret" {
 
 # Store the test service account key in secret manager.
 resource "google_secret_manager_secret_version" "test-sa-creds-json-secret-version" {
-  secret         = google_secret_manager_secret.test-sa-creds-json-secret.id
-  secret_data_wo = base64decode(google_service_account_key.test-sa-creds-principal-key.private_key)
+  secret                 = google_secret_manager_secret.test-sa-creds-json-secret.id
+  secret_data_wo         = base64decode(google_service_account_key.test-sa-creds-principal-key.private_key)
+  secret_data_wo_version = time_rotating.key_rotation.unix
 }
 
 # The "secret" that will be accessed by the principal testing service account


### PR DESCRIPTION
Trigger to rotate service account keys currently is not triggering an new secret version.