### PR TITLE
impl(auth): not_supported build error should still be gated

### DIFF
--- a/src/auth/src/build_errors.rs
+++ b/src/auth/src/build_errors.rs
@@ -48,6 +48,7 @@ impl Error {
         matches!(self.0, ErrorKind::MissingField(_))
     }
 
+    #[cfg(any(feature = "idtoken", google_cloud_unstable_signed_url))]
     /// The credential type is not supported for the given use case.
     pub fn is_not_supported(&self) -> bool {
         matches!(self.0, ErrorKind::NotSupported(_))
@@ -83,6 +84,7 @@ impl Error {
         Error(ErrorKind::MissingField(field))
     }
 
+    #[cfg(any(feature = "idtoken", google_cloud_unstable_signed_url))]
     /// The given credential type is not supported.
     pub(crate) fn not_supported<T>(credential_type: T) -> Error
     where
@@ -102,6 +104,7 @@ enum ErrorKind {
     UnknownType(#[source] BoxError),
     #[error("missing required field: {0}")]
     MissingField(&'static str),
+    #[cfg(any(feature = "idtoken", google_cloud_unstable_signed_url))]
     #[error("credentials type not supported: {0}")]
     NotSupported(#[source] BoxError),
 }


### PR DESCRIPTION
#4056 ended exposing `not_supported` builder error without any feature flag, which raised warning around it not being used.