### PR TITLE
impl(storage): `ObjectDescriptor` accepts more stubs

### DIFF
--- a/src/storage/src/object_descriptor.rs
+++ b/src/storage/src/object_descriptor.rs
@@ -138,7 +138,7 @@ impl ObjectDescriptor {
     /// Create a new instance.
     pub fn new<T>(inner: T) -> Self
     where
-        T: ObjectDescriptorStub + 'static,
+        T: crate::stub::ObjectDescriptor + 'static,
     {
         Self {
             inner: Box::new(inner),


### PR DESCRIPTION
We only need stubs that implement `crate::stub::ObjectDescriptor`. We hold a `dynamic::*`, but we can be more generous on what we accept, and using a public trait seems like a better idea.
