### PR TITLE
cleanup: handwritten READMEs for auth/storage

### DIFF
--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -1,10 +1,22 @@
 # Google Cloud Client Libraries for Rust - Authentication
 
-The Client Libraries for Rust are under active development. We are creating
-placeholder crates so we can reference them in our code and tooling.
+This crate contains types and functions used to authenticate applications on
+Google Cloud. The SDK clients consume an implementation of
+[credentials::Credentials] and use these credentials to authenticate RPCs issued
+by the application.
+
+[Authentication methods at Google] is a good introduction on the topic of
+authentication for Google Cloud services and other Google products. The guide
+also describes the common terminology used with authentication, such as
+[Principals], [Tokens], and [Credentials].
 
 > This crate used to contain a different implementation, with a different
 > surface. [@yoshidan](https://github.com/yoshidan) generously donated the crate
 > name to Google. Their crate continues to live as [gcloud-auth].
 
+[authentication methods at google]: https://cloud.google.com/docs/authentication
+[credentials]: https://cloud.google.com/docs/authentication#credentials
+[credentials::credentials]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credentials.html
 [gcloud-auth]: https://crates.io/crates/gcloud-auth
+[principals]: https://cloud.google.com/docs/authentication#principal
+[tokens]: https://cloud.google.com/docs/authentication#token

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -21,8 +21,7 @@ should not introduce breaking changes to the client libraries.
 
 ## More Information
 
-- Read the
-  [crate's documentation](https://docs.rs/google-cloud-storage/latest/google-cloud-storage)
+- Read the [crate's documentation](https://docs.rs/google-cloud-storage/latest)
 
 [gcloud-storage]: https://crates.io/crates/gcloud-storage
 [google cloud storage]: https://cloud.google.com/storage


### PR DESCRIPTION
Auth had a stale description, and storage had a broken link.