### PR TITLE
impl(storage): reduce `ReadError` variants

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -139,76 +139,24 @@ pub enum ReadError {
     ///
     /// # Troubleshooting
     ///
-    /// This indicates a bug in the service or a corrupted message in
-    /// transit Please contact [Google Cloud support] with as much detail as
-    /// possible.
+    /// This indicates a bug in the client, the service, or a message corrupted
+    /// while in transit. Please [open an issue] or contact [Google Cloud support]
+    /// with as much detail as possible.
     ///
     /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues/new/choose
     /// [Google Cloud support]: https://cloud.google.com/support
     #[cfg(google_cloud_unstable_storage_bidi)]
-    #[error("invalid offset in bidi response: {0}")]
-    BadOffsetInBidiResponse(i64),
+    #[error("the bidi streaming read response is invalid: {0}")]
+    InvalidBidiStreamingReadResponse(#[source] BoxedSource),
+}
 
-    /// A bidi read received an invalid length.
-    ///
-    /// # Troubleshooting
-    ///
-    /// This indicates a bug in the service or a corrupted message in
-    /// transit. Please contact [Google Cloud support] with as much detail as
-    /// possible.
-    ///
-    /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues/new/choose
-    /// [Google Cloud support]: https://cloud.google.com/support
+impl ReadError {
     #[cfg(google_cloud_unstable_storage_bidi)]
-    #[error("invalid length in bidi response: {0}")]
-    BadLengthInBidiResponse(i64),
-
-    /// A bidi read without a valid range.
-    ///
-    /// # Troubleshooting
-    ///
-    /// This indicates a bug in the service or a corrupted message in
-    /// transit Please contact [Google Cloud support] with as much detail as
-    /// possible.
-    ///
-    /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues/new/choose
-    /// [Google Cloud support]: https://cloud.google.com/support
-    #[cfg(google_cloud_unstable_storage_bidi)]
-    #[error("missing range in bidi response")]
-    MissingRangeInBidiResponse,
-
-    /// An out of order bidi read.
-    ///
-    /// # Troubleshooting
-    ///
-    /// The client library received an out-of-sequence range of data. This
-    /// indicates a bug in the service or the client library.
-    ///
-    /// Please [open an issue] with as much detail as possible or contact
-    /// [Google Cloud support].
-    ///
-    /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues/new/choose
-    /// [Google Cloud support]: https://cloud.google.com/support
-    #[cfg(google_cloud_unstable_storage_bidi)]
-    #[error("out of order bidi response, expected offset={expected}, got={got}")]
-    OutOfOrderBidiResponse { got: i64, expected: i64 },
-
-    /// The service returned a range id unknown to the client library.
-    ///
-    /// # Troubleshooting
-    ///
-    /// In bidi reads the application may issue multiple concurrent reads for
-    /// different ranges of the same object. The client library assigns ids to
-    /// each range. This indicates a bug in the service or the client library.
-    ///
-    /// Please [open an issue] with as much detail as possible or contact
-    /// [Google Cloud support].
-    ///
-    /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues/new/choose
-    /// [Google Cloud support]: https://cloud.google.com/support
-    #[cfg(google_cloud_unstable_storage_bidi)]
-    #[error("unknown range id in bidi response: {0}")]
-    UnknownBidiRangeId(i64),
+    pub(crate) fn bidi_out_of_order(expected: i64, got: i64) -> Self {
+        Self::InvalidBidiStreamingReadResponse(
+            format!("message offset mismatch, expected={expected}, got={got}").into(),
+        )
+    }
 }
 
 /// An unrecoverable problem in the upload protocol.

--- a/src/storage/src/storage/bidi/active_read.rs
+++ b/src/storage/src/storage/bidi/active_read.rs
@@ -227,7 +227,7 @@ mod tests {
             .handle_data(Some(data), proto_range, false)
             .unwrap_err();
         assert!(
-            matches!(err, ReadError::OutOfOrderBidiResponse{ ref got, ref expected } if *got == 25 && *expected == 0),
+            matches!(err, ReadError::InvalidBidiStreamingReadResponse(_)),
             "err={err:?} range={range:?}"
         );
         Ok(())
@@ -239,7 +239,9 @@ mod tests {
         let requested = ReadRange::all().0;
         let mut range = ActiveRead::new(tx, requested);
         range
-            .handle_error(ReadError::MissingRangeInBidiResponse)
+            .handle_error(ReadError::InvalidBidiStreamingReadResponse(
+                "test-only".into(),
+            ))
             .await;
         let got = rx
             .recv()
@@ -247,7 +249,7 @@ mod tests {
             .expect("the active reader propagates error messages")
             .unwrap_err();
         assert!(
-            matches!(got, ReadError::MissingRangeInBidiResponse),
+            matches!(got, ReadError::InvalidBidiStreamingReadResponse(_)),
             "{got:?}"
         );
 
@@ -256,7 +258,9 @@ mod tests {
         let _guard = tracing::subscriber::set_default(capture.clone());
         rx.close();
         range
-            .handle_error(ReadError::MissingRangeInBidiResponse)
+            .handle_error(ReadError::InvalidBidiStreamingReadResponse(
+                "test-only".into(),
+            ))
             .await;
         let events = capture.events();
         let got = events


### PR DESCRIPTION
Most of the variants required the application to file a bug, using a single variant is simpler if there is nothing else to do.

Fixes #4090 