### PR TITLE
impl(storage): more recoverable errors under gRPC

### DIFF
--- a/src/storage/src/read_resume_policy.rs
+++ b/src/storage/src/read_resume_policy.rs
@@ -152,12 +152,10 @@ fn is_transient(error: &Error) -> bool {
 
 fn is_transient_code(code: Code) -> bool {
     // DeadlineExceeded is safe in this context because local deadline errors are not reported via e.status()
-    match code {
-        Code::Unavailable | Code::ResourceExhausted | Code::Internal | Code::DeadlineExceeded => {
-            true
-        }
-        _ => false,
-    }
+    matches!(
+        code,
+        Code::Unavailable | Code::ResourceExhausted | Code::Internal | Code::DeadlineExceeded
+    )
 }
 
 /// A resume policy that resumes regardless of the error type.


### PR DESCRIPTION
These are based on the C++ policies.

Fixes #4069 