### PR TITLE
impl(storage): cleanup dead code warnings

### DIFF
--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 #[cfg(google_cloud_unstable_storage_bidi)]
-#[allow(dead_code)]
 pub(crate) mod bidi;
 pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod common_options;
 #[cfg(google_cloud_unstable_storage_bidi)]
-#[allow(dead_code)]
 pub(crate) mod open_object;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage/bidi/active_read.rs
+++ b/src/storage/src/storage/bidi/active_read.rs
@@ -64,12 +64,6 @@ impl ActiveRead {
         )))
     }
 
-    pub(super) async fn handle_error(&mut self, error: ReadError) {
-        if let Err(e) = self.sender.send(Err(error)).await {
-            tracing::error!("cannot notify reader (dropped?) about: {e:?}");
-        }
-    }
-
     pub(super) async fn interrupted(&mut self, error: Arc<crate::Error>) {
         if let Err(e) = self
             .sender
@@ -231,42 +225,6 @@ mod tests {
             "err={err:?} range={range:?}"
         );
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn handle_error() {
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let requested = ReadRange::all().0;
-        let mut range = ActiveRead::new(tx, requested);
-        range
-            .handle_error(ReadError::InvalidBidiStreamingReadResponse(
-                "test-only".into(),
-            ))
-            .await;
-        let got = rx
-            .recv()
-            .await
-            .expect("the active reader propagates error messages")
-            .unwrap_err();
-        assert!(
-            matches!(got, ReadError::InvalidBidiStreamingReadResponse(_)),
-            "{got:?}"
-        );
-
-        // Sending errors on closed stream does not panic and gets logged.
-        let capture = CaptureEvents::new();
-        let _guard = tracing::subscriber::set_default(capture.clone());
-        rx.close();
-        range
-            .handle_error(ReadError::InvalidBidiStreamingReadResponse(
-                "test-only".into(),
-            ))
-            .await;
-        let events = capture.events();
-        let got = events
-            .iter()
-            .find(|m| m.contains("cannot notify reader (dropped?) about: "));
-        assert!(got.is_some(), "{events:?}");
     }
 
     #[tokio::test]

--- a/src/storage/src/storage/bidi/normalized_range.rs
+++ b/src/storage/src/storage/bidi/normalized_range.rs
@@ -76,10 +76,6 @@ impl NormalizedRange {
         }
     }
 
-    pub fn offset(&self) -> i64 {
-        self.offset
-    }
-
     pub fn length(&self) -> Option<i64> {
         self.length
     }
@@ -90,10 +86,6 @@ impl NormalizedRange {
             read_offset: self.offset,
             read_length: self.length.unwrap_or_default(),
         }
-    }
-
-    pub fn matching_offset(&self, requested_offset: u64) -> bool {
-        self.offset as u64 == requested_offset
     }
 
     pub fn update(&mut self, response: ProtoRange) -> ReadResult<()> {
@@ -140,7 +132,6 @@ mod tests {
             length: None,
         };
         assert_eq!(got, want);
-        assert_eq!(got.offset(), 100, "{got:?}");
         assert!(got.length().is_none(), "{got:?}");
 
         let proto = got.as_proto(123456);
@@ -150,9 +141,6 @@ mod tests {
             read_length: 0,
         };
         assert_eq!(proto, want);
-
-        assert!(got.matching_offset(100_u64), "{got:?}");
-        assert!(!got.matching_offset(105_u64), "{got:?}");
 
         Ok(())
     }
@@ -176,7 +164,6 @@ mod tests {
             length: Some(50),
         };
         assert_eq!(got, want);
-        assert_eq!(got.offset(), 100, "{got:?}");
         assert_eq!(got.length(), Some(50), "{got:?}");
 
         let proto = got.as_proto(123456);
@@ -186,9 +173,6 @@ mod tests {
             read_length: 50,
         };
         assert_eq!(proto, want);
-
-        assert!(got.matching_offset(100_u64), "{got:?}");
-        assert!(!got.matching_offset(105_u64), "{got:?}");
 
         Ok(())
     }
@@ -235,15 +219,15 @@ mod tests {
         let mut normalized = NormalizedRange::new(100)?.with_length(200)?;
         let response = proto_range(100, 25);
         normalized.update(response)?;
-        assert_eq!((normalized.offset(), normalized.length()), (125, Some(175)));
+        assert_eq!((normalized.offset, normalized.length()), (125, Some(175)));
 
         let response = proto_range(125, 50);
         normalized.update(response)?;
-        assert_eq!((normalized.offset(), normalized.length()), (175, Some(125)));
+        assert_eq!((normalized.offset, normalized.length()), (175, Some(125)));
 
         let response = proto_range(175, 0);
         normalized.update(response)?;
-        assert_eq!((normalized.offset(), normalized.length()), (175, Some(125)));
+        assert_eq!((normalized.offset, normalized.length()), (175, Some(125)));
         Ok(())
     }
 
@@ -252,15 +236,15 @@ mod tests {
         let mut normalized = NormalizedRange::new(100)?;
         let response = proto_range(100, 25);
         normalized.update(response)?;
-        assert_eq!((normalized.offset(), normalized.length()), (125, None));
+        assert_eq!((normalized.offset, normalized.length()), (125, None));
 
         let response = proto_range(125, 50);
         normalized.update(response)?;
-        assert_eq!((normalized.offset(), normalized.length()), (175, None));
+        assert_eq!((normalized.offset, normalized.length()), (175, None));
 
         let response = proto_range(175, 0);
         normalized.update(response)?;
-        assert_eq!((normalized.offset(), normalized.length()), (175, None));
+        assert_eq!((normalized.offset, normalized.length()), (175, None));
         Ok(())
     }
 

--- a/src/storage/src/storage/bidi/requested_range.rs
+++ b/src/storage/src/storage/bidi/requested_range.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::ReadError;
 use crate::google::storage::v2::ReadRange as ProtoRange;
 use crate::model_ext::RequestedRange;
-
-type ReadResult<T> = std::result::Result<T, ReadError>;
 
 /// Additional functions to use `RequestedRange` in pending requests.
 ///

--- a/src/storage/src/storage/bidi/transport.rs
+++ b/src/storage/src/storage/bidi/transport.rs
@@ -14,7 +14,6 @@
 
 use super::active_read::ActiveRead;
 use super::range_reader::RangeReader;
-use crate::error::ReadError;
 use crate::model::Object;
 use crate::model_ext::ReadRange;
 use crate::read_object::ReadObjectResponse;
@@ -23,8 +22,6 @@ use crate::{Error, Result};
 use http::HeaderMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
-
-type ReadResult<T> = std::result::Result<T, ReadError>;
 
 #[derive(Debug)]
 pub struct ObjectDescriptorTransport {
@@ -89,6 +86,7 @@ impl ObjectDescriptor for ObjectDescriptorTransport {
 mod tests {
     use super::super::mocks::{MockTestClient, mock_connector};
     use super::*;
+    use crate::error::ReadError;
     use crate::google::storage::v2::{
         BidiReadHandle, BidiReadObjectResponse, ChecksummedData, Object as ProtoObject,
         ObjectRangeData, ReadRange as ProtoRange,

--- a/src/storage/src/storage/open_object.rs
+++ b/src/storage/src/storage/open_object.rs
@@ -42,7 +42,6 @@ pub struct OpenObject<S = crate::storage::transport::Storage> {
     stub: Arc<S>,
     request: OpenObjectRequest,
     options: RequestOptions,
-    reconnect_attempts: u32,
 }
 
 impl<S> OpenObject<S>
@@ -82,7 +81,6 @@ impl<S> OpenObject<S> {
             request,
             options,
             stub,
-            reconnect_attempts: 0_u32,
         }
     }
 

--- a/src/storage/src/storage/request_options.rs
+++ b/src/storage/src/storage/request_options.rs
@@ -119,7 +119,6 @@ impl RequestOptions {
     }
 
     #[cfg(google_cloud_unstable_storage_bidi)]
-    #[allow(dead_code)]
     pub(crate) fn gax(&self) -> gax::options::RequestOptions {
         let mut options = gax::options::RequestOptions::default();
         options.set_backoff_policy(self.backoff_policy.clone());


### PR DESCRIPTION
Enable dead code warnings for the bidi code, remove the code that was really dead.

Part of the work for #4106 