### PR TITLE
impl(storage): handle closed object descriptors

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -100,6 +100,8 @@ pub enum KeyAes256Error {
     InvalidLength,
 }
 
+type BoxedSource = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 /// Represents an error that can occur when reading response data.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
@@ -126,10 +128,7 @@ pub enum ReadError {
 
     /// The received header format is invalid.
     #[error("the format for header '{0}' is incorrect")]
-    BadHeaderFormat(
-        &'static str,
-        #[source] Box<dyn std::error::Error + Send + Sync + 'static>,
-    ),
+    BadHeaderFormat(&'static str, #[source] BoxedSource),
 
     /// A bidi read was interrupted with an unrecoverable error.
     #[cfg(google_cloud_unstable_storage_bidi)]
@@ -210,6 +209,18 @@ pub enum ReadError {
     #[cfg(google_cloud_unstable_storage_bidi)]
     #[error("unknown range id in bidi response: {0}")]
     UnknownBidiRangeId(i64),
+
+    /// A `read_range()` request failed because the object descriptor is closed.
+    ///
+    /// # Troubleshooting
+    ///
+    /// The object descriptor closes only when there is an unrecoverable I/O
+    /// error. Consider using a more lenient [ReadResumePolicy].
+    ///
+    /// [ReadResumePolicy]: [crate::read_resume_policy::ReadResumePolicy]
+    #[cfg(google_cloud_unstable_storage_bidi)]
+    #[error("read worker terminated on an unrecoverable read error")]
+    CannotScheduleRangeRead(#[source] BoxedSource),
 }
 
 /// An unrecoverable problem in the upload protocol.


### PR DESCRIPTION
The object descriptor may be closed if the worker finds an unrecoverable error. In that case, we return a reader that immediately returns an error.

Part of the work for #4052, found while working on #3953 