### PR TITLE
impl(storage-random): use a shared client

### DIFF
--- a/src/storage/benchmarks/random/src/bidi.rs
+++ b/src/storage/benchmarks/random/src/bidi.rs
@@ -15,9 +15,8 @@
 use super::args::Args;
 use super::experiment::{Experiment, Range};
 use super::sample::Attempt;
-use anyhow::Result;
-use anyhow::bail;
-use google_cloud_auth::credentials::Credentials;
+use anyhow::{Result, bail};
+use google_cloud_storage::client::Storage;
 use google_cloud_storage::model_ext::ReadRange;
 use google_cloud_storage::object_descriptor::ObjectDescriptor;
 use std::collections::HashMap;
@@ -28,11 +27,7 @@ pub struct Runner {
 }
 
 impl Runner {
-    pub async fn new(args: &Args, objects: Vec<String>, credentials: Credentials) -> Result<Self> {
-        let client = google_cloud_storage::client::Storage::builder()
-            .with_credentials(credentials)
-            .build()
-            .await?;
+    pub async fn new(args: &Args, objects: Vec<String>, client: Storage) -> Result<Self> {
         let bucket_name = format!("projects/_/buckets/{}", args.bucket_name);
         let mut descriptors = HashMap::new();
         for name in objects {

--- a/src/storage/benchmarks/random/src/json.rs
+++ b/src/storage/benchmarks/random/src/json.rs
@@ -15,7 +15,6 @@
 use super::experiment::{Experiment, Range};
 use super::sample::Attempt;
 use anyhow::Result;
-use google_cloud_auth::credentials::Credentials;
 use google_cloud_storage::client::Storage;
 use google_cloud_storage::model_ext::ReadRange;
 use std::time::Instant;
@@ -25,11 +24,7 @@ pub struct Runner {
 }
 
 impl Runner {
-    pub async fn new(credentials: Credentials) -> Result<Self> {
-        let client = google_cloud_storage::client::Storage::builder()
-            .with_credentials(credentials)
-            .build()
-            .await?;
+    pub async fn new(client: Storage) -> Result<Self> {
         Ok(Self { client })
     }
 


### PR DESCRIPTION
All the tasks use the same client. This is a more realistic configuration, or at least one that is more interesting to test.

Part of the work for #3952 