### PR TITLE
test(storage-random): reduce straggler tasks

### DIFF
--- a/src/storage/benchmarks/random/src/args.rs
+++ b/src/storage/benchmarks/random/src/args.rs
@@ -41,7 +41,7 @@ pub struct Args {
     #[arg(long, default_value_t = 1)]
     pub task_count: usize,
 
-    /// The number of iterations for each task.
+    /// The total number of iterations across all tasks.
     #[arg(long, default_value_t = 1)]
     pub iterations: u64,
 


### PR DESCRIPTION
If all tasks perform the same number of iterations, some of them may run slower and become stragglers. If we stop all the tasks once "enough" samples are collected then all tasks finish at around the same time, and we can complete the test faster.

Fixes #3953 