### PR TITLE
chore: cleaner diffs for rotation updates

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -24,11 +24,11 @@ ignored-directories = [
 # By default, only search in the `googleapis-root` directory.
 roots = 'googleapis'
 # This is the commit SHA for v0.36.2.
-showcase-extracted-name  = 'gapic-showcase-69bdd62035d793f3d23a0c960dee547023c1c5ac'
-showcase-root            = 'https://github.com/googleapis/gapic-showcase/archive/69bdd62035d793f3d23a0c960dee547023c1c5ac.tar.gz'
-showcase-sha256          = '96491310ba1b5c0c71738d3d80327a95196c1b6ac16f033e3fa440870efbbf5c'
-googleapis-root          = 'https://github.com/googleapis/googleapis/archive/b607ece2e97f19a8f105a6cd40368da68e7bc613.tar.gz'
-googleapis-sha256        = '24195ff2ca9cae989d09fe0765cb7e2b19986fd636beb4c1741e56d752998d89'
+showcase-extracted-name = 'gapic-showcase-69bdd62035d793f3d23a0c960dee547023c1c5ac'
+showcase-root           = 'https://github.com/googleapis/gapic-showcase/archive/69bdd62035d793f3d23a0c960dee547023c1c5ac.tar.gz'
+showcase-sha256         = '96491310ba1b5c0c71738d3d80327a95196c1b6ac16f033e3fa440870efbbf5c'
+googleapis-root         = 'https://github.com/googleapis/googleapis/archive/b607ece2e97f19a8f105a6cd40368da68e7bc613.tar.gz'
+googleapis-sha256       = '24195ff2ca9cae989d09fe0765cb7e2b19986fd636beb4c1741e56d752998d89'
 # Discovery sources
 discovery-extracted-name = 'discovery-artifact-manager-f85002671045f2d315ffcc140a8dc5ea8eb35769'
 discovery-root           = 'https://github.com/googleapis/discovery-artifact-manager/archive/f85002671045f2d315ffcc140a8dc5ea8eb35769.tar.gz'


### PR DESCRIPTION
It is probably too late for this[^1], but putting a divider between the `googleapis-` stuff and the `discovery-` stuff will let us send and merge updates for these sources independently.

[^1]: there is a migration afoot.