### PR TITLE
impl(pubsub): make publisher cloneable

### DIFF
--- a/src/pubsub/src/publisher/publisher.rs
+++ b/src/pubsub/src/publisher/publisher.rs
@@ -42,7 +42,7 @@ const MAX_BYTES: u32 = 1e7 as u32; // 10MB
 /// let message_id = publisher.publish(PubsubMessage::new().set_data("Hello, World"));
 /// # Ok(()) }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Publisher {
     #[allow(dead_code)]
     pub(crate) batching_options: BatchingOptions,


### PR DESCRIPTION
Implementing `Clone` for `Publisher` allows for easier and more idiomatic usage of the Pub/Sub publisher client in scenarios where multiple parts of an application need to interact with the same publisher instance.

Derive the missing `Clone` trait implementation.