### PR TITLE
fix: fix conformance source metadata for librarian

### DIFF
--- a/src/generated/cloud/aiplatform/schema/predict/instance/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/instance/.sidekick.toml
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[general]
+specification-source = 'google/cloud/aiplatform/v1/schema/predict/instance'
+service-config = 'google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml'
+
+[codec]
+copyright-year = '2025'

--- a/src/generated/cloud/aiplatform/schema/predict/params/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/params/.sidekick.toml
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[general]
+specification-source = 'google/cloud/aiplatform/v1/schema/predict/params'
+service-config = 'google/cloud/aiplatform/v1/schema/aiplatform_v1.yaml'
+
+[codec]
+copyright-year = '2025'


### PR DESCRIPTION
Conformance repo metadata was pointing to the protobuf repo.  Updated to point to conformance-test repo with correct commit.

For https://github.com/googleapis/librarian/issues/3270