### PR TITLE
impl(pubsub): timed ack/nack flushes, lease extensions

### DIFF
--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -14,9 +14,32 @@
 
 use super::leaser::Leaser;
 use std::collections::HashSet;
+use tokio::time::{Duration, Instant, Interval, interval_at};
+
+pub(crate) struct LeaseOptions {
+    /// How often we flush acks/nacks
+    pub(crate) flush_period: Duration,
+    /// How long we wait for the initial flush
+    pub(crate) flush_start: Duration,
+    /// How often we extend deadlines for messages under lease
+    pub(crate) extend_period: Duration,
+    /// How long we wait for the initial extensions
+    pub(crate) extend_start: Duration,
+}
+
+impl Default for LeaseOptions {
+    fn default() -> Self {
+        LeaseOptions {
+            flush_period: Duration::from_secs(1),
+            flush_start: Duration::from_secs(1),
+            extend_period: Duration::from_secs(3),
+            extend_start: Duration::from_millis(500),
+        }
+    }
+}
 
 #[derive(Debug)]
-struct LeaseState<L>
+pub(crate) struct LeaseState<L>
 where
     L: Leaser,
 {
@@ -26,28 +49,65 @@ where
     to_nack: Vec<String>,
     // TODO(#3964) - support exactly once acks
     leaser: L,
+
+    // A timer for flushing acks/nacks
+    flush_interval: Interval,
+    // A timer for extending leases
+    extend_interval: Interval,
+}
+
+/// Actions taken by the `LeaseState` in the lease loop.
+#[derive(Debug, PartialEq)]
+pub(crate) enum LeaseEvent {
+    /// Flush acks/nacks
+    Flush,
+    /// Extend leases
+    Extend,
 }
 
 impl<L> LeaseState<L>
 where
     L: Leaser,
 {
-    fn new(leaser: L) -> Self {
+    pub(crate) fn new(leaser: L, options: LeaseOptions) -> Self {
+        let flush_interval =
+            interval_at(Instant::now() + options.flush_start, options.flush_period);
+        let extend_interval =
+            interval_at(Instant::now() + options.extend_start, options.extend_period);
         Self {
             under_lease: HashSet::new(),
             to_ack: Vec::new(),
             to_nack: Vec::new(),
             leaser,
+            flush_interval,
+            extend_interval,
+        }
+    }
+
+    /// A future that fires when it is time to either:
+    /// - flush acks/nacks
+    /// - extend leases
+    ///
+    /// We need to centralize event handling because the lease loop can only
+    /// hold one mutable reference to `LeaseState` within its `select!`
+    /// statement.
+    pub(crate) async fn next_event(&mut self) -> LeaseEvent {
+        // TODO(#3972) - flush on size if an `Acknowledge` or
+        // `ModifyAckDeadline` RPC is full.
+
+        tokio::select! {
+            _ = self.flush_interval.tick() => LeaseEvent::Flush,
+            _ = self.extend_interval.tick() => LeaseEvent::Extend,
         }
     }
 
     /// Accept a new ack ID under lease management
-    fn add(&mut self, ack_id: String) {
+    pub(crate) fn add(&mut self, ack_id: String) {
         self.under_lease.insert(ack_id);
     }
 
     /// Process an ack from the application
-    fn ack(&mut self, ack_id: String) {
+    pub(crate) fn ack(&mut self, ack_id: String) {
         self.under_lease.remove(&ack_id);
         // Unconditionally add the ack ID to the next ack batch. It doesn't hurt
         // to optimistically add it, even if its lease has expired.
@@ -55,7 +115,7 @@ where
     }
 
     /// Process a nack from the application
-    fn nack(&mut self, ack_id: String) {
+    pub(crate) fn nack(&mut self, ack_id: String) {
         if self.under_lease.remove(&ack_id) {
             // Only add the ack ID to the nack batch if the message is under our
             // lease. If the message's lease has already expired, we do not need
@@ -65,7 +125,7 @@ where
     }
 
     /// Flush pending acks/nacks
-    async fn flush(&mut self) {
+    pub(crate) async fn flush(&mut self) {
         let to_ack = std::mem::take(&mut self.to_ack);
         let to_nack = std::mem::take(&mut self.to_nack);
         // TODO(#3975) - await these concurrently.
@@ -76,7 +136,7 @@ where
     /// Extends leases for messages under lease management
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
-    async fn extend(&mut self) {
+    pub(crate) async fn extend(&mut self) {
         // TODO(#3957) - drop expired messages
         let under_lease: Vec<String> = self.under_lease.iter().cloned().collect();
         self.leaser.extend(under_lease).await;
@@ -85,7 +145,7 @@ where
     /// Shutdown the leaser
     ///
     /// This flushes all pending acks and nacks all other messages.
-    async fn shutdown(self) {
+    pub(crate) async fn shutdown(self) {
         let mut to_nack = self.to_nack;
         to_nack.extend(self.under_lease.into_iter());
         // TODO(#3975) - await these concurrently.
@@ -110,6 +170,13 @@ pub(crate) mod tests {
     use super::super::leaser::tests::MockLeaser;
     use super::*;
 
+    fn test_interval() -> Interval {
+        interval_at(
+            Instant::now() + Duration::from_secs(900),
+            Duration::from_secs(900),
+        )
+    }
+
     fn make_state<L, A, N>(under_lease: L, to_ack: A, to_nack: N) -> LeaseState<MockLeaser>
     where
         L: IntoIterator<Item = &'static str>,
@@ -121,6 +188,8 @@ pub(crate) mod tests {
             to_ack: to_ack.into_iter().map(|s| s.to_string()).collect(),
             to_nack: to_nack.into_iter().map(|s| s.to_string()).collect(),
             leaser: MockLeaser::new(),
+            flush_interval: test_interval(),
+            extend_interval: test_interval(),
         }
     }
 
@@ -132,16 +201,16 @@ pub(crate) mod tests {
         range.map(test_id).collect()
     }
 
-    fn sorted(v: &[String]) -> Vec<String> {
+    pub(crate) fn sorted(v: &[String]) -> Vec<String> {
         let mut s = v.to_owned();
         s.sort();
         s
     }
 
-    #[test]
-    fn basic_add_ack_nack() {
+    #[tokio::test]
+    async fn basic_add_ack_nack() {
         let mock = MockLeaser::new();
-        let mut state = LeaseState::new(mock);
+        let mut state = LeaseState::new(mock, LeaseOptions::default());
         assert_eq!(state, make_state([], [], []));
 
         state.add("1".to_string());
@@ -181,7 +250,7 @@ pub(crate) mod tests {
             .withf(|v| sorted(v) == test_ids(10..20))
             .returning(|_| ());
 
-        let mut state = LeaseState::new(mock);
+        let mut state = LeaseState::new(mock, LeaseOptions::default());
         for i in 0..100 {
             state.add(test_id(i));
         }
@@ -196,6 +265,8 @@ pub(crate) mod tests {
             to_ack: test_ids(0..10),
             to_nack: test_ids(10..20),
             leaser: MockLeaser::new(),
+            flush_interval: test_interval(),
+            extend_interval: test_interval(),
         };
         assert_eq!(state, expected);
 
@@ -205,6 +276,8 @@ pub(crate) mod tests {
             to_ack: Vec::new(),
             to_nack: Vec::new(),
             leaser: MockLeaser::new(),
+            flush_interval: test_interval(),
+            extend_interval: test_interval(),
         };
         assert_eq!(state, expected);
     }
@@ -234,7 +307,7 @@ pub(crate) mod tests {
             .withf(|v| sorted(v) == test_ids(10..20))
             .returning(|_| ());
 
-        let mut state = LeaseState::new(mock);
+        let mut state = LeaseState::new(mock, LeaseOptions::default());
 
         // Accept 10 messages. These are now under lease management.
         for i in 0..10 {
@@ -273,7 +346,7 @@ pub(crate) mod tests {
             .withf(|v| sorted(v) == test_ids(10..30))
             .returning(|_| ());
 
-        let mut state = LeaseState::new(mock);
+        let mut state = LeaseState::new(mock, LeaseOptions::default());
         for i in 0..30 {
             state.add(test_id(i));
         }
@@ -286,23 +359,63 @@ pub(crate) mod tests {
         state.shutdown().await;
     }
 
-    #[test]
-    fn ack_out_of_lease_included() {
+    #[tokio::test]
+    async fn ack_out_of_lease_included() {
         let mock = MockLeaser::new();
-        let mut state = LeaseState::new(mock);
+        let mut state = LeaseState::new(mock, LeaseOptions::default());
         assert_eq!(state, make_state([], [], []));
 
         state.ack("1".to_string());
         assert_eq!(state, make_state([], ["1"], []));
     }
 
-    #[test]
-    fn nack_out_of_lease_ignored() {
+    #[tokio::test]
+    async fn nack_out_of_lease_ignored() {
         let mock = MockLeaser::new();
-        let mut state = LeaseState::new(mock);
+        let mut state = LeaseState::new(mock, LeaseOptions::default());
         assert_eq!(state, make_state([], [], []));
 
         state.nack("1".to_string());
         assert_eq!(state, make_state([], [], []));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lease_events() {
+        let start = Instant::now();
+
+        // We expect flushes at time t=[1, 3, 5, 7, ...]
+        const FLUSH_START: Duration = Duration::from_secs(1);
+        const FLUSH_PERIOD: Duration = Duration::from_secs(2);
+
+        // We expect extensions at time t=[2, 6, 10, 14, ...]
+        const EXTEND_START: Duration = Duration::from_secs(2);
+        const EXTEND_PERIOD: Duration = Duration::from_secs(4);
+
+        let mock = MockLeaser::new();
+        let options = LeaseOptions {
+            flush_start: FLUSH_START,
+            flush_period: FLUSH_PERIOD,
+            extend_start: EXTEND_START,
+            extend_period: EXTEND_PERIOD,
+        };
+        let mut state = LeaseState::new(mock, options);
+
+        assert_eq!(state.next_event().await, LeaseEvent::Flush);
+        assert_eq!(start.elapsed(), Duration::from_secs(1));
+
+        assert_eq!(state.next_event().await, LeaseEvent::Extend);
+        assert_eq!(start.elapsed(), Duration::from_secs(2));
+
+        assert_eq!(state.next_event().await, LeaseEvent::Flush);
+        assert_eq!(start.elapsed(), Duration::from_secs(3));
+
+        assert_eq!(state.next_event().await, LeaseEvent::Flush);
+        assert_eq!(start.elapsed(), Duration::from_secs(5));
+
+        assert_eq!(state.next_event().await, LeaseEvent::Extend);
+        assert_eq!(start.elapsed(), Duration::from_secs(6));
+
+        assert_eq!(state.next_event().await, LeaseEvent::Flush);
+        assert_eq!(start.elapsed(), Duration::from_secs(7));
     }
 }


### PR DESCRIPTION
Part of the work for #3957

Add basic batching logic for Acks and lease extensions. Currently the batches fire on a timer.

This logic belongs in the `LeaseState`, so we can consider batch size / outstanding RPCs / etc. in the future.

Interfaces are made `pub(crate)` because the lease loop (coming shortly) will need them.