### PR TITLE
impl(pubsub): streaming_pull for transport stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,6 +4144,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "tokio-stream",
  "tokio-test",
  "tokio-util",
  "tonic",

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -145,7 +145,6 @@ impl Client {
             .await
     }
 
-    #[cfg(google_cloud_unstable_storage_bidi)]
     /// Opens a bidirectional stream.
     pub async fn bidi_stream<Request, Response>(
         &self,
@@ -172,7 +171,6 @@ impl Client {
         .map_err(to_gax_error)
     }
 
-    #[cfg(google_cloud_unstable_storage_bidi)]
     /// Opens a bidirectional stream.
     ///
     /// Some services (notably Storage) need to examine the `tonic::Status` to

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -26,25 +26,26 @@ categories.workspace   = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait.workspace = true
-bytes.workspace       = true
-futures.workspace     = true
-gax.workspace         = true
-gaxi                  = { workspace = true, features = ["_internal-common", "_internal-grpc-client", "_internal-http-client"] }
-http.workspace        = true
-iam_v1.workspace      = true
-lazy_static.workspace = true
-prost.workspace       = true
-prost-types.workspace = true
-reqwest.workspace     = true
-serde.workspace       = true
-serde_json.workspace  = true
-serde_with.workspace  = true
-tonic.workspace       = true
-tokio                 = { workspace = true, features = ["sync"] }
-tokio-util.workspace  = true
-tracing.workspace     = true
-wkt.workspace         = true
+async-trait.workspace  = true
+bytes.workspace        = true
+futures.workspace      = true
+gax.workspace          = true
+gaxi                   = { workspace = true, features = ["_internal-common", "_internal-grpc-client", "_internal-http-client"] }
+http.workspace         = true
+iam_v1.workspace       = true
+lazy_static.workspace  = true
+prost.workspace        = true
+prost-types.workspace  = true
+reqwest.workspace      = true
+serde.workspace        = true
+serde_json.workspace   = true
+serde_with.workspace   = true
+tonic.workspace        = true
+tokio                  = { workspace = true, features = ["sync"] }
+tokio-stream.workspace = true
+tokio-util.workspace   = true
+tracing.workspace      = true
+wkt.workspace          = true
 
 [dev-dependencies]
 auth.workspace       = true

--- a/src/pubsub/src/subscriber.rs
+++ b/src/pubsub/src/subscriber.rs
@@ -18,3 +18,4 @@ pub(crate) mod lease_state;
 pub(crate) mod leaser;
 pub(crate) mod stream;
 pub(crate) mod stub;
+pub(crate) mod transport;

--- a/src/pubsub/src/subscriber/transport.rs
+++ b/src/pubsub/src/subscriber/transport.rs
@@ -1,0 +1,129 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::stub::Stub;
+use crate::Result;
+use crate::generated::gapic_dataplane::transport::Subscriber as Transport;
+use crate::google::pubsub::v1::{StreamingPullRequest, StreamingPullResponse};
+use tokio::sync::mpsc::Receiver;
+use tokio_stream::wrappers::ReceiverStream;
+
+mod info {
+    const NAME: &str = env!("CARGO_PKG_NAME");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    lazy_static::lazy_static! {
+        pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
+            let ac = gaxi::api_header::XGoogApiClient{
+                name:          NAME,
+                version:       VERSION,
+                library_type:  gaxi::api_header::GCCL,
+            };
+            ac.grpc_header_value()
+        };
+    }
+}
+
+#[async_trait::async_trait]
+impl Stub for Transport {
+    type Stream = tonic::codec::Streaming<StreamingPullResponse>;
+    async fn streaming_pull(
+        &self,
+        request_rx: Receiver<StreamingPullRequest>,
+        options: gax::options::RequestOptions,
+    ) -> Result<tonic::Response<Self::Stream>> {
+        let request = ReceiverStream::new(request_rx);
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.pubsub.v1.Subscriber",
+                "StreamingPull",
+            ));
+            e
+        };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/StreamingPull");
+        self.inner
+            .bidi_stream(
+                extensions,
+                path,
+                request,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                "",
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::google::pubsub::v1::ReceivedMessage;
+    use auth::credentials::anonymous::Builder as Anonymous;
+    use pubsub_grpc_mock::google::pubsub::v1;
+    use pubsub_grpc_mock::{MockSubscriber, start};
+
+    async fn test_transport(endpoint: String) -> anyhow::Result<Transport> {
+        let mut config = gaxi::options::ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        config.endpoint = Some(endpoint);
+        Ok(Transport::new(config).await?)
+    }
+
+    // Both crates have their own copies of the protos. We can just serialize
+    // then deserialize to convert between the two, as performance is not a
+    // concern for these unit tests.
+    fn convert(pb: &StreamingPullResponse) -> v1::StreamingPullResponse {
+        use prost::Message;
+        let v = pb.encode_to_vec();
+        v1::StreamingPullResponse::decode(v.as_slice()).expect("encoding is always valid.")
+    }
+
+    #[tokio::test]
+    async fn streaming_pull() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = tokio::sync::mpsc::channel(1);
+        let expected = StreamingPullResponse {
+            received_messages: vec![ReceivedMessage {
+                ack_id: "test-ack-id".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        response_tx.send(Ok(convert(&expected))).await?;
+
+        let (request_tx, request_rx) = tokio::sync::mpsc::channel(1);
+        request_tx.send(StreamingPullRequest::default()).await?;
+
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .return_once(|_| Ok(tonic::Response::from(response_rx)));
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = test_transport(endpoint).await?;
+        let mut stream = Stub::streaming_pull(
+            &transport,
+            request_rx,
+            gax::options::RequestOptions::default(),
+        )
+        .await?
+        .into_inner();
+
+        use futures::StreamExt;
+        assert_eq!(stream.next().await.transpose()?, Some(expected));
+
+        drop(response_tx);
+        assert_eq!(stream.next().await.transpose()?, None);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Part of the work for #3957 

Extend the internal subscriber transport stub to support streams.

Implement our internal `Stub` (which has a streaming method) for the `Transport` stub.