### PR TITLE
docs(pubsub): override the service descriptions for admin clients

### DIFF
--- a/src/pubsub/src/generated/gapic/.sidekick.toml
+++ b/src/pubsub/src/generated/gapic/.sidekick.toml
@@ -46,3 +46,15 @@ copyright-year        = '2025'
 template-override     = 'templates/http-client'
 package-name-override = 'google-cloud-pubsub'
 name-overrides        = '.google.pubsub.v1.Publisher=TopicAdmin,.google.pubsub.v1.Subscriber=SubscriptionAdmin'
+
+# Documentation overrides specific to the Rust clients.
+# Dataplane operations are excluded from the TopicAdmin and SubscriptionAdmin clients.
+[[documentation-overrides]]
+id = ".google.pubsub.v1.Publisher"
+match = "The service that an application uses to manipulate topics, and to send\nmessages to a topic."
+replace = "The service that an application uses to manipulate topics."
+
+[[documentation-overrides]]
+id = ".google.pubsub.v1.Subscriber"
+match = "The service that an application uses to manipulate subscriptions and to\nconsume messages from a subscription via the `Pull` method or by\nestablishing a bi-directional stream using the `StreamingPull` method."
+replace = "The service that an application uses to manipulate subscriptions."

--- a/src/pubsub/src/generated/gapic/client.rs
+++ b/src/pubsub/src/generated/gapic/client.rs
@@ -29,8 +29,7 @@
 ///
 /// # Service Description
 ///
-/// The service that an application uses to manipulate topics, and to send
-/// messages to a topic.
+/// The service that an application uses to manipulate topics.
 ///
 /// # Configuration
 ///
@@ -186,9 +185,7 @@ impl TopicAdmin {
 ///
 /// # Service Description
 ///
-/// The service that an application uses to manipulate subscriptions and to
-/// consume messages from a subscription via the `Pull` method or by
-/// establishing a bi-directional stream using the `StreamingPull` method.
+/// The service that an application uses to manipulate subscriptions.
 ///
 /// # Configuration
 ///


### PR DESCRIPTION
Override the service level documentation for the admin clients to remove references to the dataplane operations.

Fixes #3348